### PR TITLE
Mesh registration with closures

### DIFF
--- a/crates/ragu_circuits/src/mesh.rs
+++ b/crates/ragu_circuits/src/mesh.rs
@@ -62,11 +62,10 @@ impl<'params, F: PrimeField, R: Rank> Mesh<'params, F, R> {
         }
 
         let omega = self.current_omega;
-
-        let circuit_obj = circuit.into_circuit_object(omega)?;
+        let circuit = circuit.into_circuit_object(omega)?;
 
         self.current_omega *= self.domain.omega();
-        self.circuits.push(circuit_obj);
+        self.circuits.push(circuit);
         self.circuit_tags.insert(tag, omega);
 
         Ok(omega)


### PR DESCRIPTION
draft proposal to motivate https://github.com/tachyon-zcash/ragu/pull/34#issuecomment-3395708572, cc @ebfull. 

Instead of eagerly evaluating `into_object()`, circuit synthesis is now deferred through a lazily evaluated closure. This removes `add_circuit_object` and moves the omega logic directly up into the caller, `register_circuit()`. As a side-effect, this doesn't alter the proposed registration interface. 

Alternatively, we could introduce a **reserve system** of some kind that _pre-allocates_ a slot in the mesh (acquiring its omega value before synthesis), and then synthesizes and registers a circuit into that reserved slot. That would, for instance, enable cross-circuit parameter dependencies which allows us to do things like have circuit A access circuit D's omega during synthesis.

This still uses string tags rather than constants. 