### PR TITLE
Add (unstable) rustdoc configuration to direct links to external crates to docs.rs in rendered documentation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[doc.extern-map.registries]
+crates-io = "https://docs.rs/"


### PR DESCRIPTION
This essentially allows you to run

```
RUSTDOCFLAGS="--html-in-header katex-header.html" cargo +nightly doc --workspace --no-deps -Zrustdoc-map --document-private-items
```

to render (internal) documentation for development reasons. I'm experimenting with adding this to the website deployment workflow so that the book can link to the rust code effortlessly. **This shouldn't break local `cargo doc` operations that don't pass `-Zrustdoc-map`.**