### PR TITLE
feat: integrate split-accumulation structure and decision procedure

### DIFF
--- a/crates/ragu_circuits/src/mesh.rs
+++ b/crates/ragu_circuits/src/mesh.rs
@@ -280,6 +280,16 @@ pub fn omega_j<F: PrimeField>(id: u32) -> F {
     F::ROOT_OF_UNITY.pow([bit_reversal_id as u64])
 }
 
+/// Computes the log2 domain size needed for the application and recursion
+/// circuits being registered.
+///
+/// This function extracts the domain size computation logic from
+/// [`MeshBuilder::finalize`] to allow pre-computing the domain size before
+/// finalization
+pub fn compute_domain_size(num_circuits: usize) -> u32 {
+    num_circuits.next_power_of_two().trailing_zeros()
+}
+
 #[cfg(test)]
 mod tests {
     use super::{MeshBuilder, OmegaKey, omega_j};

--- a/crates/ragu_pcd/src/merge.rs
+++ b/crates/ragu_pcd/src/merge.rs
@@ -36,6 +36,10 @@ pub fn merge<'source, C: Cycle, R: Rank, RNG: Rng, S: Step<C>, const HEADER_SIZE
             right_header: right_header.into_inner(),
             rx,
             _marker: PhantomData,
+            witness: left.proof.witness,
+            instance: left.proof.instance,
+            endoscalars: left.proof.endoscalars,
+            deferreds: left.proof.deferreds,
         },
         aux,
     ))

--- a/crates/ragu_pcd/src/proof.rs
+++ b/crates/ragu_pcd/src/proof.rs
@@ -3,11 +3,12 @@ use ff::Field;
 use ragu_circuits::{
     CircuitExt,
     mesh::Mesh,
-    polynomials::{Rank, structured},
+    polynomials::{Rank, structured, unstructured},
 };
 
 use alloc::{vec, vec::Vec};
 use core::marker::PhantomData;
+use rand::Rng;
 
 use super::{
     circuits::{DUMMY_CIRCUIT_ID, dummy::Dummy, internal_circuit_index},
@@ -17,14 +18,130 @@ use super::{
 pub fn trivial<C: Cycle, R: Rank, const HEADER_SIZE: usize>(
     num_application_steps: usize,
     mesh: &Mesh<'_, C::CircuitField, R>,
+    host_generators: &C::HostGenerators,
 ) -> Proof<C, R> {
     let rx = Dummy.rx((), mesh.get_key()).expect("should not fail").0;
+
+    // Zero polynomials with determinstic blinding factor to avoid identity commitments.
+    let a_poly = structured::Polynomial::default();
+    let a_blinding = C::CircuitField::ONE;
+
+    let b_poly = structured::Polynomial::default();
+    let b_blinding = C::CircuitField::ONE;
+
+    let p_poly = unstructured::Polynomial::default();
+    let p_blinding = C::CircuitField::ONE;
+
+    // Trivial zero challenge points.
+    let x = C::CircuitField::ZERO;
+    let y = C::CircuitField::ZERO;
+
+    let s_poly = mesh.xy(x, y);
+    let s_blinding = C::CircuitField::ONE;
+
+    // Zero evaluations (consistent with zero polynomials).
+    let u = C::CircuitField::ZERO;
+    let v = C::CircuitField::ZERO;
+
+    let c = a_poly.revdot(&b_poly);
+
+    let s_commitment = s_poly.commit(host_generators, s_blinding);
+    let a_commitment = a_poly.commit(host_generators, a_blinding);
+    let b_commitment = b_poly.commit(host_generators, b_blinding);
+    let p_commitment = p_poly.commit(host_generators, p_blinding);
 
     Proof {
         rx,
         circuit_id: internal_circuit_index(num_application_steps, DUMMY_CIRCUIT_ID),
         left_header: vec![C::CircuitField::ZERO; HEADER_SIZE],
         right_header: vec![C::CircuitField::ZERO; HEADER_SIZE],
+        witness: AccumulatorWitness {
+            s_poly,
+            s_blinding,
+            a_poly,
+            a_blinding,
+            b_poly,
+            b_blinding,
+            p_poly,
+            p_blinding,
+        },
+        instance: AccumulatorInstance {
+            a: a_commitment,
+            b: b_commitment,
+            c,
+            p: p_commitment,
+            u: ChallengePoint(u),
+            v: EvaluationPoint(v),
+            s: s_commitment,
+            x: ChallengePoint(x),
+            y: ChallengePoint(y),
+        },
+        endoscalars: Vec::new(),
+        deferreds: Vec::new(),
+        _marker: PhantomData,
+    }
+}
+
+pub fn random<C: Cycle, R: Rank, RNG: Rng, const HEADER_SIZE: usize>(
+    num_application_steps: usize,
+    mesh: &Mesh<'_, C::CircuitField, R>,
+    host_generators: &C::HostGenerators,
+    rng: &mut RNG,
+) -> Proof<C, R> {
+    let rx = Dummy.rx((), mesh.get_key()).expect("should not fail").0;
+
+    let a_poly = structured::Polynomial::<C::CircuitField, R>::random(&mut *rng);
+    let a_blinding = C::CircuitField::random(&mut *rng);
+
+    let b_poly = structured::Polynomial::<C::CircuitField, R>::random(&mut *rng);
+    let b_blinding = C::CircuitField::random(&mut *rng);
+
+    let p_poly = unstructured::Polynomial::<C::CircuitField, R>::random(&mut *rng);
+    let p_blinding = C::CircuitField::random(&mut *rng);
+
+    let x = C::CircuitField::random(&mut *rng);
+    let y = C::CircuitField::random(&mut *rng);
+
+    let s_poly = mesh.xy(x, y);
+    let s_blinding = C::CircuitField::random(&mut *rng);
+
+    let u = C::CircuitField::random(&mut *rng);
+    let v = p_poly.eval(u);
+    let c = a_poly.revdot(&b_poly);
+
+    let s_commitment = s_poly.commit(host_generators, s_blinding);
+    let a_commitment = a_poly.commit(host_generators, a_blinding);
+    let b_commitment = b_poly.commit(host_generators, b_blinding);
+    let p_commitment = p_poly.commit(host_generators, p_blinding);
+
+    Proof {
+        rx,
+        circuit_id: internal_circuit_index(num_application_steps, DUMMY_CIRCUIT_ID),
+        left_header: vec![C::CircuitField::ZERO; HEADER_SIZE],
+        right_header: vec![C::CircuitField::ZERO; HEADER_SIZE],
+        witness: AccumulatorWitness {
+            s_poly,
+            s_blinding,
+            a_poly,
+            a_blinding,
+            b_poly,
+            b_blinding,
+            p_poly,
+            p_blinding,
+        },
+        instance: AccumulatorInstance {
+            a: a_commitment,
+            b: b_commitment,
+            c,
+            p: p_commitment,
+            u: ChallengePoint(u),
+            v: EvaluationPoint(v),
+            s: s_commitment,
+            x: ChallengePoint(x),
+            y: ChallengePoint(y),
+        },
+        endoscalars: Vec::new(),
+        deferreds: Vec::new(),
         _marker: PhantomData,
     }
 }
@@ -36,6 +153,18 @@ pub struct Proof<C: Cycle, R: Rank> {
     pub(crate) right_header: Vec<C::CircuitField>,
     pub(crate) rx: structured::Polynomial<C::CircuitField, R>,
     pub(crate) _marker: PhantomData<(C, R)>,
+
+    // Split-accumulation witness.
+    pub(crate) witness: AccumulatorWitness<C, R>,
+
+    // Split-accumulation instance.
+    pub(crate) instance: AccumulatorInstance<C>,
+
+    // Endoscalar points to be processed in this curve in the cycle (native curve).
+    pub(crate) endoscalars: Vec<C::HostCurve>,
+
+    // Deferred points to be processed in the next curve in the cycle (nested curve).
+    pub(crate) deferreds: Vec<C::NestedCurve>,
 }
 
 impl<C: Cycle, R: Rank> Clone for Proof<C, R> {
@@ -46,6 +175,29 @@ impl<C: Cycle, R: Rank> Clone for Proof<C, R> {
             right_header: self.right_header.clone(),
             rx: self.rx.clone(),
             _marker: PhantomData,
+            witness: AccumulatorWitness {
+                s_poly: self.witness.s_poly.clone(),
+                s_blinding: self.witness.s_blinding,
+                a_poly: self.witness.a_poly.clone(),
+                a_blinding: self.witness.a_blinding,
+                b_poly: self.witness.b_poly.clone(),
+                b_blinding: self.witness.b_blinding,
+                p_poly: self.witness.p_poly.clone(),
+                p_blinding: self.witness.p_blinding,
+            },
+            instance: AccumulatorInstance {
+                a: self.instance.a,
+                b: self.instance.b,
+                c: self.instance.c,
+                p: self.instance.p,
+                u: ChallengePoint(self.instance.u.0),
+                v: EvaluationPoint(self.instance.v.0),
+                s: self.instance.s,
+                x: ChallengePoint(self.instance.x.0),
+                y: ChallengePoint(self.instance.y.0),
+            },
+            endoscalars: self.endoscalars.clone(),
+            deferreds: self.deferreds.clone(),
         }
     }
 }
@@ -56,6 +208,47 @@ impl<C: Cycle, R: Rank> Proof<C, R> {
         Pcd { proof: self, data }
     }
 }
+
+/// Split-Accumulation private witness (prover's working structure).
+#[derive(Debug)]
+pub(crate) struct AccumulatorWitness<C: Cycle, R: Rank> {
+    pub(crate) s_poly: unstructured::Polynomial<C::CircuitField, R>,
+    pub(crate) s_blinding: C::CircuitField,
+
+    pub(crate) a_poly: structured::Polynomial<C::CircuitField, R>,
+    pub(crate) a_blinding: C::CircuitField,
+
+    pub(crate) b_poly: structured::Polynomial<C::CircuitField, R>,
+    pub(crate) b_blinding: C::CircuitField,
+
+    pub(crate) p_poly: unstructured::Polynomial<C::CircuitField, R>,
+    pub(crate) p_blinding: C::CircuitField,
+}
+
+/// Split-Accumulation public instance.
+#[derive(Debug)]
+pub struct AccumulatorInstance<C: Cycle> {
+    // Structured commitments & revdot claim.
+    pub a: C::HostCurve,
+    pub b: C::HostCurve,
+    pub c: C::CircuitField,
+
+    // Batching commitment & evaluation claim.
+    pub p: C::HostCurve,
+    pub u: ChallengePoint<C::CircuitField>,
+    pub v: EvaluationPoint<C::CircuitField>,
+
+    // Mesh commitments & challenges.
+    pub s: C::HostCurve,
+    pub x: ChallengePoint<C::CircuitField>,
+    pub y: ChallengePoint<C::CircuitField>,
+}
+
+#[derive(Debug)]
+pub struct ChallengePoint<F>(pub F);
+
+#[derive(Debug)]
+pub struct EvaluationPoint<F>(pub F);
 
 /// Represents proof-carrying data, a recursive proof for the correctness of
 /// some accompanying data.


### PR DESCRIPTION
Initial chunking against the scaffolding implemented in https://github.com/tachyon-zcash/ragu/pull/100. This models Penumbra's approach for using fake proofs and incrementally filling them in.

This integrates the split-accumulation structures from [accumulator.rs](https://github.com/tachyon-zcash/ragu/pull/35/files#diff-048a9503bae58ed5b2aa8820d0283e781dffb431c204b6f54343b9c339b6481d) for exercising the public API. We can then incrementally fill in the accumulation logic and dummy proof. 

Additionally, this stubs the decision procedure with basic accumulator consistency checks. Currently uses Pedersen vector commitments with direct access to the witness to check openings for testing purposes, but this will obviously later be replaced by full IPA verification.