### PR TITLE
feat: dummy transcript and staged object validation

### DIFF
--- a/crates/ragu_pcd/src/merge.rs
+++ b/crates/ragu_pcd/src/merge.rs
@@ -1,6 +1,7 @@
 use arithmetic::Cycle;
 use ragu_circuits::{CircuitExt, polynomials::Rank};
-use ragu_core::Result;
+use ragu_core::{Error, Result, drivers::emulator::Emulator};
+use ragu_primitives::Sponge;
 use rand::Rng;
 
 use core::marker::PhantomData;
@@ -22,7 +23,62 @@ pub fn merge<'source, C: Cycle, R: Rank, RNG: Rng, S: Step<C>, const HEADER_SIZE
 ) -> Result<(Proof<C, R>, S::Aux<'source>)> {
     let _host_generators = params.host_generators();
     let _nested_generators = params.nested_generators();
-    let _circuit_poseidon = params.circuit_poseidon();
+    let circuit_poseidon = params.circuit_poseidon();
+
+    ///////////////////////////////////////////////////////////////////////////////////////
+    // PHASE: Initialize transcript.
+    ///////////////////////////////////////////////////////////////////////////////////////
+
+    // Simulate a dummy transcript object using Poseidon sponge construction, using an
+    // emulator driver to run the sponge permutation. The permutations are treated as
+    // as a fixed-length hash for fiat-shamir challenge derivation.
+    //
+    // TODO: Replace with a real transcript abstraction.
+    let mut em = Emulator::execute();
+    let mut _transcript = Sponge::new(&mut em, circuit_poseidon);
+
+    ///////////////////////////////////////////////////////////////////////////////////////
+    // PHASE: Process endoscalars.
+    ///////////////////////////////////////////////////////////////////////////////////////
+
+    // TODO: Determine the endoscaling operations, representing deferreds from the
+    // other curve.
+
+    ///////////////////////////////////////////////////////////////////////////////////////
+    // PHASE: Process `StagedObjects` for staging consistency from the previous cycle.
+    ///////////////////////////////////////////////////////////////////////////////////////
+
+    // Checks each staged circuit's constraint polynomial r(X) satisfies the mesh consistency equation.
+    for staged_data in &left.proof.staged_circuits {
+        let y_challenge = left.proof.instance.y.0;
+        let sy = circuit_mesh.wy(staged_data.circuit_id, y_challenge);
+        let ky_at_y = arithmetic::eval(&staged_data.ky, y_challenge);
+        let lhs = staged_data.final_rx.revdot(&sy);
+        if lhs != ky_at_y {
+            return Err(Error::InvalidWitness(
+                "Staged circuit constraint check failed (left proof): rx.revdot(sy) != ky(y)"
+                    .into(),
+            ));
+        }
+    }
+
+    for staged_data in &right.proof.staged_circuits {
+        let y_challenge = right.proof.instance.y.0;
+        let sy = circuit_mesh.wy(staged_data.circuit_id, y_challenge);
+        let ky_at_y = arithmetic::eval(&staged_data.ky, y_challenge);
+        let lhs = staged_data.final_rx.revdot(&sy);
+        if lhs != ky_at_y {
+            return Err(Error::InvalidWitness(
+                "Staged circuit constraint check failed (right proof): rx.revdot(sy) != ky(y)"
+                    .into(),
+            ));
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////
+    // Task: Execute application logic via `Step::witness()` through the `Adapter`.
+    ///////////////////////////////////////////////////////////////////////////////////////
+
     let circuit_id = S::INDEX.circuit_index(Some(num_application_steps))?;
     let circuit = Adapter::<C, S, R, HEADER_SIZE>::new(step);
     let (rx, aux) = circuit.rx::<R>((left.data, right.data, witness), circuit_mesh.get_key())?;
@@ -40,6 +96,7 @@ pub fn merge<'source, C: Cycle, R: Rank, RNG: Rng, S: Step<C>, const HEADER_SIZE
             instance: left.proof.instance,
             endoscalars: left.proof.endoscalars,
             deferreds: left.proof.deferreds,
+            staged_circuits: left.proof.staged_circuits,
         },
         aux,
     ))

--- a/crates/ragu_pcd/tests/registration_errors.rs
+++ b/crates/ragu_pcd/tests/registration_errors.rs
@@ -204,3 +204,39 @@ fn test_decide_random_proof() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_merge_random_proof() -> Result<()> {
+    let pasta = Pasta::default();
+
+    let app = ApplicationBuilder::<Pasta, R<8>, 4>::new()
+        .register(Step0)
+        .unwrap()
+        .register(Step1)
+        .unwrap()
+        .finalize(&pasta)
+        .unwrap();
+
+    let mut rng = StdRng::seed_from_u64(1234);
+
+    let trivial = app.trivial().carry::<()>(());
+    assert!(app.verify(&trivial, &mut rng).unwrap());
+
+    let trivial_2 = app.trivial().carry::<()>(());
+    assert!(app.verify(&trivial, &mut rng).unwrap());
+
+    let left_pcd = app.rerandomize(trivial.clone(), &mut rng).unwrap();
+    assert!(app.verify(&left_pcd, &mut rng).unwrap());
+
+    let right_pcd = app.rerandomize(trivial_2.clone(), &mut rng).unwrap();
+    assert!(app.verify(&right_pcd, &mut rng).unwrap());
+
+    let merged_proof = app.merge(&mut rng, Step0, (), left_pcd, right_pcd)?;
+    let pcd = merged_proof.0.carry::<HPrefixA>(());
+
+    let is_valid = app.verify(&pcd, &mut rng)?;
+
+    assert!(is_valid, "Merged proof should verify");
+
+    Ok(())
+}


### PR DESCRIPTION
Initializes a _dummy_ transcript modeled simply as a Poseidon sponge with emulator driver (placeholder for real transcript construction that will be implemented as part of https://github.com/tachyon-zcash/ragu/issues/31). 

Performs staged circuit well-formedness checks (for each staged circuit that was deferred from the previous cycle), ` rx.revdot(sy) == ky(y)` where:
- rx is the "staged circuit" with enforced linear and multiplication gates,
- sy is the mesh polynomial at the circuit's omega position,
- ky(y) is the public inputs evaluated at challenge y

Stubs phase for processing endoscalars in this round.