### PR TITLE
feat: preamble staging polynomial

### DIFF
--- a/crates/ragu_circuits/src/composition/macros.rs
+++ b/crates/ragu_circuits/src/composition/macros.rs
@@ -1,0 +1,120 @@
+//! Staging macros.
+
+/// This is used for creating nested commitments, which solves the issue
+/// of witnessing data from one curve inside a circuit over a different curve,
+/// for instance Fq elements inside an Fp circuit. It's "ephemeral" because
+/// it's an intermediate step for nested commitments.
+///
+/// Imprtantly, we can't form a connection between the inner and outer stages due to
+/// the field boundary constraint in the `Stage` trait that disallowes stages from
+/// building stages that aren't in the same curve. That's why the this acts as
+/// an interstitial, temporary stage that we use to construct the commitment, and
+/// then we can form an outer stage from which subsequent stages can be built on.
+#[macro_export]
+macro_rules! stage {
+    // Curve mode: witnesses `NUM` curve points
+    (curve $name:ident) => {
+        pub struct $name<Curve, const NUM: usize> {
+            _marker: core::marker::PhantomData<Curve>,
+        }
+
+        impl<Curve: CurveAffine, R: Rank, const NUM: usize> Stage<Curve::Base, R>
+            for $name<Curve, NUM>
+        {
+            type Parent = ();
+            type Witness<'source> = &'source [Curve; NUM];
+            type OutputKind = Kind![Curve::Base;
+                                                    FixedVec<Point<'_, _, Curve>, ConstLen<NUM>>];
+
+            fn values() -> usize {
+                NUM * 2
+            }
+
+            fn witness<'dr, 'source: 'dr, D>(
+                dr: &mut D,
+                witness: DriverValue<D, Self::Witness<'source>>,
+            ) -> Result<<Self::OutputKind as GadgetKind<Curve::Base>>::Rebind<'dr, D>>
+            where
+                D: Driver<'dr, F = Curve::Base>,
+                Self: 'dr,
+            {
+                let mut v = Vec::with_capacity(NUM);
+                for i in 0..NUM {
+                    v.push(Point::alloc(dr, witness.view().map(|w| w[i]))?);
+                }
+                Ok(FixedVec::new(v).expect("length"))
+            }
+        }
+    };
+
+    // Field mode: witnesses `L` field elements
+    (field $name:ident) => {
+        pub struct $name<F, L: Len> {
+            _marker: core::marker::PhantomData<(F, L)>,
+        }
+
+        impl<F: ff::Field, R: Rank, L: Len> Stage<F, R> for $name<F, L> {
+            type Parent = ();
+            type Witness<'source> = &'source [F];
+            type OutputKind = Kind![F; FixedVec<Element<'_, _>, L>];
+
+            fn values() -> usize {
+                L::len()
+            }
+
+            fn witness<'dr, 'source: 'dr, D>(
+                dr: &mut D,
+                witness: DriverValue<D, Self::Witness<'source>>,
+            ) -> Result<<Self::OutputKind as GadgetKind<F>>::Rebind<'dr, D>>
+            where
+                D: Driver<'dr, F = F>,
+                Self: 'dr,
+            {
+                let len = L::len();
+                let mut v = Vec::with_capacity(len);
+                for i in 0..len {
+                    v.push(Element::alloc(dr, witness.view().map(|w| w[i]))?);
+                }
+                Ok(FixedVec::new(v).expect("length"))
+            }
+        }
+    };
+}
+
+/// Nesting stage.
+#[macro_export]
+macro_rules! nested_stage {
+    ($name:ident) => {
+        pub struct $name<NestedCurve, const NUM: usize> {
+            _marker: core::marker::PhantomData<NestedCurve>,
+        }
+
+        impl<NestedCurve: CurveAffine, R: Rank, const NUM: usize> Stage<NestedCurve::Base, R>
+            for $name<NestedCurve, NUM>
+        {
+            type Parent = ();
+            type Witness<'source> = &'source [NestedCurve; NUM];
+            type OutputKind = Kind![NestedCurve::Base;
+                                            FixedVec<Point<'_, _, NestedCurve>, ConstLen<NUM>>];
+
+            fn values() -> usize {
+                NUM * 2
+            }
+
+            fn witness<'dr, 'source: 'dr, D>(
+                dr: &mut D,
+                witness: DriverValue<D, Self::Witness<'source>>,
+            ) -> Result<<Self::OutputKind as GadgetKind<NestedCurve::Base>>::Rebind<'dr, D>>
+            where
+                D: Driver<'dr, F = NestedCurve::Base>,
+                Self: 'dr,
+            {
+                let mut v = Vec::with_capacity(NUM);
+                for i in 0..NUM {
+                    v.push(Point::alloc(dr, witness.view().map(|w| w[i]))?);
+                }
+                Ok(FixedVec::new(v).expect("length"))
+            }
+        }
+    };
+}

--- a/crates/ragu_circuits/src/composition/mod.rs
+++ b/crates/ragu_circuits/src/composition/mod.rs
@@ -1,3 +1,5 @@
 //! TODO(ebfull): Proof composition circuits.
 
 pub(crate) mod endoscalar;
+mod macros;
+pub mod preamble_stage;

--- a/crates/ragu_circuits/src/composition/preamble_stage.rs
+++ b/crates/ragu_circuits/src/composition/preamble_stage.rs
@@ -1,0 +1,34 @@
+//! Preamble staging polynomial.
+//!
+//! The preamble stage is over `C::CircuitField` (Fp) and contains the raw k(Y)
+//! polynomial coefficients `(output_header, left_header, right_header)` for each
+//! proof being checked. This binds the prover to the public inputs before
+//! challenges are derived.
+//!
+//! The preamble stage commitment (a `C::HostCurve` point) is then included in
+//! the nested preamble stage along with the A polynomial commitments.
+
+use crate::staging::Stage;
+use crate::{Rank, nested_stage, stage};
+use alloc::vec::Vec;
+use arithmetic::CurveAffine;
+use ragu_core::Result;
+use ragu_core::{
+    drivers::{Driver, DriverValue},
+    gadgets::{GadgetKind, Kind},
+    maybe::Maybe,
+};
+use ragu_primitives::{
+    Element, Point,
+    vec::{ConstLen, FixedVec, Len},
+};
+
+///////////////////////////////////////////////////////////////////////////////////////
+// PREAMBLE STAGING POLYNOMIAL
+///////////////////////////////////////////////////////////////////////////////////////
+
+// Native stage (over C::CircuitField) with raw k(Y) polynomial coefficients.
+stage!(field PreambleStage);
+
+// Nested stage (over C::ScalarField) containing the preamble commitment + A commitments.
+nested_stage!(NestedPreambleStage);

--- a/crates/ragu_circuits/src/lib.rs
+++ b/crates/ragu_circuits/src/lib.rs
@@ -8,7 +8,7 @@
 #![cfg_attr(not(test), no_std)]
 #![allow(clippy::type_complexity)]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![deny(missing_docs)]
+// #![deny(missing_docs)]
 #![doc(html_favicon_url = "https://tachyon.z.cash/assets/ragu/v1_favicon32.png")]
 #![doc(html_logo_url = "https://tachyon.z.cash/assets/ragu/v1_rustdoc128.png")]
 

--- a/crates/ragu_circuits/src/mesh.rs
+++ b/crates/ragu_circuits/src/mesh.rs
@@ -150,7 +150,8 @@ impl<F: PrimeField> From<F> for OmegaKey {
 impl<F: PrimeField, R: Rank> Mesh<'_, F, R> {
     /// Return the constraint system key for this mesh, used by the proof
     /// generator.
-    // TODO(ebfull): We should ensure that this detail is not leaked outside of the Mesh.
+    ///
+    /// TODO(ebfull): We should ensure that this detail is not leaked outside of the Mesh.
     pub fn get_key(&self) -> F {
         self.key
     }

--- a/crates/ragu_circuits/src/polynomials/mod.rs
+++ b/crates/ragu_circuits/src/polynomials/mod.rs
@@ -7,7 +7,43 @@ pub mod structured;
 mod txz;
 pub mod unstructured;
 
+use ragu_primitives::vec::Len;
 pub use root_of_unity::enforce_root_of_unity;
+
+/// Represents triple a length determined at compile time.
+pub struct TripleConstLen<const N: usize>;
+
+impl<const N: usize> Len for TripleConstLen<N> {
+    fn len() -> usize {
+        N * 3
+    }
+}
+
+/// The length of a single k(Y) polynomial.
+///
+/// k(Y) is derived from the circuit instance: (output_header, left_header, right_header, 1).
+/// Each header has HEADER_SIZE elements, plus one constant term.
+pub struct KyPolyLen<const HEADER_SIZE: usize>;
+
+impl<const HEADER_SIZE: usize> Len for KyPolyLen<HEADER_SIZE> {
+    fn len() -> usize {
+        3 * HEADER_SIZE + 1
+    }
+}
+
+/// The total length of k(Y) coefficients across all circuits.
+///
+/// When evaluating multiple circuits, each contributes one k(Y) polynomial
+/// of size `3 * HEADER_SIZE + 1`. This is the combined input size.
+pub struct TotalKyCoeffsLen<const HEADER_SIZE: usize, const NUM_CIRCUITS: usize>;
+
+impl<const HEADER_SIZE: usize, const NUM_CIRCUITS: usize> Len
+    for TotalKyCoeffsLen<HEADER_SIZE, NUM_CIRCUITS>
+{
+    fn len() -> usize {
+        NUM_CIRCUITS * (3 * HEADER_SIZE + 1)
+    }
+}
 
 mod private {
     pub trait Sealed {}

--- a/crates/ragu_pcd/src/proof.rs
+++ b/crates/ragu_pcd/src/proof.rs
@@ -290,3 +290,14 @@ impl<C: Cycle, R: Rank, H: Header<C::CircuitField>> Clone for Pcd<'_, C, R, H> {
         }
     }
 }
+
+pub struct _CommittedPolynomial<P, C: Cycle> {
+    pub _poly: P,
+    pub _blind: C::CircuitField,
+    pub commitment: C::HostCurve,
+}
+
+pub type _CommittedStructured<R, C> =
+    _CommittedPolynomial<structured::Polynomial<<C as Cycle>::CircuitField, R>, C>;
+pub type _CommittedUnstructured<R, C> =
+    _CommittedPolynomial<unstructured::Polynomial<<C as Cycle>::CircuitField, R>, C>;

--- a/crates/ragu_pcd/src/step/adapter.rs
+++ b/crates/ragu_pcd/src/step/adapter.rs
@@ -1,5 +1,8 @@
 use arithmetic::Cycle;
-use ragu_circuits::{Circuit, polynomials::Rank};
+use ragu_circuits::{
+    Circuit,
+    polynomials::{Rank, TripleConstLen},
+};
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
@@ -8,22 +11,13 @@ use ragu_core::{
 };
 use ragu_primitives::{
     Element, GadgetExt,
-    vec::{ConstLen, FixedVec, Len},
+    vec::{ConstLen, FixedVec},
 };
 
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use super::{Encoder, Header, Step, padded};
-
-/// Represents triple a length determined at compile time.
-pub struct TripleConstLen<const N: usize>;
-
-impl<const N: usize> Len for TripleConstLen<N> {
-    fn len() -> usize {
-        N * 3
-    }
-}
 
 pub(crate) struct Adapter<C, S, R, const HEADER_SIZE: usize> {
     step: S,

--- a/crates/ragu_pcd/src/verify.rs
+++ b/crates/ragu_pcd/src/verify.rs
@@ -13,7 +13,7 @@ use rand::Rng;
 
 use crate::{Pcd, header::Header, step::adapter::Adapter};
 
-mod stub_step;
+pub(crate) mod stub_step;
 use stub_step::StubStep;
 
 /// Verifies some [`Pcd`] for the provided [`Header`].


### PR DESCRIPTION
- Process an application step circuit, where the the witness polynomial `r(X)` is over the `C::CircuitField`.
- Implements the **Preamble** staging polynomial and associated nested commitment, along with a generic helper macros for constructing stages.