### PR TITLE
feat: Integrate compute c and horner's evaluation routines

### DIFF
--- a/crates/ragu_circuits/src/polynomials/compute_c.rs
+++ b/crates/ragu_circuits/src/polynomials/compute_c.rs
@@ -1,0 +1,168 @@
+//! Routine for computing c, the revdot claim for the folded accumulator.
+
+use ff::Field;
+use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue},
+    gadgets::{Gadget, GadgetKind, Kind},
+    routines::{Prediction, Routine},
+};
+use ragu_primitives::{
+    Element,
+    vec::{ConstLen, FixedVec},
+};
+
+use crate::polynomials::CrossProductsLen;
+
+/// Input gadget for the ComputeRevdotClaim routine.
+#[derive(Gadget)]
+pub struct RevdotClaimInput<'dr, D: Driver<'dr>, const NUM_CIRCUITS: usize> {
+    #[ragu(gadget)]
+    pub mu: Element<'dr, D>,
+    #[ragu(gadget)]
+    pub nu: Element<'dr, D>,
+    #[ragu(gadget)]
+    pub mu_inv: Element<'dr, D>,
+    #[ragu(gadget)]
+    pub cross_products: FixedVec<Element<'dr, D>, CrossProductsLen<NUM_CIRCUITS>>,
+    #[ragu(gadget)]
+    pub ky_values: FixedVec<Element<'dr, D>, ConstLen<NUM_CIRCUITS>>,
+}
+
+/// Routine for computing the revdot claim, c.
+#[derive(Clone, Default)]
+pub struct ComputeRevdotClaim<const NUM_CIRCUITS: usize>;
+
+impl<F: Field, const NUM_CIRCUITS: usize> Routine<F> for ComputeRevdotClaim<NUM_CIRCUITS> {
+    type Input = Kind![F; RevdotClaimInput<'_, _, NUM_CIRCUITS>];
+    type Output = Kind![F; Element<'_, _>];
+    type Aux<'dr> = ();
+
+    fn execute<'dr, D: Driver<'dr, F = F>>(
+        &self,
+        dr: &mut D,
+        input: <Self::Input as GadgetKind<F>>::Rebind<'dr, D>,
+        _: DriverValue<D, Self::Aux<'dr>>,
+    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+        let munu = input.mu.mul(dr, &input.nu)?;
+
+        let mut c_acc = Element::zero(dr);
+        let mut row_power = Element::one();
+        let mut cross_iter = 0;
+
+        for i in 0..NUM_CIRCUITS {
+            let mut col_power = row_power.clone();
+            for j in 0..NUM_CIRCUITS {
+                let term = if i == j {
+                    input.ky_values[i].clone()
+                } else {
+                    let cross_elem = input.cross_products[cross_iter].clone();
+                    cross_iter += 1;
+                    cross_elem
+                };
+
+                let contribution = col_power.mul(dr, &term)?;
+                c_acc = c_acc.add(dr, &contribution);
+                col_power = col_power.mul(dr, &munu)?;
+            }
+            row_power = row_power.mul(dr, &input.mu_inv)?;
+        }
+
+        Ok(c_acc)
+    }
+
+    fn predict<'dr, D: Driver<'dr, F = F>>(
+        &self,
+        _dr: &mut D,
+        _input: &<Self::Input as GadgetKind<F>>::Rebind<'dr, D>,
+    ) -> Result<
+        Prediction<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>, DriverValue<D, Self::Aux<'dr>>>,
+    > {
+        // Prediction requires the same computation as execution. Return Unknown to defer to execute().
+        Ok(Prediction::Unknown(D::just(|| ())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ff::Field;
+    use ragu_core::{drivers::emulator::Emulator, maybe::Maybe};
+    use ragu_pasta::Fp;
+    use ragu_primitives::vec::Len;
+    use rand::rngs::OsRng;
+
+    #[test]
+    fn test_c_routine_equivalency() -> Result<()> {
+        const NUM_CIRCUITS: usize = 3;
+
+        let mu = Fp::random(OsRng);
+        let nu = Fp::random(OsRng);
+        let mu_inv = mu.invert().unwrap();
+
+        let num_cross = CrossProductsLen::<NUM_CIRCUITS>::len();
+        let cross_products: Vec<Fp> = (0..num_cross).map(|_| Fp::random(OsRng)).collect();
+        let ky_values: Vec<Fp> = (0..NUM_CIRCUITS).map(|_| Fp::random(OsRng)).collect();
+
+        // Compute expected c value.
+        let munu = mu * nu;
+        let mut expected_c = Fp::ZERO;
+        let mut row_power = Fp::ONE;
+        let mut cross_iter = 0;
+
+        for i in 0..NUM_CIRCUITS {
+            let mut col_power = row_power;
+            for j in 0..NUM_CIRCUITS {
+                let term = if i == j {
+                    ky_values[i]
+                } else {
+                    let cross_elem = cross_products[cross_iter];
+                    cross_iter += 1;
+                    cross_elem
+                };
+
+                expected_c += col_power * term;
+                col_power *= munu;
+            }
+            row_power *= mu_inv;
+        }
+
+        // Run routine with Emulator.
+        let mut em = Emulator::execute();
+
+        let mu_elem = Element::constant(&mut em, mu);
+        let nu_elem = Element::constant(&mut em, nu);
+        let mu_inv_elem = Element::constant(&mut em, mu_inv);
+
+        let cross_vec: Vec<_> = cross_products
+            .iter()
+            .map(|&val| Element::constant(&mut em, val))
+            .collect();
+        let cross_elems = FixedVec::new(cross_vec).unwrap();
+
+        let ky_vec: Vec<_> = ky_values
+            .iter()
+            .map(|&val| Element::constant(&mut em, val))
+            .collect();
+        let ky_elems = FixedVec::new(ky_vec).unwrap();
+
+        let input = RevdotClaimInput {
+            mu: mu_elem,
+            nu: nu_elem,
+            mu_inv: mu_inv_elem,
+            cross_products: cross_elems,
+            ky_values: ky_elems,
+        };
+
+        let routine = ComputeRevdotClaim::<NUM_CIRCUITS>::default();
+        let result = em.routine(routine, input).unwrap();
+        let computed_c = result.value().take();
+
+        assert_eq!(
+            *computed_c, expected_c,
+            "C routine computed value doesn't match expected"
+        );
+
+        Ok(())
+    }
+}

--- a/crates/ragu_circuits/src/polynomials/horners.rs
+++ b/crates/ragu_circuits/src/polynomials/horners.rs
@@ -1,0 +1,171 @@
+//! Routine for evaluating the k(Y) polynomial at a challenge point y using Horner's method.
+
+use alloc::vec::Vec;
+use ff::Field;
+use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue},
+    gadgets::{GadgetKind, Kind},
+    maybe::Maybe,
+    routines::{Prediction, Routine},
+};
+use ragu_primitives::{
+    Element,
+    vec::{ConstLen, FixedVec},
+};
+
+use crate::polynomials::TotalKyCoeffsLen;
+
+#[derive(Clone)]
+pub struct EvaluateKyPolynomials<const HEADER_SIZE: usize, const NUM_CIRCUITS: usize> {
+    ky_degree: usize,
+}
+
+impl<const HEADER_SIZE: usize, const NUM_CIRCUITS: usize>
+    EvaluateKyPolynomials<HEADER_SIZE, NUM_CIRCUITS>
+{
+    pub fn new(ky_degree: usize) -> Self {
+        Self { ky_degree }
+    }
+}
+
+impl<F: Field, const HEADER_SIZE: usize, const NUM_CIRCUITS: usize> Routine<F>
+    for EvaluateKyPolynomials<HEADER_SIZE, NUM_CIRCUITS>
+{
+    type Input = Kind![F; (FixedVec<Element<'_, _>, TotalKyCoeffsLen<HEADER_SIZE, NUM_CIRCUITS>>, Element<'_, _>)];
+    type Output = Kind![F; FixedVec<Element<'_, _>, ConstLen<NUM_CIRCUITS>>];
+    type Aux<'dr> = ();
+
+    fn execute<'dr, D: Driver<'dr, F = F>>(
+        &self,
+        dr: &mut D,
+        input: <Self::Input as GadgetKind<F>>::Rebind<'dr, D>,
+        _: DriverValue<D, Self::Aux<'dr>>,
+    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+        let (ky_coefficients, y_challenge) = input;
+
+        let mut ky_elements = Vec::with_capacity(NUM_CIRCUITS);
+
+        // Evaluate each k(Y) polynomial at y.
+        for circuit_idx in 0..NUM_CIRCUITS {
+            let ky_start = circuit_idx * self.ky_degree;
+
+            // Evaluate k(y) using Horner's method.
+            let mut ky_at_y = Element::zero(dr);
+            for coeff_idx in (0..self.ky_degree).rev() {
+                let global_idx = ky_start + coeff_idx;
+                let ky_coeff = ky_coefficients[global_idx].clone();
+
+                ky_at_y = ky_at_y.mul(dr, &y_challenge)?;
+                ky_at_y = ky_at_y.add(dr, &ky_coeff);
+            }
+
+            ky_elements.push(ky_at_y);
+        }
+
+        Ok(FixedVec::new(ky_elements).expect("ky_elements length"))
+    }
+
+    fn predict<'dr, D: Driver<'dr, F = F>>(
+        &self,
+        dr: &mut D,
+        input: &<Self::Input as GadgetKind<F>>::Rebind<'dr, D>,
+    ) -> Result<
+        Prediction<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>, DriverValue<D, Self::Aux<'dr>>>,
+    > {
+        let mut ky_elements = Vec::with_capacity(NUM_CIRCUITS);
+
+        // Evaluate each k(Y) polynomial at y.
+        for circuit_idx in 0..NUM_CIRCUITS {
+            let ky_start = circuit_idx * self.ky_degree;
+            let ky_degree = self.ky_degree;
+
+            let ky_elem = Element::alloc(
+                dr,
+                D::with(|| {
+                    let ky_coefficients: Vec<F> =
+                        input.0.iter().map(|elem| *elem.value().take()).collect();
+                    let y_challenge = *input.1.value().take();
+
+                    // Evaluate using Horner's method.
+                    let mut ky_at_y = F::ZERO;
+                    for coeff_idx in (0..ky_degree).rev() {
+                        let global_idx = ky_start + coeff_idx;
+                        let ky_coeff = ky_coefficients[global_idx];
+
+                        ky_at_y *= y_challenge;
+                        ky_at_y += ky_coeff;
+                    }
+
+                    Ok(ky_at_y)
+                })?,
+            )?;
+
+            ky_elements.push(ky_elem);
+        }
+
+        Ok(Prediction::Known(
+            FixedVec::new(ky_elements).expect("ky_elements length"),
+            D::just(|| ()),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::polynomials::KyPolyLen;
+
+    use super::*;
+    use ff::Field;
+    use ragu_core::drivers::emulator::Emulator;
+    use ragu_pasta::Fp;
+    use ragu_primitives::vec::Len;
+    use rand::rngs::OsRng;
+
+    #[test]
+    fn test_evaluate_ky_polynomials() {
+        const NUM_CIRCUITS: usize = 3;
+        const HEADER_SIZE: usize = 4;
+        let ky_degree = KyPolyLen::<HEADER_SIZE>::len();
+        let total_ky_coeffs = TotalKyCoeffsLen::<HEADER_SIZE, NUM_CIRCUITS>::len();
+        let y_challenge = Fp::random(OsRng);
+
+        let mut ky_coeffs = Vec::new();
+        for _ in 0..total_ky_coeffs {
+            ky_coeffs.push(Fp::random(OsRng));
+        }
+
+        let mut expected = Vec::new();
+        for circuit_idx in 0..NUM_CIRCUITS {
+            let ky_start = circuit_idx * ky_degree;
+            let mut ky_at_y = Fp::ZERO;
+
+            for coeff_idx in (0..ky_degree).rev() {
+                let global_idx = ky_start + coeff_idx;
+                ky_at_y *= y_challenge;
+                ky_at_y += ky_coeffs[global_idx];
+            }
+
+            expected.push(ky_at_y);
+        }
+
+        // Run the routine using emulator driver.
+        let mut em = Emulator::execute();
+
+        let mut ky_elems = Vec::new();
+        for &coeff in &ky_coeffs {
+            ky_elems.push(Element::constant(&mut em, coeff));
+        }
+
+        let ky_elems_fixed = FixedVec::new(ky_elems).unwrap();
+        let y_elem = Element::constant(&mut em, y_challenge);
+
+        let routine = EvaluateKyPolynomials::<HEADER_SIZE, NUM_CIRCUITS>::new(ky_degree);
+        let result = em.routine(routine, (ky_elems_fixed, y_elem)).unwrap();
+
+        for (i, ky_elem) in result.iter().enumerate().take(NUM_CIRCUITS) {
+            let computed = *ky_elem.value().take();
+            assert_eq!(computed, expected[i], "Mismatch for circuit {}", i);
+        }
+    }
+}

--- a/crates/ragu_circuits/src/polynomials/mod.rs
+++ b/crates/ragu_circuits/src/polynomials/mod.rs
@@ -2,6 +2,8 @@
 
 use ff::Field;
 
+pub mod compute_c;
+pub mod horners;
 mod root_of_unity;
 pub mod structured;
 mod txz;

--- a/crates/ragu_core/src/drivers/emulator.rs
+++ b/crates/ragu_core/src/drivers/emulator.rs
@@ -278,7 +278,7 @@ impl<F: Field> Emulator<Wired<Always<()>, F>> {
 
 impl<M: Mode<F = F>, F: Field> Emulator<M> {
     /// Helper utility for executing a closure with this [`Emulator`].
-    fn with<R, W: Send>(
+    pub fn with<R, W: Send>(
         &mut self,
         witness: W,
         f: impl FnOnce(&mut Self, <M::MaybeKind as MaybeKind>::Rebind<W>) -> Result<R>,


### PR DESCRIPTION
Adds routines for computing revdot claim C and KY polynomial evaluation via horner's method. 

_Update:_ pulling the routine logic into a standalone PR in https://github.com/tachyon-zcash/ragu/pull/153, and this can serve as an eventual integration entry point for that. Addressing feedback in that PR, cc @ebfull.

This currently duplicates the logic in https://github.com/tachyon-zcash/ragu/pull/153 and will _need_ rebasing through the chain of PRs. 