### PR TITLE
testing: encoding, padding, and header consistency

### DIFF
--- a/crates/ragu_pcd/src/step/adapter.rs
+++ b/crates/ragu_pcd/src/step/adapter.rs
@@ -129,3 +129,120 @@ impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Circuit<C::Circuit
         Ok((FixedVec::try_from(elements).expect("correct length"), aux))
     }
 }
+
+/// Test that k(Y) computed via witness path matches k(Y) computed via VerifyAdapter.
+/// This ensures the polynomial identity check will work correctly.
+#[test]
+fn test_ky_consistency_witness_vs_verify_adapter() {
+    use crate::header::{Header, Prefix};
+    use ff::Field;
+    use ragu_circuits::{CircuitExt, polynomials};
+    use ragu_core::{
+        Result,
+        drivers::{Driver, DriverValue, emulator::Emulator},
+        gadgets::{GadgetKind, Kind},
+        maybe::{Always, Maybe, MaybeKind},
+    };
+    use ragu_pasta::{Fp, Pasta};
+
+    use super::{Encoded, Encoder, Index, verify_adapter::VerifyAdapter};
+
+    const HEADER_SIZE: usize = 4;
+    type R = polynomials::R<8>;
+
+    // Simple header that encodes a single field element
+    struct SimpleHeader;
+    impl Header<Fp> for SimpleHeader {
+        const PREFIX: Prefix = Prefix::new(0);
+        type Data<'source> = Fp;
+        type Output = Kind![Fp; Element<'_, _>];
+        fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+            dr: &mut D,
+            witness: DriverValue<D, Self::Data<'source>>,
+        ) -> Result<<Self::Output as GadgetKind<Fp>>::Rebind<'dr, D>> {
+            Element::alloc(dr, witness)
+        }
+    }
+
+    // Simple step that takes trivial inputs and produces SimpleHeader output
+    struct SimpleStep;
+    impl Step<Pasta> for SimpleStep {
+        const INDEX: Index = Index::new(0);
+        type Witness<'source> = Fp;
+        type Aux<'source> = Fp;
+        type Left = ();
+        type Right = ();
+        type Output = SimpleHeader;
+
+        fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+            &self,
+            dr: &mut D,
+            witness: DriverValue<D, Self::Witness<'source>>,
+            _left: Encoder<'dr, 'source, D, Self::Left, HS>,
+            _right: Encoder<'dr, 'source, D, Self::Right, HS>,
+        ) -> Result<(
+            (
+                Encoded<'dr, D, Self::Left, HS>,
+                Encoded<'dr, D, Self::Right, HS>,
+                Encoded<'dr, D, Self::Output, HS>,
+            ),
+            DriverValue<D, Self::Aux<'source>>,
+        )>
+        where
+            Self: 'dr,
+        {
+            let output = Element::alloc(dr, witness.clone())?;
+            let output_value = witness;
+
+            Ok((
+                (
+                    Encoded::from_gadget(()),
+                    Encoded::from_gadget(()),
+                    Encoded::from_gadget(output),
+                ),
+                output_value,
+            ))
+        }
+    }
+
+    // Create adapter for SimpleStep
+    let adapter = Adapter::<Pasta, SimpleStep, R, HEADER_SIZE>::new(SimpleStep);
+
+    // Run witness synthesis
+    let mut dr: Emulator<_> = Emulator::execute();
+    let witness_value = Fp::from(42u64);
+    let witness_data = ((), (), witness_value);
+
+    let (elements, aux) = adapter
+        .witness(&mut dr, Always::maybe_just(|| witness_data))
+        .expect("witness should succeed");
+
+    // Extract values from witness result
+    let output_header: Vec<Fp> = elements.as_ref()[0..HEADER_SIZE]
+        .iter()
+        .map(|e| *e.value().take())
+        .collect();
+    let output_header =
+        FixedVec::<_, ConstLen<HEADER_SIZE>>::try_from(output_header).expect("correct length");
+
+    let ((left_header, right_header), output_data) = aux.take();
+
+    // Compute k(Y) via witness path - manually construct what ky() would return
+    let mut ky_witness: Vec<Fp> = output_header.as_ref().to_vec();
+    ky_witness.extend(left_header.as_ref());
+    ky_witness.extend(right_header.as_ref());
+    ky_witness.push(Fp::ONE);
+    ky_witness.reverse();
+
+    // Compute k(Y) via VerifyAdapter
+    let verify_adapter =
+        Adapter::<Pasta, VerifyAdapter<SimpleHeader>, R, HEADER_SIZE>::new(VerifyAdapter::new());
+    let instance = (left_header, right_header, output_data);
+    let ky_verify = verify_adapter.ky(instance).expect("ky should succeed");
+
+    // They should match
+    assert_eq!(
+        ky_witness, ky_verify,
+        "k(Y) from witness path should match k(Y) from VerifyAdapter"
+    );
+}


### PR DESCRIPTION
(optional) various test cases for https://github.com/tachyon-zcash/ragu/pull/146, cc @ebfull 

1. `test_encode_determinism` (encoder.rs): verifies encoding the same data twice produces identical field elements
2. `test_raw_encode_determinism` (encoder.rs): same for raw_encode
3. `test_encode_and_raw_encode_produce_same_values` (encoder.rs): both produce same field element values
4. `test_mismatched_data_and_proof` (nontrivial.rs): verifies that claiming wrong data for a proof fails verification
5. `test_ky_consistency_witness_vs_verify_adapter` (adapter.rs): verifies k(Y) from witness path matches k(Y) from VerifyAdapter
6. `test_header_smaller_than_header_size` (padded.rs): padding for small headers
7. `test_padding_consistency` (padded.rs): encoding same header twice produces identical results
8. `test_header_exactly_header_size` (padded.rs): exact-fit headers (no padding needed)
9. `test_right_header_encode_vs_raw_encode_differ` (rerandomize.rs): encode vs raw_encode produce different circuits due to padding (constants vs witness variables)
10. `test_wrong_header_sizes` (lib.rs): malformed proof headers are rejected
