### PR TITLE
Add hello PCD example for ragu_pcd

### DIFF
--- a/crates/ragu_pcd/examples/EXAMPLES.md
+++ b/crates/ragu_pcd/examples/EXAMPLES.md
@@ -1,0 +1,40 @@
+# PCD Examples
+
+Ragu exposes a small, high-level API for building PCD (Proof-Carrying Data) applications.
+Two runnable examples demonstrate the typical usage pattern:
+
+## 1. hello_pcd.rs
+
+A minimal example showing:
+
+- Defining header types (LeafNode, InternalNode)
+- Implementing PCD steps (CreateLeaf, CombineNodes)
+- Creating leaf proofs from witness values
+- Merging proofs to build a simple Merkle-like structure
+- Verifying intermediate and final proofs
+
+You can run it with:
+
+```bash
+cargo run -p ragu_pcd --example hello_pcd
+```
+
+## 2. rerandomize_pcd.rs
+
+Shows how to use the built-in rerandomization step:
+
+- Build an initial PCD proof (e.g., from hello_pcd)
+- Call `app.rerandomize()` to refresh the proof's randomness
+- Verify that the rerandomized proof still validates
+- Observe that the header data remains unchanged 
+
+Run it with:
+
+```bash
+cargo run -p ragu_pcd --example rerandomize_pcd
+```
+
+---
+
+These examples demonstrate the public API surface of `ragu_pcd` and how the building blocks (headers, steps, application builder) fit together.
+More detailed documentation will be added as the API stabilizes.

--- a/crates/ragu_pcd/examples/hello_pcd.rs
+++ b/crates/ragu_pcd/examples/hello_pcd.rs
@@ -10,16 +10,17 @@ use ragu_core::{
 use ragu_pasta::{Fp, Pasta};
 use ragu_pcd::{
     ApplicationBuilder,
-    header::{Header, Prefix},
+    header::{Header, Suffix},
     step::{Encoded, Encoder, Index, Step},
 };
-use ragu_primitives::{Element, Sponge};
+use ragu_primitives::Element;
+use ragu_primitives::poseidon::Sponge;
 use rand::{SeedableRng, rngs::StdRng};
 
 struct LeafNode;
 
 impl<F: Field> Header<F> for LeafNode {
-    const PREFIX: Prefix = Prefix::new(0);
+    const SUFFIX: Suffix = Suffix::new(0);
     type Data<'source> = F;
     type Output = Kind![F; Element<'_, _>];
 
@@ -34,7 +35,7 @@ impl<F: Field> Header<F> for LeafNode {
 struct InternalNode;
 
 impl<F: Field> Header<F> for InternalNode {
-    const PREFIX: Prefix = Prefix::new(1);
+    const SUFFIX: Suffix = Suffix::new(1);
     type Data<'source> = F;
     type Output = Kind![F; Element<'_, _>];
 
@@ -146,50 +147,41 @@ fn main() -> Result<()> {
     println!("Building application...");
     let app = ApplicationBuilder::<Pasta, R<13>, 4>::new()
         .register(CreateLeaf {
-            poseidon_params: pasta.circuit_poseidon(),
+            poseidon_params: Pasta::circuit_poseidon(pasta),
         })?
         .register(CombineNodes {
-            poseidon_params: pasta.circuit_poseidon(),
+            poseidon_params: Pasta::circuit_poseidon(pasta),
         })?
-        .finalize(&pasta)?;
+        .finalize(pasta)?;
     println!("Registered CreateLeaf and CombineNodes\n");
 
-    println!("Creating trivial proof...");
-    let trivial = app.trivial().carry::<()>(());
-    assert!(app.verify(&trivial, &mut rng)?);
-    println!("Trivial proof verified\n");
-
     println!("Creating leaves...");
-    let leaf1 = app.merge(
+    let leaf1 = app.seed(
         &mut rng,
         CreateLeaf {
-            poseidon_params: pasta.circuit_poseidon(),
+            poseidon_params: Pasta::circuit_poseidon(pasta),
         },
         Fp::from(100u64),
-        trivial.clone(),
-        trivial.clone(),
     )?;
     let leaf1 = leaf1.0.carry(leaf1.1);
     assert!(app.verify(&leaf1, &mut rng)?);
 
-    let leaf2 = app.merge(
+    let leaf2 = app.seed(
         &mut rng,
         CreateLeaf {
-            poseidon_params: pasta.circuit_poseidon(),
+            poseidon_params: Pasta::circuit_poseidon(pasta),
         },
         Fp::from(200u64),
-        trivial.clone(),
-        trivial.clone(),
     )?;
     let leaf2 = leaf2.0.carry(leaf2.1);
     assert!(app.verify(&leaf2, &mut rng)?);
     println!("Created and verified leaf1 and leaf2\n");
 
     println!("Combining leaves...");
-    let node1 = app.merge(
+    let node1 = app.fuse(
         &mut rng,
         CombineNodes {
-            poseidon_params: pasta.circuit_poseidon(),
+            poseidon_params: Pasta::circuit_poseidon(pasta),
         },
         (),
         leaf1,


### PR DESCRIPTION
creating a minimal PCD example in crates/ragu_pcd/examples/

This PR adds two runnable PCD examples under crates/ragu_pcd/examples/:

hello_pcd.rs - minimal public-API example showing headers, steps, merge, and verify in a simple Merkle-style flow.

rerandomize_pcd.rs - demonstrates the rerandomization pipeline: build proof → rerandomize → verify both → compare data.

Also added:

examples.md - documentation describing both examples and how to run them.