### PR TITLE
docs(book): fix matrix indexing

### DIFF
--- a/book/src/design/circuits/constraints.md
+++ b/book/src/design/circuits/constraints.md
@@ -3,13 +3,13 @@
 The witness vectors $\v{a}, \v{b}, \v{c} \in \F^n$ must satisfy $n$ _multiplication constraints_, where the $i$th such constraint takes the form $\v{a}_i \cdot \v{b}_i = \v{c}_i$. In addition, the witness must satisfy a set of $4n$ _linear constraints_, where the $j$th such constraint is of the form
 
 $$
-\sum_{i = 0}^{n - 1} \big( \v{u}_{i,j} \cdot \mathbf{a}_i \big) +
-\sum_{i = 0}^{n - 1} \big( \v{v}_{i,j} \cdot \mathbf{b}_i \big) +
-\sum_{i = 0}^{n - 1} \big( \v{w}_{i,j} \cdot \mathbf{c}_i \big) =
+\sum_{i = 0}^{n - 1} \big( \v{u}_{j,i} \cdot \mathbf{a}_i \big) +
+\sum_{i = 0}^{n - 1} \big( \v{v}_{j,i} \cdot \mathbf{b}_i \big) +
+\sum_{i = 0}^{n - 1} \big( \v{w}_{j,i} \cdot \mathbf{c}_i \big) =
 \v{k}_j
 $$
 
-for some (sparse) public input vector $\v{k} \in \F^{4n}$ and fixed matrices $\v{u}, \v{v}, \v{w} \in \F^{n \times 4n}$, where $\v{u_{j}}, \v{v_{j}}, \v{w_{j}} \in \F^{4n}$ denote the _j-th column_ of those matrices. Because $n$ is fixed, individual circuits vary only by these matrices after this reduction.
+for some (sparse) public input vector $\v{k} \in \F^{4n}$ and fixed matrices $\v{u}, \v{v}, \v{w} \in \F^{n \times 4n}$, where $\v{u_{j}}, \v{v_{j}}, \v{w_{j}} \in \F^{4n}$ denote the _j-th row_ of those matrices. Because $n$ is fixed, individual circuits vary only by these matrices after this reduction.
 
 ## Multiplication Constraints
 
@@ -50,9 +50,9 @@ Given a choice of witness $\v{a}, \v{b}, \v{c}$, if for some random choice of $y
 
 $$
 \sum_{j=0}^{4n - 1} y^j \Bigg(
-    \sum_{i = 0}^{n - 1} \big( \v{u}_{i,j} \cdot \mathbf{a}_i \big) +
-    \sum_{i = 0}^{n - 1} \big( \v{v}_{i,j} \cdot \mathbf{b}_i \big) +
-    \sum_{i = 0}^{n - 1} \big( \v{w}_{i,j} \cdot \mathbf{c}_i \big)
+    \sum_{i = 0}^{n - 1} \big( \v{u}_{j,i} \cdot \mathbf{a}_i \big) +
+    \sum_{i = 0}^{n - 1} \big( \v{v}_{j,i} \cdot \mathbf{b}_i \big) +
+    \sum_{i = 0}^{n - 1} \big( \v{w}_{j,i} \cdot \mathbf{c}_i \big)
 \Bigg) =
 \sum_{j=0}^{4n - 1} y^j \v{k}_j
 $$


### PR DESCRIPTION
I believe linear constraints correspond to matrix rows, not columns (since a, b, and c of the witness are "column vectors" which get multiplied by rows during matrix-vector multiplication), and that [usually notation for indexing matrices](https://math.stackexchange.com/a/1780829), M_{a,b}, refers to row a and column b, not the other way around.

The matrices u, v, and w are "long", with n columns and 4n rows.