### PR TITLE
Docs/compile time circuit limitation

### DIFF
--- a/book/src/guide/requirements.md
+++ b/book/src/guide/requirements.md
@@ -3,3 +3,16 @@
 * The minimum supported [Rust](https://rust-lang.org/) version is currently **1.90.0**.
 * Ragu requires minimal dependencies and currently strives to avoid using dependencies that are not already used in [Zebra](https://github.com/ZcashFoundation/zebra).
 * Ragu does not require usage of the standard library in code that is compiled for the target architecture.
+
+## Important Limitations
+
+**Compile-time circuit definition.** Circuits in Ragu are defined at compile-time rather than runtime. This means:
+
+- Circuits are compiled directly into the binary during `cargo build`
+- Circuit serialization and deserialization to/from files is **not** supported
+- Verifying keys cannot be serialized or deserialized
+- Circuit definitions cannot be loaded dynamically at runtime
+
+This design choice stems from Ragu's architecture: the protocol does not use preprocessing, and directly translates circuit descriptions into reduced polynomial evaluations. This makes Ragu unsuitable for IR-based circuit workflows, but enables non-uniform PCD across many circuits.
+
+If your use case requires runtime circuit definition or serialized verifying keys, Ragu may not be suitable in its current form.


### PR DESCRIPTION
This PR documents the compile-time circuit limitation described in #118.

Changes:
- Add an “Important Limitations” section to README.md explaining that circuits are compiled
  into the binary, cannot be serialized, and cannot be loaded at runtime.
- Add a “Limitations → Compile-time circuit definition” section to the user guide
  in book/src/guide/index.md.

Fixes #118