### PR TITLE
feat: RangeCheckedElement gadget

### DIFF
--- a/crates/ragu_primitives/src/lib.rs
+++ b/crates/ragu_primitives/src/lib.rs
@@ -23,10 +23,10 @@ mod lazy;
 mod point;
 mod poseidon;
 pub mod promotion;
+mod range_checked_element;
 mod simulator;
 mod util;
 pub mod vec;
-mod range_checked_element;
 
 pub use boolean::{Boolean, multipack};
 pub use element::{Element, multiadd};
@@ -34,8 +34,8 @@ pub use endoscalar::Endoscalar;
 pub use lazy::Lazy;
 pub use point::Point;
 pub use poseidon::Sponge;
-pub use simulator::Simulator;
 pub use range_checked_element::RangeCheckedElement;
+pub use simulator::Simulator;
 
 use ragu_core::{Result, drivers::Driver, gadgets::Gadget};
 

--- a/crates/ragu_primitives/src/range_checked_element.rs
+++ b/crates/ragu_primitives/src/range_checked_element.rs
@@ -1,10 +1,10 @@
+use crate::Element;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
     maybe::Maybe,
 };
 use ragu_macros::Gadget;
-use crate::Element;
 
 /// Represents a range-checked element of the CircuitField
 /// For now, it's just u64 values
@@ -43,15 +43,15 @@ impl<'dr, D: Driver<'dr>, const BOUND: u64> RangeCheckedElement<'dr, D, BOUND> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ragu_pasta::{Fp};
-    use ragu_core::maybe::{Always, MaybeKind};
     use ragu_core::Error;
+    use ragu_core::maybe::{Always, MaybeKind};
+    use ragu_pasta::Fp;
     #[test]
     fn test_valid_range_checked_element() {
         let mut simulator = crate::Simulator::<Fp>::new();
         let value = 100;
-        let _range_checked_element: RangeCheckedElement<'_, crate::Simulator<Fp>, 256> = RangeCheckedElement::alloc(&mut simulator, Always::maybe_just(|| value))
-            .unwrap();
+        let _range_checked_element: RangeCheckedElement<'_, crate::Simulator<Fp>, 256> =
+            RangeCheckedElement::alloc(&mut simulator, Always::maybe_just(|| value)).unwrap();
         assert!(simulator.num_multiplications() == 255);
         assert!(simulator.num_linear_constraints() == 511);
     }
@@ -60,7 +60,8 @@ mod tests {
     fn test_invalid_range_checked_element() {
         let mut simulator = crate::Simulator::<Fp>::new();
         let value = 256;
-        let result: Result<RangeCheckedElement<'_, crate::Simulator<Fp>, 256>> = RangeCheckedElement::alloc(&mut simulator, Always::maybe_just(|| value));
+        let result: Result<RangeCheckedElement<'_, crate::Simulator<Fp>, 256>> =
+            RangeCheckedElement::alloc(&mut simulator, Always::maybe_just(|| value));
         assert!(matches!(result, Err(Error::InvalidWitness(_))));
     }
 
@@ -68,8 +69,8 @@ mod tests {
     fn test_zero_range_checked_element() {
         let mut simulator = crate::Simulator::<Fp>::new();
         let value = 0;
-        let _range_checked_element: RangeCheckedElement<'_, crate::Simulator<Fp>, 256> = RangeCheckedElement::alloc(&mut simulator, Always::maybe_just(|| value))
-            .unwrap();
+        let _range_checked_element: RangeCheckedElement<'_, crate::Simulator<Fp>, 256> =
+            RangeCheckedElement::alloc(&mut simulator, Always::maybe_just(|| value)).unwrap();
         assert!(simulator.num_multiplications() == 255);
         assert!(simulator.num_linear_constraints() == 511);
     }
@@ -78,8 +79,8 @@ mod tests {
     fn test_max_value_range_checked_element() {
         let mut simulator = crate::Simulator::<Fp>::new();
         let value = 255;
-        let _range_checked_element: RangeCheckedElement<'_, crate::Simulator<Fp>, 256> = RangeCheckedElement::alloc(&mut simulator, Always::maybe_just(|| value))
-            .unwrap();
+        let _range_checked_element: RangeCheckedElement<'_, crate::Simulator<Fp>, 256> =
+            RangeCheckedElement::alloc(&mut simulator, Always::maybe_just(|| value)).unwrap();
         assert!(simulator.num_multiplications() == 255);
         assert!(simulator.num_linear_constraints() == 511);
     }


### PR DESCRIPTION
a gadget representing a range-checked element. Uses `u64`s as the bound.