### PR TITLE
book: explain pcs aggregation

### DIFF
--- a/book/src/protocol/core/accumulation/pcs.md
+++ b/book/src/protocol/core/accumulation/pcs.md
@@ -49,7 +49,7 @@ multiple claims share the same underlying polynomial, only one evaluation per
 polynomial is needed since $p_i(u)$ depends only on the polynomial, not the
 original evaluation point $x_i$.
 5. Verifier sends challenge $\beta\sample\F$
-6. Prover computes the aggregated polynomial (named `final_poly` by Ragu)
+6. Prover computes the aggregated polynomial
 $p(X) = f(X) + \sum_i \beta^i \cdot p_i(X)$ and the aggregated blinding factor
 $\gamma = \gamma_f + \sum_i \beta^i \cdot \gamma_i$
 7. Verifier derives the aggregated commitment


### PR DESCRIPTION
This details is referenced both in #221 and #226, but should be fairly self-contained subsection, thus not blocked by any of them.

Changes include:
- describe the batched evaluation (or rather the PCS aggregation) we use in ragu
- explain briefly why it is sound

I will add the accumulation scheme that thinly wraps around this technique in a separate PR.