### PR TITLE
feat(transcript): long-lived sponge

### DIFF
--- a/crates/ragu_pcd/src/components/transcript.rs
+++ b/crates/ragu_pcd/src/components/transcript.rs
@@ -20,6 +20,17 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle> TranscriptEmulator<'dr,
         }
     }
 
+    /// Create a transcript emulator rekeyed with a digest element.
+    ///
+    /// This is used when continuing a transcript from a previous circuit.
+    /// The digest should be the last squeezed element from the previous circuit's
+    /// transcript (e.g., `w` from c.rs).
+    pub fn rekey(dr: &mut D, params: &'dr C, digest: &Element<'dr, D>) -> Result<Self> {
+        let mut transcript = Self::new(dr, params);
+        transcript.sponge.absorb(dr, digest)?;
+        Ok(transcript)
+    }
+
     /// Absorb a point commitment into the transcript.
     pub fn absorb_point(
         &mut self,

--- a/crates/ragu_pcd/src/merge.rs
+++ b/crates/ragu_pcd/src/merge.rs
@@ -89,6 +89,11 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             .value()
             .take();
 
+        // Rekey transcript with w for v.rs challenge derivations.
+        // v.rs rekeys with w to continue the transcript without re-deriving from preamble.
+        let w_elem = Element::constant(&mut em, w);
+        let mut transcript = TranscriptEmulator::<_, C>::rekey(&mut em, self.params, &w_elem)?;
+
         // We compute a nested commitment to s' = m(w, x_i, Y).
         let x0 = left.proof.internal_circuits.x;
         let x1 = right.proof.internal_circuits.x;


### PR DESCRIPTION
References https://github.com/tachyon-zcash/ragu/issues/216

Create a new `TranscriptEmulator` struct in [transcript.rs](https://github.com/tachyon-zcash/ragu/blob/main/crates/ragu_pcd/src/components/transcript.rs) that holds:
  
```ts
pub struct TranscriptEmulator<'dr, D: Driver<'dr>, C: Cycle>
where
    D: Driver<'dr, F = C::CircuitField>,
{
    sponge: Sponge<'dr, D, C::CircuitPoseidon>,
}
```

Instead of using ephemeral emulators for challenge derivation, this constitutes a single long-lived sponge that accumulates all absorbed data, rekeys, and associatively updates all the call sites. 
