### PR TITLE
feat: optimal M + N parameter selection and optimize revdot folding

### DIFF
--- a/crates/ragu_pcd/src/components/fold_revdot.rs
+++ b/crates/ragu_pcd/src/components/fold_revdot.rs
@@ -15,8 +15,8 @@ use core::marker::PhantomData;
 /// revdot reduction.
 ///
 /// The parameters here collapse as much as $m \cdot n$ claims into a single
-/// claim using roughly $f(m, n) = n * (2m^2 + m + 2) + 2n^2 + n + 2$
-/// multiplication constraints.
+/// claim using roughly $f(m, n) = 2nm^2 + 2n^2 - n + 3$ multiplication
+/// constraints.
 pub trait Parameters: 'static + Send + Sync + Clone + Copy + Default {
     type N: Len;
     type M: Len;
@@ -51,17 +51,52 @@ impl<L: Len> Len for ErrorTermsLen<L> {
     }
 }
 
-/// Generic internal function to compute folded revdot claim `c` for a given size.
+/// Precomputed folding context for computing revdot claim `c`.
+///
+/// Computing `munu` and `mu_inv` once and reusing across multiple calls
+/// saves 2*(N-1) multiplications in the two-layer reduction.
+pub struct FoldC<'dr, D: Driver<'dr>> {
+    munu: Element<'dr, D>,
+    mu_inv: Element<'dr, D>,
+}
+
+impl<'dr, D: Driver<'dr>> FoldC<'dr, D> {
+    /// Create a folding context from mu and nu.
+    pub fn new(dr: &mut D, mu: &Element<'dr, D>, nu: &Element<'dr, D>) -> Result<Self> {
+        let munu = mu.mul(dr, nu)?;
+        let mu_inv = mu.invert(dr)?;
+        Ok(Self { munu, mu_inv })
+    }
+
+    /// Compute folded revdot claim `c` for layer 1 (M-sized reduction).
+    pub fn compute_m<P: Parameters>(
+        &self,
+        dr: &mut D,
+        error_terms: &FixedVec<Element<'dr, D>, ErrorTermsLen<P::M>>,
+        ky_values: &FixedVec<Element<'dr, D>, P::M>,
+    ) -> Result<Element<'dr, D>> {
+        compute_c_impl::<_, P::M>(dr, &self.munu, &self.mu_inv, error_terms, ky_values)
+    }
+
+    /// Compute folded revdot claim `c` for layer 2 (N-sized reduction).
+    pub fn compute_n<P: Parameters>(
+        &self,
+        dr: &mut D,
+        error_terms: &FixedVec<Element<'dr, D>, ErrorTermsLen<P::N>>,
+        ky_values: &FixedVec<Element<'dr, D>, P::N>,
+    ) -> Result<Element<'dr, D>> {
+        compute_c_impl::<_, P::N>(dr, &self.munu, &self.mu_inv, error_terms, ky_values)
+    }
+}
+
+/// Core folding computation using precomputed munu and mu_inv.
 fn compute_c_impl<'dr, D: Driver<'dr>, S: Len>(
     dr: &mut D,
-    mu: &Element<'dr, D>,
-    nu: &Element<'dr, D>,
+    munu: &Element<'dr, D>,
+    mu_inv: &Element<'dr, D>,
     error_terms: &FixedVec<Element<'dr, D>, ErrorTermsLen<S>>,
     ky_values: &FixedVec<Element<'dr, D>, S>,
 ) -> Result<Element<'dr, D>> {
-    let munu = mu.mul(dr, nu)?;
-    let mu_inv = mu.invert(dr)?;
-
     let mut error_terms = error_terms.iter();
     let mut ky_values = ky_values.iter();
 
@@ -80,38 +115,20 @@ fn compute_c_impl<'dr, D: Driver<'dr>, S: Len>(
 
             let contribution = col_power.mul(dr, term)?;
             result = result.add(dr, &contribution);
-            col_power = col_power.mul(dr, &munu)?;
+
+            // Skip last column (col_power won't be used again)
+            if j < n - 1 {
+                col_power = col_power.mul(dr, munu)?;
+            }
         }
-        row_power = row_power.mul(dr, &mu_inv)?;
+
+        // Skip last row (row_power won't be used again)
+        if i < n - 1 {
+            row_power = row_power.mul(dr, mu_inv)?;
+        }
     }
 
     Ok(result)
-}
-
-/// Compute the folded revdot claim `c` for the first layer (M-sized reduction).
-///
-/// Uses FP::M as the reduction size for layer 1 of the two-layer reduction.
-pub fn compute_c_m<'dr, D: Driver<'dr>, FP: Parameters>(
-    dr: &mut D,
-    mu: &Element<'dr, D>,
-    nu: &Element<'dr, D>,
-    error_terms: &FixedVec<Element<'dr, D>, ErrorTermsLen<FP::M>>,
-    ky_values: &FixedVec<Element<'dr, D>, FP::M>,
-) -> Result<Element<'dr, D>> {
-    compute_c_impl::<_, FP::M>(dr, mu, nu, error_terms, ky_values)
-}
-
-/// Compute the folded revdot claim `c` for the second layer (N-sized reduction).
-///
-/// Uses FP::N as the reduction size for layer 2 of the two-layer reduction.
-pub fn compute_c_n<'dr, D: Driver<'dr>, FP: Parameters>(
-    dr: &mut D,
-    mu: &Element<'dr, D>,
-    nu: &Element<'dr, D>,
-    error_terms: &FixedVec<Element<'dr, D>, ErrorTermsLen<FP::N>>,
-    ky_values: &FixedVec<Element<'dr, D>, FP::N>,
-) -> Result<Element<'dr, D>> {
-    compute_c_impl::<_, FP::N>(dr, mu, nu, error_terms, ky_values)
 }
 
 #[cfg(test)]
@@ -184,7 +201,8 @@ mod tests {
             .collect_fixed()
             .unwrap();
 
-        let result = compute_c_n::<_, P>(dr, &mu, &nu, &error_terms, &ky_values)?;
+        let fold_c = FoldC::new(dr, &mu, &nu)?;
+        let result = fold_c.compute_n::<P>(dr, &error_terms, &ky_values)?;
         let computed_c = result.value().take();
 
         assert_eq!(
@@ -204,18 +222,19 @@ mod tests {
                 let error_terms = FixedVec::from_fn(|_| Element::constant(dr, Fp::random(OsRng)));
                 let ky_values = FixedVec::from_fn(|_| Element::constant(dr, Fp::random(OsRng)));
 
-                compute_c_n::<_, P>(dr, &mu, &nu, &error_terms, &ky_values)?;
+                let fold_c = FoldC::new(dr, &mu, &nu)?;
+                fold_c.compute_n::<P>(dr, &error_terms, &ky_values)?;
                 Ok(())
             })?;
 
             Ok(sim.num_multiplications())
         }
 
-        // Formula: 2*n^2 + n + 2 (only P::N is used in compute_c_n)
-        assert_eq!(measure::<TestParams<5, 1>>()?, 57);
-        assert_eq!(measure::<TestParams<15, 1>>()?, 467);
-        assert_eq!(measure::<TestParams<30, 1>>()?, 1832);
-        assert_eq!(measure::<TestParams<60, 1>>()?, 7262);
+        // Formula: 2N^2 + 1
+        assert_eq!(measure::<TestParams<5, 1>>()?, 51);
+        assert_eq!(measure::<TestParams<15, 1>>()?, 451);
+        assert_eq!(measure::<TestParams<30, 1>>()?, 1801);
+        assert_eq!(measure::<TestParams<60, 1>>()?, 7201);
 
         Ok(())
     }
@@ -227,8 +246,11 @@ mod tests {
             let sim = Simulator::simulate(rng, |dr, mut rng| {
                 let mu = Element::alloc(dr, rng.view_mut().map(Fp::random))?;
                 let nu = Element::alloc(dr, rng.view_mut().map(Fp::random))?;
+                let mu_prime = Element::alloc(dr, rng.view_mut().map(Fp::random))?;
+                let nu_prime = Element::alloc(dr, rng.view_mut().map(Fp::random))?;
 
-                // Layer 1: N instances of M-sized reductions (mimicking c.rs)
+                // Layer 1: N instances of M-sized reductions (uses mu, nu)
+                let fold_c_layer1 = FoldC::new(dr, &mu, &nu)?;
                 let error_terms_m =
                     FixedVec::try_from_fn(|_| Element::alloc(dr, rng.view_mut().map(Fp::random)))?;
                 let ky_values_m =
@@ -236,27 +258,24 @@ mod tests {
 
                 let mut collapsed = vec![];
                 for _ in 0..P::N::len() {
-                    let v = compute_c_m::<_, P>(dr, &mu, &nu, &error_terms_m, &ky_values_m)?;
+                    let v = fold_c_layer1.compute_m::<P>(dr, &error_terms_m, &ky_values_m)?;
                     collapsed.push(v);
                 }
                 let collapsed = FixedVec::new(collapsed)?;
 
-                // Layer 2: Single N-sized reduction using collapsed as ky_values
+                // Layer 2: Single N-sized reduction (uses mu', nu' - separate FoldC)
+                let fold_c_layer2 = FoldC::new(dr, &mu_prime, &nu_prime)?;
                 let error_terms_n =
                     FixedVec::try_from_fn(|_| Element::alloc(dr, rng.view_mut().map(Fp::random)))?;
 
-                compute_c_n::<_, P>(dr, &mu, &nu, &error_terms_n, &collapsed)?;
+                fold_c_layer2.compute_n::<P>(dr, &error_terms_n, &collapsed)?;
 
                 Ok(())
             })?;
 
             let num = sim.num_multiplications();
 
-            // N * cost(M) + cost(N) where cost(x) = 2x² + x + 2
-            let expected = |m: usize, n: usize| {
-                let cost = |x: usize| 2 * x * x + x + 2;
-                n * cost(m) + cost(n)
-            };
+            let expected = |m: usize, n: usize| 2 * n * m * m + 2 * n * n - n + 3;
 
             assert_eq!(num, expected(P::M::len(), P::N::len()));
 
@@ -264,12 +283,93 @@ mod tests {
         }
 
         // TestParams<N, M> where N is layer 2 size and M is layer 1 size
-        assert_eq!(measure::<TestParams<2, 2>>()?, 36);
-        assert_eq!(measure::<TestParams<7, 3>>()?, 268);
-        assert_eq!(measure::<TestParams<11, 6>>()?, 1135);
-        assert_eq!(measure::<TestParams<10, 5>>()?, 782);
-        assert_eq!(measure::<TestParams<10, 10>>()?, 2332);
+        // Formula: 2NM^2 + 2N^2 - N + 3
+        assert_eq!(measure::<TestParams<2, 2>>()?, 25);
+        assert_eq!(measure::<TestParams<7, 3>>()?, 220);
+        assert_eq!(measure::<TestParams<11, 6>>()?, 1026);
+        assert_eq!(measure::<TestParams<10, 5>>()?, 693);
+        assert_eq!(measure::<TestParams<10, 10>>()?, 2193);
 
+        Ok(())
+    }
+
+    /// Computes the number of multiplication constraints for given M, N.
+    ///
+    /// Formula: 2NM^2 + 2N^2 - N + 3
+    /// - Layer 1: 2 + N(2M^2 - 1) = 2NM^2 - N + 2
+    /// - Layer 2: 2 + (2N^2 - 1) = 2N^2 + 1
+    fn muls(m: usize, n: usize) -> usize {
+        2 * n * m * m + 2 * n * n - n + 3
+    }
+
+    /// Computes the number of allocations for given M, N.
+    ///
+    /// Formula: M^2 + N^2 - N + 2
+    fn allocs(m: usize, n: usize) -> usize {
+        m * m + n * n - n + 2
+    }
+
+    /// This measures the effective constraint cost that accounts
+    /// for both multiplication gates and allocations for various M
+    /// and N combinations. The optimal accounting here is to maximize
+    /// M * N, while staying under the circuit budget.
+    #[test]
+    fn test_cost_formulas() -> Result<()> {
+        fn verify<const M: usize, const N: usize>() -> Result<()> {
+            let rng = OsRng;
+            let sim = Simulator::simulate(rng, |dr, mut rng| {
+                let mu = Element::alloc(dr, rng.view_mut().map(Fp::random))?;
+                let nu = Element::alloc(dr, rng.view_mut().map(Fp::random))?;
+                let mu_prime = Element::alloc(dr, rng.view_mut().map(Fp::random))?;
+                let nu_prime = Element::alloc(dr, rng.view_mut().map(Fp::random))?;
+
+                // Layer 1: N instances of M-sized reductions (uses mu, nu).
+                let fold_c_layer1 = FoldC::new(dr, &mu, &nu)?;
+                let all_error_terms_m: FixedVec<
+                    FixedVec<_, ErrorTermsLen<ConstLen<M>>>,
+                    ConstLen<N>,
+                > = FixedVec::try_from_fn(|_| {
+                    FixedVec::try_from_fn(|_| Element::alloc(dr, rng.view_mut().map(Fp::random)))
+                })?;
+                let all_ky_values_m: FixedVec<FixedVec<_, ConstLen<M>>, ConstLen<N>> =
+                    FixedVec::try_from_fn(|_| {
+                        FixedVec::try_from_fn(|_| {
+                            Element::alloc(dr, rng.view_mut().map(Fp::random))
+                        })
+                    })?;
+
+                let collapsed: FixedVec<_, ConstLen<N>> = FixedVec::try_from_fn(|i| {
+                    fold_c_layer1.compute_m::<TestParams<N, M>>(
+                        dr,
+                        &all_error_terms_m[i],
+                        &all_ky_values_m[i],
+                    )
+                })?;
+
+                // Layer 2: Single N-sized reduction (uses mu', nu' - separate FoldC).
+                let fold_c_layer2 = FoldC::new(dr, &mu_prime, &nu_prime)?;
+                let error_terms_n: FixedVec<_, ErrorTermsLen<ConstLen<N>>> =
+                    FixedVec::try_from_fn(|_| Element::alloc(dr, rng.view_mut().map(Fp::random)))?;
+
+                fold_c_layer2.compute_n::<TestParams<N, M>>(dr, &error_terms_n, &collapsed)?;
+                Ok(())
+            })?;
+
+            assert_eq!(sim.num_multiplications(), muls(M, N));
+
+            // Verify optimal parameters fit budget
+            let effective_cost = 2 * muls(6, 17) + allocs(6, 17);
+            assert!(
+                effective_cost < (2 * (1 << 11)),
+                "M = 6, N = 17 exceeds budget: {}",
+                effective_cost / 2
+            );
+
+            Ok(())
+        }
+
+        verify::<6, 17>()?;
+        verify::<7, 14>()?;
         Ok(())
     }
 }

--- a/crates/ragu_pcd/src/internal_circuits/c.rs
+++ b/crates/ragu_pcd/src/internal_circuits/c.rs
@@ -91,13 +91,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         // Layer 1 folding is verified by circuit_ky; we use error_n.collapsed directly.
         {
             // Layer 2: Single N-sized reduction using collapsed from error_n as ky_values
-            let c = fold_revdot::compute_c_n::<_, FP>(
-                dr,
-                &mu_prime,
-                &nu_prime,
-                &error_n.error_terms,
-                &error_n.collapsed,
-            )?;
+            let fold_c = fold_revdot::FoldC::new(dr, &mu_prime, &nu_prime)?;
+            let c = fold_c.compute_n::<FP>(dr, &error_n.error_terms, &error_n.collapsed)?;
             unified_output.c.set(c);
         }
 

--- a/crates/ragu_pcd/src/internal_circuits/ky.rs
+++ b/crates/ragu_pcd/src/internal_circuits/ky.rs
@@ -107,6 +107,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         // Get mu, nu from unified instance
         let mu = unified_output.mu.get(dr, unified_instance)?;
         let nu = unified_output.nu.get(dr, unified_instance)?;
+        let fold_c = fold_revdot::FoldC::new(dr, &mu, &nu)?;
 
         // Read k(y) values from error_n stage (computed and verified in hashes_1).
         let mut ky_values = [
@@ -121,7 +122,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
             let ky_values =
                 FixedVec::from_fn(|_| ky_values.next().unwrap_or_else(|| Element::zero(dr)));
 
-            fold_revdot::compute_c_m::<_, FP>(dr, &mu, &nu, error_terms, &ky_values)?
+            fold_c
+                .compute_m::<FP>(dr, error_terms, &ky_values)?
                 .enforce_equal(dr, &error_n.collapsed[i])?;
         }
 

--- a/crates/ragu_pcd/src/merge.rs
+++ b/crates/ragu_pcd/src/merge.rs
@@ -276,6 +276,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                 ]
                 .into_iter();
 
+                let fold_c = fold_revdot::FoldC::new(dr, &mu, &nu)?;
+
                 FixedVec::try_from_fn(|i| {
                     let errors = FixedVec::try_from_fn(|j| {
                         Element::alloc(dr, error_terms_m.view().map(|et| et[i][j]))
@@ -283,9 +285,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                     let ky_values = FixedVec::from_fn(|_| {
                         ky_values.next().unwrap_or_else(|| Element::zero(dr))
                     });
-                    let v = fold_revdot::compute_c_m::<_, NativeParameters>(
-                        dr, &mu, &nu, &errors, &ky_values,
-                    )?;
+
+                    let v = fold_c.compute_m::<NativeParameters>(dr, &errors, &ky_values)?;
                     Ok(*v.value().take())
                 })
             },
@@ -347,13 +348,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                     FixedVec::try_from_fn(|i| Element::alloc(dr, collapsed.view().map(|c| c[i])))?;
 
                 // Layer 2: Single N-sized reduction using collapsed as ky_values
-                let c = fold_revdot::compute_c_n::<_, NativeParameters>(
-                    dr,
-                    &mu_prime,
-                    &nu_prime,
-                    &error_terms_n,
-                    &collapsed,
-                )?;
+                let fold_c = fold_revdot::FoldC::new(dr, &mu_prime, &nu_prime)?;
+                let c = fold_c.compute_n::<NativeParameters>(dr, &error_terms_n, &collapsed)?;
 
                 Ok(*c.value().take())
             },


### PR DESCRIPTION
References https://github.com/tachyon-zcash/ragu/issues/264 and rebased over https://github.com/tachyon-zcash/ragu/pull/266

The original back-of-napkin calculation `2N^2 + 2M^2N + N + M + 4` against the constraint budget was incorrect in two-dimensions:
- It didn't account for _all_ multiplications in the two-layer reduction,
- It only used `sim.num_multiplications()` which ignored allocations,

This assumes optimal parameters _if_ the circuits only contained the internal folding operations and nothing else, as well as small wiggle room for witnessing the unified instance.

**Optimizations:**
1. Skip-last: `col_power *= munu` and `row_power *= mu_inv` were computed on the final loop iterations, but those values were never used, so we skip them.
2. Precompution: `munu` and `mu_inv` were previously computed N times, but now we compute once (for each layer) and reuse

These optimizations save 32 + 137 = **169 multiplications** for parameters `M = 6, N = 17`.

**Multiplications**: `2NM^2 + 2N^2 - N + 3`

**Layer 1 Reduction (N calls of size-M reduction, batched with shared precompute):**
- `munu = mu * nu:` 1 mul (computed once, shared)
- `mu_inv = mu.invert():` 1 mul (computed once, shared)
- `Inner loop col_power * term:` M^2 muls
- `Inner loop col_power * munu:` M^2 - M muls (skip last column)
- `Outer loop row_power * mu_inv:` M - 1 muls (skip last row)

`Total: 2 + (N * (2M^2 - 1) / call * N calls) = 2NM^2 - N + 2`

**Layer 2 Reduction (1 call of size-N reduction):** 
- `munu = mu * nu:` 1 mul
- `mu_inv = mu.invert():` 1 mul
- `Inner loop col_power * term:` N^2 muls
- `Inner loop col_power * munu:` N^2 - N muls (skip last column)
- `Outer loop row_power * mu_inv:` N - 1 muls (skip last row)

`Total:  2N^2 + 1`

Collectively, this is **1788** multiplications (for **M = 6, N = 17**).

**Allocations**: `M^2 + N^2 - N + 2`
- `mu, nu:` 2 allocs
- `error_terms_m:` M^2 - M allocs
- `ky_values_m:` M allocs
- `error_terms_n:` N^2 - N

`Total: M^2 + N^2 - N + 2`

Collectively, this is 310 allocations * ~0.5 mul / alloc = **~155* additional multiplications (for `M = 6, N = 17`).

After brute forcing the parameter space locally, the optimal local maxima that maximizes M * N without exceeding constraint budget is: 
- **M = 6, N = 17** 
- M * N = **102 revdot claims** 
- effective constraint cost of **1943 < 2048**