### PR TITLE
docs: add comprehensive user guides for PCD development

### DIFF
--- a/book/src/guide/configuration.md
+++ b/book/src/guide/configuration.md
@@ -74,21 +74,6 @@ ApplicationBuilder::<Pasta, R<13>, ...>::new()
 | `R<14>` | 16,384 | Large circuits |
 | `R<15>` | 32,768 | Very large circuits |
 
-### Constraint Types
-
-Circuits have two types of constraints:
-- **Multiplication constraints**: Cost ~1 each (finite, limited by rank)
-- **Linear constraints**: Nearly free (additions, subtractions)
-
-Common operations and their costs:
-```rust
-let a = Element::alloc(dr, value)?;        // 0 multiplications
-let b = a.add(dr, &c);                     // 0 multiplications
-let d = a.mul(dr, &b)?;                    // 1 multiplication
-let e = a.invert(dr)?;                     // ~1 multiplication
-sponge.absorb(dr, &a)?;                    // ~140 multiplications (Poseidon)
-```
-
 ### Choosing the Right Rank
 
 **For development/testing**: Start with `R<11>` or `R<12>`


### PR DESCRIPTION
What's Added

1. Getting Started Guide 
  **File:** `book/src/guide/getting_started.md`

2. Writing Circuits Guide
  **File:** `book/src/guide/writing_circuits.md`

3. Configuration Guide
  **File:** `book/src/guide/configuration.md`

*All code examples use the current main branch API (`const SUFFIX: Suffix`) following PR #225's rename from PREFIX → SUFFIX and on that note, I'll also be updating the hello_pcd example :-)