### PR TITLE
perf: improve routine for txz, cache inversions in aux

### DIFF
--- a/crates/ragu_primitives/src/element.rs
+++ b/crates/ragu_primitives/src/element.rs
@@ -245,6 +245,12 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
                 .ok_or_else(|| Error::InvalidWitness("division by zero".into()))
         })?;
 
+        self.invert_with(dr, inverse)
+    }
+
+    /// Enforce that this element times the provided `inverse` (unallocated value) equals one.
+    /// Returns the allocated `inverse` element.
+    pub fn invert_with(&self, dr: &mut D, inverse: DriverValue<D, D::F>) -> Result<Self> {
         let (a, b, c) = dr.mul(|| {
             Ok((
                 Coeff::Arbitrary(*self.value.snag()),


### PR DESCRIPTION
Finish a small TODO for `impl Routine for txz::Evaluate` by caching the `x_inv` and `z_inv` in the `aux` produced by the `predict()` to be reused later by the `execute()`. 

To facilitate this, add a new `Element::enforce_inversion()` method.