### PR TITLE
pcd: Provide type aliases for `Step` and `Header` inputs/outputs

### DIFF
--- a/crates/ragu_pcd/src/header.rs
+++ b/crates/ragu_pcd/src/header.rs
@@ -109,3 +109,9 @@ impl<F: Field> Header<F> for () {
         Ok(())
     }
 }
+
+/// Input type for header encode methods.
+pub type HeaderInput<'source, H, F, D> = DriverValue<D, <H as Header<F>>::Data<'source>>;
+
+/// Output type for header encode methods.
+pub type HeaderOutput<'dr, H, F, D> = <<H as Header<F>>::Output as GadgetKind<F>>::Rebind<'dr, D>;

--- a/crates/ragu_pcd/src/step/internal/adapter.rs
+++ b/crates/ragu_pcd/src/step/internal/adapter.rs
@@ -83,9 +83,9 @@ impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Circuit<C::Circuit
     {
         let (left, right, witness) = witness.cast();
 
-        let ((left, right, output), aux) = self
-            .step
-            .witness::<_, HEADER_SIZE>(dr, witness, left, right)?;
+        let ((left, right, output), aux) =
+            self.step
+                .witness::<_, HEADER_SIZE>(dr, witness, (left, right))?;
 
         let mut elements = Vec::with_capacity(HEADER_SIZE * 3);
         left.write(dr, &mut elements)?;

--- a/crates/ragu_pcd/src/step/internal/rerandomize.rs
+++ b/crates/ragu_pcd/src/step/internal/rerandomize.rs
@@ -13,8 +13,10 @@ use ragu_core::{
 
 use core::marker::PhantomData;
 
-use super::super::{Encoded, Index, Step};
-use crate::Header;
+use crate::{
+    Header,
+    step::{Encoded, Index, Step, StepInput, StepOutput},
+};
 
 pub(crate) use crate::step::InternalStepIndex::Rerandomize as INTERNAL_ID;
 
@@ -44,14 +46,9 @@ impl<C: Cycle, H: Header<C::CircuitField>> Step<C> for Rerandomize<H> {
         &self,
         dr: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
-        left: DriverValue<D, H::Data<'source>>,
-        right: DriverValue<D, ()>,
+        (left, right): StepInput<'source, Self, C, D>,
     ) -> Result<(
-        (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
-        ),
+        StepOutput<'dr, Self, C, D, HEADER_SIZE>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         // Use uniform encoding for left to ensure circuit uniformity across header types
@@ -74,14 +71,9 @@ impl<C: Cycle, H: Header<C::CircuitField>> Step<C> for Rerandomize<H> {
 
 #[test]
 fn test_rerandomize_consistency() {
-    use crate::header::{Header, Suffix};
+    use crate::header::{Header, HeaderInput, HeaderOutput, Suffix};
     use ragu_circuits::{CircuitExt, polynomials};
-    use ragu_core::{
-        Result,
-        drivers::{Driver, DriverValue},
-        gadgets::{GadgetKind, Kind},
-        maybe::Maybe,
-    };
+    use ragu_core::{Result, drivers::Driver, gadgets::Kind, maybe::Maybe};
     use ragu_pasta::{Fp, Pasta};
     use ragu_primitives::Element;
 
@@ -95,8 +87,8 @@ fn test_rerandomize_consistency() {
         type Output = Kind![Fp; Element<'_, _>];
         fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
             dr: &mut D,
-            witness: DriverValue<D, Self::Data<'source>>,
-        ) -> Result<<Self::Output as GadgetKind<Fp>>::Rebind<'dr, D>> {
+            witness: HeaderInput<'source, Self, Fp, D>,
+        ) -> Result<HeaderOutput<'dr, Self, Fp, D>> {
             Element::alloc(dr, witness)
         }
     }
@@ -108,8 +100,8 @@ fn test_rerandomize_consistency() {
         type Output = Kind![Fp; (Element<'_, _>, Element<'_, _>)];
         fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
             dr: &mut D,
-            witness: DriverValue<D, Self::Data<'source>>,
-        ) -> Result<<Self::Output as GadgetKind<Fp>>::Rebind<'dr, D>> {
+            witness: HeaderInput<'source, Self, Fp, D>,
+        ) -> Result<HeaderOutput<'dr, Self, Fp, D>> {
             let (a, b) = witness.cast();
             let a = Element::alloc(dr, a)?;
             let b = Element::alloc(dr, b)?;

--- a/crates/ragu_pcd/src/step/internal/trivial.rs
+++ b/crates/ragu_pcd/src/step/internal/trivial.rs
@@ -9,7 +9,7 @@ use ragu_core::{
     drivers::{Driver, DriverValue},
 };
 
-use super::super::{Encoded, Index, Step};
+use crate::step::{Encoded, Index, Step, StepInput, StepOutput};
 
 pub(crate) use crate::step::InternalStepIndex::Trivial as INTERNAL_ID;
 
@@ -35,14 +35,9 @@ impl<C: Cycle> Step<C> for Trivial {
         &self,
         dr: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
-        left: DriverValue<D, ()>,
-        right: DriverValue<D, ()>,
+        (left, right): StepInput<'source, Self, C, D>,
     ) -> Result<(
-        (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
-        ),
+        StepOutput<'dr, Self, C, D, HEADER_SIZE>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;

--- a/crates/ragu_pcd/src/step/mod.rs
+++ b/crates/ragu_pcd/src/step/mod.rs
@@ -151,16 +151,24 @@ pub trait Step<C: Cycle>: Sized + Send + Sync {
         &self,
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'source>>,
-        left: DriverValue<D, <Self::Left as Header<C::CircuitField>>::Data<'source>>,
-        right: DriverValue<D, <Self::Right as Header<C::CircuitField>>::Data<'source>>,
+        input: StepInput<'source, Self, C, D>,
     ) -> Result<(
-        (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
-        ),
+        StepOutput<'dr, Self, C, D, HEADER_SIZE>,
         DriverValue<D, Self::Aux<'source>>,
     )>
     where
         Self: 'dr;
 }
+
+/// Input tuple for step witness methods (excludes the driver parameter).
+pub type StepInput<'source, S, C, D> = (
+    DriverValue<D, <<S as Step<C>>::Left as Header<<C as Cycle>::CircuitField>>::Data<'source>>,
+    DriverValue<D, <<S as Step<C>>::Right as Header<<C as Cycle>::CircuitField>>::Data<'source>>,
+);
+
+/// Output type for step witness methods.
+pub type StepOutput<'dr, S, C, D, const HEADER_SIZE: usize> = (
+    Encoded<'dr, D, <S as Step<C>>::Left, HEADER_SIZE>,
+    Encoded<'dr, D, <S as Step<C>>::Right, HEADER_SIZE>,
+    Encoded<'dr, D, <S as Step<C>>::Output, HEADER_SIZE>,
+);

--- a/crates/ragu_pcd/tests/nontrivial.rs
+++ b/crates/ragu_pcd/tests/nontrivial.rs
@@ -4,14 +4,14 @@ use ragu_circuits::polynomials::R;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::{GadgetKind, Kind},
+    gadgets::Kind,
     maybe::Maybe,
 };
 use ragu_pasta::{Fp, Pasta};
 use ragu_pcd::{
     ApplicationBuilder,
-    header::{Header, Suffix},
-    step::{Encoded, Index, Step},
+    header::{Header, HeaderInput, HeaderOutput, Suffix},
+    step::{Encoded, Index, Step, StepInput, StepOutput},
 };
 use ragu_primitives::{Element, poseidon::Sponge};
 use rand::{SeedableRng, rngs::StdRng};
@@ -25,8 +25,8 @@ impl<F: Field> Header<F> for LeafNode {
 
     fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
         dr: &mut D,
-        witness: DriverValue<D, Self::Data<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+        witness: HeaderInput<'source, Self, F, D>,
+    ) -> Result<HeaderOutput<'dr, Self, F, D>> {
         Element::alloc(dr, witness)
     }
 }
@@ -40,8 +40,8 @@ impl<F: Field> Header<F> for InternalNode {
 
     fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
         dr: &mut D,
-        witness: DriverValue<D, Self::Data<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+        witness: HeaderInput<'source, Self, F, D>,
+    ) -> Result<HeaderOutput<'dr, Self, F, D>> {
         Element::alloc(dr, witness)
     }
 }
@@ -62,14 +62,9 @@ impl<C: Cycle> Step<C> for Hash2<'_, C> {
         &self,
         dr: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
-        left: DriverValue<D, C::CircuitField>,
-        right: DriverValue<D, C::CircuitField>,
+        (left, right): StepInput<'source, Self, C, D>,
     ) -> Result<(
-        (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
-        ),
+        StepOutput<'dr, Self, C, D, HEADER_SIZE>,
         DriverValue<D, Self::Aux<'source>>,
     )>
     where
@@ -105,14 +100,9 @@ impl<C: Cycle> Step<C> for WitnessLeaf<'_, C> {
         &self,
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'source>>,
-        _left: DriverValue<D, ()>,
-        _right: DriverValue<D, ()>,
+        (_, _): StepInput<'source, Self, C, D>,
     ) -> Result<(
-        (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
-        ),
+        StepOutput<'dr, Self, C, D, HEADER_SIZE>,
         DriverValue<D, Self::Aux<'source>>,
     )>
     where

--- a/crates/ragu_pcd/tests/registration_errors.rs
+++ b/crates/ragu_pcd/tests/registration_errors.rs
@@ -3,13 +3,12 @@ use ragu_circuits::polynomials::R;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::GadgetKind,
 };
 use ragu_pasta::Pasta;
-use ragu_pcd::step::{Encoded, Index, Step};
+use ragu_pcd::step::{Encoded, Index, Step, StepInput, StepOutput};
 use ragu_pcd::{
     ApplicationBuilder,
-    header::{Header, Suffix},
+    header::{Header, HeaderInput, HeaderOutput, Suffix},
 };
 
 // Header A with suffix 0
@@ -25,8 +24,8 @@ impl<F: Field> Header<F> for HSuffixA {
     type Output = ();
     fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
         _: &mut D,
-        _: DriverValue<D, Self::Data<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+        _: HeaderInput<'source, Self, F, D>,
+    ) -> Result<HeaderOutput<'dr, Self, F, D>> {
         Ok(())
     }
 }
@@ -37,8 +36,8 @@ impl<F: Field> Header<F> for HSuffixB {
     type Output = ();
     fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
         _: &mut D,
-        _: DriverValue<D, Self::Data<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+        _: HeaderInput<'source, Self, F, D>,
+    ) -> Result<HeaderOutput<'dr, Self, F, D>> {
         Ok(())
     }
 }
@@ -49,8 +48,8 @@ impl<F: Field> Header<F> for HSuffixAOther {
     type Output = ();
     fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
         _: &mut D,
-        _: DriverValue<D, Self::Data<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+        _: HeaderInput<'source, Self, F, D>,
+    ) -> Result<HeaderOutput<'dr, Self, F, D>> {
         Ok(())
     }
 }
@@ -68,14 +67,9 @@ impl<C: arithmetic::Cycle> Step<C> for Step0 {
         &self,
         dr: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
-        left: DriverValue<D, ()>,
-        right: DriverValue<D, ()>,
+        (left, right): StepInput<'source, Self, C, D>,
     ) -> Result<(
-        (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
-        ),
+        StepOutput<'dr, Self, C, D, HEADER_SIZE>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;
@@ -99,14 +93,9 @@ impl<C: arithmetic::Cycle> Step<C> for Step1 {
         &self,
         dr: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
-        left: DriverValue<D, ()>,
-        right: DriverValue<D, ()>,
+        (left, right): StepInput<'source, Self, C, D>,
     ) -> Result<(
-        (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
-        ),
+        StepOutput<'dr, Self, C, D, HEADER_SIZE>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;
@@ -130,14 +119,9 @@ impl<C: arithmetic::Cycle> Step<C> for Step1Dup {
         &self,
         dr: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
-        left: DriverValue<D, ()>,
-        right: DriverValue<D, ()>,
+        (left, right): StepInput<'source, Self, C, D>,
     ) -> Result<(
-        (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
-        ),
+        StepOutput<'dr, Self, C, D, HEADER_SIZE>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;

--- a/crates/ragu_pcd/tests/rerandomization.rs
+++ b/crates/ragu_pcd/tests/rerandomization.rs
@@ -4,13 +4,12 @@ use ragu_circuits::polynomials::R;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::GadgetKind,
 };
 use ragu_pasta::Pasta;
 use ragu_pcd::{
     ApplicationBuilder,
-    header::{Header, Suffix},
-    step::{Encoded, Index, Step},
+    header::{Header, HeaderInput, HeaderOutput, Suffix},
+    step::{Encoded, Index, Step, StepInput, StepOutput},
 };
 use rand::SeedableRng;
 use rand::rngs::StdRng;
@@ -24,8 +23,8 @@ impl<F: Field> Header<F> for HeaderA {
     type Output = ();
     fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
         _: &mut D,
-        _: DriverValue<D, Self::Data<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+        _: HeaderInput<'source, Self, F, D>,
+    ) -> Result<HeaderOutput<'dr, Self, F, D>> {
         Ok(())
     }
 }
@@ -43,14 +42,9 @@ impl<C: Cycle> Step<C> for Step0 {
         &self,
         dr: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
-        left: DriverValue<D, ()>,
-        right: DriverValue<D, ()>,
+        (left, right): StepInput<'source, Self, C, D>,
     ) -> Result<(
-        (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
-        ),
+        StepOutput<'dr, Self, C, D, HEADER_SIZE>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;
@@ -72,14 +66,9 @@ impl<C: Cycle> Step<C> for Step1 {
         &self,
         dr: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
-        left: DriverValue<D, ()>,
-        right: DriverValue<D, ()>,
+        (left, right): StepInput<'source, Self, C, D>,
     ) -> Result<(
-        (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
-        ),
+        StepOutput<'dr, Self, C, D, HEADER_SIZE>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;


### PR DESCRIPTION
the current `Step::witness` impl signature is verbose:

```rust
impl<C: Cycle> Step<C> for MyStep<C> {
    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
        &self,
        dr: &mut D,
        witness: DriverValue<D, Self::Witness<'source>>,
        left: Encoder<'dr, 'source, D, Self::Left, HEADER_SIZE>,
        right: Encoder<'dr, 'source, D, Self::Right, HEADER_SIZE>,
    ) -> Result<(
        (
            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
        ),
        DriverValue<D, Self::Aux<'source>>,
    )>
    where
        Self: 'dr,
    {
        // ... step logic ...
    }
    
}
```

## Proposed Change

1. consolidate `Step::witness` parameters into a tuple.
2. add type aliases (`StepInput`, `StepOutput`, `HeaderInput`, `HeaderOutput`)
3. apply the alias where implementing and destructure the tuple.

```rust
impl<C: Cycle> Step<C> for MyStep<C> {
    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HS: usize>(
        &self,
        dr: &mut D,
        (witness, left, right): StepInput<'dr, 'source, Self, C, D, HS>,
    ) -> Result<StepOutput<'dr, 'source, Self, C, D, HS>>
    where
        Self: 'dr,
    {
        // ... step logic ...
    }
}
```

i noticed this diff would conflict with https://github.com/tachyon-zcash/ragu/pull/327 but it's simple to merge. implementing both would eliminate the `'dr` lifetime from the alias.

an alias for headers is a smaller benefit but provides nice consistency.