### PR TITLE
circuits: Introduce DriverExt::enforce_public_output and enforce_one

### DIFF
--- a/crates/ragu_circuits/src/s/sxy.rs
+++ b/crates/ragu_circuits/src/s/sxy.rs
@@ -11,7 +11,7 @@ use ragu_primitives::GadgetExt;
 
 use alloc::vec;
 
-use crate::{Circuit, polynomials::Rank};
+use crate::{Circuit, DriverExt, polynomials::Rank};
 
 use super::{Wire, WireSum};
 
@@ -163,10 +163,12 @@ pub fn eval<F: Field, C: Circuit<F>, R: Rank>(circuit: &C, x: F, y: F, key: F) -
 
     let (io, _) = circuit.witness(&mut dr, Empty)?;
     io.write(&mut dr, &mut outputs)?;
+    // Bind circuit witness outputs to k(Y) coefficients k_j
     for output in outputs {
-        dr.enforce_zero(|lc| lc.add(output.wire()))?;
+        dr.enforce_public_output(|lc| lc.add(output.wire()))?;
     }
-    dr.enforce_zero(|lc| lc.add(&one))?;
+    // Bind constant ONE wire to k_0 (=1)
+    dr.enforce_one(|lc| lc.add(&one))?;
 
     Ok(dr.result)
 }

--- a/crates/ragu_circuits/src/s/sy.rs
+++ b/crates/ragu_circuits/src/s/sy.rs
@@ -13,7 +13,7 @@ use alloc::{vec, vec::Vec};
 use core::cell::RefCell;
 
 use crate::{
-    Circuit,
+    Circuit, DriverExt,
     polynomials::{Rank, structured},
 };
 
@@ -334,10 +334,12 @@ pub fn eval<F: Field, C: Circuit<F>, R: Rank>(
             let (io, _) = circuit.witness(&mut collector, Empty)?;
             io.write(&mut collector, &mut outputs)?;
 
+            // Bind circuit witness outputs to k(Y) coefficients k_j
             for output in outputs {
-                collector.enforce_zero(|lc| lc.add(output.wire()))?;
+                collector.enforce_public_output(|lc| lc.add(output.wire()))?;
             }
-            collector.enforce_zero(|lc| lc.add(&one))?;
+            // Bind constant ONE wire to k_0 (=1)
+            collector.enforce_one(|lc| lc.add(&one))?;
             assert_eq!(collector.linear_constraints, num_linear_constraints);
         }
 


### PR DESCRIPTION
Motivation: 
When I look at code like 

```rust
    for output in outputs {
        dr.enforce_zero(|lc| lc.add(output.wire()))?;
    }
    dr.enforce_zero(|lc| lc.add(&one))?;
```
This is quite unintuitive, how could `ONE` wire equals to zero? same for the public output? 
What we are actually enforcing is that `j`-th output is equal to the `k_j` defined in the `k(y)` vectors. 
So the dual semantic of `enforce_zero()` for `s::*` drivers need some clarification.

Even though this is just internal code, I think some clarification could be helpful. Here's what I propose:

```rust
// private to `ragu_circuit`, only used by s drivers
pub(crate) trait DriverExt<'dr>: Driver<'dr> {
    fn enforce_public_output(
        &mut self,
        lc: impl Fn(Self::LCenforce) -> Self::LCenforce,
    ) -> Result<()>;
    fn enforce_one(&mut self, lc: impl Fn(Self::LCenforce) -> Self::LCenforce) -> Result<()>;
}

// so that we clear intention

    // Bind circuit witness outputs to k(Y) coefficients k_j
    for output in outputs {
        dr.enforce_public_output(|lc| lc.add(output.wire()))?;
    }
    // Bind constant ONE wire to k_0 (=1)
    dr.enforce_one(|lc| lc.add(&one))?;
```