### PR TITLE
nit: avoid unwrap in rx::eval()

### DIFF
--- a/crates/ragu_core/src/errors.rs
+++ b/crates/ragu_core/src/errors.rs
@@ -38,6 +38,11 @@ pub enum Error {
     #[error("invalid witness: {0}")]
     InvalidWitness(Box<dyn error::Error + Send + Sync + 'static>),
 
+    /// Mesh keys may be invalid if initialization is buggy or mesh digest
+    /// is accidentally zero (astronomically unlikely).
+    #[error("invalid mesh key, cannot be zero")]
+    InvalidMeshKey,
+
     /// Synthesis can fail if data cannot be decoded from a stream like a proof
     /// string
     #[error("malformed encoding: {0}")]


### PR DESCRIPTION
Changes include:

- Rename `Collector` to `Evaluator` (to be consistent with #352)
- remove `.unwrap()` and return `Err::InvalidMeshKey` instead during `rx::eval()`