### PR TITLE
circuits: rename StageObject to StageMask

### DIFF
--- a/crates/ragu_pcd/src/circuits/native/mod.rs
+++ b/crates/ragu_pcd/src/circuits/native/mod.rs
@@ -69,8 +69,8 @@ pub(crate) fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
     // Insert the stages.
     {
         // preamble stage
-        mesh = mesh
-            .register_circuit_object(stages::preamble::Stage::<C, R, HEADER_SIZE>::into_object()?)?;
+        mesh =
+            mesh.register_circuit_object(stages::preamble::Stage::<C, R, HEADER_SIZE>::mask()?)?;
 
         // error_m stage
         mesh = mesh.register_circuit_object(stages::error_m::Stage::<
@@ -78,7 +78,7 @@ pub(crate) fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
             R,
             HEADER_SIZE,
             NativeParameters,
-        >::into_object()?)?;
+        >::mask()?)?;
 
         // error_n stage
         mesh = mesh.register_circuit_object(stages::error_n::Stage::<
@@ -86,15 +86,13 @@ pub(crate) fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
             R,
             HEADER_SIZE,
             NativeParameters,
-        >::into_object()?)?;
+        >::mask()?)?;
 
         // query stage
-        mesh = mesh
-            .register_circuit_object(stages::query::Stage::<C, R, HEADER_SIZE>::into_object()?)?;
+        mesh = mesh.register_circuit_object(stages::query::Stage::<C, R, HEADER_SIZE>::mask()?)?;
 
         // eval stage
-        mesh =
-            mesh.register_circuit_object(stages::eval::Stage::<C, R, HEADER_SIZE>::into_object()?)?;
+        mesh = mesh.register_circuit_object(stages::eval::Stage::<C, R, HEADER_SIZE>::mask()?)?;
     }
 
     // Insert the "final stage polynomials" for each stage.
@@ -108,7 +106,7 @@ pub(crate) fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
             R,
             HEADER_SIZE,
             NativeParameters,
-        >::final_into_object()?)?;
+        >::final_mask()?)?;
 
         // preamble -> error_n -> [CIRCUIT] (hashes_1, hashes_2, full_collapse)
         mesh = mesh.register_circuit_object(stages::error_n::Stage::<
@@ -116,12 +114,11 @@ pub(crate) fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
             R,
             HEADER_SIZE,
             NativeParameters,
-        >::final_into_object()?)?;
+        >::final_mask()?)?;
 
         // preamble -> query -> eval -> [CIRCUIT] (compute_v)
-        mesh = mesh.register_circuit_object(
-            stages::eval::Stage::<C, R, HEADER_SIZE>::final_into_object()?,
-        )?;
+        mesh =
+            mesh.register_circuit_object(stages::eval::Stage::<C, R, HEADER_SIZE>::final_mask()?)?;
     }
 
     // Insert the internal circuits.

--- a/crates/ragu_pcd/src/circuits/nested/mod.rs
+++ b/crates/ragu_pcd/src/circuits/nested/mod.rs
@@ -32,11 +32,11 @@ pub(crate) const NUM_ENDOSCALING_POINTS: usize = 37;
 /// These correspond to the circuit objects registered in [`register_all`].
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum InternalCircuitIndex {
-    /// `EndoscalarStage` stage object (index 0)
+    /// `EndoscalarStage` stage mask (index 0)
     EndoscalarStage,
-    /// `PointsStage` stage object (index 1)
+    /// `PointsStage` stage mask (index 1)
     PointsStage,
-    /// `PointsStage` final staged object (index 2)
+    /// `PointsStage` final staged mask (index 2)
     PointsFinalStaged,
     /// `EndoscalingStep` circuit at given step (indices 3+)
     EndoscalingStep(usize),
@@ -61,14 +61,13 @@ pub mod stages;
 pub(crate) fn register_all<'params, C: Cycle, R: Rank>(
     mut mesh: MeshBuilder<'params, C::ScalarField, R>,
 ) -> Result<MeshBuilder<'params, C::ScalarField, R>> {
-    mesh = mesh.register_circuit_object(EndoscalarStage::into_object()?)?;
+    mesh = mesh.register_circuit_object(EndoscalarStage::mask()?)?;
+
+    mesh =
+        mesh.register_circuit_object(PointsStage::<C::HostCurve, NUM_ENDOSCALING_POINTS>::mask()?)?;
 
     mesh = mesh.register_circuit_object(
-        PointsStage::<C::HostCurve, NUM_ENDOSCALING_POINTS>::into_object()?,
-    )?;
-
-    mesh = mesh.register_circuit_object(
-        PointsStage::<C::HostCurve, NUM_ENDOSCALING_POINTS>::final_into_object()?,
+        PointsStage::<C::HostCurve, NUM_ENDOSCALING_POINTS>::final_mask()?,
     )?;
 
     let num_steps = NumStepsLen::<NUM_ENDOSCALING_POINTS>::len();

--- a/crates/ragu_pcd/src/components/endoscalar.rs
+++ b/crates/ragu_pcd/src/components/endoscalar.rs
@@ -435,9 +435,9 @@ mod tests {
 
             let staged = Staged::new(step_circuit.clone());
 
-            let endoscalar_s = EndoscalarStage::into_object()?;
-            let points_s = PointsStage::<EpAffine, NUM_POINTS>::into_object()?;
-            let final_s = PointsStage::<EpAffine, NUM_POINTS>::final_into_object()?;
+            let endoscalar_mask = EndoscalarStage::mask()?;
+            let points_mask = PointsStage::<EpAffine, NUM_POINTS>::mask()?;
+            let final_mask = PointsStage::<EpAffine, NUM_POINTS>::final_mask()?;
 
             let endoscalar_rx = <EndoscalarStage as StageExt<Fp, R>>::rx(endoscalar)?;
             let points_rx = <PointsStage<EpAffine, NUM_POINTS> as StageExt<Fp, R>>::rx(&points)?;
@@ -455,9 +455,9 @@ mod tests {
             let y = Fp::random(thread_rng());
 
             // Verify revdot identities for each stage.
-            assert_eq!(endoscalar_rx.revdot(&endoscalar_s.sy(y, key)), Fp::ZERO);
-            assert_eq!(points_rx.revdot(&points_s.sy(y, key)), Fp::ZERO);
-            assert_eq!(final_rx.revdot(&final_s.sy(y, key)), Fp::ZERO);
+            assert_eq!(endoscalar_rx.revdot(&endoscalar_mask.sy(y, key)), Fp::ZERO);
+            assert_eq!(points_rx.revdot(&points_mask.sy(y, key)), Fp::ZERO);
+            assert_eq!(final_rx.revdot(&final_mask.sy(y, key)), Fp::ZERO);
 
             // Verify combined circuit identity.
             let mut lhs = final_rx.clone();


### PR DESCRIPTION
Changes include:

- Rename `StageObject` to `StageMask`, constructed via `S::mask()` or `S::final_mask()` 
- update all tests, docs
  - meanwhile fix a small error in the doc of `staging/mod.rs` 