### PR TITLE
chore: merge-gating on codeowner file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owner for all files
+* @ebfull


### PR DESCRIPTION
added to prevent accidental pushes to main on another reviewers approval that isn't a codeowner. Requires commensurate branch protections to be configured. 