### PR TITLE
ci: fix dispatch err in forks

### DIFF
--- a/.github/workflows/notify-website.yml
+++ b/.github/workflows/notify-website.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
+    if: github.repository == 'tachyon-zcash/ragu'
     steps:
       - name: Trigger repository_dispatch in website
         uses: peter-evans/repository-dispatch@v3


### PR DESCRIPTION
Right now, the dispatch (doc/book website push) will be triggered (then failed) on forks, add a condition to skip on forks. 