### PR TITLE
pcd: More ergonomic PCD seed and fuse API

### DIFF
--- a/crates/ragu_pcd/src/fuse/mod.rs
+++ b/crates/ragu_pcd/src/fuse/mod.rs
@@ -50,8 +50,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         witness: S::Witness<'source>,
         left: Pcd<'source, C, R, S::Left>,
         right: Pcd<'source, C, R, S::Right>,
-    ) -> Result<(Proof<C, R>, S::Aux<'source>)> {
-        let (left, right, application, application_aux) =
+    ) -> Result<Pcd<'source, C, R, S::Output>> {
+        let (left, right, application, application_data) =
             self.compute_application_proof(rng, step, witness, left, right)?;
 
         let mut dr = Emulator::execute();
@@ -145,23 +145,22 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             &challenges,
         )?;
 
-        Ok((
-            Proof {
-                application,
-                preamble,
-                s_prime,
-                error_n,
-                error_m,
-                ab,
-                query,
-                f,
-                eval,
-                p,
-                challenges,
-                circuits,
-            },
-            application_aux,
-        ))
+        let proof = Proof {
+            application,
+            preamble,
+            s_prime,
+            error_n,
+            error_m,
+            ab,
+            query,
+            f,
+            eval,
+            p,
+            challenges,
+            circuits,
+        };
+
+        Ok(proof.carry(application_data))
     }
 }
 

--- a/crates/ragu_pcd/src/step/internal/trivial.rs
+++ b/crates/ragu_pcd/src/step/internal/trivial.rs
@@ -10,6 +10,7 @@ use ragu_core::{
 };
 
 use super::super::{Encoded, Index, Step};
+use crate::Header;
 
 pub(crate) use crate::step::InternalStepIndex::Trivial as INTERNAL_ID;
 
@@ -25,7 +26,6 @@ impl<C: Cycle> Step<C> for Trivial {
     const INDEX: Index = Index::internal(INTERNAL_ID);
 
     type Witness<'source> = ();
-    type Aux<'source> = ();
 
     type Left = ();
     type Right = ();
@@ -43,7 +43,7 @@ impl<C: Cycle> Step<C> for Trivial {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, Self::Aux<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;
         let right = Encoded::new(dr, right)?;

--- a/crates/ragu_pcd/src/step/mod.rs
+++ b/crates/ragu_pcd/src/step/mod.rs
@@ -133,10 +133,6 @@ pub trait Step<C: Cycle>: Sized + Send + Sync {
     /// The witness data needed to construct a proof for this step.
     type Witness<'source>: Send;
 
-    /// Auxiliary information produced during circuit synthesis. This may be
-    /// necessary to construct the [`Header::Data`] for the resulting proof.
-    type Aux<'source>: Send;
-
     /// The "left" header expected during this step.
     type Left: Header<C::CircuitField>;
 
@@ -147,6 +143,9 @@ pub trait Step<C: Cycle>: Sized + Send + Sync {
     type Output: Header<C::CircuitField>;
 
     /// The main synthesis method that checks the validity of this merging step.
+    ///
+    /// Returns the encoded headers (left, right, output) and the data to be
+    /// carried in the resulting PCD.
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
         &self,
         dr: &mut D,
@@ -159,7 +158,7 @@ pub trait Step<C: Cycle>: Sized + Send + Sync {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, Self::Aux<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
     )>
     where
         Self: 'dr;

--- a/crates/ragu_pcd/tests/nontrivial.rs
+++ b/crates/ragu_pcd/tests/nontrivial.rs
@@ -53,7 +53,6 @@ struct Hash2<'params, C: Cycle> {
 impl<C: Cycle> Step<C> for Hash2<'_, C> {
     const INDEX: Index = Index::new(1);
     type Witness<'source> = ();
-    type Aux<'source> = C::CircuitField;
     type Left = LeafNode;
     type Right = LeafNode;
     type Output = InternalNode;
@@ -70,7 +69,7 @@ impl<C: Cycle> Step<C> for Hash2<'_, C> {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, Self::Aux<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
     )>
     where
         Self: 'dr,
@@ -96,7 +95,6 @@ struct WitnessLeaf<'params, C: Cycle> {
 impl<C: Cycle> Step<C> for WitnessLeaf<'_, C> {
     const INDEX: Index = Index::new(0);
     type Witness<'source> = C::CircuitField;
-    type Aux<'source> = C::CircuitField;
     type Left = ();
     type Right = ();
     type Output = LeafNode;
@@ -113,7 +111,7 @@ impl<C: Cycle> Step<C> for WitnessLeaf<'_, C> {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, Self::Aux<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
     )>
     where
         Self: 'dr,
@@ -157,7 +155,6 @@ fn various_merging_operations() -> Result<()> {
         },
         Fp::from(42u64),
     )?;
-    let leaf1 = leaf1.0.carry(leaf1.1);
     assert!(app.verify(&leaf1, &mut rng)?);
 
     let leaf2 = app.seed(
@@ -167,7 +164,6 @@ fn various_merging_operations() -> Result<()> {
         },
         Fp::from(42u64),
     )?;
-    let leaf2 = leaf2.0.carry(leaf2.1);
     assert!(app.verify(&leaf2, &mut rng)?);
 
     let node1 = app.fuse(
@@ -179,8 +175,6 @@ fn various_merging_operations() -> Result<()> {
         leaf1,
         leaf2,
     )?;
-    let node1 = node1.0.carry::<InternalNode>(node1.1);
-
     assert!(app.verify(&node1, &mut rng)?);
 
     Ok(())

--- a/crates/ragu_pcd/tests/registration_errors.rs
+++ b/crates/ragu_pcd/tests/registration_errors.rs
@@ -60,7 +60,6 @@ struct Step0;
 impl<C: arithmetic::Cycle> Step<C> for Step0 {
     const INDEX: Index = Index::new(0);
     type Witness<'source> = ();
-    type Aux<'source> = ();
     type Left = ();
     type Right = ();
     type Output = HSuffixA;
@@ -76,7 +75,7 @@ impl<C: arithmetic::Cycle> Step<C> for Step0 {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, Self::Aux<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;
         let right = Encoded::new(dr, right)?;
@@ -91,7 +90,6 @@ struct Step1;
 impl<C: arithmetic::Cycle> Step<C> for Step1 {
     const INDEX: Index = Index::new(1);
     type Witness<'source> = ();
-    type Aux<'source> = ();
     type Left = HSuffixA;
     type Right = HSuffixA;
     type Output = HSuffixB;
@@ -107,7 +105,7 @@ impl<C: arithmetic::Cycle> Step<C> for Step1 {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, Self::Aux<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;
         let right = Encoded::new(dr, right)?;
@@ -122,7 +120,6 @@ struct Step1Dup;
 impl<C: arithmetic::Cycle> Step<C> for Step1Dup {
     const INDEX: Index = Index::new(1);
     type Witness<'source> = ();
-    type Aux<'source> = ();
     type Left = HSuffixA;
     type Right = HSuffixA;
     type Output = HSuffixAOther;
@@ -138,7 +135,7 @@ impl<C: arithmetic::Cycle> Step<C> for Step1Dup {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, Self::Aux<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;
         let right = Encoded::new(dr, right)?;


### PR DESCRIPTION
Motivation starts with the observation of an awkward and arguably an unintended abuse that escape the compiler check:

```rust
// in pcd/tests/nontrivial.rs

    let leaf1 = app.seed(
        &mut rng,
        WitnessLeaf {
            poseidon_params: Pasta::circuit_poseidon(pasta),
        },
        Fp::from(42u64),
    )?;
    let leaf1 = leaf1.0.carry(leaf1.1);
```

here `leaf1: (Proof, S::Aux)`, but `carry()` expect `Header::Data`, in this step, the aux happens to be the same type of the output data type.

We could add a `Step::aux_to_data()` method and requiring implementators to specify their conversion in case the auxiliary data is really different or more succinct than the output data. But after examining all occurrences, my personal conclusion is that there's currently no material benefit of `Step::Aux`. 
(^^ correct me if I'm wrong)

Thus, here are my changes:
- Remove `Step::Aux`, return output data directly: `Step::witness() -> (.., DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>)`
- Simplify `Application::fuse() -> Pcd` instead of returning the aux and forcing the caller to manually `.carry()` them. 
- Let `Rerandomize` step to pass through the left data directly as part of its step, simpler logic in `App::rerandomize()`.

IMHO, this is a more ergonomic API.