### PR TITLE
docs: add module-level documentation to
   internal crates

### DIFF
--- a/crates/ragu_circuits/src/ky.rs
+++ b/crates/ragu_circuits/src/ky.rs
@@ -1,3 +1,10 @@
+//! Assembly of the $k(Y)$ public input polynomial.
+//!
+//! The [`eval`] function in this module processes some instance data for a
+//! particular [`Circuit`] and computes its public inputs, arranging them into
+//! the low degree coefficient vector for the circuit's $k(Y)$ instance
+//! polynomial.
+
 use ff::Field;
 use ragu_core::{
     Result,

--- a/crates/ragu_circuits/src/metrics.rs
+++ b/crates/ragu_circuits/src/metrics.rs
@@ -1,3 +1,9 @@
+//! Circuit constraint analysis and metrics collection.
+//!
+//! This module provides constraint system analysis by simulating circuit
+//! execution without computing actual values, counting the number of
+//! multiplication and linear constraints a circuit requires.
+
 use arithmetic::Coeff;
 use ff::Field;
 use ragu_core::{

--- a/crates/ragu_circuits/src/rx.rs
+++ b/crates/ragu_circuits/src/rx.rs
@@ -1,3 +1,8 @@
+//! Assembly of the $r(X)$ witness polynomial.
+//!
+//! The [`eval`] function in this module processes some witness data for a
+//! particular [`Circuit`] and assembles the corresponding $r(X)$ polynomial.
+
 use arithmetic::Coeff;
 use ff::Field;
 use ragu_core::{

--- a/crates/ragu_pcd/src/circuits/mod.rs
+++ b/crates/ragu_pcd/src/circuits/mod.rs
@@ -1,3 +1,8 @@
+//! Internal circuits for recursive proof verification.
+//!
+//! Contains native and nested curve circuits that implement the recursive
+//! verification logic, including proof components and internal circuit registration.
+
 pub(crate) mod native;
 pub(crate) mod nested;
 

--- a/crates/ragu_pcd/src/circuits/native/mod.rs
+++ b/crates/ragu_pcd/src/circuits/native/mod.rs
@@ -1,3 +1,5 @@
+//! Native curve circuits for recursive verification.
+
 use arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::Rank,

--- a/crates/ragu_pcd/src/fuse/mod.rs
+++ b/crates/ragu_pcd/src/fuse/mod.rs
@@ -1,3 +1,8 @@
+//! Proof fusion implementation for combining child proofs.
+//!
+//! Implements the core [`Application::fuse`] operation that takes two child
+//! proofs and produces a new proof, computing each proof component in sequence.
+
 mod _01_application;
 mod _02_preamble;
 mod _03_s_prime;

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -1,3 +1,9 @@
+//! Proof and proof-carrying data structures.
+//!
+//! Defines the [`Proof`] structure containing witness polynomials, commitments,
+//! and accumulated claims, along with [`Pcd`] which bundles a [`Proof`] with the
+//! data that a [`Header`] succinctly encodes.
+
 #![allow(dead_code)]
 
 pub(crate) mod components;

--- a/crates/ragu_primitives/src/boolean.rs
+++ b/crates/ragu_primitives/src/boolean.rs
@@ -1,3 +1,8 @@
+//! Boolean gadget for constrained binary values.
+//!
+//! Provides the [`Boolean`] type representing a wire constrained to be zero or
+//! one, with logical operations implemented as circuit constraints.
+
 use arithmetic::Coeff;
 use ff::{Field, PrimeField};
 use ragu_core::{

--- a/crates/ragu_primitives/src/element.rs
+++ b/crates/ragu_primitives/src/element.rs
@@ -1,3 +1,8 @@
+//! Field element gadget for arithmetic circuit wires.
+//!
+//! Provides the [`Element`] type representing a wire and its field element
+//! assignment, the fundamental building block for circuit construction.
+
 use arithmetic::Coeff;
 use arithmetic::PrimeFieldExt;
 use ff::{Field, PrimeField};

--- a/crates/ragu_primitives/src/foreign.rs
+++ b/crates/ragu_primitives/src/foreign.rs
@@ -1,3 +1,8 @@
+//! [`Write`] implementations for foreign standard library types.
+//!
+//! Enables types like `()`, arrays, tuples, and `Box<T>` to participate in
+//! the circuit IO system by implementing the [`Write`] trait.
+
 use ff::Field;
 use ragu_core::{Result, drivers::Driver};
 

--- a/crates/ragu_primitives/src/point.rs
+++ b/crates/ragu_primitives/src/point.rs
@@ -1,3 +1,8 @@
+//! Elliptic curve point gadget for in-circuit curve operations.
+//!
+//! Provides the [`Point`] type representing an affine curve point with
+//! constrained coordinates for in-circuit elliptic curve arithmetic.
+
 use arithmetic::{Coeff, CurveAffine};
 use ff::{Field, WithSmallOrderMulGroup};
 use ragu_core::{

--- a/crates/ragu_primitives/src/simulator.rs
+++ b/crates/ragu_primitives/src/simulator.rs
@@ -1,3 +1,8 @@
+//! Simulation driver for testing and constraint verification.
+//!
+//! Provides a [`Simulator`] driver that fully executes circuit synthesis,
+//! tracking constraint counts and enforcing constraint satisfaction.
+
 use arithmetic::Coeff;
 use ff::Field;
 use ragu_core::{


### PR DESCRIPTION
Closes #351                        
                                                               
  internal crates:                                             
                                                               
  **ragu_circuits:**                                           
  - `ky.rs` - public input polynomial evaluation             
  - `rx.rs` - witness polynomial evaluation                  
  - `metrics.rs` - constraint analysis                       
                                                               
  **ragu_primitives:**                                         
  - `boolean.rs` - Boolean gadget                            
  - `element.rs` - Element gadget                            
  - `foreign.rs` - Write impls for std types                 
  - `point.rs` - Point gadget                                
  - `simulator.rs` - Simulator driver                        
                                                               
  **ragu_pcd:**                                                
  - `circuits/mod.rs` - internal verification circuits       
  - `circuits/native/mod.rs` - native curve circuits         
  - `fuse/mod.rs` - proof fusion                             
  - `proof/mod.rs` - Proof and Pcd structures