### PR TITLE
feat(pcd): add `endoscale_challenges` circuit for challenge smuggling

### DIFF
--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -246,7 +246,7 @@ mod tests {
     use ragu_core::{
         Result,
         drivers::{Driver, DriverValue, LinearExpression, emulator::Emulator},
-        gadgets::{Bound, Consistent, Gadget, GadgetKind},
+        gadgets::{Bound, Consistent, Gadget},
         maybe::Maybe,
         routines::{Prediction, Routine},
     };
@@ -1037,7 +1037,7 @@ mod tests {
             &self,
             dr: &mut D,
             witness: DriverValue<D, Self::Witness<'source>>,
-        ) -> Result<<Self::OutputKind as GadgetKind<Fp>>::Rebind<'dr, D>>
+        ) -> Result<Bound<'dr, D, Self::OutputKind>>
         where
             Self: 'dr,
         {

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -1,4 +1,5 @@
 use ff::Field;
+use ragu_arithmetic::{CurveAffine, FixedGenerators};
 use ragu_core::Result;
 
 use alloc::vec::Vec;
@@ -245,7 +246,7 @@ mod tests {
     use ragu_core::{
         Result,
         drivers::{Driver, DriverValue, LinearExpression, emulator::Emulator},
-        gadgets::{Bound, Consistent, Gadget},
+        gadgets::{Bound, Consistent, Gadget, GadgetKind},
         maybe::Maybe,
         routines::{Prediction, Routine},
     };
@@ -1072,10 +1073,10 @@ mod tests {
         let rx: structured::Polynomial<Fp, R> = AOnlyStage::rx(challenges).unwrap();
         let poly_commitment: EqAffine = rx.commit(generators, blind);
 
-        // Build `StageObject` with matching parameters.
+        // Build `StageMask` with matching parameters.
         let skip = AOnlyStage::skip_multiplications(); // 0 for root stage
         let num = <AOnlyStage as StageExt<Fp, R>>::num_multiplications(); // ceil(6/2) = 3
-        let stage_obj = StageObject::<R>::new(skip, num).unwrap();
+        let stage_obj = StageMask::<R>::new(skip, num).unwrap();
 
         // Manually compute expected commitment using generator_for_a_coefficient.
         let mut manual_commitment = EqAffine::identity();

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -996,4 +996,97 @@ mod tests {
             "Commitment via staging mechanism should match manual computation"
         );
     }
+
+    /// A stage that allocates values only in a-positions (b = 0) for challenge smuggling.
+    ///
+    /// Each value is paired with a zero to ensure it lands in an a-coefficient position
+    /// when the polynomial is built. This mimics the pattern used for smuggling challenges.
+    #[derive(Default)]
+    struct AOnlyStage;
+
+    #[derive(ragu_core::gadgets::Gadget, ragu_primitives::io::Write)]
+    struct ThreeAOnlyElements<'dr, #[ragu(driver)] D: Driver<'dr>> {
+        #[ragu(gadget)]
+        a0: Element<'dr, D>,
+        #[ragu(gadget)]
+        b0: Element<'dr, D>,
+        #[ragu(gadget)]
+        a1: Element<'dr, D>,
+        #[ragu(gadget)]
+        b1: Element<'dr, D>,
+        #[ragu(gadget)]
+        a2: Element<'dr, D>,
+        #[ragu(gadget)]
+        b2: Element<'dr, D>,
+    }
+
+    impl Stage<Fp, R> for AOnlyStage {
+        type Parent = ();
+        type Witness<'source> = [Fp; 3];
+        type OutputKind = <ThreeAOnlyElements<'static, PhantomData<Fp>> as Gadget<
+            'static,
+            PhantomData<Fp>,
+        >>::Kind;
+
+        fn values() -> usize {
+            6 // 3 values + 3 zeros = 6 values = 3 multiplication gates
+        }
+
+        fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+            &self,
+            dr: &mut D,
+            witness: DriverValue<D, Self::Witness<'source>>,
+        ) -> Result<<Self::OutputKind as GadgetKind<Fp>>::Rebind<'dr, D>>
+        where
+            Self: 'dr,
+        {
+            // Allocate each challenge value followed by zero, which
+            // ensures challenges land in a-positions, zeros in b-positions.
+            let a0 = Element::alloc(dr, witness.view().map(|w| w[0]))?;
+            let b0 = Element::zero(dr);
+            let a1 = Element::alloc(dr, witness.view().map(|w| w[1]))?;
+            let b1 = Element::zero(dr);
+            let a2 = Element::alloc(dr, witness.view().map(|w| w[2]))?;
+            let b2 = Element::zero(dr);
+
+            Ok(ThreeAOnlyElements {
+                a0,
+                b0,
+                a1,
+                b1,
+                a2,
+                b2,
+            })
+        }
+    }
+
+    #[test]
+    fn test_a_only_commitment_via_staging_mechanism() {
+        let pasta = Pasta::baked();
+        let generators = Pasta::host_generators(pasta);
+
+        let challenges = [Fp::from(42u64), Fp::from(123u64), Fp::from(456u64)];
+        let blind = Fp::ZERO;
+
+        // Use the actual staging mechanism to build rx.
+        let rx: structured::Polynomial<Fp, R> = AOnlyStage::rx(challenges).unwrap();
+        let poly_commitment: EqAffine = rx.commit(generators, blind);
+
+        // Build `StageObject` with matching parameters.
+        let skip = AOnlyStage::skip_multiplications(); // 0 for root stage
+        let num = <AOnlyStage as StageExt<Fp, R>>::num_multiplications(); // ceil(6/2) = 3
+        let stage_obj = StageObject::<R>::new(skip, num).unwrap();
+
+        // Manually compute expected commitment using generator_for_a_coefficient.
+        let mut manual_commitment = EqAffine::identity();
+        for (i, &challenge) in challenges.iter().enumerate() {
+            let a_gen = stage_obj.generator_for_a_coefficient(generators, i);
+            manual_commitment = (manual_commitment.to_curve() + a_gen * challenge).to_affine();
+        }
+
+        assert_eq!(
+            poly_commitment, manual_commitment,
+            "Commitment via staging mechanism should match manual computation"
+        );
+    }
 }

--- a/crates/ragu_circuits/src/staging/mod.rs
+++ b/crates/ragu_circuits/src/staging/mod.rs
@@ -132,7 +132,7 @@ use crate::{
 };
 
 pub use builder::{StageBuilder, StageGuard};
-pub use object::StageObject;
+pub use mask::StageMask as StageObject;
 
 /// Represents a partial trace component for a multi-stage circuit.
 pub trait Stage<F: Field, R: Rank> {

--- a/crates/ragu_circuits/src/staging/mod.rs
+++ b/crates/ragu_circuits/src/staging/mod.rs
@@ -132,6 +132,7 @@ use crate::{
 };
 
 pub use builder::{StageBuilder, StageGuard};
+pub use object::StageObject;
 
 /// Represents a partial trace component for a multi-stage circuit.
 pub trait Stage<F: Field, R: Rank> {

--- a/crates/ragu_pcd/src/circuits/native/compute_v.rs
+++ b/crates/ragu_pcd/src/circuits/native/compute_v.rs
@@ -276,6 +276,7 @@ struct InternalCircuitDenominators<'dr, D: Driver<'dr>> {
     partial_collapse_circuit: Element<'dr, D>,
     full_collapse_circuit: Element<'dr, D>,
     compute_v_circuit: Element<'dr, D>,
+    endoscale_challenges_circuit: Element<'dr, D>,
 }
 
 /// Denominator component of all quotient polynomial evaluations.
@@ -340,6 +341,7 @@ impl<'dr, D: Driver<'dr>> Denominators<'dr, D> {
         let partial_collapse_circuit = inverter.add_circuit(dr, PartialCollapseCircuit)?;
         let full_collapse_circuit = inverter.add_circuit(dr, FullCollapseCircuit)?;
         let compute_v_circuit = inverter.add_circuit(dr, ComputeVCircuit)?;
+        let endoscale_challenges_circuit = inverter.add_circuit(dr, EndoscaleChallengesCircuit)?;
 
         let inverted = inverter.invert(dr)?;
 
@@ -376,6 +378,7 @@ impl<'dr, D: Driver<'dr>> Denominators<'dr, D> {
                 partial_collapse_circuit: inverted[partial_collapse_circuit].clone(),
                 full_collapse_circuit: inverted[full_collapse_circuit].clone(),
                 compute_v_circuit: inverted[compute_v_circuit].clone(),
+                endoscale_challenges_circuit: inverted[endoscale_challenges_circuit].clone(),
             },
         })
     }
@@ -643,19 +646,20 @@ fn poly_queries<'a, 'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HE
     ].into_iter()
     // m(\omega^j, x, y) evaluations for each internal index j
     .chain([
-        (&query.fixed_registry.preamble_stage,           &d.internal.preamble_stage),
-        (&query.fixed_registry.error_n_stage,            &d.internal.error_n_stage),
-        (&query.fixed_registry.error_m_stage,            &d.internal.error_m_stage),
-        (&query.fixed_registry.query_stage,              &d.internal.query_stage),
-        (&query.fixed_registry.eval_stage,               &d.internal.eval_stage),
-        (&query.fixed_registry.error_m_final_staged,     &d.internal.error_m_final_staged),
-        (&query.fixed_registry.error_n_final_staged,     &d.internal.error_n_final_staged),
-        (&query.fixed_registry.eval_final_staged,        &d.internal.eval_final_staged),
-        (&query.fixed_registry.hashes_1_circuit,         &d.internal.hashes_1_circuit),
-        (&query.fixed_registry.hashes_2_circuit,         &d.internal.hashes_2_circuit),
-        (&query.fixed_registry.partial_collapse_circuit, &d.internal.partial_collapse_circuit),
-        (&query.fixed_registry.full_collapse_circuit,    &d.internal.full_collapse_circuit),
-        (&query.fixed_registry.compute_v_circuit,        &d.internal.compute_v_circuit),
+        (&query.fixed_registry.preamble_stage,                &d.internal.preamble_stage),
+        (&query.fixed_registry.error_n_stage,                 &d.internal.error_n_stage),
+        (&query.fixed_registry.error_m_stage,                 &d.internal.error_m_stage),
+        (&query.fixed_registry.query_stage,                   &d.internal.query_stage),
+        (&query.fixed_registry.eval_stage,                    &d.internal.eval_stage),
+        (&query.fixed_registry.error_m_final_staged,          &d.internal.error_m_final_staged),
+        (&query.fixed_registry.error_n_final_staged,          &d.internal.error_n_final_staged),
+        (&query.fixed_registry.eval_final_staged,             &d.internal.eval_final_staged),
+        (&query.fixed_registry.hashes_1_circuit,              &d.internal.hashes_1_circuit),
+        (&query.fixed_registry.hashes_2_circuit,              &d.internal.hashes_2_circuit),
+        (&query.fixed_registry.partial_collapse_circuit,      &d.internal.partial_collapse_circuit),
+        (&query.fixed_registry.full_collapse_circuit,         &d.internal.full_collapse_circuit),
+        (&query.fixed_registry.compute_v_circuit,             &d.internal.compute_v_circuit),
+        (&query.fixed_registry.endoscale_challenges_circuit,  &d.internal.endoscale_challenges_circuit),
     ].into_iter().map(|(v, denom)| (&eval.registry_xy, v, denom)))
     .chain([
         // m(circuit_id_i, x, y) evaluations for the ith child proof
@@ -678,17 +682,18 @@ fn poly_queries<'a, 'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HE
     .chain([(&eval.left, &query.left), (&eval.right, &query.right)]
         .into_iter()
         .flat_map(|(eval, query)| [
-            (&eval.preamble,         &query.preamble),
-            (&eval.error_n,          &query.error_n),
-            (&eval.error_m,          &query.error_m),
-            (&eval.query,            &query.query),
-            (&eval.eval,             &query.eval),
-            (&eval.application,      &query.application),
-            (&eval.hashes_1,         &query.hashes_1),
-            (&eval.hashes_2,         &query.hashes_2),
-            (&eval.partial_collapse, &query.partial_collapse),
-            (&eval.full_collapse,    &query.full_collapse),
-            (&eval.compute_v,        &query.compute_v),
+            (&eval.preamble,             &query.preamble),
+            (&eval.error_n,              &query.error_n),
+            (&eval.error_m,              &query.error_m),
+            (&eval.query,                &query.query),
+            (&eval.eval,                 &query.eval),
+            (&eval.application,          &query.application),
+            (&eval.hashes_1,             &query.hashes_1),
+            (&eval.hashes_2,             &query.hashes_2),
+            (&eval.partial_collapse,     &query.partial_collapse),
+            (&eval.full_collapse,        &query.full_collapse),
+            (&eval.compute_v,            &query.compute_v),
+            (&eval.endoscale_challenges, &query.endoscale_challenges),
         ].into_iter().map(|(e, q)| (e, q, &d.challenges.xz))))
 }
 

--- a/crates/ragu_pcd/src/circuits/native/compute_v.rs
+++ b/crates/ragu_pcd/src/circuits/native/compute_v.rs
@@ -411,6 +411,10 @@ impl<'a, 'dr, D: Driver<'dr>> Source for EvaluationSource<'a, 'dr, D> {
             PartialCollapse => (&self.left.partial_collapse, &self.right.partial_collapse),
             FullCollapse => (&self.left.full_collapse, &self.right.full_collapse),
             ComputeV => (&self.left.compute_v, &self.right.compute_v),
+            EndoscaleChallenges => (
+                &self.left.endoscale_challenges,
+                &self.right.endoscale_challenges,
+            ),
             Preamble => (&self.left.preamble, &self.right.preamble),
             ErrorM => (&self.left.error_m, &self.right.error_m),
             ErrorN => (&self.left.error_n, &self.right.error_n),

--- a/crates/ragu_pcd/src/circuits/native/endoscale_challenges.rs
+++ b/crates/ragu_pcd/src/circuits/native/endoscale_challenges.rs
@@ -1,0 +1,102 @@
+//! Circuit for extracting and verifying challenge endoscalars.
+
+use arithmetic::Cycle;
+use ragu_circuits::{
+    polynomials::Rank,
+    staging::{StageBuilder, Staged, StagedCircuit},
+};
+use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue},
+    gadgets::GadgetKind,
+    maybe::Maybe,
+};
+use ragu_primitives::Endoscalar;
+
+use core::marker::PhantomData;
+
+use super::stages::{error_n as native_error_n, preamble as native_preamble};
+use super::unified::{self, OutputBuilder};
+use crate::components::fold_revdot;
+
+pub(crate) use super::InternalCircuitIndex::EndoscaleChallengesCircuit as CIRCUIT_ID;
+
+/// Circuit that extracts and verifies challenge endoscalars.
+pub struct Circuit<C: Cycle, R, const HEADER_SIZE: usize, FP> {
+    _marker: PhantomData<(C, R, FP)>,
+}
+
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
+    Circuit<C, R, HEADER_SIZE, FP>
+{
+    pub fn new() -> Staged<C::CircuitField, R, Self> {
+        Staged::new(Circuit {
+            _marker: PhantomData,
+        })
+    }
+}
+
+/// Witness for the endoscale_challenges circuit.
+pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters> {
+    pub unified_instance: &'a unified::Instance<C>,
+    pub preamble_witness: &'a native_preamble::Witness<'a, C, R, HEADER_SIZE>,
+    pub error_n_witness: &'a native_error_n::Witness<C, FP>,
+}
+
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
+    StagedCircuit<C::CircuitField, R> for Circuit<C, R, HEADER_SIZE, FP>
+{
+    type Final = native_error_n::Stage<C, R, HEADER_SIZE, FP>;
+
+    type Instance<'source> = &'source unified::Instance<C>;
+    type Witness<'source> = Witness<'source, C, R, HEADER_SIZE, FP>;
+    type Output = unified::InternalOutputKind<C>;
+    type Aux<'source> = ();
+
+    fn instance<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>>(
+        &self,
+        _: &mut D,
+        _: DriverValue<D, Self::Instance<'source>>,
+    ) -> Result<<Self::Output as GadgetKind<C::CircuitField>>::Rebind<'dr, D>>
+    where
+        Self: 'dr,
+    {
+        unreachable!("instance for internal circuits is not invoked")
+    }
+
+    fn witness<'a, 'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>>(
+        &self,
+        builder: StageBuilder<'a, 'dr, D, R, (), Self::Final>,
+        witness: DriverValue<D, Self::Witness<'source>>,
+    ) -> Result<(
+        <Self::Output as GadgetKind<C::CircuitField>>::Rebind<'dr, D>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let (preamble, builder) =
+            builder.add_stage::<native_preamble::Stage<C, R, HEADER_SIZE>>()?;
+        let (error_n, builder) =
+            builder.add_stage::<native_error_n::Stage<C, R, HEADER_SIZE, FP>>()?;
+        let dr = builder.finish();
+
+        let _preamble = preamble.unenforced(dr, witness.view().map(|w| w.preamble_witness))?;
+        let _error_n = error_n.unenforced(dr, witness.view().map(|w| w.error_n_witness))?;
+
+        let unified_instance = &witness.view().map(|w| w.unified_instance);
+        let mut unified_output = OutputBuilder::new();
+
+        // Retrieve y and z challenges from the unified instance (more challenges added later).
+        let y = unified_output.y.get(dr, unified_instance)?;
+        let z = unified_output.z.get(dr, unified_instance)?;
+
+        let y_endo = Endoscalar::extract(dr, y)?;
+        let z_endo = Endoscalar::extract(dr, z)?;
+
+        let _y_coeff = y_endo.field_scale(dr)?;
+        let _z_coeff = z_endo.field_scale(dr)?;
+
+        Ok((unified_output.finish(dr, unified_instance)?, D::just(|| ())))
+    }
+}

--- a/crates/ragu_pcd/src/circuits/native/endoscale_challenges.rs
+++ b/crates/ragu_pcd/src/circuits/native/endoscale_challenges.rs
@@ -8,7 +8,7 @@ use ragu_circuits::{
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::{Gadget, GadgetKind, Kind},
+    gadgets::{Bound, Gadget, Kind},
     maybe::Maybe,
 };
 use ragu_primitives::{Element, Endoscalar, io::Write};
@@ -92,7 +92,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         &self,
         _: &mut D,
         _: DriverValue<D, Self::Instance<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<C::CircuitField>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::Output>>
     where
         Self: 'dr,
     {
@@ -104,7 +104,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         builder: StageBuilder<'a, 'dr, D, R, (), Self::Last>,
         witness: DriverValue<D, Self::Witness<'source>>,
     ) -> Result<(
-        <Self::Output as GadgetKind<C::CircuitField>>::Rebind<'dr, D>,
+        Bound<'dr, D, Self::Output>,
         DriverValue<D, Self::Aux<'source>>,
     )>
     where

--- a/crates/ragu_pcd/src/circuits/native/endoscale_challenges.rs
+++ b/crates/ragu_pcd/src/circuits/native/endoscale_challenges.rs
@@ -1,9 +1,9 @@
 //! Circuit for extracting and verifying challenge endoscalars.
 
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::Rank,
-    staging::{StageBuilder, Staged, StagedCircuit},
+    staging::{MultiStage, MultiStageCircuit, StageBuilder},
 };
 use ragu_core::{
     Result,
@@ -47,7 +47,7 @@ pub struct SmuggledChallenges<'dr, D: Driver<'dr>> {
 ///
 /// Combines the unified instance with smuggled challenge coefficients.
 #[derive(Gadget, Write)]
-pub struct Output<'dr, D: Driver<'dr>, C: Cycle> {
+pub struct Output<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>> {
     /// The unified instance shared across internal circuits.
     #[ragu(gadget)]
     pub unified: unified::Output<'dr, D, C>,
@@ -64,8 +64,8 @@ pub struct Circuit<C: Cycle, R, const HEADER_SIZE: usize, FP> {
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
     Circuit<C, R, HEADER_SIZE, FP>
 {
-    pub fn new() -> Staged<C::CircuitField, R, Self> {
-        Staged::new(Circuit {
+    pub fn new() -> MultiStage<C::CircuitField, R, Self> {
+        MultiStage::new(Circuit {
             _marker: PhantomData,
         })
     }
@@ -79,9 +79,9 @@ pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_rev
 }
 
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    StagedCircuit<C::CircuitField, R> for Circuit<C, R, HEADER_SIZE, FP>
+    MultiStageCircuit<C::CircuitField, R> for Circuit<C, R, HEADER_SIZE, FP>
 {
-    type Final = native_error_n::Stage<C, R, HEADER_SIZE, FP>;
+    type Last = native_error_n::Stage<C, R, HEADER_SIZE, FP>;
 
     type Instance<'source> = &'source unified::Instance<C>;
     type Witness<'source> = Witness<'source, C, R, HEADER_SIZE, FP>;
@@ -101,7 +101,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
 
     fn witness<'a, 'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>>(
         &self,
-        builder: StageBuilder<'a, 'dr, D, R, (), Self::Final>,
+        builder: StageBuilder<'a, 'dr, D, R, (), Self::Last>,
         witness: DriverValue<D, Self::Witness<'source>>,
     ) -> Result<(
         <Self::Output as GadgetKind<C::CircuitField>>::Rebind<'dr, D>,
@@ -129,8 +129,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         // Extract endoscalars from challenges and compute their field-scaled values.
         let y_endo = Endoscalar::extract(dr, y)?;
         let z_endo = Endoscalar::extract(dr, z)?;
-        let y_coeff = y_endo.field_scale(dr)?;
-        let z_coeff = z_endo.field_scale(dr)?;
+        let y_coeff = y_endo.lift(dr)?;
+        let z_coeff = z_endo.lift(dr)?;
 
         // Create zero elements for b-positions.
         // This ensures coefficients land in a-positions when rx is built.

--- a/crates/ragu_pcd/src/circuits/native/mod.rs
+++ b/crates/ragu_pcd/src/circuits/native/mod.rs
@@ -13,6 +13,7 @@ use crate::step;
 pub mod stages;
 
 pub(crate) mod compute_v;
+pub(crate) mod endoscale_challenges;
 pub(crate) mod full_collapse;
 pub(crate) mod hashes_1;
 pub(crate) mod hashes_2;
@@ -38,11 +39,12 @@ pub(crate) enum InternalCircuitIndex {
     PartialCollapseCircuit = 10,
     FullCollapseCircuit = 11,
     ComputeVCircuit = 12,
+    EndoscaleChallengesCircuit = 13,
 }
 
-/// The number of internal circuits registered by [`register_all`],
-/// equal to the number of variants in [`InternalCircuitIndex`].
-pub(crate) const NUM_INTERNAL_CIRCUITS: usize = 13;
+/// The number of internal circuits registered by [`register_all`] and
+/// [`super::nested::register_all`], and the number of variants in [`InternalCircuitIndex`].
+pub(crate) const NUM_INTERNAL_CIRCUITS: usize = 14;
 
 /// Compute the total circuit count and log2 domain size from the number of
 /// application-defined steps.
@@ -157,6 +159,14 @@ pub(crate) fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
         // compute_v
         registry =
             registry.register_internal_circuit(compute_v::Circuit::<C, R, HEADER_SIZE>::new())?;
+
+        // endoscale_challenges
+        registry = registry.register_internal_circuit(endoscale_challenges::Circuit::<
+            C,
+            R,
+            HEADER_SIZE,
+            NativeParameters,
+        >::new())?;
     }
 
     // Verify we registered the expected number of internal circuits.

--- a/crates/ragu_pcd/src/circuits/native/partial_collapse.rs
+++ b/crates/ragu_pcd/src/circuits/native/partial_collapse.rs
@@ -177,6 +177,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
             right_bridge: error_n.right.unified_bridge.clone(),
             left_unified: error_n.left.unified.clone(),
             right_unified: error_n.right.unified.clone(),
+            left_endoscale: error_n.left.endoscale.clone(),
+            right_endoscale: error_n.right.endoscale.clone(),
             zero: Element::zero(dr),
         };
         let mut ky = ky_values(&ky);

--- a/crates/ragu_pcd/src/circuits/native/stages/error_n.rs
+++ b/crates/ragu_pcd/src/circuits/native/stages/error_n.rs
@@ -30,6 +30,8 @@ pub struct ChildKyValues<F> {
     pub unified: F,
     /// k(y) for the header-unified binding.
     pub unified_bridge: F,
+    /// k(y) for the endoscale_challenges circuit.
+    pub endoscale: F,
 }
 
 /// $k(Y)$ evaluation values computed during fuse operation.
@@ -74,6 +76,9 @@ pub struct ChildKyOutputs<'dr, D: Driver<'dr>> {
     /// k(y) for the header-unified binding.
     #[ragu(gadget)]
     pub unified_bridge: Element<'dr, D>,
+    /// k(y) for the endoscale_challenges circuit.
+    #[ragu(gadget)]
+    pub endoscale: Element<'dr, D>,
 }
 
 /// Prover-internal output gadget for the error_n stage.
@@ -118,10 +123,10 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
     type OutputKind = Kind![C::CircuitField; Output<'_, _, FP, C::CircuitPoseidon>];
 
     fn values() -> usize {
-        // N² - N error terms + N collapsed values + 6 ky values + sponge state elements
+        // N² - N error terms + N collapsed values + 8 ky values + sponge state elements
         ErrorTermsLen::<FP::N>::len()
             + FP::N::len()
-            + 6
+            + 8
             + PoseidonStateLen::<C::CircuitField, C::CircuitPoseidon>::len()
     }
 
@@ -143,11 +148,13 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
             application: Element::alloc(dr, witness.view().map(|w| w.ky.left.application))?,
             unified: Element::alloc(dr, witness.view().map(|w| w.ky.left.unified))?,
             unified_bridge: Element::alloc(dr, witness.view().map(|w| w.ky.left.unified_bridge))?,
+            endoscale: Element::alloc(dr, witness.view().map(|w| w.ky.left.endoscale))?,
         };
         let right = ChildKyOutputs {
             application: Element::alloc(dr, witness.view().map(|w| w.ky.right.application))?,
             unified: Element::alloc(dr, witness.view().map(|w| w.ky.right.unified))?,
             unified_bridge: Element::alloc(dr, witness.view().map(|w| w.ky.right.unified_bridge))?,
+            endoscale: Element::alloc(dr, witness.view().map(|w| w.ky.right.endoscale))?,
         };
         let sponge_state = SpongeState::from_elements(FixedVec::try_from_fn(|i| {
             Element::alloc(dr, witness.view().map(|w| w.sponge_state_elements[i]))

--- a/crates/ragu_pcd/src/circuits/native/stages/eval.rs
+++ b/crates/ragu_pcd/src/circuits/native/stages/eval.rs
@@ -35,6 +35,7 @@ pub struct ChildEvaluationsWitness<F> {
     pub partial_collapse: F,
     pub full_collapse: F,
     pub compute_v: F,
+    pub endoscale_challenges: F,
 }
 
 impl<F: PrimeField> ChildEvaluationsWitness<F> {
@@ -56,6 +57,7 @@ impl<F: PrimeField> ChildEvaluationsWitness<F> {
             partial_collapse: proof.circuits.partial_collapse_rx.eval(u),
             full_collapse: proof.circuits.full_collapse_rx.eval(u),
             compute_v: proof.circuits.compute_v_rx.eval(u),
+            endoscale_challenges: proof.circuits.endoscale_challenges_rx.eval(u),
         }
     }
 }
@@ -116,6 +118,8 @@ pub struct ChildEvaluations<'dr, D: Driver<'dr>> {
     pub full_collapse: Element<'dr, D>,
     #[ragu(gadget)]
     pub compute_v: Element<'dr, D>,
+    #[ragu(gadget)]
+    pub endoscale_challenges: Element<'dr, D>,
 }
 
 impl<'dr, D: Driver<'dr>> ChildEvaluations<'dr, D> {
@@ -140,6 +144,10 @@ impl<'dr, D: Driver<'dr>> ChildEvaluations<'dr, D> {
             partial_collapse: Element::alloc(dr, witness.view().map(|w| w.partial_collapse))?,
             full_collapse: Element::alloc(dr, witness.view().map(|w| w.full_collapse))?,
             compute_v: Element::alloc(dr, witness.view().map(|w| w.compute_v))?,
+            endoscale_challenges: Element::alloc(
+                dr,
+                witness.view().map(|w| w.endoscale_challenges),
+            )?,
         })
     }
 }
@@ -181,8 +189,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> staging::Stage<C::CircuitField
     type OutputKind = Kind![C::CircuitField; Output<'_, _>];
 
     fn values() -> usize {
-        // 2 * ChildEvaluations (15 each) + current step elements (6)
-        2 * 15 + 6
+        // 2 * ChildEvaluations (16 each) + current step elements (6)
+        2 * 16 + 6
     }
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>>(

--- a/crates/ragu_pcd/src/circuits/native/stages/preamble.rs
+++ b/crates/ragu_pcd/src/circuits/native/stages/preamble.rs
@@ -151,15 +151,15 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usiz
     where
         D::F: ff::WithSmallOrderMulGroup<3>,
     {
-        use ragu_primitives::{compute_endoscalar, extract_endoscalar};
+        use ragu_primitives::{extract_endoscalar, lift_endoscalar};
 
         // Get the y and z challenges from the unified instance
         let challenge_y = *self.unified.y.value().take();
         let challenge_z = *self.unified.z.value().take();
 
         // Compute field-scaled endoscalars (same as what the circuit does)
-        let y_coeff: D::F = compute_endoscalar(extract_endoscalar(challenge_y));
-        let z_coeff: D::F = compute_endoscalar(extract_endoscalar(challenge_z));
+        let y_coeff: D::F = lift_endoscalar(extract_endoscalar(challenge_y));
+        let z_coeff: D::F = lift_endoscalar(extract_endoscalar(challenge_z));
 
         // Build k(y) for (unified, y_coeff, 0, z_coeff, 0, suffix=0)
         let mut ky = Ky::new(y);

--- a/crates/ragu_pcd/src/circuits/nested/mod.rs
+++ b/crates/ragu_pcd/src/circuits/nested/mod.rs
@@ -18,13 +18,13 @@ use crate::components::endoscalar::{EndoscalarStage, EndoscalingStep, NumStepsLe
 /// endoscaling verification.
 ///
 /// This is the sum of:
-/// - 2 proofs × 15 commitment components = 30
+/// - 2 proofs × 16 commitment components = 32
 /// - 6 stage proof components (registry_wx0, registry_wx1, registry_wy, ab.a, ab.b, registry_xy)
 /// - 1 f.commitment (base polynomial)
 ///
-/// The endoscaling circuits process these 37 points across
+/// The endoscaling circuits process these 39 points across
 /// `NumStepsLen::<NUM_ENDOSCALING_POINTS>::len()` = 9 steps.
-pub(crate) const NUM_ENDOSCALING_POINTS: usize = 37;
+pub(crate) const NUM_ENDOSCALING_POINTS: usize = 39;
 
 /// Index of internal nested circuits registered into the registry.
 ///

--- a/crates/ragu_pcd/src/circuits/nested/mod.rs
+++ b/crates/ragu_pcd/src/circuits/nested/mod.rs
@@ -12,7 +12,9 @@ use ragu_circuits::{
 use ragu_core::Result;
 use ragu_primitives::vec::Len;
 
-use crate::components::endoscalar::{EndoscalarStage, EndoscalingStep, NumStepsLen, PointsStage};
+use crate::components::endoscalar::{
+    EndoscalarStage, EndoscalingStep, NumStepsLen, PointsStage, SmuggledChallengesStage,
+};
 
 /// Number of curve points accumulated during `compute_p` for nested field
 /// endoscaling verification.
@@ -37,6 +39,8 @@ pub(crate) enum InternalCircuitIndex {
     PointsStage,
     /// `PointsStage` final staged mask.
     PointsFinalStaged,
+    /// `SmuggledChallengesStage` stage mask for challenge coefficients.
+    SmuggledChallengesStage,
     /// `EndoscalingStep` circuit at given step.
     EndoscalingStep(u32),
 }
@@ -48,7 +52,8 @@ impl InternalCircuitIndex {
             Self::EndoscalarStage => CircuitIndex::from_u32(0),
             Self::PointsStage => CircuitIndex::from_u32(1),
             Self::PointsFinalStaged => CircuitIndex::from_u32(2),
-            Self::EndoscalingStep(step) => CircuitIndex::from_u32(3 + step),
+            Self::SmuggledChallengesStage => CircuitIndex::from_u32(3),
+            Self::EndoscalingStep(step) => CircuitIndex::from_u32(4 + step),
         }
     }
 }
@@ -69,6 +74,10 @@ pub(crate) fn register_all<'params, C: Cycle, R: Rank>(
 
     registry = registry
         .register_internal_final_mask::<PointsStage<C::HostCurve, NUM_ENDOSCALING_POINTS>>()?;
+
+    registry = registry
+        .register_internal_mask::<SmuggledChallengesStage<C::HostCurve, NUM_ENDOSCALING_POINTS>>(
+        )?;
 
     let num_steps = NumStepsLen::<NUM_ENDOSCALING_POINTS>::len();
     for step in 0..num_steps {

--- a/crates/ragu_pcd/src/circuits/tests.rs
+++ b/crates/ragu_pcd/src/circuits/tests.rs
@@ -62,11 +62,12 @@ fn test_internal_circuit_constraint_counts() {
         }};
     }
 
-    check_constraints!(Hashes1Circuit,         mul = 2045, lin = 3423);
-    check_constraints!(Hashes2Circuit,         mul = 1879, lin = 2952);
-    check_constraints!(PartialCollapseCircuit, mul = 1756, lin = 1919);
-    check_constraints!(FullCollapseCircuit,    mul = 811 , lin = 809);
-    check_constraints!(ComputeVCircuit,        mul = 1140, lin = 1774);
+    check_constraints!(Hashes1Circuit,              mul = 2045, lin = 3423);
+    check_constraints!(Hashes2Circuit,              mul = 1879, lin = 2952);
+    check_constraints!(PartialCollapseCircuit,      mul = 1756, lin = 1919);
+    check_constraints!(FullCollapseCircuit,         mul = 811 , lin = 809);
+    check_constraints!(ComputeVCircuit,             mul = 1140, lin = 1774);
+    check_constraints!(EndoscaleChallengesCircuit,  mul = 1339, lin = 1864);
 }
 
 #[rustfmt::skip]
@@ -82,8 +83,8 @@ fn test_internal_stage_parameters() {
     check_stage!(Preamble, skip =   0, num = 225);
     check_stage!(ErrorN,  skip = 225, num = 186);
     check_stage!(ErrorM,  skip = 411, num = 399);
-    check_stage!(Query,   skip = 225, num =  23);
-    check_stage!(Eval,    skip = 248, num =  18);
+    check_stage!(Query,   skip = 225, num =  37);
+    check_stage!(Eval,    skip = 262, num =  19);
 }
 
 /// Helper test to print current constraint counts in copy-pasteable format.
@@ -112,6 +113,10 @@ fn print_internal_circuit_constraint_counts() {
             InternalCircuitIndex::FullCollapseCircuit,
         ),
         ("ComputeVCircuit", InternalCircuitIndex::ComputeVCircuit),
+        (
+            "EndoscaleChallengesCircuit",
+            InternalCircuitIndex::EndoscaleChallengesCircuit,
+        ),
     ];
 
     println!("\n// Copy-paste the following into test_internal_circuit_constraint_counts:");

--- a/crates/ragu_pcd/src/circuits/tests.rs
+++ b/crates/ragu_pcd/src/circuits/tests.rs
@@ -62,12 +62,12 @@ fn test_internal_circuit_constraint_counts() {
         }};
     }
 
-    check_constraints!(Hashes1Circuit,              mul = 2045, lin = 3423);
-    check_constraints!(Hashes2Circuit,              mul = 1879, lin = 2952);
-    check_constraints!(PartialCollapseCircuit,      mul = 1756, lin = 1919);
-    check_constraints!(FullCollapseCircuit,         mul = 811 , lin = 809);
-    check_constraints!(ComputeVCircuit,             mul = 1140, lin = 1774);
-    check_constraints!(EndoscaleChallengesCircuit,  mul = 1339, lin = 1864);
+    check_constraints!(Hashes1Circuit,              mul = 2046, lin = 3423);
+    check_constraints!(Hashes2Circuit,              mul = 1880, lin = 2952);
+    check_constraints!(PartialCollapseCircuit,      mul = 1757, lin = 1919);
+    check_constraints!(FullCollapseCircuit,         mul = 812 , lin = 809);
+    check_constraints!(ComputeVCircuit,             mul = 1423, lin = 2310);
+    check_constraints!(EndoscaleChallengesCircuit,  mul = 1340, lin = 1868);
 }
 
 #[rustfmt::skip]
@@ -81,8 +81,8 @@ fn test_internal_stage_parameters() {
     }
 
     check_stage!(Preamble, skip =   0, num = 225);
-    check_stage!(ErrorN,  skip = 225, num = 186);
-    check_stage!(ErrorM,  skip = 411, num = 399);
+    check_stage!(ErrorN,  skip = 225, num = 187);
+    check_stage!(ErrorM,  skip = 412, num = 399);
     check_stage!(Query,   skip = 225, num =  37);
     check_stage!(Eval,    skip = 262, num =  19);
 }

--- a/crates/ragu_pcd/src/circuits/tests.rs
+++ b/crates/ragu_pcd/src/circuits/tests.rs
@@ -66,7 +66,7 @@ fn test_internal_circuit_constraint_counts() {
     check_constraints!(Hashes2Circuit,              mul = 1880, lin = 2952);
     check_constraints!(PartialCollapseCircuit,      mul = 1757, lin = 1919);
     check_constraints!(FullCollapseCircuit,         mul = 812 , lin = 809);
-    check_constraints!(ComputeVCircuit,             mul = 1423, lin = 2310);
+    check_constraints!(ComputeVCircuit,             mul = 1154, lin = 1796);
     check_constraints!(EndoscaleChallengesCircuit,  mul = 1340, lin = 1868);
 }
 
@@ -83,8 +83,8 @@ fn test_internal_stage_parameters() {
     check_stage!(Preamble, skip =   0, num = 225);
     check_stage!(ErrorN,  skip = 225, num = 187);
     check_stage!(ErrorM,  skip = 412, num = 399);
-    check_stage!(Query,   skip = 225, num =  37);
-    check_stage!(Eval,    skip = 262, num =  19);
+    check_stage!(Query,   skip = 225, num =  25);
+    check_stage!(Eval,    skip = 250, num =  19);
 }
 
 /// Helper test to print current constraint counts in copy-pasteable format.
@@ -173,7 +173,7 @@ fn test_native_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fp!(0x3fa421a73ff73957cc8c40c4184c576f0e28e2cf88a4281b9f28fad818ad9726);
+    let expected = fp!(0x2bd7ef37cbcfbc760f4e580006521472c09742e1428124d54fa9c0ffa3843226);
 
     assert_eq!(
         app.native_registry.digest(),
@@ -197,7 +197,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x245758c98f3c46ca03bfafe1bb50c38d0dcaed48231fd7547f40e3b208e67729);
+    let expected = fq!(0x02f14d2b48a6b85648cfa1a65f015210ffe5b38101aa683f88d41fdc2b00ae86);
 
     assert_eq!(
         app.nested_registry.digest(),

--- a/crates/ragu_pcd/src/circuits/tests.rs
+++ b/crates/ragu_pcd/src/circuits/tests.rs
@@ -197,7 +197,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x02f14d2b48a6b85648cfa1a65f015210ffe5b38101aa683f88d41fdc2b00ae86);
+    let expected = fq!(0x3aa486336fb98d485f8b6c15750ecc2f2ec79fbe1ebf82b49cccedd10740edea);
 
     assert_eq!(
         app.nested_registry.digest(),

--- a/crates/ragu_pcd/src/components/claims/nested.rs
+++ b/crates/ragu_pcd/src/components/claims/nested.rs
@@ -21,6 +21,8 @@ pub enum RxComponent {
     EndoscalarStage,
     /// PointsStage rx polynomial.
     PointsStage,
+    /// SmuggledChallengesStage rx polynomial.
+    SmuggledChallengesStage,
     /// EndoscalingStep circuit rx polynomial (indexed by step number).
     EndoscalingStep(u32),
 }
@@ -104,6 +106,12 @@ where
 
     // PointsStage (index 1)
     processor.stage(InternalCircuitIndex::PointsStage, source.rx(PointsStage))?;
+
+    // SmuggledChallengesStage (index 3)
+    processor.stage(
+        InternalCircuitIndex::SmuggledChallengesStage,
+        source.rx(SmuggledChallengesStage),
+    )?;
 
     // PointsFinalStaged (index 2) - final stage check
     // Aggregates all EndoscalingStep rxs from all proofs

--- a/crates/ragu_pcd/src/fuse/_05_error_n.rs
+++ b/crates/ragu_pcd/src/fuse/_05_error_n.rs
@@ -83,6 +83,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                     preamble.left.unified_ky_values(dr, &y)?;
                 let (right_unified_ky, right_unified_bridge_ky) =
                     preamble.right.unified_ky_values(dr, &y)?;
+                let left_endoscale_ky = preamble.left.endoscale_ky(dr, &y)?;
+                let right_endoscale_ky = preamble.right.endoscale_ky(dr, &y)?;
 
                 let mu = Element::alloc(dr, mu)?;
                 let nu = Element::alloc(dr, nu)?;
@@ -97,6 +99,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                     right_bridge: right_unified_bridge_ky.clone(),
                     left_unified: left_unified_ky.clone(),
                     right_unified: right_unified_ky.clone(),
+                    left_endoscale: left_endoscale_ky.clone(),
+                    right_endoscale: right_endoscale_ky.clone(),
                     zero: Element::zero(dr),
                 };
                 let mut ky = claims::native::ky_values(&ky);
@@ -118,11 +122,13 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                         application: *left_application_ky.value().take(),
                         unified: *left_unified_ky.value().take(),
                         unified_bridge: *left_unified_bridge_ky.value().take(),
+                        endoscale: *left_endoscale_ky.value().take(),
                     },
                     right: ChildKyValues {
                         application: *right_application_ky.value().take(),
                         unified: *right_unified_ky.value().take(),
                         unified_bridge: *right_unified_bridge_ky.value().take(),
+                        endoscale: *right_endoscale_ky.value().take(),
                     },
                 };
 

--- a/crates/ragu_pcd/src/fuse/_07_query.rs
+++ b/crates/ragu_pcd/src/fuse/_07_query.rs
@@ -78,6 +78,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                 partial_collapse_circuit: registry_at(PartialCollapseCircuit),
                 full_collapse_circuit: registry_at(FullCollapseCircuit),
                 compute_v_circuit: registry_at(ComputeVCircuit),
+                endoscale_challenges_circuit: registry_at(EndoscaleChallengesCircuit),
             },
             registry_wxy: registry_xy_poly.eval(w),
             left: query::ChildEvaluationsWitness::from_proof(

--- a/crates/ragu_pcd/src/fuse/_08_f.rs
+++ b/crates/ragu_pcd/src/fuse/_08_f.rs
@@ -115,6 +115,10 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             ),
             factor_iter(
                 query.registry_xy_poly.iter_coeffs(),
+                omega_j(EndoscaleChallengesCircuit),
+            ),
+            factor_iter(
+                query.registry_xy_poly.iter_coeffs(),
                 left.application.circuit_id.omega_j(),
             ),
             factor_iter(
@@ -142,6 +146,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             factor_iter(left.circuits.partial_collapse_rx.iter_coeffs(), xz),
             factor_iter(left.circuits.full_collapse_rx.iter_coeffs(), xz),
             factor_iter(left.circuits.compute_v_rx.iter_coeffs(), xz),
+            factor_iter(left.circuits.endoscale_challenges_rx.iter_coeffs(), xz),
             factor_iter(right.preamble.native_rx.iter_coeffs(), xz),
             factor_iter(right.error_n.native_rx.iter_coeffs(), xz),
             factor_iter(right.error_m.native_rx.iter_coeffs(), xz),
@@ -153,6 +158,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             factor_iter(right.circuits.partial_collapse_rx.iter_coeffs(), xz),
             factor_iter(right.circuits.full_collapse_rx.iter_coeffs(), xz),
             factor_iter(right.circuits.compute_v_rx.iter_coeffs(), xz),
+            factor_iter(right.circuits.endoscale_challenges_rx.iter_coeffs(), xz),
         ];
 
         let mut coeffs = Vec::new();

--- a/crates/ragu_pcd/src/fuse/_10_p.rs
+++ b/crates/ragu_pcd/src/fuse/_10_p.rs
@@ -156,6 +156,11 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                     proof.circuits.compute_v_blind,
                     proof.circuits.compute_v_commitment,
                 );
+                acc.acc(
+                    &proof.circuits.endoscale_challenges_rx,
+                    proof.circuits.endoscale_challenges_blind,
+                    proof.circuits.endoscale_challenges_commitment,
+                );
             }
 
             acc.acc(

--- a/crates/ragu_pcd/src/fuse/_11_circuits.rs
+++ b/crates/ragu_pcd/src/fuse/_11_circuits.rs
@@ -137,6 +137,22 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         let compute_v_rx_commitment =
             compute_v_rx.commit(C::host_generators(self.params), compute_v_rx_blind);
 
+        let (endoscale_challenges_rx, _) =
+            native::endoscale_challenges::Circuit::<C, R, HEADER_SIZE, NativeParameters>::new()
+                .rx::<R>(
+                    native::endoscale_challenges::Witness {
+                        unified_instance,
+                        preamble_witness,
+                        error_n_witness,
+                    },
+                    self.native_mesh.get_key(),
+                )?;
+        let endoscale_challenges_rx_blind = C::CircuitField::random(&mut *rng);
+        let endoscale_challenges_rx_commitment = endoscale_challenges_rx.commit(
+            C::host_generators(self.params),
+            endoscale_challenges_rx_blind,
+        );
+
         Ok(proof::InternalCircuits {
             hashes_1_rx,
             hashes_1_blind: hashes_1_rx_blind,
@@ -153,6 +169,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             compute_v_rx,
             compute_v_blind: compute_v_rx_blind,
             compute_v_commitment: compute_v_rx_commitment,
+            endoscale_challenges_rx,
+            endoscale_challenges_blind: endoscale_challenges_rx_blind,
+            endoscale_challenges_commitment: endoscale_challenges_rx_commitment,
         })
     }
 }

--- a/crates/ragu_pcd/src/fuse/_11_circuits.rs
+++ b/crates/ragu_pcd/src/fuse/_11_circuits.rs
@@ -137,16 +137,17 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         let compute_v_rx_commitment =
             compute_v_rx.commit(C::host_generators(self.params), compute_v_rx_blind);
 
-        let (endoscale_challenges_rx, _) =
+        let (endoscale_challenges_trace, _) =
             native::endoscale_challenges::Circuit::<C, R, HEADER_SIZE, NativeParameters>::new()
-                .rx::<R>(
-                    native::endoscale_challenges::Witness {
-                        unified_instance,
-                        preamble_witness,
-                        error_n_witness,
-                    },
-                    self.native_mesh.get_key(),
-                )?;
+                .rx(native::endoscale_challenges::Witness {
+                    unified_instance,
+                    preamble_witness,
+                    error_n_witness,
+                })?;
+        let endoscale_challenges_rx = self.native_registry.assemble(
+            &endoscale_challenges_trace,
+            native::endoscale_challenges::CIRCUIT_ID.circuit_index(),
+        )?;
         let endoscale_challenges_rx_blind = C::CircuitField::random(&mut *rng);
         let endoscale_challenges_rx_commitment = endoscale_challenges_rx.commit(
             C::host_generators(self.params),

--- a/crates/ragu_pcd/src/fuse/mod.rs
+++ b/crates/ragu_pcd/src/fuse/mod.rs
@@ -125,7 +125,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         let pre_beta = transcript.squeeze(&mut dr)?;
 
         let p = self.compute_p(
-            &pre_beta, &u, &left, &right, &s_prime, &error_m, &ab, &query, &f,
+            &y, &z, &pre_beta, &u, &left, &right, &s_prime, &error_m, &ab, &query, &f,
         )?;
 
         let challenges = proof::Challenges::new(

--- a/crates/ragu_pcd/src/fuse/mod.rs
+++ b/crates/ragu_pcd/src/fuse/mod.rs
@@ -207,6 +207,10 @@ impl<'rx, C: Cycle, R: Rank> Source for FuseProofSource<'rx, C, R> {
                 &self.left.circuits.compute_v_rx,
                 &self.right.circuits.compute_v_rx,
             ),
+            EndoscaleChallenges => (
+                &self.left.circuits.endoscale_challenges_rx,
+                &self.right.circuits.endoscale_challenges_rx,
+            ),
             Preamble => (
                 &self.left.preamble.native_rx,
                 &self.right.preamble.native_rx,

--- a/crates/ragu_pcd/src/proof/components.rs
+++ b/crates/ragu_pcd/src/proof/components.rs
@@ -210,4 +210,7 @@ pub(crate) struct InternalCircuits<C: Cycle, R: Rank> {
     pub(crate) compute_v_rx: structured::Polynomial<C::CircuitField, R>,
     pub(crate) compute_v_blind: C::CircuitField,
     pub(crate) compute_v_commitment: C::HostCurve,
+    pub(crate) endoscale_challenges_rx: structured::Polynomial<C::CircuitField, R>,
+    pub(crate) endoscale_challenges_blind: C::CircuitField,
+    pub(crate) endoscale_challenges_commitment: C::HostCurve,
 }

--- a/crates/ragu_pcd/src/proof/components.rs
+++ b/crates/ragu_pcd/src/proof/components.rs
@@ -125,6 +125,7 @@ pub(crate) struct P<C: Cycle, R: Rank> {
     pub(crate) v: C::CircuitField,
     pub(crate) endoscalar_rx: structured::Polynomial<C::ScalarField, R>,
     pub(crate) points_rx: structured::Polynomial<C::ScalarField, R>,
+    pub(crate) smuggled_challenges_rx: structured::Polynomial<C::ScalarField, R>,
     pub(crate) step_rxs: Vec<structured::Polynomial<C::ScalarField, R>>,
 }
 

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -196,9 +196,12 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
                 full_collapse_rx: zero_structured_host.clone(),
                 full_collapse_blind: host_blind,
                 full_collapse_commitment: host_commitment,
-                compute_v_rx: zero_structured_host,
+                compute_v_rx: zero_structured_host.clone(),
                 compute_v_blind: host_blind,
                 compute_v_commitment: host_commitment,
+                endoscale_challenges_rx: zero_structured_host,
+                endoscale_challenges_blind: host_blind,
+                endoscale_challenges_commitment: host_commitment,
             },
         }
     }

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -177,6 +177,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
                 v: C::CircuitField::ZERO,
                 endoscalar_rx: zero_structured_nested.clone(),
                 points_rx: zero_structured_nested.clone(),
+                smuggled_challenges_rx: zero_structured_nested.clone(),
                 step_rxs: vec![
                     zero_structured_nested.clone();
                     NumStepsLen::<NUM_ENDOSCALING_POINTS>::len()

--- a/crates/ragu_pcd/src/verify.rs
+++ b/crates/ragu_pcd/src/verify.rs
@@ -159,6 +159,7 @@ mod native {
                 PartialCollapse => &self.proof.circuits.partial_collapse_rx,
                 FullCollapse => &self.proof.circuits.full_collapse_rx,
                 ComputeV => &self.proof.circuits.compute_v_rx,
+                EndoscaleChallenges => &self.proof.circuits.endoscale_challenges_rx,
                 Preamble => &self.proof.preamble.native_rx,
                 ErrorM => &self.proof.error_m.native_rx,
                 ErrorN => &self.proof.error_n.native_rx,

--- a/crates/ragu_pcd/src/verify.rs
+++ b/crates/ragu_pcd/src/verify.rs
@@ -238,6 +238,7 @@ mod nested {
             let poly = match component {
                 EndoscalarStage => &self.proof.p.endoscalar_rx,
                 PointsStage => &self.proof.p.points_rx,
+                SmuggledChallengesStage => &self.proof.p.smuggled_challenges_rx,
                 EndoscalingStep(step) => &self.proof.p.step_rxs[step as usize], // TODO: bounds
             };
             core::iter::once(poly)


### PR DESCRIPTION
Supersedes https://github.com/tachyon-zcash/ragu/pull/356 and references https://github.com/tachyon-zcash/ragu/issues/71. Extracts y / z / etc. challenges from the unified instance and produces field-scaled coefficients (calls `Endoscalar::extract_endoscalar()` and `Endoscalar::lift_endoscalar()` on each challenge) placed in a-positions of the trace polynomial (essentially models a staging polynomial inside the circuit). Challenges need to end up in a-positions of the trace polynomial so they can be endoscaled on the nested curve side.

Intended to build on the anticipated dual-pipeline PR, from which some supplemental context is currently missing. Once the wiring is in place, we'll still require nested circuit verification of the smuggled challenges.

**Update:** extracted stage mask API independently into https://github.com/tachyon-zcash/ragu/pull/504, so this will need to be rebased. 

Additionally, added nested-side logic for stage mask checks:                                                                                                                                                                                              
  - `SmuggledChallengesStage` and `SmuggledChallengesWitness`                                                                                                                                                                                            
  - `smuggled_challenges_rx` generation in fuse                                                                                                                                                                                                        
  - `StageMask` registration in nested registry                                                                                                                                                                                                       
  - `rx.revdot(sy) == 0` verification in nested claims   