### PR TITLE
chore: endoscalar API minor improvement

### DIFF
--- a/crates/ragu_pcd/src/circuits/native/compute_v.rs
+++ b/crates/ragu_pcd/src/circuits/native/compute_v.rs
@@ -16,7 +16,7 @@
 //!   (first query receives highest $\alpha$ power)
 //!
 //! ### $v$ computation
-//! - Extract endoscalar from [$\beta$] and compute effective beta via field_scale
+//! - Extract endoscalar from [$\beta$] and compute effective beta via lift
 //! - Compute $v = f(u) + \text{effective\_beta} \cdot \text{eval}$
 //! - Set computed [$v$] in unified output, enforcing correctness
 //!
@@ -229,7 +229,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> MultiStageCircuit<C::CircuitFi
             let computed_v = {
                 let pre_beta = unified_output.pre_beta.get(dr, unified_instance)?;
                 let beta_endo = Endoscalar::extract(dr, pre_beta)?;
-                let effective_beta = beta_endo.field_scale(dr)?;
+                let effective_beta = beta_endo.lift(dr)?;
                 let mut horner = Horner::new(&effective_beta);
                 fu.write(dr, &mut horner)?;
                 eval.write(dr, &mut horner)?;

--- a/crates/ragu_pcd/src/components/endoscalar.rs
+++ b/crates/ragu_pcd/src/components/endoscalar.rs
@@ -30,7 +30,7 @@ use ragu_core::{
     maybe::Maybe,
 };
 use ragu_primitives::{
-    Element, Endoscalar, Point, compute_endoscalar,
+    Element, Endoscalar, Point,
     vec::{FixedVec, Len},
 };
 
@@ -118,7 +118,7 @@ where
         let points = &points[1..];
         let inputs = FixedVec::from_fn(|i| points[i]);
 
-        let endoscalar: C::Scalar = compute_endoscalar(endoscalar);
+        let endoscalar: C::Scalar = ragu_primitives::lift_endoscalar(endoscalar);
 
         // Compute interstitials using chunked Horner iteration
         let mut interstitials = vec::Vec::with_capacity(NumStepsLen::<NUM_POINTS>::len());
@@ -344,11 +344,11 @@ mod tests {
 
     type R = polynomials::R<13>;
 
-    /// Computes the effective scalar for an endoscalar via emulated `field_scale`.
+    /// Computes the effective scalar for an endoscalar via emulated `lift`.
     fn compute_effective_scalar(endo: Uendo) -> Fq {
         Emulator::<Wired<Fq>>::emulate_wired(endo, |dr, witness| {
             let e = Endoscalar::alloc(dr, witness)?;
-            let scalar = e.field_scale(dr)?;
+            let scalar = e.lift(dr)?;
             Ok(*scalar.value().take())
         })
         .unwrap()

--- a/crates/ragu_pcd/src/fuse/_10_p.rs
+++ b/crates/ragu_pcd/src/fuse/_10_p.rs
@@ -22,7 +22,7 @@ use ragu_core::{
     drivers::Driver,
     maybe::{Always, Maybe},
 };
-use ragu_primitives::{Element, compute_endoscalar, extract_endoscalar, vec::Len};
+use ragu_primitives::{Element, extract_endoscalar, lift_endoscalar, vec::Len};
 
 use crate::circuits::nested::NUM_ENDOSCALING_POINTS;
 use crate::components::endoscalar::{
@@ -82,7 +82,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         // Extract endoscalar from pre_beta and compute effective beta
         let pre_beta_value = *pre_beta.value().take();
         let beta_endo = extract_endoscalar(pre_beta_value);
-        let effective_beta = compute_endoscalar(beta_endo);
+        let effective_beta = lift_endoscalar(beta_endo);
 
         {
             let mut acc: Accumulator<'_, C, R> = Accumulator {

--- a/crates/ragu_primitives/benches/primitives.rs
+++ b/crates/ragu_primitives/benches/primitives.rs
@@ -156,14 +156,14 @@ fn endoscalar_extract((mut emu, (elem,)): (BenchEmu, (Element<'static, BenchEmu>
 }
 
 #[library_benchmark(setup = setup_emu)]
-#[bench::endoscalar_field_scale((alloc_endo,))]
-fn endoscalar_field_scale((mut emu, (endo,)): (BenchEmu, (Endoscalar<'static, BenchEmu>,))) {
-    black_box(endo.field_scale(&mut emu)).unwrap();
+#[bench::endoscalar_lift((alloc_endo,))]
+fn endoscalar_lift((mut emu, (endo,)): (BenchEmu, (Endoscalar<'static, BenchEmu>,))) {
+    black_box(endo.lift(&mut emu)).unwrap();
 }
 
 library_benchmark_group!(
     name = endoscalar_ops;
-    benchmarks = endoscalar_group_scale, endoscalar_extract, endoscalar_field_scale
+    benchmarks = endoscalar_group_scale, endoscalar_extract, endoscalar_lift
 );
 
 main!(

--- a/crates/ragu_primitives/src/endoscalar.rs
+++ b/crates/ragu_primitives/src/endoscalar.rs
@@ -17,7 +17,7 @@ use arithmetic::{Coeff, CurveAffine, Uendo};
 use ff::{Field, PrimeField, WithSmallOrderMulGroup};
 use ragu_core::{
     Result,
-    drivers::{Driver, DriverValue, LinearExpression},
+    drivers::{Driver, DriverValue, LinearExpression, emulator::Emulator},
     gadgets::Gadget,
     maybe::Maybe,
 };
@@ -168,8 +168,8 @@ impl<'dr, D: Driver<'dr>> Endoscalar<'dr, D> {
         Ok(acc)
     }
 
-    /// Scale $1$ by the endoscalar.
-    pub fn field_scale(&self, dr: &mut D) -> Result<Element<'dr, D>>
+    /// Lifts this endoscalar to a field element (scales $1$ by the endoscalar).
+    pub fn lift(&self, dr: &mut D) -> Result<Element<'dr, D>>
     where
         D::F: WithSmallOrderMulGroup<3>,
     {
@@ -208,11 +208,11 @@ impl<'dr, D: Driver<'dr>> Endoscalar<'dr, D> {
     }
 }
 
-/// Computes the effective scalar for an endoscalar.
+/// Lifts an endoscalar to a field element (computes the effective scalar).
 ///
 /// This implements [Algorithm 2, \[BGH19\]](https://eprint.iacr.org/2019/1021)
-/// and is the native counterpart to [`Endoscalar::field_scale`].
-pub fn compute_endoscalar<F: WithSmallOrderMulGroup<3>>(endo: Uendo) -> F {
+/// and is the native counterpart to [`Endoscalar::lift`].
+pub fn lift_endoscalar<F: WithSmallOrderMulGroup<3>>(endo: Uendo) -> F {
     let mut acc = (F::ZETA + F::ONE).double();
     for i in 0..(Uendo::BITS as usize / 2) {
         let bits = endo >> (i << 1);
@@ -233,20 +233,13 @@ pub fn compute_endoscalar<F: WithSmallOrderMulGroup<3>>(endo: Uendo) -> F {
 /// Given a random output of a secure algebraic hash function, this extracts
 /// `k` bits of "randomness" from the value by checking whether `value + i`
 /// is a quadratic residue for each bit position `i`.
-///
-/// This is the native counterpart to [`Endoscalar::extract`].
-pub fn extract_endoscalar<F: PrimeField>(value: F) -> Uendo {
-    // TODO: Consider iterating forward like the circuit implementation.
-    let mut endoscalar = Uendo::from(0u64);
-
-    for i in (0..Uendo::BITS).rev() {
-        endoscalar <<= 1;
-        if (value + F::from(i as u64)).sqrt().into_option().is_some() {
-            endoscalar |= Uendo::from(1u64);
-        }
-    }
-
-    endoscalar
+pub fn extract_endoscalar<F: PrimeField + WithSmallOrderMulGroup<3>>(value: F) -> Uendo {
+    Emulator::emulate_wireless(value, |dr, witness| {
+        let elem = Element::alloc(dr, witness)?;
+        let endo = Endoscalar::extract(dr, elem)?;
+        Ok(*endo.value.snag())
+    })
+    .expect("wireless emulation should not fail")
 }
 
 #[cfg(test)]
@@ -285,12 +278,12 @@ mod tests {
         }
 
         /// Implements [Algorithm 2, \[BGH19\]](https://eprint.iacr.org/2019/1021).
-        pub fn compute_scalar<F: WithSmallOrderMulGroup<3>>(&self) -> F {
-            super::compute_endoscalar(self.value)
+        pub fn lift<F: WithSmallOrderMulGroup<3>>(&self) -> F {
+            super::lift_endoscalar(self.value)
         }
     }
 
-    pub fn extract_endoscalar<F: PrimeField>(value: F) -> EndoscalarTest {
+    pub fn extract<F: PrimeField + WithSmallOrderMulGroup<3>>(value: F) -> EndoscalarTest {
         EndoscalarTest {
             value: super::extract_endoscalar(value),
         }
@@ -307,7 +300,7 @@ mod tests {
             value: Uendo::from(206786806484900909362154774549736492353u128),
         };
         let scaled = e.scale(&p);
-        let expected: EpAffine = (p * e.compute_scalar::<Fq>()).into();
+        let expected: EpAffine = (p * e.lift::<Fq>()).into();
 
         assert_eq!(scaled, expected);
     }
@@ -316,7 +309,7 @@ mod tests {
     fn test_extract() -> Result<()> {
         let p = EpAffine::generator();
         let r = Fp::random(&mut rand::rng());
-        let extracted = extract_endoscalar(r).value;
+        let extracted = extract(r).value;
 
         Simulator::<Fp>::simulate((r, extracted, p), |dr, witness| {
             let (r, extracted, p) = witness.cast();
@@ -362,13 +355,13 @@ mod tests {
     }
 
     #[test]
-    fn test_endopacking() -> Result<()> {
+    fn test_endoscalar_lift() -> Result<()> {
         let r: Uendo = rand::rng().random();
-        let expected: Fp = EndoscalarTest { value: r }.compute_scalar();
+        let expected: Fp = EndoscalarTest { value: r }.lift();
 
         Simulator::<Fp>::simulate(r, |dr, witness| {
             let r = Endoscalar::alloc(dr, witness)?;
-            let s = r.field_scale(dr)?;
+            let s = r.lift(dr)?;
 
             assert_eq!(*s.value().take(), expected);
 

--- a/crates/ragu_primitives/src/lib.rs
+++ b/crates/ragu_primitives/src/lib.rs
@@ -33,7 +33,7 @@ use promotion::Demoted;
 
 pub use boolean::{Boolean, multipack};
 pub use element::{Element, multiadd};
-pub use endoscalar::{Endoscalar, compute_endoscalar, extract_endoscalar};
+pub use endoscalar::{Endoscalar, extract_endoscalar, lift_endoscalar};
 pub use point::Point;
 pub use simulator::Simulator;
 


### PR DESCRIPTION
To align with language in the [book](https://tachyon.z.cash/ragu/protocol/extensions/endoscalar.html), I made these nit changes:

- rename `compute_scalar()`/`Endoscalar::field_scale()` to  `lift()`
- reuse circuit logic for native execution for `lift()` using `Emulator`
  - while keeping `extract()` as is since the native code is more straightforward and simpler than its circuit code
- rename `extract_endoscalar()` to `extract()`
- update call side to `endoscalar::lift(Uendo) -> F` and `endoscalar::extract(F)->Uendo` which aligns with the book definition.