### PR TITLE
docs: add inline docs for revdot claims, proof layout, and polynomial structure

### DIFF
--- a/crates/ragu_circuits/src/polynomials/mod.rs
+++ b/crates/ragu_circuits/src/polynomials/mod.rs
@@ -41,7 +41,15 @@ pub trait Rank:
         Self::RANK - 2
     }
 
-    /// Computes the coefficients of $$t(X, z) = -\sum_{i=0}^{n - 1} X^{4n - 1 - i} (z^{2n - 1 - i} + z^{2n + i})$$ for some $z \in \mathbb{F}$.
+    /// Computes the coefficients of
+    /// $$t(X, z) = -\sum_{i=0}^{n - 1} X^{4n - 1 - i} (z^{2n - 1 - i} + z^{2n + i})$$
+    /// for some $z \in \mathbb{F}$.
+    ///
+    /// This polynomial is designed to align with the structured coefficient
+    /// layout, so it can be added directly to structured `b(X)` values. It is
+    /// the fixed term needed for the revdot identity that ties the witness
+    /// polynomial to the public input polynomial. The full derivation belongs
+    /// in the book.
     fn tz<F: Field>(z: F) -> sparse::Polynomial<F, Self> {
         let mut view = sparse::View::wiring();
         if z != F::ZERO {
@@ -59,7 +67,13 @@ pub trait Rank:
         view.build()
     }
 
-    /// Computes the coefficients of $$t(x, Z) = -\sum_{i=0}^{n - 1} x^{4n - 1 - i} (Z^{2n - 1 - i} + Z^{2n + i})$$ for some $x \in \mathbb{F}$.
+    /// Computes the coefficients of
+    /// $$t(x, Z) = -\sum_{i=0}^{n - 1} x^{4n - 1 - i} (Z^{2n - 1 - i} + Z^{2n + i})$$
+    /// for some $x \in \mathbb{F}$.
+    ///
+    /// This is the symmetric counterpart to [`Rank::tz`] and is used to
+    /// evaluate the same polynomial when the roles of `x` and `z` are flipped.
+    /// The full derivation belongs in the book.
     fn tx<F: Field>(x: F) -> sparse::Polynomial<F, Self> {
         let mut view = sparse::View::wiring();
         if x != F::ZERO {
@@ -76,7 +90,13 @@ pub trait Rank:
         view.build()
     }
 
-    /// Computes $$t(x, z) = -\sum_{i=0}^{n - 1} x^{4n - 1 - i} (z^{2n - 1 - i} + z^{2n + i})$$ for some $x, z \in \mathbb{F}$.
+    /// Computes
+    /// $$t(x, z) = -\sum_{i=0}^{n - 1} x^{4n - 1 - i} (z^{2n - 1 - i} + z^{2n + i})$$
+    /// for some $x, z \in \mathbb{F}$.
+    ///
+    /// The exponent pattern mirrors the structured polynomial layout, which
+    /// is why this function delegates to the circuit-friendly evaluator in
+    /// [`txz::Evaluate`]. The full derivation belongs in the book.
     fn txz<F: Field>(x: F, z: F) -> F {
         if x == F::ZERO || z == F::ZERO {
             return F::ZERO;

--- a/crates/ragu_circuits/src/polynomials/mod.rs
+++ b/crates/ragu_circuits/src/polynomials/mod.rs
@@ -45,10 +45,9 @@ pub trait Rank:
     /// $$t(X, z) = -\sum_{i=0}^{n - 1} X^{4n - 1 - i} (z^{2n - 1 - i} + z^{2n + i})$$
     /// for some $z \in \mathbb{F}$.
     ///
-    /// This polynomial is designed to align with the structured coefficient
-    /// layout, so it can be added directly to structured `b(X)` values. It is
-    /// the fixed term needed for the revdot identity that ties the witness
-    /// polynomial to the public input polynomial.
+    /// Fixes $Z = z$ to produce a univariate polynomial in $X$. The resulting
+    /// structured polynomial aligns with the `b(X)` coefficient layout and
+    /// supplies the fixed term for the revdot identity.
     fn tz<F: Field>(z: F) -> sparse::Polynomial<F, Self> {
         let mut view = sparse::View::wiring();
         if z != F::ZERO {
@@ -70,8 +69,8 @@ pub trait Rank:
     /// $$t(x, Z) = -\sum_{i=0}^{n - 1} x^{4n - 1 - i} (Z^{2n - 1 - i} + Z^{2n + i})$$
     /// for some $x \in \mathbb{F}$.
     ///
-    /// This is the symmetric counterpart to [`Rank::tz`]: here $x$ is the
-    /// evaluation point and $Z$ remains the indeterminate.
+    /// Fixes $X = x$ to produce a univariate polynomial in $Z$. This is
+    /// the symmetric counterpart to [`Rank::tz`].
     fn tx<F: Field>(x: F) -> sparse::Polynomial<F, Self> {
         let mut view = sparse::View::wiring();
         if x != F::ZERO {

--- a/crates/ragu_circuits/src/polynomials/mod.rs
+++ b/crates/ragu_circuits/src/polynomials/mod.rs
@@ -48,8 +48,7 @@ pub trait Rank:
     /// This polynomial is designed to align with the structured coefficient
     /// layout, so it can be added directly to structured `b(X)` values. It is
     /// the fixed term needed for the revdot identity that ties the witness
-    /// polynomial to the public input polynomial. The full derivation belongs
-    /// in the book.
+    /// polynomial to the public input polynomial.
     fn tz<F: Field>(z: F) -> sparse::Polynomial<F, Self> {
         let mut view = sparse::View::wiring();
         if z != F::ZERO {
@@ -73,7 +72,6 @@ pub trait Rank:
     ///
     /// This is the symmetric counterpart to [`Rank::tz`] and is used to
     /// evaluate the same polynomial when the roles of `x` and `z` are flipped.
-    /// The full derivation belongs in the book.
     fn tx<F: Field>(x: F) -> sparse::Polynomial<F, Self> {
         let mut view = sparse::View::wiring();
         if x != F::ZERO {
@@ -96,7 +94,7 @@ pub trait Rank:
     ///
     /// The exponent pattern mirrors the structured polynomial layout, which
     /// is why this function delegates to the circuit-friendly evaluator in
-    /// [`txz::Evaluate`]. The full derivation belongs in the book.
+    /// [`txz::Evaluate`].
     fn txz<F: Field>(x: F, z: F) -> F {
         if x == F::ZERO || z == F::ZERO {
             return F::ZERO;

--- a/crates/ragu_circuits/src/polynomials/mod.rs
+++ b/crates/ragu_circuits/src/polynomials/mod.rs
@@ -70,8 +70,8 @@ pub trait Rank:
     /// $$t(x, Z) = -\sum_{i=0}^{n - 1} x^{4n - 1 - i} (Z^{2n - 1 - i} + Z^{2n + i})$$
     /// for some $x \in \mathbb{F}$.
     ///
-    /// This is the symmetric counterpart to [`Rank::tz`] and is used to
-    /// evaluate the same polynomial when the roles of `x` and `z` are flipped.
+    /// This is the symmetric counterpart to [`Rank::tz`]: here $x$ is the
+    /// evaluation point and $Z$ remains the indeterminate.
     fn tx<F: Field>(x: F) -> sparse::Polynomial<F, Self> {
         let mut view = sparse::View::wiring();
         if x != F::ZERO {

--- a/crates/ragu_circuits/src/polynomials/txz.rs
+++ b/crates/ragu_circuits/src/polynomials/txz.rs
@@ -1,4 +1,10 @@
 //! Evaluation of the $t(X, Z)$ polynomial.
+//!
+//! The `t(X, Z)` polynomial is a fixed “identity” term used in the revdot
+//! relation that binds a circuit witness polynomial `r(X)` to the public input
+//! polynomial. It shares the same exponent pattern as the structured layout so
+//! it can be evaluated efficiently inside the circuit. The full explanation
+//! should live in the book.
 
 use core::marker::PhantomData;
 

--- a/crates/ragu_circuits/src/polynomials/txz.rs
+++ b/crates/ragu_circuits/src/polynomials/txz.rs
@@ -1,9 +1,6 @@
-//! Evaluation of the $t(X, Z)$ polynomial.
-//!
-//! The `t(X, Z)` polynomial is a fixed “identity” term used in the revdot
-//! relation that binds a circuit witness polynomial `r(X)` to the public input
-//! polynomial. It shares the same exponent pattern as the structured layout so
-//! it can be evaluated efficiently inside the circuit.
+//! The $t(X, Z)$ polynomial helps enforce multiplication constraints in the
+//! witness. It shares the same exponent pattern as the structured layout so it
+//! can be evaluated efficiently inside the circuit.
 
 use core::marker::PhantomData;
 

--- a/crates/ragu_circuits/src/polynomials/txz.rs
+++ b/crates/ragu_circuits/src/polynomials/txz.rs
@@ -3,8 +3,7 @@
 //! The `t(X, Z)` polynomial is a fixed “identity” term used in the revdot
 //! relation that binds a circuit witness polynomial `r(X)` to the public input
 //! polynomial. It shares the same exponent pattern as the structured layout so
-//! it can be evaluated efficiently inside the circuit. The full explanation
-//! should live in the book.
+//! it can be evaluated efficiently inside the circuit.
 
 use core::marker::PhantomData;
 

--- a/crates/ragu_circuits/src/s/mod.rs
+++ b/crates/ragu_circuits/src/s/mod.rs
@@ -26,6 +26,11 @@
 //! matrices determined by the `enforce_zero` (and indirectly,
 //! [`add`](ragu_core::drivers::Driver::add)) calls.
 //!
+//! The exponent layout matches the structured polynomial representation. This
+//! is what allows revdot-style checks to line up with circuit constraints and
+//! with the `t(X, z)` identity polynomial defined in the polynomials module.
+//! The full derivation belongs in the book.
+//!
 //! ### Circuit Synthesis
 //!
 //! Naively, one could pre-compute $s(X, Y)$ as a bivariate polynomial for each

--- a/crates/ragu_circuits/src/s/mod.rs
+++ b/crates/ragu_circuits/src/s/mod.rs
@@ -29,7 +29,6 @@
 //! The exponent layout matches the structured polynomial representation. This
 //! is what allows revdot-style checks to line up with circuit constraints and
 //! with the `t(X, z)` identity polynomial defined in the polynomials module.
-//! The full derivation belongs in the book.
 //!
 //! ### Circuit Synthesis
 //!

--- a/crates/ragu_pcd/src/internal/claims.rs
+++ b/crates/ragu_pcd/src/internal/claims.rs
@@ -2,8 +2,8 @@
 //!
 //! # Revdot claims
 //!
-//! A **revdot claim** asserts that two structured polynomials `a(X)` and `b(X)`
-//! satisfy a reversed inner product:
+//! A **revdot claim** asserts that the coefficient vectors of two structured
+//! polynomials $a(X)$ and $b(X)$ satisfy a reversed inner product:
 //!
 //! ```text
 //! revdot(a, b) := ⟨a, reverse(b)⟩

--- a/crates/ragu_pcd/src/internal/claims.rs
+++ b/crates/ragu_pcd/src/internal/claims.rs
@@ -23,8 +23,7 @@
 //! many such claims into a single claim plus a small set of error terms.
 //!
 //! This module provides helpers to build the `(a, b)` pairs for each claim and
-//! to aggregate them consistently across proof components. The full conceptual
-//! derivation is intended for the Ragu book.
+//! to aggregate them consistently across proof components.
 
 use alloc::{borrow::Cow, vec::Vec};
 use core::borrow::Borrow;

--- a/crates/ragu_pcd/src/internal/claims.rs
+++ b/crates/ragu_pcd/src/internal/claims.rs
@@ -1,4 +1,30 @@
 //! Common abstraction for orchestrating revdot claims.
+//!
+//! # Revdot claims
+//!
+//! A **revdot claim** asserts that two structured polynomials `a(X)` and `b(X)`
+//! satisfy a reversed inner product:
+//!
+//! ```text
+//! revdot(a, b) := ⟨a, reverse(b)⟩
+//! ```
+//!
+//! Concretely, `revdot(a, b)` is computed by pairing coefficients of `a` with
+//! coefficients of `b` in reverse order (see
+//! [`sparse::Polynomial::revdot`]). In the proof system, each circuit stage
+//! produces a claim of the form:
+//!
+//! ```text
+//! revdot(a(X), b(X)) = k(Y)
+//! ```
+//!
+//! where `k(Y)` is the public-input polynomial restricted at a verifier
+//! challenge. Verifiers check these claims, and the folding machinery reduces
+//! many such claims into a single claim plus a small set of error terms.
+//!
+//! This module provides helpers to build the `(a, b)` pairs for each claim and
+//! to aggregate them consistently across proof components. The full conceptual
+//! derivation is intended for the Ragu book.
 
 use alloc::{borrow::Cow, vec::Vec};
 use core::borrow::Borrow;

--- a/crates/ragu_pcd/src/internal/fold_revdot.rs
+++ b/crates/ragu_pcd/src/internal/fold_revdot.rs
@@ -1,4 +1,9 @@
 //! Operations and utilities for reasoning about folded revdot claims.
+//!
+//! Folding combines many revdot claims into a single claim using verifier
+//! challenges. The off-diagonal products (i ≠ j) form the error terms that must
+//! also be enforced to preserve soundness. A longer derivation belongs in the
+//! book.
 
 use core::{borrow::Borrow, iter, marker::PhantomData};
 

--- a/crates/ragu_pcd/src/internal/fold_revdot.rs
+++ b/crates/ragu_pcd/src/internal/fold_revdot.rs
@@ -2,8 +2,7 @@
 //!
 //! Folding combines many revdot claims into a single claim using verifier
 //! challenges. The off-diagonal products (i ≠ j) form the error terms that must
-//! also be enforced to preserve soundness. A longer derivation belongs in the
-//! book.
+//! also be enforced to preserve soundness.
 
 use core::{borrow::Borrow, iter, marker::PhantomData};
 

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -2,7 +2,10 @@
 //!
 //! Defines the [`Proof`] structure containing trace polynomials, commitments,
 //! and accumulated claims, along with [`Pcd`] which bundles a [`Proof`] with the
-//! data that a [`Header`] succinctly encodes.
+//! data that a [`Header`] succinctly encodes. Each field corresponds to a phase
+//! of the protocol (application proof, folding, query/evaluation, and commitment
+//! opening), and is kept separately to make verification and proof
+//! transformation explicit.
 
 #![allow(dead_code)]
 


### PR DESCRIPTION
 Note: I made these intentionally concise inline docs for dev context and thinking of adding the full conceptual derivations (revdot, t(X,z), structured layout) in the book. confirming if this is useful so I can open a follow‑up issue for that.