### PR TITLE
chore: add CryptoRng trait bound

### DIFF
--- a/crates/ragu_circuits/src/polynomials/structured.rs
+++ b/crates/ragu_circuits/src/polynomials/structured.rs
@@ -2,7 +2,7 @@
 
 use arithmetic::CurveAffine;
 use ff::Field;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use alloc::vec::Vec;
 use core::borrow::Borrow;
@@ -78,7 +78,7 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     }
 
     /// Creates a new polynomial with random coefficients.
-    pub fn random<RNG: Rng + CryptoRng>(rng: &mut RNG) -> Self {
+    pub fn random<RNG: CryptoRng>(rng: &mut RNG) -> Self {
         let mut random_vec = || (0..R::n()).map(|_| F::random(&mut *rng)).collect();
         Self {
             u: random_vec(),

--- a/crates/ragu_circuits/src/polynomials/unstructured.rs
+++ b/crates/ragu_circuits/src/polynomials/unstructured.rs
@@ -3,7 +3,7 @@
 
 use arithmetic::CurveAffine;
 use ff::Field;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use alloc::{vec, vec::Vec};
 use core::ops::{AddAssign, Deref, DerefMut};
@@ -48,7 +48,7 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     }
 
     /// Creates a new polynomial with random coefficients.
-    pub fn random<RNG: Rng + CryptoRng>(rng: &mut RNG) -> Self {
+    pub fn random<RNG: CryptoRng>(rng: &mut RNG) -> Self {
         let mut coeffs = Vec::with_capacity(R::num_coeffs());
         for _ in 0..R::num_coeffs() {
             coeffs.push(F::random(&mut *rng));

--- a/crates/ragu_pcd/src/fuse/_01_application.rs
+++ b/crates/ragu_pcd/src/fuse/_01_application.rs
@@ -10,7 +10,7 @@ use arithmetic::Cycle;
 use ff::Field;
 use ragu_circuits::{CircuitExt, polynomials::Rank};
 use ragu_core::Result;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use crate::{
     Application, Pcd, Proof, proof,
@@ -18,7 +18,7 @@ use crate::{
 };
 
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
-    pub(super) fn compute_application_proof<'source, RNG: Rng + CryptoRng, S: Step<C>>(
+    pub(super) fn compute_application_proof<'source, RNG: CryptoRng, S: Step<C>>(
         &self,
         rng: &mut RNG,
         step: S,

--- a/crates/ragu_pcd/src/fuse/_02_preamble.rs
+++ b/crates/ragu_pcd/src/fuse/_02_preamble.rs
@@ -7,7 +7,7 @@ use arithmetic::Cycle;
 use ff::Field;
 use ragu_circuits::{polynomials::Rank, staging::StageExt};
 use ragu_core::Result;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use crate::{
     Application, Proof,
@@ -16,7 +16,7 @@ use crate::{
 };
 
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
-    pub(super) fn compute_preamble<'a, RNG: Rng + CryptoRng>(
+    pub(super) fn compute_preamble<'a, RNG: CryptoRng>(
         &self,
         rng: &mut RNG,
         left: &'a Proof<C, R>,

--- a/crates/ragu_pcd/src/fuse/_03_s_prime.rs
+++ b/crates/ragu_pcd/src/fuse/_03_s_prime.rs
@@ -12,12 +12,12 @@ use ragu_core::{
     maybe::{Always, Maybe},
 };
 use ragu_primitives::Element;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use crate::{Application, Proof, circuits::nested, proof};
 
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
-    pub(super) fn compute_s_prime<'dr, D, RNG: Rng + CryptoRng>(
+    pub(super) fn compute_s_prime<'dr, D, RNG: CryptoRng>(
         &self,
         rng: &mut RNG,
         w: &Element<'dr, D>,

--- a/crates/ragu_pcd/src/fuse/_04_error_m.rs
+++ b/crates/ragu_pcd/src/fuse/_04_error_m.rs
@@ -16,7 +16,7 @@ use ragu_core::{
     maybe::{Always, Maybe},
 };
 use ragu_primitives::Element;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use crate::{
     Application, Proof,
@@ -31,7 +31,7 @@ use crate::{
 use super::FuseProofSource;
 
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
-    pub(super) fn compute_errors_m<'dr, 'rx, D, RNG: Rng + CryptoRng>(
+    pub(super) fn compute_errors_m<'dr, 'rx, D, RNG: CryptoRng>(
         &self,
         rng: &mut RNG,
         w: &Element<'dr, D>,

--- a/crates/ragu_pcd/src/fuse/_05_error_n.rs
+++ b/crates/ragu_pcd/src/fuse/_05_error_n.rs
@@ -18,7 +18,7 @@ use ragu_core::{
     maybe::{Always, Maybe},
 };
 use ragu_primitives::{Element, vec::FixedVec};
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use crate::{
     Application,
@@ -37,7 +37,7 @@ use crate::{
 type NativeN = <NativeParameters as fold_revdot::Parameters>::N;
 
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
-    pub(super) fn compute_errors_n<'dr, D, RNG: Rng + CryptoRng>(
+    pub(super) fn compute_errors_n<'dr, D, RNG: CryptoRng>(
         &self,
         rng: &mut RNG,
         preamble_witness: &native::stages::preamble::Witness<'_, C, R, HEADER_SIZE>,

--- a/crates/ragu_pcd/src/fuse/_06_ab.rs
+++ b/crates/ragu_pcd/src/fuse/_06_ab.rs
@@ -39,7 +39,7 @@ use ragu_core::{
     maybe::{Always, Maybe},
 };
 use ragu_primitives::{Element, vec::FixedVec};
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use crate::{
     Application,
@@ -51,7 +51,7 @@ use crate::{
 type NativeN = <NativeParameters as fold_revdot::Parameters>::N;
 
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
-    pub(super) fn compute_ab<'dr, D, RNG: Rng + CryptoRng>(
+    pub(super) fn compute_ab<'dr, D, RNG: CryptoRng>(
         &self,
         rng: &mut RNG,
         a: FixedVec<structured::Polynomial<C::CircuitField, R>, NativeN>,

--- a/crates/ragu_pcd/src/fuse/_07_query.rs
+++ b/crates/ragu_pcd/src/fuse/_07_query.rs
@@ -17,7 +17,7 @@ use ragu_core::{
     maybe::{Always, Maybe},
 };
 use ragu_primitives::Element;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use crate::{
     Application, Proof,
@@ -27,7 +27,7 @@ use crate::{
 use native::InternalCircuitIndex;
 
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
-    pub(super) fn compute_query<'dr, D, RNG: Rng + CryptoRng>(
+    pub(super) fn compute_query<'dr, D, RNG: CryptoRng>(
         &self,
         rng: &mut RNG,
         w: &Element<'dr, D>,

--- a/crates/ragu_pcd/src/fuse/_08_f.rs
+++ b/crates/ragu_pcd/src/fuse/_08_f.rs
@@ -21,7 +21,7 @@ use ragu_core::{
     maybe::{Always, Maybe},
 };
 use ragu_primitives::Element;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use alloc::vec::Vec;
 
@@ -30,7 +30,7 @@ use crate::{
 };
 
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
-    pub(super) fn compute_f<'dr, D, RNG: Rng + CryptoRng>(
+    pub(super) fn compute_f<'dr, D, RNG: CryptoRng>(
         &self,
         rng: &mut RNG,
         w: &Element<'dr, D>,

--- a/crates/ragu_pcd/src/fuse/_09_eval.rs
+++ b/crates/ragu_pcd/src/fuse/_09_eval.rs
@@ -13,7 +13,7 @@ use ragu_core::{
     maybe::{Always, Maybe},
 };
 use ragu_primitives::Element;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use crate::{
     Application, Proof,
@@ -22,7 +22,7 @@ use crate::{
 };
 
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
-    pub(super) fn compute_eval<'dr, D, RNG: Rng + CryptoRng>(
+    pub(super) fn compute_eval<'dr, D, RNG: CryptoRng>(
         &self,
         rng: &mut RNG,
         u: &Element<'dr, D>,

--- a/crates/ragu_pcd/src/fuse/_11_circuits.rs
+++ b/crates/ragu_pcd/src/fuse/_11_circuits.rs
@@ -2,7 +2,7 @@ use arithmetic::Cycle;
 use ff::Field;
 use ragu_circuits::{CircuitExt, polynomials::Rank};
 use ragu_core::Result;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use crate::{
     Application,
@@ -12,7 +12,7 @@ use crate::{
 };
 
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
-    pub(super) fn compute_internal_circuits<RNG: Rng + CryptoRng>(
+    pub(super) fn compute_internal_circuits<RNG: CryptoRng>(
         &self,
         rng: &mut RNG,
         preamble: &proof::Preamble<C, R>,

--- a/crates/ragu_pcd/src/fuse/mod.rs
+++ b/crates/ragu_pcd/src/fuse/mod.rs
@@ -22,7 +22,7 @@ use ragu_circuits::{
 };
 use ragu_core::{Result, drivers::emulator::Emulator, maybe::Maybe};
 use ragu_primitives::{GadgetExt, Point, poseidon::Sponge, vec::CollectFixed};
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use crate::{
     Application, Pcd, Proof,
@@ -48,7 +48,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
     ///   [`Step::Left`] header.
     /// * `right`: the right [`Pcd`] to fuse in this step; must correspond to
     ///   the [`Step::Right`] header.
-    pub fn fuse<'source, RNG: Rng + CryptoRng, S: Step<C>>(
+    pub fn fuse<'source, RNG: CryptoRng, S: Step<C>>(
         &self,
         rng: &mut RNG,
         step: S,

--- a/crates/ragu_pcd/src/lib.rs
+++ b/crates/ragu_pcd/src/lib.rs
@@ -27,7 +27,7 @@ use ragu_circuits::{
     registry::{Registry, RegistryBuilder},
 };
 use ragu_core::{Error, Result};
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use alloc::collections::BTreeMap;
 use core::{any::TypeId, cell::OnceCell, marker::PhantomData};
@@ -192,7 +192,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
     /// This is the entry point for creating leaf nodes in a PCD tree.
     /// Internally creates minimal trivial proofs with `()` headers and fuses
     /// them with the provided step to produce a valid proof.
-    pub fn seed<'source, RNG: Rng + CryptoRng, S: Step<C, Left = (), Right = ()>>(
+    pub fn seed<'source, RNG: CryptoRng, S: Step<C, Left = (), Right = ()>>(
         &self,
         rng: &mut RNG,
         step: S,
@@ -210,10 +210,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
     /// The proof is lazily created on first use and cached. *Importantly*,
     /// note that this may return the same proof on subsequent calls, and
     /// is not random.
-    fn seeded_trivial_pcd<'source, RNG: Rng + CryptoRng>(
-        &self,
-        rng: &mut RNG,
-    ) -> Pcd<'source, C, R, ()> {
+    fn seeded_trivial_pcd<'source, RNG: CryptoRng>(&self, rng: &mut RNG) -> Pcd<'source, C, R, ()> {
         let proof = self.seeded_trivial.get_or_init(|| {
             self.seed(rng, step::internal::trivial::Trivial::new(), ())
                 .expect("seeded trivial seed should not fail")
@@ -229,7 +226,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
     /// is valid for the same [`Header`] but reveals nothing else about the
     /// original proof. As a result, [`Application::verify`] should produce the
     /// same result on the provided `pcd` as it would the output of this method.
-    pub fn rerandomize<'source, RNG: Rng + CryptoRng, H: Header<C::CircuitField>>(
+    pub fn rerandomize<'source, RNG: CryptoRng, H: Header<C::CircuitField>>(
         &self,
         pcd: Pcd<'source, C, R, H>,
         rng: &mut RNG,

--- a/crates/ragu_pcd/src/verify.rs
+++ b/crates/ragu_pcd/src/verify.rs
@@ -8,7 +8,7 @@ use ragu_circuits::{
 };
 use ragu_core::{Result, drivers::emulator::Emulator, maybe::Maybe};
 use ragu_primitives::Element;
-use rand::{CryptoRng, Rng};
+use rand::CryptoRng;
 
 use core::iter::once;
 
@@ -19,7 +19,7 @@ use crate::{
 
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
     /// Verifies some [`Pcd`] for the provided [`Header`].
-    pub fn verify<RNG: Rng + CryptoRng, H: Header<C::CircuitField>>(
+    pub fn verify<RNG: CryptoRng, H: Header<C::CircuitField>>(
         &self,
         pcd: &Pcd<'_, C, R, H>,
         mut rng: RNG,


### PR DESCRIPTION
References #116 

Right now, we mostly use `StdRng` which already implements `CryptoRng` (even though not deterministic) or [not as fast as `ChaCha20Rng`](https://rust-random.github.io/book/guide-rngs.html#cryptographically-secure-pseudo-random-number-generators-csprngs).

But this should be a first step towards `CryptoRng` trait bounds to relevant APIs.