### PR TITLE
chore: add CLAUDE.md for sharing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,18 @@ cargo test --all-features <test_name>
 - `just bench` - Auto-detects platform (Linux native, macOS uses Docker)
 - macOS benchmarks run in Docker with valgrind for profiling
 
+### Worktree Setup
+
+When creating a new worktree, if `CLAUDE.md` and `.claude/` are not version controlled, create symlinks to them from the main worktree:
+
+```bash
+# From the new worktree directory
+ln -s ../path/to/main/CLAUDE.md CLAUDE.md
+ln -s ../path/to/main/.claude .claude
+```
+
+This ensures consistent configuration and guidance across all worktrees.
+
 ### Tool Preferences
 
 When running terminal commands, respect the following preference, fallback to default option if unavailable:


### PR DESCRIPTION
As per [claude's doc ](https://code.claude.com/docs/en/best-practices?search=share#write-an-effective-claude-md)recommends: 

> You can place CLAUDE.md files in several locations:
> - Home folder (~/.claude/CLAUDE.md): Applies to all Claude sessions
> - Project root (./CLAUDE.md): Check into git to share with your team, or name it CLAUDE.local.md and .gitignore it

This is my current instructions, some `/init` generated, some manually summarized by my experience of getting PR review from Sean and Tal. 

Don't need to merge if we don't want to force upon everyone. But feel free to pick piecemeal section (such as "documentation style") from it. 