### PR TITLE
update and align (transitive) dependencies, and bump to rand 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "addchain"
+version = "0.2.0"
+source = "git+https://github.com/ebfull/addchain?rev=da4099a81bc29c895f3ca0ebcaae21c860494c12#da4099a81bc29c895f3ca0ebcaae21c860494c12"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,9 +26,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bincode"
@@ -46,9 +56,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bitvec"
@@ -64,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
+checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -75,15 +85,15 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "derive_more"
@@ -114,9 +124,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
@@ -130,13 +140,27 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+version = "0.14.0-pre.0"
+source = "git+https://github.com/ebfull/ff?rev=e46e1d268bc026708c8ddeb2d49766ea49f9e70e#e46e1d268bc026708c8ddeb2d49766ea49f9e70e"
 dependencies = [
  "bitvec",
- "rand_core 0.6.4",
+ "ff_derive",
+ "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "ff_derive"
+version = "0.14.0-pre.0"
+source = "git+https://github.com/ebfull/ff?rev=e46e1d268bc026708c8ddeb2d49766ea49f9e70e#e46e1d268bc026708c8ddeb2d49766ea49f9e70e"
+dependencies = [
+ "addchain",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -153,35 +177,24 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasip2",
 ]
 
 [[package]]
 name = "group"
-version = "0.13.0"
+version = "0.14.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+checksum = "1ff6a0b2dd4b981b1ae9e3e6830ab146771f3660d31d57bafd9018805a91b0f1"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -224,15 +237,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -255,21 +268,21 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "num-bigint"
@@ -308,14 +321,13 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 [[package]]
 name = "pasta_curves"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+source = "git+https://github.com/ebfull/pasta_curves?rev=32152d552b1c39fb3ffab8f0d8646f946c4adecc#32152d552b1c39fb3ffab8f0d8646f946c4adecc"
 dependencies = [
  "blake2b_simd",
  "ff",
  "group",
  "lazy_static",
- "rand 0.8.5",
+ "rand",
  "static_assertions",
  "subtle",
 ]
@@ -331,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
 ]
@@ -362,26 +374,25 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.7.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags",
- "lazy_static",
  "num-traits",
- "rand 0.9.1",
- "rand_chacha 0.9.0",
+ "rand",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -397,9 +408,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -436,7 +447,7 @@ dependencies = [
  "pasta_curves",
  "proptest",
  "ragu_macros",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -451,7 +462,7 @@ dependencies = [
  "ragu_core",
  "ragu_pasta",
  "ragu_primitives",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -464,7 +475,7 @@ dependencies = [
  "ragu_arithmetic",
  "ragu_macros",
  "ragu_pasta",
- "rand 0.8.5",
+ "rand",
  "thiserror",
 ]
 
@@ -510,7 +521,7 @@ dependencies = [
  "ragu_core",
  "ragu_pasta",
  "ragu_primitives",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -524,39 +535,18 @@ dependencies = [
  "ragu_core",
  "ragu_macros",
  "ragu_pasta",
- "rand 0.8.5",
+ "rand",
  "thiserror",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -566,25 +556,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.2.16",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.3",
+ "getrandom",
 ]
 
 [[package]]
@@ -593,14 +574,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rustc_version"
@@ -613,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags",
  "errno",
@@ -626,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "rusty-fork"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
  "quick-error",
@@ -705,9 +686,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -722,12 +703,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -735,18 +716,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -755,18 +736,31 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
  "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
  "winnow",
 ]
 
@@ -778,9 +772,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "wait-timeout"
@@ -792,110 +786,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
-dependencies = [
- "wit-bindgen-rt",
-]
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "wyz"
@@ -908,18 +835,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.33"
+version = "0.8.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.33"
+version = "0.8.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -928,6 +855,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.14"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,10 +61,27 @@ rust-version = "1.90"
 repository = "https://github.com/tachyon-zcash/ragu"
 
 [workspace.dependencies]
-ff = { version = "0.13", default-features = false }
-group = { version = "0.13", default-features = false }
+ff = { version = "0.14.0-pre.0", default-features = false }
+group = { version = "0.14.0-pre.0", default-features = false }
 pasta_curves = "0.5.1"
-rand = "0.8.5"
+rand = "0.9"
 lazy_static = "1.5.0"
 proptest = "1.7.0"
 gungraun = "0.17.0"
+
+[patch.crates-io]
+# `ebfull/addchain` branch `bump-num-bigint` is a replica of
+# https://github.com/str4d/addchain/pull/3
+# that updates `addchain` to use `num_bigint 0.4`
+addchain = { git = "https://github.com/ebfull/addchain", rev = "da4099a81bc29c895f3ca0ebcaae21c860494c12" }
+
+# `ebfull/ff` branch `release-0.14.0` is a fork of
+# https://github.com/zkcrypto/ff/pull/130
+# which updates `ff` to bump `num-bigint` and `syn`
+# dependencies to align with our local usage in `ragu_macros`
+ff = { git = "https://github.com/ebfull/ff", rev = "e46e1d268bc026708c8ddeb2d49766ea49f9e70e" }
+
+# `ebfull/pasta_curves` branch `ff-0.14` is a replica of
+# https://github.com/zcash/pasta_curves/pull/86
+# that updates `pasta_curves` to use `ff`/`group` `0.14.0-pre.0`
+pasta_curves = { git = "https://github.com/ebfull/pasta_curves", rev = "32152d552b1c39fb3ffab8f0d8646f946c4adecc" }

--- a/crates/ragu_arithmetic/src/uendo.rs
+++ b/crates/ragu_arithmetic/src/uendo.rs
@@ -35,11 +35,11 @@ pub struct Uendo {
     limbs: [u64; LIMBS],
 }
 
-impl rand::distributions::Distribution<Uendo> for rand::distributions::Standard {
+impl rand::distr::Distribution<Uendo> for rand::distr::StandardUniform {
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Uendo {
         let mut limbs = [0; LIMBS];
         for limb in &mut limbs {
-            *limb = rng.r#gen();
+            *limb = rng.random();
         }
         Uendo { limbs }.normalized()
     }

--- a/crates/ragu_arithmetic/src/util.rs
+++ b/crates/ragu_arithmetic/src/util.rs
@@ -331,7 +331,6 @@ pub fn poly_with_roots<F: PrimeField>(roots: &[F]) -> Vec<F> {
 #[cfg(test)]
 mod poly_with_roots_tests {
     use super::*;
-    use alloc::format;
     use ff::Field;
     use pasta_curves::Fp as F;
     use proptest::prelude::*;

--- a/crates/ragu_circuits/src/polynomials/mod.rs
+++ b/crates/ragu_circuits/src/polynomials/mod.rs
@@ -122,7 +122,6 @@ impl_rank_for_R! {2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,2
 #[test]
 fn test_tz() {
     use ragu_pasta::Fp;
-    use rand::thread_rng;
 
     type DemoR = R<7>;
 
@@ -131,7 +130,7 @@ fn test_tz() {
         poly.u.push(Fp::ONE);
         poly.v.push(Fp::ONE);
     }
-    let z = Fp::random(thread_rng());
+    let z = Fp::random(&mut rand::rng());
     poly.dilate(z);
     poly.negate();
 
@@ -151,10 +150,9 @@ fn test_tz() {
 #[test]
 fn test_txz_consistency() {
     use ragu_pasta::Fp;
-    use rand::thread_rng;
     type DemoR = R<10>;
-    let z = Fp::random(thread_rng());
-    let x = Fp::random(thread_rng());
+    let z = Fp::random(&mut rand::rng());
+    let x = Fp::random(&mut rand::rng());
     let txz = DemoR::txz(x, z);
     let tx0 = DemoR::txz(x, Fp::ZERO);
     let t0z: Fp = DemoR::txz(Fp::ZERO, z);

--- a/crates/ragu_circuits/src/polynomials/structured.rs
+++ b/crates/ragu_circuits/src/polynomials/structured.rs
@@ -364,20 +364,19 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
 #[test]
 fn test_eval() {
     use ragu_pasta::Fp;
-    use rand::thread_rng;
 
     type R = super::R<6>;
 
     for insertions in 0..R::n() {
         let mut poly = Polynomial::<Fp, R>::new();
         for _ in 0..insertions {
-            poly.u.push(Fp::random(thread_rng()));
-            poly.v.push(Fp::random(thread_rng()));
-            poly.w.push(Fp::random(thread_rng()));
-            poly.d.push(Fp::random(thread_rng()));
+            poly.u.push(Fp::random(&mut rand::rng()));
+            poly.v.push(Fp::random(&mut rand::rng()));
+            poly.w.push(Fp::random(&mut rand::rng()));
+            poly.d.push(Fp::random(&mut rand::rng()));
         }
 
-        let x = Fp::random(thread_rng());
+        let x = Fp::random(&mut rand::rng());
 
         assert_eq!(
             arithmetic::eval(&poly.unstructured().coeffs, x),
@@ -429,7 +428,6 @@ fn test_backward_forward() {
 #[test]
 fn test_dilate() {
     use ragu_pasta::Fp;
-    use rand::thread_rng;
 
     type R = super::R<5>;
 
@@ -439,19 +437,19 @@ fn test_dilate() {
                 for insertions_d in 0..R::n() {
                     let mut poly = Polynomial::<Fp, R>::new();
                     for _ in 0..insertions_a {
-                        poly.u.push(Fp::random(thread_rng()));
+                        poly.u.push(Fp::random(&mut rand::rng()));
                     }
                     for _ in 0..insertions_b {
-                        poly.v.push(Fp::random(thread_rng()));
+                        poly.v.push(Fp::random(&mut rand::rng()));
                     }
                     for _ in 0..insertions_c {
-                        poly.w.push(Fp::random(thread_rng()));
+                        poly.w.push(Fp::random(&mut rand::rng()));
                     }
                     for _ in 0..insertions_d {
-                        poly.d.push(Fp::random(thread_rng()));
+                        poly.d.push(Fp::random(&mut rand::rng()));
                     }
-                    let x = Fp::random(thread_rng());
-                    let z = Fp::random(thread_rng());
+                    let x = Fp::random(&mut rand::rng());
+                    let z = Fp::random(&mut rand::rng());
                     let upoly = poly.unstructured();
                     poly.dilate(z);
                     let vpoly = poly.unstructured();
@@ -468,17 +466,16 @@ fn test_dilate() {
 #[test]
 fn test_negate() {
     use ragu_pasta::Fp;
-    use rand::thread_rng;
 
     type R = super::R<6>;
 
     for insertions in 0..R::n() {
         let mut poly = Polynomial::<Fp, R>::new();
         for _ in 0..insertions {
-            poly.u.push(Fp::random(thread_rng()));
-            poly.v.push(Fp::random(thread_rng()));
-            poly.w.push(Fp::random(thread_rng()));
-            poly.d.push(Fp::random(thread_rng()));
+            poly.u.push(Fp::random(&mut rand::rng()));
+            poly.v.push(Fp::random(&mut rand::rng()));
+            poly.w.push(Fp::random(&mut rand::rng()));
+            poly.d.push(Fp::random(&mut rand::rng()));
         }
 
         let original = poly.clone();
@@ -502,7 +499,7 @@ fn test_negate() {
             assert_eq!(*negated, -*orig);
         }
 
-        let x = Fp::random(thread_rng());
+        let x = Fp::random(&mut rand::rng());
         assert_eq!(poly.eval(x), -original.eval(x));
     }
 }
@@ -510,12 +507,11 @@ fn test_negate() {
 #[test]
 fn test_constant_term() {
     use ragu_pasta::Fp;
-    use rand::thread_rng;
 
     type R = super::R<6>;
 
     let mut poly = Polynomial::<Fp, R>::new();
-    let random_value = Fp::random(thread_rng());
+    let random_value = Fp::random(&mut rand::rng());
 
     *poly.constant_term() = random_value;
 
@@ -528,7 +524,6 @@ fn test_constant_term() {
 #[test]
 fn test_prod() {
     use ragu_pasta::Fp;
-    use rand::thread_rng;
 
     type R = super::R<7>;
 
@@ -536,8 +531,8 @@ fn test_prod() {
     {
         let rx = rx.forward();
         for _ in 0..R::n() {
-            let a = Fp::random(thread_rng());
-            let b = Fp::random(thread_rng());
+            let a = Fp::random(&mut rand::rng());
+            let b = Fp::random(&mut rand::rng());
 
             rx.a.push(a);
             rx.b.push(b);
@@ -546,7 +541,7 @@ fn test_prod() {
     }
 
     let mut rzx = rx.clone();
-    let z = Fp::random(thread_rng());
+    let z = Fp::random(&mut rand::rng());
     rzx.dilate(z);
     rzx.add_assign(&R::tz::<Fp>(z));
 
@@ -561,28 +556,27 @@ fn test_prod() {
 fn test_commit_consistency() {
     use arithmetic::Cycle;
     use ragu_pasta::{Fp, Pasta};
-    use rand::thread_rng;
 
     type R = super::R<10>;
 
     let pasta = Pasta::baked();
     let generators = Pasta::host_generators(pasta);
 
-    let blind = Fp::random(thread_rng());
+    let blind = Fp::random(&mut rand::rng());
 
     let mut poly = Polynomial::<Fp, R>::new();
 
     for _ in 0..R::n() / 4 {
-        poly.u.push(Fp::random(thread_rng()));
+        poly.u.push(Fp::random(&mut rand::rng()));
     }
     for _ in 0..R::n() / 3 {
-        poly.v.push(Fp::random(thread_rng()));
+        poly.v.push(Fp::random(&mut rand::rng()));
     }
     for _ in 0..R::n() / 2 {
-        poly.w.push(Fp::random(thread_rng()));
+        poly.w.push(Fp::random(&mut rand::rng()));
     }
     for _ in 0..R::n() {
-        poly.d.push(Fp::random(thread_rng()));
+        poly.d.push(Fp::random(&mut rand::rng()));
     }
 
     let structured_commitment = poly.commit(generators, blind);
@@ -594,7 +588,6 @@ fn test_commit_consistency() {
 #[test]
 fn test_product_with_dot() {
     use ragu_pasta::Fp;
-    use rand::thread_rng;
 
     type R = super::R<5>;
 
@@ -602,29 +595,29 @@ fn test_product_with_dot() {
     let mut poly2 = Polynomial::<Fp, R>::new();
 
     for _ in 0..3 {
-        poly1.u.push(Fp::random(thread_rng()));
+        poly1.u.push(Fp::random(&mut rand::rng()));
     }
     for _ in 0..5 {
-        poly1.v.push(Fp::random(thread_rng()));
+        poly1.v.push(Fp::random(&mut rand::rng()));
     }
     for _ in 0..7 {
-        poly1.w.push(Fp::random(thread_rng()));
+        poly1.w.push(Fp::random(&mut rand::rng()));
     }
     for _ in 0..2 {
-        poly1.d.push(Fp::random(thread_rng()));
+        poly1.d.push(Fp::random(&mut rand::rng()));
     }
 
     for _ in 0..4 {
-        poly2.u.push(Fp::random(thread_rng()));
+        poly2.u.push(Fp::random(&mut rand::rng()));
     }
     for _ in 0..6 {
-        poly2.v.push(Fp::random(thread_rng()));
+        poly2.v.push(Fp::random(&mut rand::rng()));
     }
     for _ in 0..1 {
-        poly2.w.push(Fp::random(thread_rng()));
+        poly2.w.push(Fp::random(&mut rand::rng()));
     }
     for _ in 0..8 {
-        poly2.d.push(Fp::random(thread_rng()));
+        poly2.d.push(Fp::random(&mut rand::rng()));
     }
 
     assert_eq!(
@@ -639,11 +632,10 @@ fn test_product_with_dot() {
 #[test]
 fn ring_poly_test() {
     use ragu_pasta::Fp;
-    use rand::thread_rng;
 
     type R = super::R<5>;
 
-    let rand = || Fp::random(thread_rng());
+    let rand = || Fp::random(&mut rand::rng());
 
     let little = arithmetic::Domain::<Fp>::new(2);
     let big = arithmetic::Domain::<Fp>::new(3);

--- a/crates/ragu_circuits/src/polynomials/txz.rs
+++ b/crates/ragu_circuits/src/polynomials/txz.rs
@@ -145,15 +145,14 @@ mod tests {
     use crate::polynomials::R;
     use ragu_pasta::Fp;
     use ragu_primitives::Simulator;
-    use rand::thread_rng;
 
     #[test]
     fn simulate_txz() -> Result<()> {
         // R<13> has log2_n = 11
         type TestRank = R<13>;
 
-        let x = Fp::random(thread_rng());
-        let z = Fp::random(thread_rng());
+        let x = Fp::random(&mut rand::rng());
+        let z = Fp::random(&mut rand::rng());
         let evaluator = Evaluate::<TestRank>::new();
 
         Simulator::simulate((x, z), |dr, witness| {

--- a/crates/ragu_circuits/src/polynomials/unstructured.rs
+++ b/crates/ragu_circuits/src/polynomials/unstructured.rs
@@ -162,25 +162,24 @@ impl<F: Field, R: Rank> AddAssign<&super::structured::Polynomial<F, R>> for Poly
 #[test]
 fn test_add_structured() {
     use ragu_pasta::Fp;
-    use rand::thread_rng;
 
     type R = super::R<13>;
 
-    let p = super::structured::Polynomial::<Fp, R>::random(&mut thread_rng());
+    let p = super::structured::Polynomial::<Fp, R>::random(&mut rand::rng());
 
     let mut q = super::structured::Polynomial::<Fp, R>::new();
     for i in 0..R::n() {
         if i % 7 == 0 {
-            q.u.push(Fp::random(thread_rng()));
+            q.u.push(Fp::random(&mut rand::rng()));
         }
         if i % 5 == 0 {
-            q.v.push(Fp::random(thread_rng()));
+            q.v.push(Fp::random(&mut rand::rng()));
         }
         if i % 3 == 0 {
-            q.w.push(Fp::random(thread_rng()));
+            q.w.push(Fp::random(&mut rand::rng()));
         }
         if i % 2 == 0 {
-            q.d.push(Fp::random(thread_rng()));
+            q.d.push(Fp::random(&mut rand::rng()));
         }
     }
 

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -484,7 +484,6 @@ mod tests {
     use ff::PrimeField;
     use ragu_core::Result;
     use ragu_pasta::{Fp, Pasta};
-    use rand::thread_rng;
 
     type TestRank = R<8>;
     type TestRegistryBuilder<'a> = RegistryBuilder<'a, Fp, TestRank>;
@@ -527,9 +526,9 @@ mod tests {
             .register_circuit(SquareCircuit { times: 19 })?
             .finalize(poseidon)?;
 
-        let w = Fp::random(thread_rng());
-        let x = Fp::random(thread_rng());
-        let y = Fp::random(thread_rng());
+        let w = Fp::random(&mut rand::rng());
+        let x = Fp::random(&mut rand::rng());
+        let y = Fp::random(&mut rand::rng());
 
         let xy_poly = registry.xy(x, y);
         let wy_poly = registry.wy(w, y);
@@ -661,9 +660,9 @@ mod tests {
             let expected_domain_size = num_circuits.next_power_of_two();
             assert_eq!(registry.domain.n(), expected_domain_size);
 
-            let w = Fp::random(thread_rng());
-            let x = Fp::random(thread_rng());
-            let y = Fp::random(thread_rng());
+            let w = Fp::random(&mut rand::rng());
+            let x = Fp::random(&mut rand::rng());
+            let y = Fp::random(&mut rand::rng());
 
             let wxy = registry.wxy(w, x, y);
             let xy = registry.xy(x, y);

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -230,7 +230,7 @@ mod tests {
     };
     use ragu_pasta::{EpAffine, Fp, Fq};
     use ragu_primitives::{Element, Endoscalar, Point, io::Write};
-    use rand::{Rng, thread_rng};
+    use rand::Rng;
 
     use crate::{
         CircuitExt, CircuitObject, metrics, polynomials::Rank, registry, s::sy,
@@ -348,10 +348,10 @@ mod tests {
             }
         }
 
-        let endoscalar_a: Uendo = thread_rng().r#gen();
-        let endoscalar_b: Uendo = thread_rng().r#gen();
-        let p1 = (EpAffine::generator() * Fq::random(thread_rng())).into();
-        let p2 = (EpAffine::generator() * Fq::random(thread_rng())).into();
+        let endoscalar_a: Uendo = rand::rng().random();
+        let endoscalar_b: Uendo = rand::rng().random();
+        let p1 = (EpAffine::generator() * Fq::random(&mut rand::rng())).into();
+        let p2 = (EpAffine::generator() * Fq::random(&mut rand::rng())).into();
 
         let rx1_a = MyStage1::rx(endoscalar_a)?;
         let rx1_b = MyStage1::rx(endoscalar_b)?;
@@ -360,9 +360,9 @@ mod tests {
         let circ1 = MyStage1::mask()?;
         let circ2 = MyStage2::mask()?;
 
-        let z = Fp::random(thread_rng());
-        let y = Fp::random(thread_rng());
-        let k = registry::Key::new(Fp::random(thread_rng()));
+        let z = Fp::random(&mut rand::rng());
+        let y = Fp::random(&mut rand::rng());
+        let k = registry::Key::new(Fp::random(&mut rand::rng()));
 
         {
             let rhs = circ1.sy(y, &k);
@@ -391,9 +391,9 @@ mod tests {
     fn test_skip_multiplications_zero() {
         let stage_mask = StageMask::<R>::new(0, 5).unwrap();
 
-        let x = Fp::random(thread_rng());
-        let y = Fp::random(thread_rng());
-        let k = registry::Key::new(Fp::random(thread_rng()));
+        let x = Fp::random(&mut rand::rng());
+        let y = Fp::random(&mut rand::rng());
+        let k = registry::Key::new(Fp::random(&mut rand::rng()));
 
         let sxy = stage_mask.sxy(x, y, &k);
         let sx = stage_mask.sx(x, &k);
@@ -407,9 +407,9 @@ mod tests {
     fn test_stage_mask_all_multiplications() {
         // Edge case: skip = 0, num = R::n() - 1, reserved = 0.
         let stage = StageMask::<R>::new(0, R::n() - 1).unwrap();
-        let x = Fp::random(thread_rng());
-        let y = Fp::random(thread_rng());
-        let k = registry::Key::new(Fp::random(thread_rng()));
+        let x = Fp::random(&mut rand::rng());
+        let y = Fp::random(&mut rand::rng());
+        let k = registry::Key::new(Fp::random(&mut rand::rng()));
 
         let comparison_mask = stage.clone().into_object::<R>().unwrap();
 
@@ -422,8 +422,8 @@ mod tests {
     #[test]
     fn test_minimum_linear_constraints() {
         let circuit = SquareCircuit { times: 2 };
-        let y = Fp::random(thread_rng());
-        let k = registry::Key::new(Fp::random(thread_rng()));
+        let y = Fp::random(&mut rand::rng());
+        let k = registry::Key::new(Fp::random(&mut rand::rng()));
 
         let metrics = metrics::eval(&circuit).expect("metrics should succeed");
         let mut sy = sy::eval::<_, _, R>(&circuit, y, &k, metrics.num_linear_constraints)
@@ -455,9 +455,9 @@ mod tests {
         // When reserved = 0, all gates except one are used.
         let stage = StageMask::<R>::new(0, R::n() - 1).expect("skip multiplications");
 
-        let x = Fp::random(thread_rng());
-        let y = Fp::random(thread_rng());
-        let k = registry::Key::new(Fp::random(thread_rng()));
+        let x = Fp::random(&mut rand::rng());
+        let y = Fp::random(&mut rand::rng());
+        let k = registry::Key::new(Fp::random(&mut rand::rng()));
 
         let sxy = stage.sxy(x, y, &k);
         let sx = stage.sx(x, &k);
@@ -492,7 +492,7 @@ mod tests {
             let stage_mask = StageMask::<R>::new(skip, num).unwrap();
             let comparison_mask = stage_mask.clone().into_object::<R>().unwrap();
 
-            let k = registry::Key::new(Fp::random(thread_rng()));
+            let k = registry::Key::new(Fp::random(&mut rand::rng()));
 
             let check = |x: Fp, y: Fp| {
                 let xn_minus_1 = x.pow_vartime([(4 * R::n() - 1) as u64]);
@@ -519,8 +519,8 @@ mod tests {
                 Ok(())
             };
 
-            let x = Fp::random(thread_rng());
-            let y = Fp::random(thread_rng());
+            let x = Fp::random(&mut rand::rng());
+            let y = Fp::random(&mut rand::rng());
             check(x, y)?;
             check(Fp::ZERO, y)?;
             check(x, Fp::ZERO)?;
@@ -592,7 +592,7 @@ mod tests {
         let stage_mask = ConstrainedStage::mask::<'_>().unwrap();
 
         // rx.revdot(&stage_mask) == 0 for well-formed stages
-        let y = Fp::random(thread_rng());
+        let y = Fp::random(&mut rand::rng());
         let k = registry::Key::new(Fp::ONE);
         let sy = stage_mask.sy(y, &k);
 

--- a/crates/ragu_circuits/src/staging/mod.rs
+++ b/crates/ragu_circuits/src/staging/mod.rs
@@ -67,8 +67,8 @@
 //! let a = MyStage::rx(my_stage_witness)?;
 //!
 //! let mask = MyStage::mask()?;
-//! let y = Fp::random(thread_rng());
-//! let registry_key = Fp::random(thread_rng());
+//! let y = Fp::random(&mut rand::rng());
+//! let registry_key = Fp::random(&mut rand::rng());
 //! assert_eq!(a.revdot(&mask.sy(y, registry_key)), Fp::ZERO);
 //! ```
 //!
@@ -80,15 +80,15 @@
 //! let b = MyStage::rx(my_stage_witness)?;
 //!
 //! // Sample random challenge z after committing to `a` and `b`
-//! let z = Fp::random(thread_rng());
+//! let z = Fp::random(&mut rand::rng());
 //!
 //! let mut combined = a.clone();
 //! combined.scale(z);
 //! combined.add_assign(&b);
 //!
 //! let mask = MyStage::mask()?;
-//! let y = Fp::random(thread_rng());
-//! let registry_key = Fp::random(thread_rng());
+//! let y = Fp::random(&mut rand::rng());
+//! let registry_key = Fp::random(&mut rand::rng());
 //! assert_eq!(combined.revdot(&mask.sy(y, registry_key)), Fp::ZERO);
 //! ```
 //!

--- a/crates/ragu_circuits/src/tests/mod.rs
+++ b/crates/ragu_circuits/src/tests/mod.rs
@@ -9,7 +9,6 @@ use ragu_core::{
 };
 use ragu_pasta::Fp;
 use ragu_primitives::Element;
-use rand::thread_rng;
 
 use crate::{
     Circuit, CircuitExt, CircuitObject,
@@ -59,9 +58,9 @@ impl Circuit<Fp> for SquareCircuit {
 }
 
 fn consistency_checks<R: Rank>(circuit: &dyn CircuitObject<Fp, R>) {
-    let x = Fp::random(thread_rng());
-    let y = Fp::random(thread_rng());
-    let k = registry::Key::new(Fp::random(thread_rng()));
+    let x = Fp::random(&mut rand::rng());
+    let y = Fp::random(&mut rand::rng());
+    let k = registry::Key::new(Fp::random(&mut rand::rng()));
 
     let sxy_eval = circuit.sxy(x, y, &k);
     let s0y_eval = circuit.sxy(Fp::ZERO, y, &k);
@@ -158,8 +157,8 @@ fn test_simple_circuit() {
 
     consistency_checks(&*circuit);
 
-    let y = Fp::random(thread_rng());
-    let z = Fp::random(thread_rng());
+    let y = Fp::random(&mut rand::rng());
+    let z = Fp::random(&mut rand::rng());
     let k = registry::Key::default();
 
     let a = assignment.clone();

--- a/crates/ragu_pcd/src/components/endoscalar.rs
+++ b/crates/ragu_pcd/src/components/endoscalar.rs
@@ -340,7 +340,7 @@ mod tests {
     };
     use ragu_pasta::{Ep, EpAffine, Fp, Fq};
     use ragu_primitives::{Endoscalar, vec::Len};
-    use rand::{Rng, thread_rng};
+    use rand::Rng;
 
     type R = polynomials::R<13>;
 
@@ -416,9 +416,9 @@ mod tests {
         let num_steps = NumStepsLen::<NUM_POINTS>::len();
 
         // Generate random endoscalar and base input points.
-        let endoscalar: Uendo = thread_rng().r#gen();
+        let endoscalar: Uendo = rand::rng().random();
         let base_inputs: [EpAffine; NUM_POINTS] = core::array::from_fn(|_| {
-            (Ep::generator() * <Ep as Group>::Scalar::random(thread_rng())).to_affine()
+            (Ep::generator() * <Ep as Group>::Scalar::random(&mut rand::rng())).to_affine()
         });
 
         // Compute expected final result via Horner over all base inputs.
@@ -453,7 +453,7 @@ mod tests {
 
             let staged_s = staged.clone().into_object()?;
             let ky = staged.ky(())?;
-            let y = Fp::random(thread_rng());
+            let y = Fp::random(&mut rand::rng());
 
             // Verify revdot identities for each stage.
             assert_eq!(endoscalar_rx.revdot(&endoscalar_mask.sy(y, &key)), Fp::ZERO);
@@ -486,9 +486,9 @@ mod tests {
         assert_eq!(InputsLen::<NUM_POINTS>::len(), 10);
 
         // Generate random endoscalar and base input points.
-        let endoscalar: Uendo = thread_rng().r#gen();
+        let endoscalar: Uendo = rand::rng().random();
         let base_inputs: [EpAffine; NUM_POINTS] = core::array::from_fn(|_| {
-            (Ep::generator() * <Ep as Group>::Scalar::random(thread_rng())).to_affine()
+            (Ep::generator() * <Ep as Group>::Scalar::random(&mut rand::rng())).to_affine()
         });
 
         // Compute expected final result via Horner over all base inputs.
@@ -517,7 +517,7 @@ mod tests {
 
             let staged_s = staged.clone().into_object()?;
             let ky = staged.ky(())?;
-            let y = Fp::random(thread_rng());
+            let y = Fp::random(&mut rand::rng());
 
             let endoscalar_rx = <EndoscalarStage as StageExt<Fp, R>>::rx(endoscalar)?;
             let points_rx = <PointsStage<EpAffine, NUM_POINTS> as StageExt<Fp, R>>::rx(&points)?;
@@ -624,9 +624,9 @@ mod tests {
     fn test_points_witness_new() {
         /// Verifies PointsWitness::new produces identical results to manual construction.
         fn check<const NUM_POINTS: usize>() {
-            let endoscalar: Uendo = thread_rng().r#gen();
+            let endoscalar: Uendo = rand::rng().random();
             let base_inputs: [EpAffine; NUM_POINTS] = core::array::from_fn(|_| {
-                (Ep::generator() * <Ep as Group>::Scalar::random(thread_rng())).to_affine()
+                (Ep::generator() * <Ep as Group>::Scalar::random(&mut rand::rng())).to_affine()
             });
 
             // Compute via PointsWitness::new

--- a/crates/ragu_primitives/benches/setup/mod.rs
+++ b/crates/ragu_primitives/benches/setup/mod.rs
@@ -64,7 +64,7 @@ pub fn alloc_point(emu: &mut BenchEmu, rng: &mut StdRng) -> Point<'static, Bench
 }
 
 pub fn alloc_endo(emu: &mut BenchEmu, rng: &mut StdRng) -> Endoscalar<'static, BenchEmu> {
-    let u: Uendo = rng.r#gen();
+    let u: Uendo = rng.random();
     Endoscalar::alloc(emu, BenchEmu::just(|| u)).unwrap()
 }
 
@@ -94,7 +94,7 @@ pub fn alloc_bools<const N: usize>(
 ) -> Vec<Boolean<'static, BenchEmu>> {
     (0..N)
         .map(|_| {
-            let v: bool = rng.r#gen();
+            let v: bool = rng.random();
             Boolean::alloc(emu, BenchEmu::just(|| v)).unwrap()
         })
         .collect()

--- a/crates/ragu_primitives/src/endoscalar.rs
+++ b/crates/ragu_primitives/src/endoscalar.rs
@@ -257,7 +257,7 @@ mod tests {
     use group::{Group, prime::PrimeCurveAffine};
     use ragu_core::Result;
     use ragu_pasta::{EpAffine, Fp};
-    use rand::{Rng, thread_rng};
+    use rand::Rng;
 
     use crate::Simulator;
 
@@ -315,7 +315,7 @@ mod tests {
     #[test]
     fn test_extract() -> Result<()> {
         let p = EpAffine::generator();
-        let r = Fp::random(thread_rng());
+        let r = Fp::random(&mut rand::rng());
         let extracted = extract_endoscalar(r).value;
 
         Simulator::<Fp>::simulate((r, extracted, p), |dr, witness| {
@@ -340,7 +340,7 @@ mod tests {
     #[test]
     fn test_endoscaling() -> Result<()> {
         let p = EpAffine::generator();
-        let r: Uendo = thread_rng().r#gen();
+        let r: Uendo = rand::rng().random();
         let expected = EndoscalarTest { value: r }.scale(&p);
 
         Simulator::simulate((p, r), |dr, witness| {
@@ -363,7 +363,7 @@ mod tests {
 
     #[test]
     fn test_endopacking() -> Result<()> {
-        let r: Uendo = thread_rng().r#gen();
+        let r: Uendo = rand::rng().random();
         let expected: Fp = EndoscalarTest { value: r }.compute_scalar();
 
         Simulator::<Fp>::simulate(r, |dr, witness| {


### PR DESCRIPTION
Bump `ff`/`group` to 0.14.0-pre.0, `rand` to 0.9, and align dependency versions with the Zebra ecosystem.

- **`ff`**: 0.13 -> 0.14.0-pre.0 (via [ebfull/ff](https://github.com/ebfull/ff), replicates [zkcrypto/ff#130](https://github.com/zkcrypto/ff/pull/130) — bumps `num-bigint` and `syn` to align with `ragu_macros`)
- **`group`**: 0.13 -> 0.14.0-pre.0
- **`rand`**: 0.8.5 -> 0.9
- **`pasta_curves`**: patched to [ebfull/pasta_curves](https://github.com/ebfull/pasta_curves) (`ff-0.14` branch, replicates [zcash/pasta_curves#86](https://github.com/zcash/pasta_curves/pull/86))
- **`addchain`**: patched to [ebfull/addchain](https://github.com/ebfull/addchain) (`bump-num-bigint` branch, replicates [str4d/addchain#3](https://github.com/str4d/addchain/pull/3))

The `ff` 0.14 and `rand` 0.9 bumps collapse several duplicated dependency trees into single versions: `rand`, `rand_core`, `rand_chacha`, `getrandom`, `wasi` (now `wasip2`), and `windows-targets` + 8 platform crates (now single `windows-link`).