### PR TITLE
chore(pcd): macroize unified instance

### DIFF
--- a/crates/ragu_pcd/src/circuits/native/unified.rs
+++ b/crates/ragu_pcd/src/circuits/native/unified.rs
@@ -287,7 +287,7 @@ impl<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>> Output<'dr, D, C> {
     /// proof's components and challenges. Useful for testing or when the full
     /// proof structure is available.
     ///
-    /// Note: Field order must match `define_unified_instance!`.
+    /// Note: Field order follows `define_unified_instance!` for consistency.
     pub fn alloc_from_proof<R: Rank>(
         dr: &mut D,
         proof: DriverValue<D, &Proof<C, R>>,


### PR DESCRIPTION
References https://github.com/tachyon-zcash/ragu/issues/217. Implements a declarative macro to reduce boilerplate in the unified instance interface. We already had some internal macro usage (`point_slot!` and `element_slot!`), but this macroizes more of the module. Instead of repeating field definitions in multiple locations and updating each when adding a field, there's now a single source of truth (`define_unified_instance`) where you modify one call site, which is less error prone and reduces code. The macro generates `Output`, `Instance`, `OutputBuilder` (`OutputBuilder::new()`, and `OutputBuilder::finish_no_suffix()`). Existing doc comments are reordered and preserved.