### PR TITLE
chore(ci): re-enable windows and macos test jobs in the CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,8 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Temporarily disabled windows-latest and macos-latest to speed up CI
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust


### PR DESCRIPTION
References https://github.com/tachyon-zcash/ragu/issues/140 to re-enable jobs in our CI workflow.