### PR TITLE
chore(build): add dist profile inheriting from release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,10 @@ members = [
 
 resolver = "2"
 
+# The profile that 'cargo dist' will build with
+[profile.dist]
+inherits = "release"
+
 [workspace.package]
 version = "0.0.0"
 authors = ["Sean Bowe <ewillbefull@gmail.com>"]


### PR DESCRIPTION
References https://github.com/tachyon-zcash/ragu/issues/49. Adds a `[profile.dist]` section that inherits from release, similar to https://github.com/penumbra-zone/penumbra/blob/main/Cargo.toml.