### PR TITLE
chore(crates): use `ragu_arithmetic` instead of `arithmetic` alias

### DIFF
--- a/crates/ragu_circuits/Cargo.toml
+++ b/crates/ragu_circuits/Cargo.toml
@@ -21,13 +21,13 @@ all-features = true
 
 [features]
 default = []
-unstable-test-fixtures = ["arithmetic/unstable-test-fixtures"]
+unstable-test-fixtures = ["ragu_arithmetic/unstable-test-fixtures"]
 
 [lib]
 bench = false
 
 [dependencies]
-arithmetic = { path = "../ragu_arithmetic", version = "0.0.0", package = "ragu_arithmetic" }
+ragu_arithmetic = { path = "../ragu_arithmetic", version = "0.0.0" }
 blake2b_simd = { workspace = true }
 ff = { workspace = true }
 group = { workspace = true }

--- a/crates/ragu_circuits/benches/circuits.rs
+++ b/crates/ragu_circuits/benches/circuits.rs
@@ -4,8 +4,8 @@ mod setup;
 
 use std::hint::black_box;
 
-use arithmetic::Cycle;
 use gungraun::{library_benchmark, library_benchmark_group, main};
+use ragu_arithmetic::Cycle;
 use ragu_circuits::polynomials::{R, structured, unstructured};
 use ragu_circuits::registry::{Key, Registry, RegistryBuilder};
 use ragu_circuits::test_fixtures::{MySimpleCircuit, SquareCircuit};

--- a/crates/ragu_circuits/src/metrics.rs
+++ b/crates/ragu_circuits/src/metrics.rs
@@ -4,8 +4,8 @@
 //! execution without computing actual values, counting the number of
 //! multiplication and linear constraints a circuit requires.
 
-use arithmetic::Coeff;
 use ff::Field;
+use ragu_arithmetic::Coeff;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverTypes, emulator::Emulator},

--- a/crates/ragu_circuits/src/polynomials/mod.rs
+++ b/crates/ragu_circuits/src/polynomials/mod.rs
@@ -159,27 +159,27 @@ fn test_txz_consistency() {
     let t00 = DemoR::txz(Fp::ZERO, Fp::ZERO);
     assert_eq!(
         txz,
-        arithmetic::eval(&DemoR::tz::<Fp>(z).unstructured().coeffs, x)
+        ragu_arithmetic::eval(&DemoR::tz::<Fp>(z).unstructured().coeffs, x)
     );
     assert_eq!(
         tx0,
-        arithmetic::eval(&DemoR::tz::<Fp>(Fp::ZERO).unstructured().coeffs, x)
+        ragu_arithmetic::eval(&DemoR::tz::<Fp>(Fp::ZERO).unstructured().coeffs, x)
     );
     assert_eq!(
         txz,
-        arithmetic::eval(&DemoR::tx::<Fp>(x).unstructured().coeffs, z)
+        ragu_arithmetic::eval(&DemoR::tx::<Fp>(x).unstructured().coeffs, z)
     );
     assert_eq!(
         t0z,
-        arithmetic::eval(&DemoR::tx::<Fp>(Fp::ZERO).unstructured().coeffs, z)
+        ragu_arithmetic::eval(&DemoR::tx::<Fp>(Fp::ZERO).unstructured().coeffs, z)
     );
 
     assert_eq!(
         t00,
-        arithmetic::eval(&DemoR::tz::<Fp>(Fp::ZERO).unstructured().coeffs, Fp::ZERO)
+        ragu_arithmetic::eval(&DemoR::tz::<Fp>(Fp::ZERO).unstructured().coeffs, Fp::ZERO)
     );
     assert_eq!(
         t00,
-        arithmetic::eval(&DemoR::tx::<Fp>(Fp::ZERO).unstructured().coeffs, Fp::ZERO)
+        ragu_arithmetic::eval(&DemoR::tx::<Fp>(Fp::ZERO).unstructured().coeffs, Fp::ZERO)
     );
 }

--- a/crates/ragu_circuits/src/polynomials/structured.rs
+++ b/crates/ragu_circuits/src/polynomials/structured.rs
@@ -1,7 +1,7 @@
 //! Polynomials with coefficients in a split structure arrangement.
 
-use arithmetic::CurveAffine;
 use ff::Field;
+use ragu_arithmetic::CurveAffine;
 use rand::CryptoRng;
 
 use alloc::vec::Vec;
@@ -44,7 +44,7 @@ pub struct Polynomial<F: Field, R: Rank> {
     _marker: core::marker::PhantomData<R>,
 }
 
-impl<F: Field, R: Rank> arithmetic::Ring for Polynomial<F, R> {
+impl<F: Field, R: Rank> ragu_arithmetic::Ring for Polynomial<F, R> {
     type R = Self;
     type F = F;
 
@@ -216,7 +216,7 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     /// Compute a commitment to this polynomial using the provided generators.
     pub fn commit<C: CurveAffine<ScalarExt = F>>(
         &self,
-        generators: &impl arithmetic::FixedGenerators<C>,
+        generators: &impl ragu_arithmetic::FixedGenerators<C>,
         blind: F,
     ) -> C {
         self.assert_bounds();
@@ -228,7 +228,7 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
         let u_start = &v_start[self.v.len()..];
         let d_start = &u_start[self.u.len() + self.second_padding()..];
 
-        arithmetic::mul(
+        ragu_arithmetic::mul(
             self.w
                 .iter()
                 .chain(self.v.iter().rev())
@@ -379,7 +379,7 @@ fn test_eval() {
         let x = Fp::random(&mut rand::rng());
 
         assert_eq!(
-            arithmetic::eval(&poly.unstructured().coeffs, x),
+            ragu_arithmetic::eval(&poly.unstructured().coeffs, x),
             poly.eval(x)
         );
     }
@@ -454,8 +454,8 @@ fn test_dilate() {
                     poly.dilate(z);
                     let vpoly = poly.unstructured();
                     assert_eq!(
-                        arithmetic::eval(&upoly.coeffs, x * z),
-                        arithmetic::eval(&vpoly.coeffs, x)
+                        ragu_arithmetic::eval(&upoly.coeffs, x * z),
+                        ragu_arithmetic::eval(&vpoly.coeffs, x)
                     );
                 }
             }
@@ -549,12 +549,12 @@ fn test_prod() {
     let mut b = rzx.unstructured().coeffs;
     b.reverse();
 
-    assert_eq!(arithmetic::dot(&a, &b), Fp::ZERO);
+    assert_eq!(ragu_arithmetic::dot(&a, &b), Fp::ZERO);
 }
 
 #[test]
 fn test_commit_consistency() {
-    use arithmetic::Cycle;
+    use ragu_arithmetic::Cycle;
     use ragu_pasta::{Fp, Pasta};
 
     type R = super::R<10>;
@@ -622,7 +622,7 @@ fn test_product_with_dot() {
 
     assert_eq!(
         poly1.revdot(&poly2),
-        arithmetic::dot(
+        ragu_arithmetic::dot(
             poly1.unstructured().iter(),
             poly2.unstructured().iter().rev(),
         )
@@ -637,8 +637,8 @@ fn ring_poly_test() {
 
     let rand = || Fp::random(&mut rand::rng());
 
-    let little = arithmetic::Domain::<Fp>::new(2);
-    let big = arithmetic::Domain::<Fp>::new(3);
+    let little = ragu_arithmetic::Domain::<Fp>::new(2);
+    let big = ragu_arithmetic::Domain::<Fp>::new(3);
 
     let mut a_polys = vec![];
     let mut b_polys = vec![];

--- a/crates/ragu_circuits/src/polynomials/unstructured.rs
+++ b/crates/ragu_circuits/src/polynomials/unstructured.rs
@@ -1,8 +1,8 @@
 //! Polynomials with coefficients in an unstructured (monomial basis)
 //! arrangement.
 
-use arithmetic::CurveAffine;
 use ff::Field;
+use ragu_arithmetic::CurveAffine;
 use rand::CryptoRng;
 
 use alloc::{vec, vec::Vec};
@@ -78,7 +78,7 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
 
     /// Evaluate this polynomial at the given point.
     pub fn eval(&self, x: F) -> F {
-        arithmetic::eval(&self.coeffs[..], x)
+        ragu_arithmetic::eval(&self.coeffs[..], x)
     }
 
     /// Scale the coefficients of the polynomial by the given factor.
@@ -130,12 +130,12 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     /// Compute a commitment to this polynomial using the provided generators.
     pub fn commit<C: CurveAffine<ScalarExt = F>>(
         &self,
-        generators: &impl arithmetic::FixedGenerators<C>,
+        generators: &impl ragu_arithmetic::FixedGenerators<C>,
         blind: F,
     ) -> C {
         assert!(generators.g().len() >= R::num_coeffs()); // TODO(ebfull)
 
-        arithmetic::mul(
+        ragu_arithmetic::mul(
             self.coeffs.iter().chain(Some(&blind)),
             generators
                 .g()

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -15,9 +15,9 @@
 //! to compile the added circuits into a registry polynomial representation that can
 //! be efficiently evaluated at different restrictions.
 
-use arithmetic::{Domain, bitreverse};
 use blake2b_simd::Params;
 use ff::{Field, FromUniformBytes, PrimeField};
+use ragu_arithmetic::{Domain, bitreverse};
 use ragu_core::{Error, Result};
 
 use alloc::{boxed::Box, collections::btree_map::BTreeMap, vec::Vec};
@@ -496,9 +496,9 @@ mod tests {
     use crate::tests::SquareCircuit;
     use alloc::collections::BTreeSet;
     use alloc::collections::btree_map::BTreeMap;
-    use arithmetic::{Domain, bitreverse};
     use ff::Field;
     use ff::PrimeField;
+    use ragu_arithmetic::{Domain, bitreverse};
     use ragu_core::Result;
     use ragu_pasta::Fp;
 

--- a/crates/ragu_circuits/src/rx.rs
+++ b/crates/ragu_circuits/src/rx.rs
@@ -3,8 +3,8 @@
 //! The [`eval`] function in this module processes some witness data for a
 //! particular [`Circuit`] and assembles the corresponding $r(X)$ polynomial.
 
-use arithmetic::Coeff;
 use ff::Field;
+use ragu_arithmetic::Coeff;
 use ragu_core::{
     Error, Result,
     drivers::{Driver, DriverTypes, emulator::Emulator},

--- a/crates/ragu_circuits/src/s/common.rs
+++ b/crates/ragu_circuits/src/s/common.rs
@@ -32,8 +32,8 @@
 //! [`sy`]: super::sy
 //! [`Driver::ONE`]: ragu_core::drivers::Driver::ONE
 
-use arithmetic::Coeff;
 use ff::Field;
+use ragu_arithmetic::Coeff;
 use ragu_core::drivers::LinearExpression;
 
 /// Represents a wire's evaluated monomial during polynomial synthesis.

--- a/crates/ragu_circuits/src/s/mod.rs
+++ b/crates/ragu_circuits/src/s/mod.rs
@@ -66,7 +66,7 @@
 //! [`enforce_zero`]: ragu_core::drivers::Driver::enforce_zero
 //! [wiring polynomials]: http://TODO
 
-use arithmetic::Coeff;
+use ragu_arithmetic::Coeff;
 use ragu_core::{
     Result,
     drivers::{Driver, LinearExpression},

--- a/crates/ragu_circuits/src/s/sx.rs
+++ b/crates/ragu_circuits/src/s/sx.rs
@@ -62,8 +62,8 @@
 //! [`Driver::mul`]: ragu_core::drivers::Driver::mul
 //! [`sxy`]: super::sxy
 
-use arithmetic::Coeff;
 use ff::Field;
+use ragu_arithmetic::Coeff;
 use ragu_core::{
     Error, Result,
     drivers::{Driver, DriverTypes, emulator::Emulator},

--- a/crates/ragu_circuits/src/s/sxy.rs
+++ b/crates/ragu_circuits/src/s/sxy.rs
@@ -48,8 +48,8 @@
 //! [`sx`]: super::sx
 //! [`Driver::enforce_zero`]: ragu_core::drivers::Driver::enforce_zero
 
-use arithmetic::Coeff;
 use ff::Field;
+use ragu_arithmetic::Coeff;
 use ragu_core::{
     Error, Result,
     drivers::{Driver, DriverTypes, emulator::Emulator},

--- a/crates/ragu_circuits/src/s/sy.rs
+++ b/crates/ragu_circuits/src/s/sy.rs
@@ -66,8 +66,8 @@
 //! [`Driver::add`]: ragu_core::drivers::Driver::add
 //! [`structured::View`]: crate::polynomials::structured::View
 
-use arithmetic::Coeff;
 use ff::Field;
+use ragu_arithmetic::Coeff;
 use ragu_core::{
     Error, Result,
     drivers::{Driver, DriverTypes, LinearExpression, emulator::Emulator},

--- a/crates/ragu_circuits/src/staging/builder.rs
+++ b/crates/ragu_circuits/src/staging/builder.rs
@@ -38,7 +38,7 @@
 //!
 //! [staging chapter]: https://tachyon.z.cash/ragu/protocol/extensions/staging
 
-use arithmetic::Coeff;
+use ragu_arithmetic::Coeff;
 use ragu_core::{
     Result,
     drivers::{

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -87,8 +87,8 @@ impl<F: Field, R: Rank> CircuitObject<F, R> for StageMask<R> {
             let v = y2 * x.pow_vartime([(2 * R::n() + 1 + end) as u64]);
             let u = y3 * x.pow_vartime([(2 * R::n() - 2 - end) as u64]);
 
-            let plus = arithmetic::geosum::<F>(x_y3, len);
-            let minus = arithmetic::geosum::<F>(xinv_y3, len);
+            let plus = ragu_arithmetic::geosum::<F>(x_y3, len);
+            let minus = ragu_arithmetic::geosum::<F>(xinv_y3, len);
 
             w * plus + v * minus + u * plus
         };
@@ -218,10 +218,10 @@ impl<F: Field, R: Rank> CircuitObject<F, R> for StageMask<R> {
 mod tests {
     use core::marker::PhantomData;
 
-    use arithmetic::{Coeff, Uendo};
     use ff::Field;
     use group::prime::PrimeCurveAffine;
     use proptest::prelude::*;
+    use ragu_arithmetic::{Coeff, Uendo};
     use ragu_core::{
         Result,
         drivers::{Driver, DriverValue, LinearExpression, emulator::Emulator},

--- a/crates/ragu_circuits/src/tests/mod.rs
+++ b/crates/ragu_circuits/src/tests/mod.rs
@@ -72,14 +72,14 @@ fn consistency_checks<R: Rank>(circuit: &dyn CircuitObject<Fp, R>) {
     let s0Y_poly = circuit.sx(Fp::ZERO, &k);
     let sX0_poly = circuit.sy(Fp::ZERO, &k).unstructured();
 
-    assert_eq!(sxy_eval, arithmetic::eval(&sXy_poly[..], x));
-    assert_eq!(sxy_eval, arithmetic::eval(&sxY_poly[..], y));
-    assert_eq!(s0y_eval, arithmetic::eval(&sXy_poly[..], Fp::ZERO));
-    assert_eq!(sx0_eval, arithmetic::eval(&sxY_poly[..], Fp::ZERO));
-    assert_eq!(s0y_eval, arithmetic::eval(&s0Y_poly[..], y));
-    assert_eq!(sx0_eval, arithmetic::eval(&sX0_poly[..], x));
-    assert_eq!(s00_eval, arithmetic::eval(&s0Y_poly[..], Fp::ZERO));
-    assert_eq!(s00_eval, arithmetic::eval(&sX0_poly[..], Fp::ZERO));
+    assert_eq!(sxy_eval, ragu_arithmetic::eval(&sXy_poly[..], x));
+    assert_eq!(sxy_eval, ragu_arithmetic::eval(&sxY_poly[..], y));
+    assert_eq!(s0y_eval, ragu_arithmetic::eval(&sXy_poly[..], Fp::ZERO));
+    assert_eq!(sx0_eval, ragu_arithmetic::eval(&sxY_poly[..], Fp::ZERO));
+    assert_eq!(s0y_eval, ragu_arithmetic::eval(&s0Y_poly[..], y));
+    assert_eq!(sx0_eval, ragu_arithmetic::eval(&sX0_poly[..], x));
+    assert_eq!(s00_eval, ragu_arithmetic::eval(&s0Y_poly[..], Fp::ZERO));
+    assert_eq!(s00_eval, ragu_arithmetic::eval(&sX0_poly[..], Fp::ZERO));
 }
 
 #[test]
@@ -167,7 +167,7 @@ fn test_simple_circuit() {
     b.add_assign(&circuit.sy(y, &k));
     b.add_assign(&MyRank::tz(z));
 
-    let expected = arithmetic::eval(
+    let expected = ragu_arithmetic::eval(
         &MySimpleCircuit
             .ky((
                 Fp::from_raw([
@@ -190,7 +190,7 @@ fn test_simple_circuit() {
     let a = a.unstructured();
     let b = b.unstructured();
 
-    assert_eq!(expected, arithmetic::dot(a.iter(), b.iter().rev()),);
+    assert_eq!(expected, ragu_arithmetic::dot(a.iter(), b.iter().rev()),);
 }
 
 #[derive(Clone)]

--- a/crates/ragu_core/Cargo.toml
+++ b/crates/ragu_core/Cargo.toml
@@ -33,7 +33,7 @@ default = ["alloc"]
 bench = false
 
 [dependencies]
-arithmetic = { path = "../ragu_arithmetic", version = "0.0.0", package = "ragu_arithmetic" }
+ragu_arithmetic = { path = "../ragu_arithmetic", version = "0.0.0" }
 ff = { workspace = true }
 ragu_macros = { path = "../ragu_macros", version = "0.0.0" }
 thiserror = "2.0.12"

--- a/crates/ragu_core/src/drivers.rs
+++ b/crates/ragu_core/src/drivers.rs
@@ -48,8 +48,8 @@ pub mod emulator;
 mod linexp;
 mod phantom;
 
-use arithmetic::Coeff;
 use ff::Field;
+use ragu_arithmetic::Coeff;
 
 use crate::{
     Result,

--- a/crates/ragu_pasta/Cargo.toml
+++ b/crates/ragu_pasta/Cargo.toml
@@ -24,7 +24,7 @@ default = []
 baked = ["lazy_static"]
 
 [build-dependencies]
-arithmetic = { path = "../ragu_arithmetic", version = "0.0.0", package = "ragu_arithmetic" }
+ragu_arithmetic = { path = "../ragu_arithmetic", version = "0.0.0" }
 ff = { workspace = true }
 group = { workspace = true }
 pasta_curves = { workspace = true }
@@ -33,7 +33,7 @@ pasta_curves = { workspace = true }
 bench = false
 
 [dependencies]
-arithmetic = { path = "../ragu_arithmetic", version = "0.0.0", package = "ragu_arithmetic" }
+ragu_arithmetic = { path = "../ragu_arithmetic", version = "0.0.0" }
 ff = { workspace = true }
 group = { workspace = true }
 pasta_curves = { workspace = true }

--- a/crates/ragu_pasta/pasta_common.rs
+++ b/crates/ragu_pasta/pasta_common.rs
@@ -1,4 +1,4 @@
-use arithmetic::CurveExt;
+use ragu_arithmetic::CurveExt;
 use group::{Curve, prime::PrimeCurveAffine};
 use pasta_curves::{
     EpAffine,

--- a/crates/ragu_pasta/src/lib.rs
+++ b/crates/ragu_pasta/src/lib.rs
@@ -36,7 +36,7 @@ mod common {
 mod poseidon_fp;
 mod poseidon_fq;
 
-use arithmetic::{Cycle, FixedGenerators};
+use ragu_arithmetic::{Cycle, FixedGenerators};
 
 pub use common::{PallasGenerators, PastaParams, VestaGenerators};
 pub use pasta_curves::{Ep, EpAffine, Eq, EqAffine, Fp, Fq};
@@ -165,7 +165,7 @@ mod baked {
 
     #[test]
     fn test_baked_params() {
-        use arithmetic::{Cycle, FixedGenerators};
+        use ragu_arithmetic::{Cycle, FixedGenerators};
 
         let params = Pasta::baked();
 

--- a/crates/ragu_pasta/src/macros.rs
+++ b/crates/ragu_pasta/src/macros.rs
@@ -2,7 +2,7 @@
 #[macro_export]
 macro_rules! fp {
     ( $x:expr ) => {
-        $crate::Fp::from_raw(arithmetic::repr256!($x))
+        $crate::Fp::from_raw(ragu_arithmetic::repr256!($x))
     };
 }
 
@@ -10,6 +10,6 @@ macro_rules! fp {
 #[macro_export]
 macro_rules! fq {
     ( $x:expr ) => {
-        $crate::Fq::from_raw(arithmetic::repr256!($x))
+        $crate::Fq::from_raw(ragu_arithmetic::repr256!($x))
     };
 }

--- a/crates/ragu_pasta/src/poseidon_fp.rs
+++ b/crates/ragu_pasta/src/poseidon_fp.rs
@@ -6,7 +6,7 @@ pub struct PoseidonFp;
 // sage generate_parameters_grain.sage 1 0 255 5 8 56 0x40000000000000000000000000000000224698fc094cf91b992d30ed00000001
 // which has the correct round constants (8 and 56) given the output of calc_round_numbers.py for the state size 5 and the
 // use of x^5 for the sbox, for the prime p
-impl arithmetic::PoseidonPermutation<pasta_curves::Fp> for PoseidonFp {
+impl ragu_arithmetic::PoseidonPermutation<pasta_curves::Fp> for PoseidonFp {
     const T: usize = 5;
     const RATE: usize = 4;
     const FULL_ROUNDS: usize = 8;

--- a/crates/ragu_pasta/src/poseidon_fq.rs
+++ b/crates/ragu_pasta/src/poseidon_fq.rs
@@ -6,7 +6,7 @@ pub struct PoseidonFq;
 // sage generate_parameters_grain.sage 1 0 255 5 8 56 0x40000000000000000000000000000000224698fc0994a8dd8c46eb2100000001
 // which has the correct round constants (8 and 56) given the output of calc_round_numbers.py for the state size 5 and the
 // use of x^5 for the sbox, for the prime q
-impl arithmetic::PoseidonPermutation<pasta_curves::Fq> for PoseidonFq {
+impl ragu_arithmetic::PoseidonPermutation<pasta_curves::Fq> for PoseidonFq {
     const T: usize = 5;
     const RATE: usize = 4;
     const FULL_ROUNDS: usize = 8;

--- a/crates/ragu_pcd/Cargo.toml
+++ b/crates/ragu_pcd/Cargo.toml
@@ -27,13 +27,13 @@ all-features = true
 
 [features]
 default = []
-unstable-test-fixtures = ["arithmetic/unstable-test-fixtures"]
+unstable-test-fixtures = ["ragu_arithmetic/unstable-test-fixtures"]
 
 [lib]
 bench = false
 
 [dependencies]
-arithmetic = { path = "../ragu_arithmetic", version = "0.0.0", package = "ragu_arithmetic" }
+ragu_arithmetic = { path = "../ragu_arithmetic", version = "0.0.0" }
 ff = { workspace = true }
 pasta_curves = { workspace = true }
 ragu_circuits = { path = "../ragu_circuits", version = "0.0.0" }

--- a/crates/ragu_pcd/benches/pcd.rs
+++ b/crates/ragu_pcd/benches/pcd.rs
@@ -2,8 +2,8 @@
 
 mod setup;
 
-use arithmetic::Cycle;
 use gungraun::{library_benchmark, library_benchmark_group, main};
+use ragu_arithmetic::Cycle;
 use ragu_circuits::polynomials::R;
 use ragu_pasta::{Fp, Pasta};
 use ragu_pcd::test_fixtures::nontrivial;

--- a/crates/ragu_pcd/benches/setup/mod.rs
+++ b/crates/ragu_pcd/benches/setup/mod.rs
@@ -1,4 +1,4 @@
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::polynomials::R;
 use ragu_pasta::{Fp, Pasta};
 use ragu_pcd::test_fixtures::nontrivial;

--- a/crates/ragu_pcd/src/circuits/native/compute_v.rs
+++ b/crates/ragu_pcd/src/circuits/native/compute_v.rs
@@ -43,7 +43,7 @@
 //! [$\mu'$]: unified::Output::mu_prime
 //! [$\nu'$]: unified::Output::nu_prime
 
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::{Rank, txz::Evaluate},
     staging::{MultiStage, MultiStageCircuit, StageBuilder},

--- a/crates/ragu_pcd/src/circuits/native/full_collapse.rs
+++ b/crates/ragu_pcd/src/circuits/native/full_collapse.rs
@@ -46,7 +46,7 @@
 //! [`FoldProducts::fold_products_n`]: fold_revdot::FoldProducts::fold_products_n
 //! [`is_base_case`]: super::stages::preamble::Output::is_base_case
 
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::Rank,
     staging::{MultiStage, MultiStageCircuit, StageBuilder},

--- a/crates/ragu_pcd/src/circuits/native/hashes_1.rs
+++ b/crates/ragu_pcd/src/circuits/native/hashes_1.rs
@@ -72,7 +72,7 @@
 //! [`WithSuffix`]: crate::components::suffix::WithSuffix
 //! [`Sponge::save_state`]: ragu_primitives::poseidon::Sponge::save_state
 
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::Rank,
     staging::{MultiStage, MultiStageCircuit, StageBuilder},

--- a/crates/ragu_pcd/src/circuits/native/hashes_2.rs
+++ b/crates/ragu_pcd/src/circuits/native/hashes_2.rs
@@ -58,7 +58,7 @@
 //! [`WithSuffix`]: crate::components::suffix::WithSuffix
 //! [`Sponge::resume_and_squeeze`]: ragu_primitives::poseidon::Sponge::resume_and_squeeze
 
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::Rank,
     staging::{MultiStage, MultiStageCircuit, StageBuilder},

--- a/crates/ragu_pcd/src/circuits/native/mod.rs
+++ b/crates/ragu_pcd/src/circuits/native/mod.rs
@@ -1,6 +1,6 @@
 //! Native curve circuits for recursive verification.
 
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::Rank,
     registry::{CircuitIndex, RegistryBuilder},

--- a/crates/ragu_pcd/src/circuits/native/partial_collapse.rs
+++ b/crates/ragu_pcd/src/circuits/native/partial_collapse.rs
@@ -53,7 +53,7 @@
 //! [`FoldProducts::fold_products_m`]: fold_revdot::FoldProducts::fold_products_m
 //! [`TwoProofKySource`]: crate::components::claims::native::TwoProofKySource
 
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::Rank,
     staging::{MultiStage, MultiStageCircuit, StageBuilder},

--- a/crates/ragu_pcd/src/circuits/native/stages/error_m.rs
+++ b/crates/ragu_pcd/src/circuits/native/stages/error_m.rs
@@ -2,7 +2,7 @@
 //!
 //! This stage handles N separate M-sized revdot claim reductions.
 
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{polynomials::Rank, staging};
 use ragu_core::{
     Result,

--- a/crates/ragu_pcd/src/circuits/native/stages/error_n.rs
+++ b/crates/ragu_pcd/src/circuits/native/stages/error_n.rs
@@ -2,7 +2,7 @@
 //!
 //! This stage handles the final N-sized revdot claim reduction.
 
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{polynomials::Rank, staging};
 use ragu_core::{
     Result,
@@ -82,7 +82,7 @@ pub struct Output<
     'dr,
     D: Driver<'dr>,
     FP: fold_revdot::Parameters,
-    Poseidon: arithmetic::PoseidonPermutation<D::F>,
+    Poseidon: ragu_arithmetic::PoseidonPermutation<D::F>,
 > {
     /// Error term elements for layer 2.
     #[ragu(gadget)]

--- a/crates/ragu_pcd/src/circuits/native/stages/eval.rs
+++ b/crates/ragu_pcd/src/circuits/native/stages/eval.rs
@@ -1,7 +1,7 @@
 //! Eval stage for fuse operations.
 
-use arithmetic::Cycle;
 use ff::PrimeField;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{polynomials::Rank, staging};
 use ragu_core::{
     Result,

--- a/crates/ragu_pcd/src/circuits/native/stages/preamble.rs
+++ b/crates/ragu_pcd/src/circuits/native/stages/preamble.rs
@@ -2,7 +2,7 @@
 //!
 //! Verifies child proof headers and computes the Ky term.
 
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{polynomials::Rank, staging};
 use ragu_core::{
     Error, Result,

--- a/crates/ragu_pcd/src/circuits/native/stages/query.rs
+++ b/crates/ragu_pcd/src/circuits/native/stages/query.rs
@@ -14,8 +14,8 @@
 //! Additionally witnesses the $a$/$b$ polynomial evaluations and registry
 //! transition evaluations needed for mesh consistency checks.
 
-use arithmetic::Cycle;
 use ff::PrimeField;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::{Rank, structured, unstructured},
     staging,

--- a/crates/ragu_pcd/src/circuits/native/unified.rs
+++ b/crates/ragu_pcd/src/circuits/native/unified.rs
@@ -18,7 +18,7 @@
 //! [`hashes_1`]: super::hashes_1
 //! [`hashes_2`]: super::hashes_2
 
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::polynomials::Rank;
 use ragu_core::{
     Result,

--- a/crates/ragu_pcd/src/circuits/nested/mod.rs
+++ b/crates/ragu_pcd/src/circuits/nested/mod.rs
@@ -3,7 +3,7 @@
 //! These circuits operate over the scalar field and verify that the
 //! commitment accumulation was computed correctly via Horner's rule.
 
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::Rank,
     registry::{CircuitIndex, RegistryBuilder},

--- a/crates/ragu_pcd/src/circuits/nested/stages/mod.rs
+++ b/crates/ragu_pcd/src/circuits/nested/stages/mod.rs
@@ -27,7 +27,7 @@ macro_rules! define_nested_stage {
         }
     ) => {
         pub mod $mod_name {
-            use arithmetic::CurveAffine;
+            use ragu_arithmetic::CurveAffine;
             use ragu_circuits::polynomials::Rank;
             use ragu_core::{
                 Result,

--- a/crates/ragu_pcd/src/circuits/nested/stages/preamble.rs
+++ b/crates/ragu_pcd/src/circuits/nested/stages/preamble.rs
@@ -2,7 +2,7 @@
 //!
 //! Collects child proof commitments for cross-curve accumulation.
 
-use arithmetic::{CurveAffine, Cycle};
+use ragu_arithmetic::{CurveAffine, Cycle};
 use ragu_circuits::polynomials::Rank;
 
 use crate::Proof;

--- a/crates/ragu_pcd/src/components/endoscalar.rs
+++ b/crates/ragu_pcd/src/components/endoscalar.rs
@@ -16,9 +16,9 @@
 //! will vary in the number of steps and points, the code is generic over the
 //! curve type and number of points.
 
-use arithmetic::{CurveAffine, Uendo};
 use ff::{Field, WithSmallOrderMulGroup};
 use pasta_curves::group::{Curve, prime::PrimeCurveAffine};
+use ragu_arithmetic::{CurveAffine, Uendo};
 use ragu_circuits::{
     polynomials::Rank,
     staging::{MultiStageCircuit, Stage, StageBuilder},
@@ -324,9 +324,9 @@ mod tests {
         ENDOSCALINGS_PER_STEP, EndoscalarStage, EndoscalingStep, EndoscalingStepWitness, InputsLen,
         NumStepsLen, PointsStage, PointsWitness,
     };
-    use arithmetic::Uendo;
     use ff::Field;
     use pasta_curves::group::{Curve, Group, prime::PrimeCurveAffine};
+    use ragu_arithmetic::Uendo;
     use ragu_circuits::{
         CircuitExt,
         polynomials::{self},
@@ -464,7 +464,10 @@ mod tests {
             let mut lhs = final_rx.clone();
             lhs.add_assign(&endoscalar_rx);
             lhs.add_assign(&points_rx);
-            assert_eq!(lhs.revdot(&staged_s.sy(y, &key)), arithmetic::eval(&ky, y));
+            assert_eq!(
+                lhs.revdot(&staged_s.sy(y, &key)),
+                ragu_arithmetic::eval(&ky, y)
+            );
         }
 
         Ok(())
@@ -526,7 +529,10 @@ mod tests {
             let mut lhs = final_rx.clone();
             lhs.add_assign(&endoscalar_rx);
             lhs.add_assign(&points_rx);
-            assert_eq!(lhs.revdot(&staged_s.sy(y, &key)), arithmetic::eval(&ky, y));
+            assert_eq!(
+                lhs.revdot(&staged_s.sy(y, &key)),
+                ragu_arithmetic::eval(&ky, y)
+            );
         }
 
         Ok(())

--- a/crates/ragu_pcd/src/fuse/_01_application.rs
+++ b/crates/ragu_pcd/src/fuse/_01_application.rs
@@ -6,8 +6,8 @@
 //! returned to the caller along with the auxiliary data from the application
 //! synthesis.
 
-use arithmetic::Cycle;
 use ff::Field;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{CircuitExt, polynomials::Rank};
 use ragu_core::Result;
 use rand::CryptoRng;

--- a/crates/ragu_pcd/src/fuse/_02_preamble.rs
+++ b/crates/ragu_pcd/src/fuse/_02_preamble.rs
@@ -3,8 +3,8 @@
 //! This creates the [`proof::Preamble`] component of the proof, which commits
 //! to the public inputs and witness polynomials used in the fuse step.
 
-use arithmetic::Cycle;
 use ff::Field;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{polynomials::Rank, staging::StageExt};
 use ragu_core::Result;
 use rand::CryptoRng;

--- a/crates/ragu_pcd/src/fuse/_03_s_prime.rs
+++ b/crates/ragu_pcd/src/fuse/_03_s_prime.rs
@@ -3,8 +3,8 @@
 //! This creates the [`proof::SPrime`] component of the proof, which commits to
 //! the $m(w, x_i, Y)$ polynomials for the $i$th child proof's $x$ challenge.
 
-use arithmetic::Cycle;
 use ff::Field;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{polynomials::Rank, staging::StageExt};
 use ragu_core::{
     Result,

--- a/crates/ragu_pcd/src/fuse/_04_error_m.rs
+++ b/crates/ragu_pcd/src/fuse/_04_error_m.rs
@@ -7,8 +7,8 @@
 //! This phase of the fuse operation is also used to commit to the $m(w, X, y)$
 //! restriction.
 
-use arithmetic::Cycle;
 use ff::Field;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{polynomials::Rank, staging::StageExt};
 use ragu_core::{
     Result,

--- a/crates/ragu_pcd/src/fuse/_05_error_n.rs
+++ b/crates/ragu_pcd/src/fuse/_05_error_n.rs
@@ -6,8 +6,8 @@
 //! the $k(Y)$ evaluations for the child proofs, as well as the temporary sponge
 //! state used to split the hashing operations across two circuits.
 
-use arithmetic::Cycle;
 use ff::Field;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::{Rank, structured},
     staging::{Stage as StageTrait, StageExt},

--- a/crates/ragu_pcd/src/fuse/_06_ab.rs
+++ b/crates/ragu_pcd/src/fuse/_06_ab.rs
@@ -27,8 +27,8 @@
 //! evaluations that $B(x)$ already needs, eliminating separate
 //! $r\_i(x)$ queries.
 
-use arithmetic::Cycle;
 use ff::Field;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::{Rank, structured},
     staging::StageExt,

--- a/crates/ragu_pcd/src/fuse/_07_query.rs
+++ b/crates/ragu_pcd/src/fuse/_07_query.rs
@@ -8,8 +8,8 @@
 //! This phase of the fuse operation is also used to commit to the $m(W, x, y)$
 //! restriction.
 
-use arithmetic::Cycle;
 use ff::Field;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{polynomials::Rank, staging::StageExt};
 use ragu_core::{
     Result,

--- a/crates/ragu_pcd/src/fuse/_08_f.rs
+++ b/crates/ragu_pcd/src/fuse/_08_f.rs
@@ -9,8 +9,8 @@
 //! $(p\_i(X) - v\_i) / (X - x\_i)$ for a single query. The total number of
 //! terms must match `poly_queries` in the `compute_v` circuit exactly.
 
-use arithmetic::Cycle;
 use ff::Field;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::{Rank, unstructured},
     staging::StageExt,
@@ -49,7 +49,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         D: Driver<'dr, F = C::CircuitField, MaybeKind = Always<()>>,
     {
         use InternalCircuitIndex::*;
-        use arithmetic::factor_iter;
+        use ragu_arithmetic::factor_iter;
 
         let w = *w.value().take();
         let y = *y.value().take();

--- a/crates/ragu_pcd/src/fuse/_09_eval.rs
+++ b/crates/ragu_pcd/src/fuse/_09_eval.rs
@@ -4,8 +4,8 @@
 //! evaluations of every committed or accumulated polynomial (thus far) at the
 //! point $u$, except $f(u)$ which is _derived_ from said evaluations.
 
-use arithmetic::Cycle;
 use ff::Field;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{polynomials::Rank, staging::StageExt};
 use ragu_core::{
     Result,

--- a/crates/ragu_pcd/src/fuse/_10_p.rs
+++ b/crates/ragu_pcd/src/fuse/_10_p.rs
@@ -10,8 +10,8 @@
 //! The commitment is computed via [`PointsWitness`] Horner evaluation.
 
 use alloc::vec::Vec;
-use arithmetic::Cycle;
 use core::ops::AddAssign;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     CircuitExt,
     polynomials::{Rank, unstructured},

--- a/crates/ragu_pcd/src/fuse/_11_circuits.rs
+++ b/crates/ragu_pcd/src/fuse/_11_circuits.rs
@@ -1,5 +1,5 @@
-use arithmetic::Cycle;
 use ff::Field;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{CircuitExt, polynomials::Rank};
 use ragu_core::Result;
 use rand::CryptoRng;

--- a/crates/ragu_pcd/src/fuse/mod.rs
+++ b/crates/ragu_pcd/src/fuse/mod.rs
@@ -15,7 +15,7 @@ mod _09_eval;
 mod _10_p;
 mod _11_circuits;
 
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::{Rank, structured},
     registry::CircuitIndex,

--- a/crates/ragu_pcd/src/lib.rs
+++ b/crates/ragu_pcd/src/lib.rs
@@ -21,7 +21,7 @@ mod verify;
 #[doc(hidden)]
 pub mod test_fixtures;
 
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::Rank,
     registry::{Registry, RegistryBuilder},

--- a/crates/ragu_pcd/src/proof/components.rs
+++ b/crates/ragu_pcd/src/proof/components.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
-use arithmetic::Cycle;
 use ff::Field;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::{Rank, structured, unstructured},
     registry::CircuitIndex,

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -9,8 +9,8 @@
 pub(crate) mod components;
 pub(crate) use components::*;
 
-use arithmetic::Cycle;
 use ff::Field;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::{Rank, structured, unstructured},
     registry::CircuitIndex,

--- a/crates/ragu_pcd/src/step/internal/adapter.rs
+++ b/crates/ragu_pcd/src/step/internal/adapter.rs
@@ -1,4 +1,4 @@
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{Circuit, polynomials::Rank};
 use ragu_core::{
     Result,

--- a/crates/ragu_pcd/src/step/internal/rerandomize.rs
+++ b/crates/ragu_pcd/src/step/internal/rerandomize.rs
@@ -5,7 +5,7 @@
 //! this rerandomization step synthesizes the same circuit no matter what the
 //! left header is, we use a _uniform_ encoding of the left header.
 
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},

--- a/crates/ragu_pcd/src/step/internal/trivial.rs
+++ b/crates/ragu_pcd/src/step/internal/trivial.rs
@@ -3,7 +3,7 @@
 //! Used in rerandomization to create a properly-structured trivial proof that
 //! can be folded with a valid proof without causing C value mismatches.
 
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},

--- a/crates/ragu_pcd/src/step/mod.rs
+++ b/crates/ragu_pcd/src/step/mod.rs
@@ -3,7 +3,7 @@
 mod encoder;
 pub(crate) mod internal;
 
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::registry::CircuitIndex;
 use ragu_core::{
     Result,

--- a/crates/ragu_pcd/src/test_fixtures/nontrivial.rs
+++ b/crates/ragu_pcd/src/test_fixtures/nontrivial.rs
@@ -1,7 +1,7 @@
 //! Nontrivial test fixtures with Poseidon hashing.
 
-use arithmetic::Cycle;
 use ff::Field;
+use ragu_arithmetic::Cycle;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},

--- a/crates/ragu_pcd/src/verify.rs
+++ b/crates/ragu_pcd/src/verify.rs
@@ -1,7 +1,7 @@
 //! This module provides the [`Application::verify`] method implementation.
 
-use arithmetic::Cycle;
 use ff::Field;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::{Rank, structured},
     registry::CircuitIndex,

--- a/crates/ragu_pcd/tests/nontrivial.rs
+++ b/crates/ragu_pcd/tests/nontrivial.rs
@@ -1,4 +1,4 @@
-use arithmetic::Cycle;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::polynomials::R;
 use ragu_core::Result;
 use ragu_pasta::{Fp, Pasta};

--- a/crates/ragu_pcd/tests/registration_errors.rs
+++ b/crates/ragu_pcd/tests/registration_errors.rs
@@ -57,7 +57,7 @@ impl<F: Field> Header<F> for HSuffixAOther {
 
 // Step 0 -> produces HSuffixA
 struct Step0;
-impl<C: arithmetic::Cycle> Step<C> for Step0 {
+impl<C: ragu_arithmetic::Cycle> Step<C> for Step0 {
     const INDEX: Index = Index::new(0);
     type Witness<'source> = ();
     type Aux<'source> = ();
@@ -88,7 +88,7 @@ impl<C: arithmetic::Cycle> Step<C> for Step0 {
 
 // Step 1 -> consumes A and produces B
 struct Step1;
-impl<C: arithmetic::Cycle> Step<C> for Step1 {
+impl<C: ragu_arithmetic::Cycle> Step<C> for Step1 {
     const INDEX: Index = Index::new(1);
     type Witness<'source> = ();
     type Aux<'source> = ();
@@ -119,7 +119,7 @@ impl<C: arithmetic::Cycle> Step<C> for Step1 {
 
 // Duplicate suffix step (index 1) producing different header with same suffix
 struct Step1Dup;
-impl<C: arithmetic::Cycle> Step<C> for Step1Dup {
+impl<C: ragu_arithmetic::Cycle> Step<C> for Step1Dup {
     const INDEX: Index = Index::new(1);
     type Witness<'source> = ();
     type Aux<'source> = ();

--- a/crates/ragu_pcd/tests/rerandomization.rs
+++ b/crates/ragu_pcd/tests/rerandomization.rs
@@ -1,5 +1,5 @@
-use arithmetic::Cycle;
 use ff::Field;
+use ragu_arithmetic::Cycle;
 use ragu_circuits::polynomials::R;
 use ragu_core::{
     Result,

--- a/crates/ragu_primitives/Cargo.toml
+++ b/crates/ragu_primitives/Cargo.toml
@@ -27,13 +27,13 @@ all-features = true
 
 [features]
 default = []
-unstable-test-fixtures = ["arithmetic/unstable-test-fixtures"]
+unstable-test-fixtures = ["ragu_arithmetic/unstable-test-fixtures"]
 
 [lib]
 bench = false
 
 [dependencies]
-arithmetic = { path = "../ragu_arithmetic", version = "0.0.0", package = "ragu_arithmetic" }
+ragu_arithmetic = { path = "../ragu_arithmetic", version = "0.0.0" }
 ff = { workspace = true }
 ragu_core = { path = "../ragu_core", version = "0.0.0" }
 thiserror = "2.0.12"

--- a/crates/ragu_primitives/benches/setup/mod.rs
+++ b/crates/ragu_primitives/benches/setup/mod.rs
@@ -1,6 +1,6 @@
-use arithmetic::{Cycle, Uendo};
 use ff::Field;
 use group::prime::PrimeCurveAffine;
+use ragu_arithmetic::{Cycle, Uendo};
 use ragu_core::drivers::Driver;
 use ragu_core::drivers::emulator::{Emulator, Wireless};
 use ragu_core::maybe::Always;

--- a/crates/ragu_primitives/src/boolean.rs
+++ b/crates/ragu_primitives/src/boolean.rs
@@ -3,8 +3,8 @@
 //! Provides the [`Boolean`] type representing a wire constrained to be zero or
 //! one, with logical operations implemented as circuit constraints.
 
-use arithmetic::Coeff;
 use ff::{Field, PrimeField};
+use ragu_arithmetic::Coeff;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue, LinearExpression},

--- a/crates/ragu_primitives/src/element.rs
+++ b/crates/ragu_primitives/src/element.rs
@@ -3,8 +3,8 @@
 //! Provides the [`Element`] type representing a wire and its field element
 //! assignment, the fundamental building block for circuit construction.
 
-use arithmetic::Coeff;
 use ff::Field;
+use ragu_arithmetic::Coeff;
 use ragu_core::{
     Error, Result,
     drivers::{Driver, DriverValue, LinearExpression},

--- a/crates/ragu_primitives/src/endoscalar.rs
+++ b/crates/ragu_primitives/src/endoscalar.rs
@@ -13,8 +13,8 @@
 //! recovering the effective scalar that an endoscalar maps to for a particular
 //! prime field.
 
-use arithmetic::{Coeff, CurveAffine, Uendo};
 use ff::{Field, PrimeField, WithSmallOrderMulGroup};
+use ragu_arithmetic::{Coeff, CurveAffine, Uendo};
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue, LinearExpression},
@@ -252,9 +252,9 @@ pub fn extract_endoscalar<F: PrimeField>(value: F) -> Uendo {
 #[cfg(test)]
 mod tests {
     use super::{Element, Endoscalar, Maybe, Point};
-    use arithmetic::{CurveAffine, CurveExt, Uendo};
     use ff::{Field, PrimeField, WithSmallOrderMulGroup};
     use group::{Group, prime::PrimeCurveAffine};
+    use ragu_arithmetic::{CurveAffine, CurveExt, Uendo};
     use ragu_core::Result;
     use ragu_pasta::{EpAffine, Fp};
     use rand::Rng;

--- a/crates/ragu_primitives/src/io.rs
+++ b/crates/ragu_primitives/src/io.rs
@@ -61,7 +61,7 @@ pub trait Buffer<'dr, D: Driver<'dr>> {
 /// ## Example
 ///
 /// ```rust
-/// # use arithmetic::CurveAffine;
+/// # use ragu_arithmetic::CurveAffine;
 /// # use ragu_core::{drivers::{Driver, DriverValue}, gadgets::Gadget};
 /// # use ragu_primitives::{Element, io::Write};
 /// # use core::marker::PhantomData;

--- a/crates/ragu_primitives/src/point.rs
+++ b/crates/ragu_primitives/src/point.rs
@@ -6,8 +6,8 @@
 //! This module only supports curves with `a = 0` in the short Weierstrass form,
 //! specifically curves of the form `y^2 = x^3 + b`.
 
-use arithmetic::{Coeff, CurveAffine};
 use ff::{Field, WithSmallOrderMulGroup};
+use ragu_arithmetic::{Coeff, CurveAffine};
 use ragu_core::{
     Error, Result,
     drivers::{Driver, DriverValue, LinearExpression},
@@ -279,8 +279,8 @@ fn test_point_double() -> Result<()> {
 #[test]
 fn test_add_incomplete() -> Result<()> {
     use alloc::vec;
-    use arithmetic::CurveExt;
     use group::{Group, prime::PrimeCurveAffine};
+    use ragu_arithmetic::CurveExt;
 
     type F = ragu_pasta::Fp;
     type C = ragu_pasta::EpAffine;
@@ -331,8 +331,8 @@ fn test_add_incomplete() -> Result<()> {
 fn test_double_and_add_incomplete() -> Result<()> {
     use alloc::vec;
     use alloc::vec::Vec;
-    use arithmetic::CurveExt;
     use group::{Group, prime::PrimeCurveAffine};
+    use ragu_arithmetic::CurveExt;
 
     type F = ragu_pasta::Fp;
     type C = ragu_pasta::EpAffine;

--- a/crates/ragu_primitives/src/promotion.rs
+++ b/crates/ragu_primitives/src/promotion.rs
@@ -1,8 +1,8 @@
 //! Strips away the witness data from a gadget while still preserving access to
 //! it.
 
-use arithmetic::Coeff;
 use ff::Field;
+use ragu_arithmetic::Coeff;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverTypes, DriverValue, FromDriver},

--- a/crates/ragu_primitives/src/simulator.rs
+++ b/crates/ragu_primitives/src/simulator.rs
@@ -3,8 +3,8 @@
 //! Provides a [`Simulator`] driver that fully executes circuit synthesis,
 //! tracking constraint counts and enforcing constraint satisfaction.
 
-use arithmetic::Coeff;
 use ff::Field;
+use ragu_arithmetic::Coeff;
 use ragu_core::{
     Error, Result,
     drivers::{DirectSum, Driver, DriverTypes},

--- a/crates/ragu_primitives/src/util.rs
+++ b/crates/ragu_primitives/src/util.rs
@@ -1,8 +1,8 @@
 //! This is an internal module used to store helper utilities that are not part
 //! of the public API (yet).
 
-use arithmetic::Coeff;
 use ff::Field;
+use ragu_arithmetic::Coeff;
 use ragu_core::maybe::{Maybe, MaybeKind};
 
 use core::borrow::Borrow;


### PR DESCRIPTION
References https://github.com/tachyon-zcash/ragu/issues/14. Use the full crate name everywhere for consistency with other crates (`arithmetic` was the only offender that broke consistency). 