### PR TITLE
feat(pcd): port IPA

### DIFF
--- a/crates/ragu_arithmetic/src/lib.rs
+++ b/crates/ragu_arithmetic/src/lib.rs
@@ -173,11 +173,14 @@ pub trait FixedGenerators<C: CurveAffine>: Send + Sync + 'static {
     fn g(&self) -> &[C];
 
     /// Generator used as a blinding factor or randomization.
-    fn h(&self) -> &C;
+    fn w(&self) -> &C;
+
+    /// Auxiliary generator used in the IPA.
+    fn u(&self) -> &C;
 
     /// Compute a commitment to a single value.
     fn short_commit(&self, value: C::ScalarExt, blind: C::ScalarExt) -> C {
-        (self.g()[0] * value + *self.h() * blind).into()
+        (self.g()[0] * value + *self.w() * blind).into()
     }
 }
 

--- a/crates/ragu_arithmetic/src/lib.rs
+++ b/crates/ragu_arithmetic/src/lib.rs
@@ -98,7 +98,8 @@ pub use ragu_macros::repr256;
 /// like 134-bit challenges. This may end up being removed if 128 bits suffices.
 pub use u128 as Uendo;
 pub use util::{
-    batch_to_affine, dot, eval, factor, factor_iter, geosum, low_u64, mul, poly_with_roots,
+    batch_to_affine, dot, eval, factor, factor_iter, geosum, low_u64, mul, parallelize,
+    poly_with_roots,
 };
 
 /// Represents a "cycle" of elliptic curves where the scalar field of one curve

--- a/crates/ragu_arithmetic/src/multicore.rs
+++ b/crates/ragu_arithmetic/src/multicore.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "multicore")]
 pub use maybe_rayon::{current_num_threads, iter::ParallelIterator};
-pub use maybe_rayon::{iter::IntoParallelIterator, join};
+pub use maybe_rayon::{iter::IntoParallelIterator, join, scope};
 
 #[cfg(not(feature = "multicore"))]
 pub fn current_num_threads() -> usize {

--- a/crates/ragu_arithmetic/src/util.rs
+++ b/crates/ragu_arithmetic/src/util.rs
@@ -172,6 +172,27 @@ pub fn batch_to_affine<C: CurveAffine, const N: usize>(projectives: [C::Curve; N
     affines
 }
 
+/// This simple utility function will parallelize an operation that is to be
+/// performed over a mutable slice.
+pub fn parallelize<T: Send, F: Fn(&mut [T], usize) + Send + Sync + Clone>(v: &mut [T], f: F) {
+    let n = v.len();
+    let num_threads = crate::multicore::current_num_threads();
+    let mut chunk = n / num_threads;
+    if chunk < num_threads {
+        chunk = n;
+    }
+
+    crate::multicore::scope(|scope| {
+        for (chunk_num, v) in v.chunks_mut(chunk).enumerate() {
+            let f = f.clone();
+            scope.spawn(move |_| {
+                let start = chunk_num * chunk;
+                f(v, start);
+            });
+        }
+    });
+}
+
 /// Compute the multiscalar multiplication $\langle \mathbf{a}, \mathbf{G} \rangle$ where
 /// $\mathbf{a} \in \mathbb{F}^n$ is a vector of scalars and $\mathbf{G} \in \mathbb{G}^n$
 /// is a vector of bases.

--- a/crates/ragu_pasta/build.rs
+++ b/crates/ragu_pasta/build.rs
@@ -24,11 +24,17 @@ fn write_point<C: CurveAffine, W: Write>(v: &mut W, point: C) -> Result<()> {
     Ok(())
 }
 
-fn write_params_for_curve<C: CurveAffine, W: Write>(v: &mut W, g: &[C], h: &C) -> Result<()> {
+fn write_params_for_curve<C: CurveAffine, Out: Write>(
+    out: &mut Out,
+    g: &[C],
+    w: &C,
+    u: &C,
+) -> Result<()> {
     for point in g {
-        write_point(v, *point)?;
+        write_point(out, *point)?;
     }
-    write_point(v, *h)?;
+    write_point(out, *w)?;
+    write_point(out, *u)?;
 
     Ok(())
 }
@@ -44,6 +50,6 @@ fn main() {
     let params = common::PastaParams::generate();
 
     let mut f = File::create(out_path).unwrap();
-    write_params_for_curve(&mut f, &params.pallas.g, &params.pallas.h).unwrap();
-    write_params_for_curve(&mut f, &params.vesta.g, &params.vesta.h).unwrap();
+    write_params_for_curve(&mut f, &params.pallas.g, &params.pallas.w, &params.pallas.u).unwrap();
+    write_params_for_curve(&mut f, &params.vesta.g, &params.vesta.w, &params.vesta.u).unwrap();
 }

--- a/crates/ragu_pasta/pasta_common.rs
+++ b/crates/ragu_pasta/pasta_common.rs
@@ -12,8 +12,8 @@ pub const DEFAULT_EQ_K: usize = 13;
 /// Runtime parameters for the Pasta curve cycle, holding generator points
 /// for the Pallas and Vesta curves.
 pub struct PastaParams {
-    pub(crate) pallas: Generators<EpAffine>,
-    pub(crate) vesta: Generators<EqAffine>,
+    pub(crate) pallas: PallasGenerators,
+    pub(crate) vesta: VestaGenerators,
 }
 
 /// Fixed generators for one curve of the Pasta cycle.

--- a/crates/ragu_pasta/pasta_common.rs
+++ b/crates/ragu_pasta/pasta_common.rs
@@ -1,13 +1,8 @@
-use ragu_arithmetic::CurveExt;
-use group::{Curve, prime::PrimeCurveAffine};
-use pasta_curves::{
-    EpAffine,
-    EqAffine,
-    Ep,
-    Eq
-};
-
 use alloc::{vec, vec::Vec};
+
+use group::{Curve, prime::PrimeCurveAffine};
+use pasta_curves::{Ep, EpAffine, Eq, EqAffine, arithmetic::CurveAffine};
+use ragu_arithmetic::CurveExt;
 
 const DOMAIN_PREFIX: &str = "Ragu-Parameters";
 
@@ -17,23 +12,24 @@ pub const DEFAULT_EQ_K: usize = 13;
 /// Runtime parameters for the Pasta curve cycle, holding generator points
 /// for the Pallas and Vesta curves.
 pub struct PastaParams {
-    pub(crate) pallas: PallasGenerators,
-    pub(crate) vesta: VestaGenerators,
+    pub(crate) pallas: Generators<EpAffine>,
+    pub(crate) vesta: Generators<EqAffine>,
+}
+
+/// Fixed generators for one curve of the Pasta cycle.
+pub struct Generators<C: CurveAffine> {
+    pub(crate) g: Vec<C>,
+    pub(crate) w: C,
+    pub(crate) u: C,
 }
 
 /// Fixed generators for the Pallas curve.
-pub struct PallasGenerators {
-    pub(crate) g: Vec<EpAffine>,
-    pub(crate) h: EpAffine,
-}
+pub type PallasGenerators = Generators<EpAffine>;
 
 /// Fixed generators for the Vesta curve.
-pub struct VestaGenerators {
-    pub(crate) g: Vec<EqAffine>,
-    pub(crate) h: EqAffine,
-}
+pub type VestaGenerators = Generators<EqAffine>;
 
-fn params_for_curve<C: CurveExt>(n: usize) -> (Vec<C::AffineExt>, C::AffineExt) {
+fn params_for_curve<C: CurveExt>(n: usize) -> (Vec<C::AffineExt>, C::AffineExt, C::AffineExt) {
     let g_projective = {
         let hasher = C::hash_to_curve(DOMAIN_PREFIX);
         let mut g = Vec::with_capacity(n);
@@ -47,26 +43,29 @@ fn params_for_curve<C: CurveExt>(n: usize) -> (Vec<C::AffineExt>, C::AffineExt) 
     let mut g = vec![C::AffineExt::identity(); n];
     Curve::batch_normalize(&g_projective[..], &mut g);
 
-    let h: C::AffineExt = C::hash_to_curve(DOMAIN_PREFIX)(&[1]).into();
+    let w: C::AffineExt = C::hash_to_curve(DOMAIN_PREFIX)(&[1]).into();
+    let u: C::AffineExt = C::hash_to_curve(DOMAIN_PREFIX)(&[2]).into();
 
-    (g, h)
+    (g, w, u)
 }
 
 impl PastaParams {
     /// Generate Pasta parameters at runtime via hash-to-curve.
     pub(crate) fn generate() -> Self {
-        let (ep_g, ep_h) = params_for_curve::<Ep>(1usize << DEFAULT_EP_K);
-        let (eq_g, eq_h) = params_for_curve::<Eq>(1usize << DEFAULT_EQ_K);
+        let (ep_g, ep_w, ep_u) = params_for_curve::<Ep>(1usize << DEFAULT_EP_K);
+        let (eq_g, eq_w, eq_u) = params_for_curve::<Eq>(1usize << DEFAULT_EQ_K);
 
         PastaParams {
-            pallas: PallasGenerators {
+            pallas: Generators {
                 g: ep_g,
-                h: ep_h,
+                w: ep_w,
+                u: ep_u,
             },
-            vesta: VestaGenerators {
+            vesta: Generators {
                 g: eq_g,
-                h: eq_h,
-            }
+                w: eq_w,
+                u: eq_u,
+            },
         }
     }
 }

--- a/crates/ragu_pasta/pasta_common.rs
+++ b/crates/ragu_pasta/pasta_common.rs
@@ -24,9 +24,11 @@ pub struct Generators<C: CurveAffine> {
 }
 
 /// Fixed generators for the Pallas curve.
+#[allow(dead_code)]
 pub type PallasGenerators = Generators<EpAffine>;
 
 /// Fixed generators for the Vesta curve.
+#[allow(dead_code)]
 pub type VestaGenerators = Generators<EqAffine>;
 
 fn params_for_curve<C: CurveExt>(n: usize) -> (Vec<C::AffineExt>, C::AffineExt, C::AffineExt) {

--- a/crates/ragu_pasta/src/lib.rs
+++ b/crates/ragu_pasta/src/lib.rs
@@ -42,7 +42,8 @@ mod common {
 mod poseidon_fp;
 mod poseidon_fq;
 
-pub use common::{PallasGenerators, PastaParams, VestaGenerators};
+pub use common::{Generators, PallasGenerators, PastaParams, VestaGenerators};
+use pasta_curves::arithmetic::CurveAffine;
 pub use pasta_curves::{Ep, EpAffine, Eq, EqAffine, Fp, Fq};
 pub use poseidon_fp::PoseidonFp;
 pub use poseidon_fq::PoseidonFq;
@@ -93,23 +94,17 @@ impl Cycle for Pasta {
     }
 }
 
-impl FixedGenerators<pasta_curves::EpAffine> for PallasGenerators {
-    fn g(&self) -> &[pasta_curves::EpAffine] {
+impl<C: CurveAffine> FixedGenerators<C> for Generators<C> {
+    fn g(&self) -> &[C] {
         &self.g
     }
 
-    fn h(&self) -> &pasta_curves::EpAffine {
-        &self.h
-    }
-}
-
-impl FixedGenerators<pasta_curves::EqAffine> for VestaGenerators {
-    fn g(&self) -> &[pasta_curves::EqAffine] {
-        &self.g
+    fn w(&self) -> &C {
+        &self.w
     }
 
-    fn h(&self) -> &pasta_curves::EqAffine {
-        &self.h
+    fn u(&self) -> &C {
+        &self.u
     }
 }
 
@@ -121,7 +116,7 @@ mod baked {
     use lazy_static::lazy_static;
     use pasta_curves::arithmetic::CurveAffine;
 
-    use super::{PallasGenerators, Pasta, PastaParams, VestaGenerators};
+    use super::{Generators, Pasta, PastaParams};
 
     const RAW_PARAMETERS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/pasta_parameters.bin"));
 
@@ -138,28 +133,39 @@ mod baked {
         C::from_xy(x, y).unwrap()
     }
 
-    fn get_points_for_curve<C: CurveAffine>(source: &mut &[u8], n: usize) -> (Vec<C>, C) {
+    fn get_points_for_curve<C: CurveAffine>(source: &mut &[u8], n: usize) -> (Vec<C>, C, C) {
         let mut g = Vec::with_capacity(n);
         for _ in 0..n {
             g.push(get_point(source));
         }
-        let h = get_point(source);
+        let w = get_point(source);
+        let u = get_point(source);
 
-        (g, h)
+        (g, w, u)
     }
 
     lazy_static! {
         static ref PASTA_PARAMETERS: PastaParams = {
             let mut params = RAW_PARAMETERS;
 
-            let (ep_g, ep_h) = get_points_for_curve(&mut params, 1 << crate::common::DEFAULT_EP_K);
-            let (eq_g, eq_h) = get_points_for_curve(&mut params, 1 << crate::common::DEFAULT_EQ_K);
+            let (ep_g, ep_w, ep_u) =
+                get_points_for_curve(&mut params, 1 << crate::common::DEFAULT_EP_K);
+            let (eq_g, eq_w, eq_u) =
+                get_points_for_curve(&mut params, 1 << crate::common::DEFAULT_EQ_K);
 
             assert_eq!(params.len(), 0);
 
             PastaParams {
-                pallas: PallasGenerators { g: ep_g, h: ep_h },
-                vesta: VestaGenerators { g: eq_g, h: eq_h },
+                pallas: Generators {
+                    g: ep_g,
+                    w: ep_w,
+                    u: ep_u,
+                },
+                vesta: Generators {
+                    g: eq_g,
+                    w: eq_w,
+                    u: eq_u,
+                },
             }
         };
     }
@@ -197,12 +203,30 @@ mod baked {
             Pasta::host_generators(&regenerated).g()
         );
         assert_eq!(
-            Pasta::nested_generators(params).h(),
-            Pasta::nested_generators(&regenerated).h()
+            Pasta::nested_generators(params).w(),
+            Pasta::nested_generators(&regenerated).w()
         );
         assert_eq!(
-            Pasta::host_generators(params).h(),
-            Pasta::host_generators(&regenerated).h()
+            Pasta::host_generators(params).w(),
+            Pasta::host_generators(&regenerated).w()
+        );
+        assert_eq!(
+            Pasta::nested_generators(params).u(),
+            Pasta::nested_generators(&regenerated).u()
+        );
+        assert_eq!(
+            Pasta::host_generators(params).u(),
+            Pasta::host_generators(&regenerated).u()
+        );
+
+        // u must differ from w (distinct hash_to_curve domain tags).
+        assert_ne!(
+            Pasta::nested_generators(params).u(),
+            Pasta::nested_generators(params).w()
+        );
+        assert_ne!(
+            Pasta::host_generators(params).u(),
+            Pasta::host_generators(params).w()
         );
     }
 }

--- a/crates/ragu_pcd/src/ipa/compress.rs
+++ b/crates/ragu_pcd/src/ipa/compress.rs
@@ -1,0 +1,134 @@
+//! Compressed proof structures and operations.
+
+use alloc::vec::Vec;
+
+use ff::{Field, PrimeField};
+use ragu_arithmetic::Cycle;
+use ragu_circuits::polynomials::Rank;
+use ragu_core::{
+    Result,
+    drivers::emulator::{Emulator, Wireless},
+    maybe::Always,
+};
+use ragu_primitives::{Element, GadgetExt};
+use rand::CryptoRng;
+
+use super::{Blind, IPA_TAG, IpaProof, absorb_point, prover, verifier};
+use crate::{internal::transcript::Transcript, proof::Proof};
+
+/// Succinct proof for external verification.
+///
+/// Currently only covers the $P(u) = v$ opening. The revdot-to-polynomial
+/// reduction that binds $a$, $b$ to the claimed inner product is intentionally
+/// out of scope at this layer and will be added on top of this IPA foundation.
+#[derive(Clone, Debug)]
+pub struct CompressedProof<C: Cycle> {
+    /// P polynomial commitment.
+    pub p_commitment: C::HostCurve,
+    /// Evaluation point.
+    pub u: C::CircuitField,
+    /// Claimed evaluation $P(u)$.
+    pub v: C::CircuitField,
+    /// IPA opening proof for $P(u) = v$.
+    pub ipa: IpaProof<C::HostCurve>,
+}
+
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, HEADER_SIZE> {
+    /// Compress an uncompressed proof into succinct form.
+    pub fn compress<RNG: CryptoRng>(
+        &self,
+        proof: &Proof<C, R>,
+        rng: &mut RNG,
+    ) -> Result<CompressedProof<C>>
+    where
+        C::CircuitField: PrimeField,
+        C::ScalarField: PrimeField,
+    {
+        let generators = C::host_generators(self.params);
+        let mut dr = Emulator::<Wireless<Always<()>, C::CircuitField>>::execute();
+        let mut transcript = Transcript::new(&mut dr, C::circuit_poseidon(self.params), IPA_TAG)?;
+
+        let p_commitment = proof.native_p_commitment();
+        let u = proof.u;
+        let v = proof.v();
+
+        absorb_point::<C>(&mut dr, &mut transcript, &p_commitment)?;
+        Element::constant(&mut dr, u).write(&mut dr, &mut transcript)?;
+        Element::constant(&mut dr, v).write(&mut dr, &mut transcript)?;
+
+        // Ragu's native polynomial commitments are non-hiding (rerandomization
+        // provides ZK); pass zero as the blinding factor so the IPA's
+        // reconstructed commitment matches `native_p_commitment` exactly.
+        let p_coeffs: Vec<_> = proof.native_p_poly().iter_coeffs().collect();
+        let ipa = prover::create_proof::<C, _, _>(
+            generators,
+            rng,
+            &mut dr,
+            &mut transcript,
+            &p_coeffs,
+            Blind(C::CircuitField::ZERO),
+            u,
+        )?;
+
+        Ok(CompressedProof {
+            p_commitment,
+            u,
+            v,
+            ipa,
+        })
+    }
+
+    /// Verify a compressed proof.
+    pub fn verify_compressed(&self, compressed: &CompressedProof<C>) -> Result<bool>
+    where
+        C::CircuitField: PrimeField,
+        C::ScalarField: PrimeField,
+    {
+        let generators = C::host_generators(self.params);
+        let mut dr = Emulator::<Wireless<Always<()>, C::CircuitField>>::execute();
+        let mut transcript = Transcript::new(&mut dr, C::circuit_poseidon(self.params), IPA_TAG)?;
+
+        absorb_point::<C>(&mut dr, &mut transcript, &compressed.p_commitment)?;
+        Element::constant(&mut dr, compressed.u).write(&mut dr, &mut transcript)?;
+        Element::constant(&mut dr, compressed.v).write(&mut dr, &mut transcript)?;
+
+        verifier::verify_proof::<C, _>(
+            generators,
+            &mut dr,
+            &mut transcript,
+            compressed.p_commitment,
+            compressed.u,
+            compressed.v,
+            &compressed.ipa,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ragu_circuits::polynomials::R;
+    use ragu_pasta::Pasta;
+    use rand::{SeedableRng, rngs::StdRng};
+
+    use crate::ApplicationBuilder;
+
+    type TestR = R<13>;
+    const HEADER_SIZE: usize = 4;
+
+    fn create_test_app() -> crate::Application<'static, Pasta, TestR, HEADER_SIZE> {
+        let pasta = Pasta::baked();
+        ApplicationBuilder::<Pasta, TestR, HEADER_SIZE>::new()
+            .finalize(pasta)
+            .expect("failed to create test application")
+    }
+
+    #[test]
+    fn test_compress_and_verify() {
+        let app = create_test_app();
+        let mut rng = StdRng::seed_from_u64(54321);
+
+        let proof = app.trivial_proof();
+        let compressed = app.compress(&proof, &mut rng).unwrap();
+        assert!(app.verify_compressed(&compressed).unwrap());
+    }
+}

--- a/crates/ragu_pcd/src/ipa/compress.rs
+++ b/crates/ragu_pcd/src/ipa/compress.rs
@@ -13,7 +13,7 @@ use ragu_core::{
 use ragu_primitives::{Element, GadgetExt};
 use rand::CryptoRng;
 
-use super::{Blind, IPA_TAG, IpaProof, absorb_point, prover, verifier};
+use super::{Blind, IPA_TAG, IpaProof, MSM, Params, absorb_point, prover, verifier};
 use crate::{internal::transcript::Transcript, proof::Proof};
 
 /// Succinct proof for external verification.
@@ -45,6 +45,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
         C::ScalarField: PrimeField,
     {
         let generators = C::host_generators(self.params);
+        let params = Params::<C::HostCurve>::new(generators);
         let mut dr = Emulator::<Wireless<Always<()>, C::CircuitField>>::execute();
         let mut transcript = Transcript::new(&mut dr, C::circuit_poseidon(self.params), IPA_TAG)?;
 
@@ -52,7 +53,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
         let u = proof.u;
         let v = proof.v();
 
-        absorb_point::<C>(&mut dr, &mut transcript, &p_commitment)?;
+        absorb_point(&mut dr, &mut transcript, &p_commitment)?;
         Element::constant(&mut dr, u).write(&mut dr, &mut transcript)?;
         Element::constant(&mut dr, v).write(&mut dr, &mut transcript)?;
 
@@ -60,8 +61,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
         // provides ZK); pass zero as the blinding factor so the IPA's
         // reconstructed commitment matches `native_p_commitment` exactly.
         let p_coeffs: Vec<_> = proof.native_p_poly().iter_coeffs().collect();
-        let ipa = prover::create_proof::<C, _, _>(
-            generators,
+        let ipa = prover::create_proof::<C::HostCurve, _, _>(
+            &params,
             rng,
             &mut dr,
             &mut transcript,
@@ -85,22 +86,28 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
         C::ScalarField: PrimeField,
     {
         let generators = C::host_generators(self.params);
+        let params = Params::<C::HostCurve>::new(generators);
         let mut dr = Emulator::<Wireless<Always<()>, C::CircuitField>>::execute();
         let mut transcript = Transcript::new(&mut dr, C::circuit_poseidon(self.params), IPA_TAG)?;
 
-        absorb_point::<C>(&mut dr, &mut transcript, &compressed.p_commitment)?;
+        absorb_point(&mut dr, &mut transcript, &compressed.p_commitment)?;
         Element::constant(&mut dr, compressed.u).write(&mut dr, &mut transcript)?;
         Element::constant(&mut dr, compressed.v).write(&mut dr, &mut transcript)?;
 
-        verifier::verify_proof::<C, _>(
-            generators,
+        // Seed the MSM with P (the commitment being opened) at scalar 1.
+        let mut msm = MSM::new(&params);
+        msm.append_term(C::CircuitField::ONE, compressed.p_commitment);
+
+        let guard = verifier::verify_proof::<C::HostCurve, _>(
+            &params,
+            msm,
             &mut dr,
             &mut transcript,
-            compressed.p_commitment,
+            &compressed.ipa,
             compressed.u,
             compressed.v,
-            &compressed.ipa,
-        )
+        )?;
+        Ok(guard.use_challenges().eval())
     }
 }
 

--- a/crates/ragu_pcd/src/ipa/mod.rs
+++ b/crates/ragu_pcd/src/ipa/mod.rs
@@ -1,12 +1,11 @@
 //! Inner Product Argument (IPA) for polynomial commitments.
 //!
 //! Adapted from halo2's `halo2_proofs/src/poly/commitment`. Fiat-Shamir reuses
-//! the PCD [`Transcript`](crate::internal::transcript::Transcript) executed at
-//! concrete values via the [`Emulator`](ragu_core::drivers::emulator::Emulator)
-//! driver. Host curve commitments are hashed into the circuit-field transcript
-//! by reinterpreting each coordinate's little-endian byte representation as a
-//! circuit-field element (see [`field_from_bytes`]); infinity is rejected,
-//! matching halo2's `common_point`.
+//! the PCD `Transcript` executed at concrete values via the `Emulator` driver.
+//! Host curve commitments are hashed into the circuit-field transcript by
+//! reinterpreting each coordinate's little-endian byte representation as a
+//! circuit-field element; infinity is rejected, matching halo2's
+//! `common_point`.
 
 use alloc::vec::Vec;
 
@@ -19,10 +18,12 @@ use ragu_primitives::{Element, GadgetExt};
 use crate::internal::transcript::Transcript;
 
 pub mod compress;
+mod msm;
 mod prover;
 mod verifier;
 
 pub use compress::CompressedProof;
+pub use msm::MSM;
 pub use prover::create_proof;
 pub use verifier::verify_proof;
 

--- a/crates/ragu_pcd/src/ipa/mod.rs
+++ b/crates/ragu_pcd/src/ipa/mod.rs
@@ -1,0 +1,176 @@
+//! Inner Product Argument (IPA) for polynomial commitments.
+//!
+//! Adapted from halo2's `halo2_proofs/src/poly/commitment`. Fiat-Shamir reuses
+//! the PCD [`Transcript`](crate::internal::transcript::Transcript) executed at
+//! concrete values via the [`Emulator`](ragu_core::drivers::emulator::Emulator)
+//! driver. Host curve commitments are hashed into the circuit-field transcript
+//! by reinterpreting each coordinate's little-endian byte representation as a
+//! circuit-field element (see [`field_from_bytes`]); infinity is rejected,
+//! matching halo2's `common_point`.
+
+use alloc::vec::Vec;
+
+use ff::{Field, PrimeField};
+use pasta_curves::arithmetic::CurveAffine;
+use ragu_arithmetic::{FixedGenerators, PoseidonPermutation, mul as best_multiexp};
+use ragu_core::{Error, Result, drivers::Driver};
+use ragu_primitives::{Element, GadgetExt};
+
+use crate::internal::transcript::Transcript;
+
+pub mod compress;
+mod msm;
+mod prover;
+mod verifier;
+
+pub use msm::MSM;
+
+pub use compress::CompressedProof;
+pub use prover::create_proof;
+pub use verifier::verify_proof;
+
+/// Domain separation tag for the IPA sub-protocol.
+pub(crate) const IPA_TAG: &[u8] = b"ragu-ipa";
+
+/// These are the public parameters for the polynomial commitment scheme,
+/// mirroring halo2's `Params<C>`.
+#[derive(Clone, Debug)]
+pub struct Params<C: CurveAffine> {
+    pub(crate) k: u32,
+    pub(crate) n: u64,
+    pub(crate) g: Vec<C>,
+    pub(crate) w: C,
+    pub(crate) u: C,
+}
+
+impl<C: CurveAffine> Params<C> {
+    /// Bundles an existing [`FixedGenerators`] into halo2-style `Params`.
+    pub fn new<G: FixedGenerators<C>>(generators: &G) -> Self {
+        let n = generators.g().len() as u64;
+        assert!(n.is_power_of_two());
+        Params {
+            k: n.ilog2(),
+            n,
+            g: generators.g().to_vec(),
+            w: *generators.w(),
+            u: *generators.u(),
+        }
+    }
+
+    /// Commits to a polynomial described by the provided slice of
+    /// coefficients. The commitment is blinded by the blinding factor `r`.
+    pub fn commit(&self, poly: &[C::Scalar], r: Blind<C::Scalar>) -> C::Curve
+    where
+        C::Scalar: PrimeField,
+    {
+        best_multiexp(poly, &self.g) + self.w * r.0
+    }
+}
+
+/// Wrapper type around a blinding factor, distinguishing it from other
+/// scalars at the type level. Mirrors halo2's `Blind<F>`.
+#[derive(Copy, Clone, Debug)]
+pub struct Blind<F>(pub F);
+
+impl<F: Field> Default for Blind<F> {
+    fn default() -> Self {
+        Blind(F::ONE)
+    }
+}
+
+impl<F: Field> core::ops::Add for Blind<F> {
+    type Output = Self;
+
+    fn add(self, rhs: Blind<F>) -> Self {
+        Blind(self.0 + rhs.0)
+    }
+}
+
+impl<F: Field> core::ops::Mul for Blind<F> {
+    type Output = Self;
+
+    fn mul(self, rhs: Blind<F>) -> Self {
+        Blind(self.0 * rhs.0)
+    }
+}
+
+impl<F: Field> core::ops::AddAssign for Blind<F> {
+    fn add_assign(&mut self, rhs: Blind<F>) {
+        self.0 += rhs.0;
+    }
+}
+
+impl<F: Field> core::ops::MulAssign for Blind<F> {
+    fn mul_assign(&mut self, rhs: Blind<F>) {
+        self.0 *= rhs.0;
+    }
+}
+
+impl<F: Field> core::ops::AddAssign<F> for Blind<F> {
+    fn add_assign(&mut self, rhs: F) {
+        self.0 += rhs;
+    }
+}
+
+impl<F: Field> core::ops::MulAssign<F> for Blind<F> {
+    fn mul_assign(&mut self, rhs: F) {
+        self.0 *= rhs;
+    }
+}
+
+/// Log-size IPA proof.
+#[derive(Clone, Debug)]
+pub struct IpaProof<C: CurveAffine> {
+    /// Commitment to blinding polynomial S.
+    pub s_commitment: C,
+    /// Cross-term commitments $(L_j, R_j)$ per round.
+    pub rounds: Vec<(C, C)>,
+    /// Final collapsed coefficient.
+    pub c: C::ScalarExt,
+    /// Synthetic blinding factor.
+    pub f: C::ScalarExt,
+}
+
+/// Absorb a curve point into the IPA transcript by byte-reinterpreting each
+/// coordinate as a transcript-field element. Matches halo2's `common_point`:
+/// points at infinity are rejected.
+pub(super) fn absorb_point<'dr, C, D, P>(
+    dr: &mut D,
+    transcript: &mut Transcript<'dr, D, P>,
+    point: &C,
+) -> Result<()>
+where
+    C: CurveAffine,
+    C::Base: PrimeField,
+    D: Driver<'dr>,
+    D::F: PrimeField,
+    P: PoseidonPermutation<D::F>,
+{
+    let coords = point.coordinates().into_option().ok_or_else(|| {
+        Error::InvalidWitness("cannot write points at infinity to the transcript".into())
+    })?;
+    let x = field_from_bytes::<D::F>(coords.x().to_repr().as_ref());
+    let y = field_from_bytes::<D::F>(coords.y().to_repr().as_ref());
+    Element::constant(dr, x).write(dr, transcript)?;
+    Element::constant(dr, y).write(dr, transcript)?;
+    Ok(())
+}
+
+/// Reinterpret the little-endian bytes of a scalar from one prime field as an
+/// element of another. Host curve commitments have coordinates in
+/// `C::ScalarField` but Ragu's transcript sponges over `C::CircuitField`, so
+/// each coordinate is byte-reinterpreted before being absorbed.
+pub(super) fn field_from_bytes<F: PrimeField>(bytes: &[u8]) -> F {
+    let mut repr = F::Repr::default();
+    let len = core::cmp::min(bytes.len(), repr.as_ref().len());
+    repr.as_mut()[..len].copy_from_slice(&bytes[..len]);
+    F::from_repr_vartime(repr).unwrap_or_else(|| {
+        bytes
+            .iter()
+            .take(32)
+            .enumerate()
+            .fold(F::ZERO, |acc, (i, &b)| {
+                acc + F::from(b as u64) * F::from(256u64).pow([i as u64])
+            })
+    })
+}

--- a/crates/ragu_pcd/src/ipa/mod.rs
+++ b/crates/ragu_pcd/src/ipa/mod.rs
@@ -19,11 +19,8 @@ use ragu_primitives::{Element, GadgetExt};
 use crate::internal::transcript::Transcript;
 
 pub mod compress;
-mod msm;
 mod prover;
 mod verifier;
-
-pub use msm::MSM;
 
 pub use compress::CompressedProof;
 pub use prover::create_proof;

--- a/crates/ragu_pcd/src/ipa/mod.rs
+++ b/crates/ragu_pcd/src/ipa/mod.rs
@@ -28,7 +28,20 @@ pub use prover::create_proof;
 pub use verifier::verify_proof;
 
 /// Domain separation tag for the IPA sub-protocol.
-pub(crate) const IPA_TAG: &[u8] = b"ragu-ipa";
+pub(crate) const IPA_TAG: &[u8] = b"FIXME";
+
+/// Log-size IPA proof.
+#[derive(Clone, Debug)]
+pub struct IpaProof<C: CurveAffine> {
+    /// Commitment to blinding polynomial S.
+    pub s_commitment: C,
+    /// Cross-term commitments $(L_j, R_j)$ per round.
+    pub rounds: Vec<(C, C)>,
+    /// Final collapsed coefficient.
+    pub c: C::ScalarExt,
+    /// Synthetic blinding factor.
+    pub f: C::ScalarExt,
+}
 
 /// These are the public parameters for the polynomial commitment scheme,
 /// mirroring halo2's `Params<C>`.
@@ -114,19 +127,6 @@ impl<F: Field> core::ops::MulAssign<F> for Blind<F> {
     fn mul_assign(&mut self, rhs: F) {
         self.0 *= rhs;
     }
-}
-
-/// Log-size IPA proof.
-#[derive(Clone, Debug)]
-pub struct IpaProof<C: CurveAffine> {
-    /// Commitment to blinding polynomial S.
-    pub s_commitment: C,
-    /// Cross-term commitments $(L_j, R_j)$ per round.
-    pub rounds: Vec<(C, C)>,
-    /// Final collapsed coefficient.
-    pub c: C::ScalarExt,
-    /// Synthetic blinding factor.
-    pub f: C::ScalarExt,
 }
 
 /// Absorb a curve point into the IPA transcript by byte-reinterpreting each

--- a/crates/ragu_pcd/src/ipa/msm.rs
+++ b/crates/ragu_pcd/src/ipa/msm.rs
@@ -110,12 +110,12 @@ impl<'a, C: CurveAffine> MSM<'a, C> {
 
     /// Add to `w_scalar`
     pub fn add_to_w_scalar(&mut self, scalar: C::Scalar) {
-        self.w_scalar = self.w_scalar.map_or(Some(scalar), |a| Some(a + &scalar));
+        self.w_scalar = self.w_scalar.map_or(Some(scalar), |a| Some(a + scalar));
     }
 
     /// Add to `u_scalar`
     pub fn add_to_u_scalar(&mut self, scalar: C::Scalar) {
-        self.u_scalar = self.u_scalar.map_or(Some(scalar), |a| Some(a + &scalar));
+        self.u_scalar = self.u_scalar.map_or(Some(scalar), |a| Some(a + scalar));
     }
 
     /// Scale all scalars in the MSM by some scaling factor
@@ -130,8 +130,8 @@ impl<'a, C: CurveAffine> MSM<'a, C> {
             other.0 *= factor;
         }
 
-        self.w_scalar = self.w_scalar.map(|a| a * &factor);
-        self.u_scalar = self.u_scalar.map(|a| a * &factor);
+        self.w_scalar = self.w_scalar.map(|a| a * factor);
+        self.u_scalar = self.u_scalar.map(|a| a * factor);
     }
 
     /// Perform multiexp and check that it results in zero

--- a/crates/ragu_pcd/src/ipa/msm.rs
+++ b/crates/ragu_pcd/src/ipa/msm.rs
@@ -1,0 +1,172 @@
+use alloc::{collections::BTreeMap, vec, vec::Vec};
+
+use ff::Field;
+use pasta_curves::group::Group;
+use ragu_arithmetic::{CurveAffine, mul as best_multiexp};
+
+use super::Params;
+
+/// A multiscalar multiplication in the polynomial commitment scheme
+#[derive(Debug, Clone)]
+pub struct MSM<'a, C: CurveAffine> {
+    pub(crate) params: &'a Params<C>,
+    g_scalars: Option<Vec<C::Scalar>>,
+    w_scalar: Option<C::Scalar>,
+    u_scalar: Option<C::Scalar>,
+    // x-coordinate -> (scalar, y-coordinate)
+    other: BTreeMap<C::Base, (C::Scalar, C::Base)>,
+}
+
+impl<'a, C: CurveAffine> MSM<'a, C> {
+    /// Create a new, empty MSM using the provided parameters.
+    pub fn new(params: &'a Params<C>) -> Self {
+        let g_scalars = None;
+        let w_scalar = None;
+        let u_scalar = None;
+        let other = BTreeMap::new();
+
+        MSM {
+            params,
+            g_scalars,
+            w_scalar,
+            u_scalar,
+            other,
+        }
+    }
+
+    /// Add another multiexp into this one
+    pub fn add_msm(&mut self, other: &Self) {
+        for (x, (scalar, y)) in other.other.iter() {
+            self.other
+                .entry(*x)
+                .and_modify(|(our_scalar, our_y)| {
+                    if our_y == y {
+                        *our_scalar += *scalar;
+                    } else {
+                        assert!(*our_y == -*y);
+                        *our_scalar -= *scalar;
+                    }
+                })
+                .or_insert((*scalar, *y));
+        }
+
+        if let Some(g_scalars) = &other.g_scalars {
+            self.add_to_g_scalars(g_scalars);
+        }
+
+        if let Some(w_scalar) = &other.w_scalar {
+            self.add_to_w_scalar(*w_scalar);
+        }
+
+        if let Some(u_scalar) = &other.u_scalar {
+            self.add_to_u_scalar(*u_scalar);
+        }
+    }
+
+    /// Add arbitrary term (the scalar and the point)
+    pub fn append_term(&mut self, scalar: C::Scalar, point: C) {
+        if !bool::from(point.is_identity()) {
+            let xy = point.coordinates().unwrap();
+            let x = *xy.x();
+            let y = *xy.y();
+
+            self.other
+                .entry(x)
+                .and_modify(|(our_scalar, our_y)| {
+                    if *our_y == y {
+                        *our_scalar += scalar;
+                    } else {
+                        assert!(*our_y == -y);
+                        *our_scalar -= scalar;
+                    }
+                })
+                .or_insert((scalar, y));
+        }
+    }
+
+    /// Add a value to the first entry of `g_scalars`.
+    pub fn add_constant_term(&mut self, constant: C::Scalar) {
+        if let Some(g_scalars) = self.g_scalars.as_mut() {
+            g_scalars[0] += &constant;
+        } else {
+            let mut g_scalars = vec![C::Scalar::ZERO; self.params.n as usize];
+            g_scalars[0] += &constant;
+            self.g_scalars = Some(g_scalars);
+        }
+    }
+
+    /// Add a vector of scalars to `g_scalars`. This function will panic if the
+    /// caller provides a slice of scalars that is not of length `params.n`.
+    pub fn add_to_g_scalars(&mut self, scalars: &[C::Scalar]) {
+        assert_eq!(scalars.len(), self.params.n as usize);
+        if let Some(g_scalars) = &mut self.g_scalars {
+            for (g_scalar, scalar) in g_scalars.iter_mut().zip(scalars.iter()) {
+                *g_scalar += scalar;
+            }
+        } else {
+            self.g_scalars = Some(scalars.to_vec());
+        }
+    }
+
+    /// Add to `w_scalar`
+    pub fn add_to_w_scalar(&mut self, scalar: C::Scalar) {
+        self.w_scalar = self.w_scalar.map_or(Some(scalar), |a| Some(a + &scalar));
+    }
+
+    /// Add to `u_scalar`
+    pub fn add_to_u_scalar(&mut self, scalar: C::Scalar) {
+        self.u_scalar = self.u_scalar.map_or(Some(scalar), |a| Some(a + &scalar));
+    }
+
+    /// Scale all scalars in the MSM by some scaling factor
+    pub fn scale(&mut self, factor: C::Scalar) {
+        if let Some(g_scalars) = &mut self.g_scalars {
+            for g_scalar in g_scalars {
+                *g_scalar *= &factor;
+            }
+        }
+
+        for other in self.other.values_mut() {
+            other.0 *= factor;
+        }
+
+        self.w_scalar = self.w_scalar.map(|a| a * &factor);
+        self.u_scalar = self.u_scalar.map(|a| a * &factor);
+    }
+
+    /// Perform multiexp and check that it results in zero
+    pub fn eval(self) -> bool {
+        let len = self.g_scalars.as_ref().map(|v| v.len()).unwrap_or(0)
+            + self.w_scalar.map(|_| 1).unwrap_or(0)
+            + self.u_scalar.map(|_| 1).unwrap_or(0)
+            + self.other.len();
+        let mut scalars: Vec<C::Scalar> = Vec::with_capacity(len);
+        let mut bases: Vec<C> = Vec::with_capacity(len);
+
+        scalars.extend(self.other.values().map(|(scalar, _)| scalar));
+        bases.extend(
+            self.other
+                .iter()
+                .map(|(x, (_, y))| C::from_xy(*x, *y).unwrap()),
+        );
+
+        if let Some(w_scalar) = self.w_scalar {
+            scalars.push(w_scalar);
+            bases.push(self.params.w);
+        }
+
+        if let Some(u_scalar) = self.u_scalar {
+            scalars.push(u_scalar);
+            bases.push(self.params.u);
+        }
+
+        if let Some(g_scalars) = &self.g_scalars {
+            scalars.extend(g_scalars);
+            bases.extend(self.params.g.iter());
+        }
+
+        assert_eq!(scalars.len(), len);
+
+        bool::from(best_multiexp(&scalars, &bases).is_identity())
+    }
+}

--- a/crates/ragu_pcd/src/ipa/prover.rs
+++ b/crates/ragu_pcd/src/ipa/prover.rs
@@ -1,0 +1,190 @@
+use alloc::vec::Vec;
+
+use ff::{Field, PrimeField};
+use pasta_curves::group::Curve;
+use rand::CryptoRng;
+use ragu_arithmetic::{
+    CurveAffine, PoseidonPermutation, dot as compute_inner_product, eval as eval_polynomial,
+    mul as best_multiexp, parallelize,
+};
+use ragu_core::{
+    Result,
+    drivers::emulator::{Emulator, Wireless},
+    maybe::{Always, Maybe},
+};
+use ragu_primitives::{Element, GadgetExt};
+
+use super::{Blind, IpaProof, Params, absorb_point};
+use crate::internal::transcript::Transcript;
+
+/// Create a polynomial commitment opening proof for the polynomial defined
+/// by the coefficients `px`, the blinding factor `blind` used for the
+/// polynomial commitment, and the point `x` that the polynomial is
+/// evaluated at.
+///
+/// This function will panic if the provided polynomial is too large with
+/// respect to the polynomial commitment parameters.
+///
+/// **Important:** This function assumes that the provided `transcript` has
+/// already seen the common inputs: the polynomial commitment P, the claimed
+/// opening v, and the point x. It's probably also nice for the transcript
+/// to have seen the elliptic curve description and the URS, if you want to
+/// be rigorous.
+pub fn create_proof<'dr, C, P, R>(
+    params: &Params<C>,
+    mut rng: R,
+    dr: &mut Emulator<Wireless<Always<()>, C::Scalar>>,
+    transcript: &mut Transcript<'dr, Emulator<Wireless<Always<()>, C::Scalar>>, P>,
+    p_poly: &[C::Scalar],
+    p_blind: Blind<C::Scalar>,
+    x_3: C::Scalar,
+) -> Result<IpaProof<C>>
+where
+    C: CurveAffine,
+    C::Base: PrimeField,
+    C::Scalar: PrimeField,
+    P: PoseidonPermutation<C::Scalar>,
+    R: CryptoRng,
+{
+    // We're limited to polynomials of degree n - 1.
+    assert_eq!(p_poly.len(), params.n as usize);
+
+    // Sample a random polynomial (of same degree) that has a root at x_3, first
+    // by setting all coefficients to random values.
+    let mut s_poly = p_poly.to_vec();
+    for coeff in s_poly.iter_mut() {
+        *coeff = C::Scalar::random(&mut rng);
+    }
+    // Evaluate the random polynomial at x_3
+    let s_at_x3 = eval_polynomial(&s_poly[..], x_3);
+    // Subtract constant coefficient to get a random polynomial with a root at x_3
+    s_poly[0] -= &s_at_x3;
+    // And sample a random blind
+    let s_poly_blind = Blind(C::Scalar::random(&mut rng));
+
+    // Write a commitment to the random polynomial to the transcript
+    let s_poly_commitment = params.commit(&s_poly, s_poly_blind).to_affine();
+    absorb_point(dr, transcript, &s_poly_commitment)?;
+
+    // Challenge that will ensure that the prover cannot change P but can only
+    // witness a random polynomial commitment that agrees with P at x_3, with high
+    // probability.
+    let xi = *transcript.challenge(dr)?.value().take();
+
+    // Challenge that ensures that the prover did not interfere with the U term
+    // in their commitments.
+    let z = *transcript.challenge(dr)?.value().take();
+
+    // We'll be opening `P' = P - [v] G_0 + [ξ] S` to ensure it has a root at
+    // zero.
+    let mut p_prime_poly: Vec<_> = s_poly
+        .iter()
+        .zip(p_poly.iter())
+        .map(|(s, p)| *s * xi + *p)
+        .collect();
+    let v = eval_polynomial(&p_prime_poly, x_3);
+    p_prime_poly[0] -= &v;
+    let p_prime_blind = s_poly_blind * Blind(xi) + p_blind;
+
+    // This accumulates the synthetic blinding factor `f` starting
+    // with the blinding factor for `P'`.
+    let mut f = p_prime_blind.0;
+
+    // Initialize the vector `p_prime` as the coefficients of the polynomial.
+    let mut p_prime = p_prime_poly;
+    assert_eq!(p_prime.len(), params.n as usize);
+
+    // Initialize the vector `b` as the powers of `x_3`. The inner product of
+    // `p_prime` and `b` is the evaluation of the polynomial at `x_3`.
+    let mut b = Vec::with_capacity(1 << params.k);
+    {
+        let mut cur = C::Scalar::ONE;
+        for _ in 0..(1 << params.k) {
+            b.push(cur);
+            cur *= &x_3;
+        }
+    }
+
+    // Initialize the vector `G'` from the URS. We'll be progressively collapsing
+    // this vector into smaller and smaller vectors until it is of length 1.
+    let mut g_prime = params.g.clone();
+
+    // Collect `(L_j, R_j)` per round for the returned `IpaProof` — halo2
+    // captures these implicitly via `write_point` into the byte-stream
+    // transcript.
+    let mut rounds = Vec::with_capacity(params.k as usize);
+
+    // Perform the inner product argument, round by round.
+    for j in 0..params.k {
+        let half = 1 << (params.k - j - 1); // half the length of `p_prime`, `b`, `G'`
+
+        // Compute L, R
+        //
+        // TODO: If we modify multiexp to take "extra" bases, we could speed
+        // this piece up a bit by combining the multiexps.
+        let l_j = best_multiexp(&p_prime[half..], &g_prime[0..half]);
+        let r_j = best_multiexp(&p_prime[0..half], &g_prime[half..]);
+        let value_l_j = compute_inner_product(&p_prime[half..], &b[0..half]);
+        let value_r_j = compute_inner_product(&p_prime[0..half], &b[half..]);
+        let l_j_randomness = C::Scalar::random(&mut rng);
+        let r_j_randomness = C::Scalar::random(&mut rng);
+        let l_j = l_j + &best_multiexp(&[value_l_j * &z, l_j_randomness], &[params.u, params.w]);
+        let r_j = r_j + &best_multiexp(&[value_r_j * &z, r_j_randomness], &[params.u, params.w]);
+        let l_j = l_j.to_affine();
+        let r_j = r_j.to_affine();
+
+        // Feed L and R into the real transcript
+        absorb_point(dr, transcript, &l_j)?;
+        absorb_point(dr, transcript, &r_j)?;
+        rounds.push((l_j, r_j));
+
+        let u_j = *transcript.challenge(dr)?.value().take();
+        let u_j_inv = u_j.invert().unwrap(); // TODO, bubble this up
+
+        // Collapse `p_prime` and `b`.
+        // TODO: parallelize
+        #[allow(clippy::assign_op_pattern)]
+        for i in 0..half {
+            p_prime[i] = p_prime[i] + &(p_prime[i + half] * &u_j_inv);
+            b[i] = b[i] + &(b[i + half] * &u_j);
+        }
+        p_prime.truncate(half);
+        b.truncate(half);
+
+        // Collapse `G'`
+        parallel_generator_collapse(&mut g_prime, u_j);
+        g_prime.truncate(half);
+
+        // Update randomness (the synthetic blinding factor at the end)
+        f += &(l_j_randomness * &u_j_inv);
+        f += &(r_j_randomness * &u_j);
+    }
+
+    // We have fully collapsed `p_prime`, `b`, `G'`
+    assert_eq!(p_prime.len(), 1);
+    let c = p_prime[0];
+
+    Element::constant(dr, c).write(dr, transcript)?;
+    Element::constant(dr, f).write(dr, transcript)?;
+
+    Ok(IpaProof {
+        s_commitment: s_poly_commitment,
+        rounds,
+        c,
+        f,
+    })
+}
+
+fn parallel_generator_collapse<C: CurveAffine>(g: &mut [C], challenge: C::Scalar) {
+    let len = g.len() / 2;
+    let (g_lo, g_hi) = g.split_at_mut(len);
+
+    parallelize(g_lo, |g_lo, start| {
+        let g_hi = &g_hi[start..];
+        let mut tmp = Vec::with_capacity(g_lo.len());
+        for (g_lo, g_hi) in g_lo.iter().zip(g_hi.iter()) {
+            tmp.push(g_lo.to_curve() + &(*g_hi * challenge));
+        }
+        C::Curve::batch_normalize(&tmp, g_lo);
+    });
+}

--- a/crates/ragu_pcd/src/ipa/prover.rs
+++ b/crates/ragu_pcd/src/ipa/prover.rs
@@ -2,7 +2,6 @@ use alloc::vec::Vec;
 
 use ff::{Field, PrimeField};
 use pasta_curves::group::Curve;
-use rand::CryptoRng;
 use ragu_arithmetic::{
     CurveAffine, PoseidonPermutation, dot as compute_inner_product, eval as eval_polynomial,
     mul as best_multiexp, parallelize,
@@ -13,6 +12,7 @@ use ragu_core::{
     maybe::{Always, Maybe},
 };
 use ragu_primitives::{Element, GadgetExt};
+use rand::CryptoRng;
 
 use super::{Blind, IpaProof, Params, absorb_point};
 use crate::internal::transcript::Transcript;
@@ -128,8 +128,8 @@ where
         let value_r_j = compute_inner_product(&p_prime[0..half], &b[half..]);
         let l_j_randomness = C::Scalar::random(&mut rng);
         let r_j_randomness = C::Scalar::random(&mut rng);
-        let l_j = l_j + &best_multiexp(&[value_l_j * &z, l_j_randomness], &[params.u, params.w]);
-        let r_j = r_j + &best_multiexp(&[value_r_j * &z, r_j_randomness], &[params.u, params.w]);
+        let l_j = l_j + best_multiexp(&[value_l_j * z, l_j_randomness], &[params.u, params.w]);
+        let r_j = r_j + best_multiexp(&[value_r_j * z, r_j_randomness], &[params.u, params.w]);
         let l_j = l_j.to_affine();
         let r_j = r_j.to_affine();
 
@@ -145,8 +145,8 @@ where
         // TODO: parallelize
         #[allow(clippy::assign_op_pattern)]
         for i in 0..half {
-            p_prime[i] = p_prime[i] + &(p_prime[i + half] * &u_j_inv);
-            b[i] = b[i] + &(b[i + half] * &u_j);
+            p_prime[i] = p_prime[i] + (p_prime[i + half] * u_j_inv);
+            b[i] = b[i] + (b[i + half] * u_j);
         }
         p_prime.truncate(half);
         b.truncate(half);
@@ -156,8 +156,8 @@ where
         g_prime.truncate(half);
 
         // Update randomness (the synthetic blinding factor at the end)
-        f += &(l_j_randomness * &u_j_inv);
-        f += &(r_j_randomness * &u_j);
+        f += &(l_j_randomness * u_j_inv);
+        f += &(r_j_randomness * u_j);
     }
 
     // We have fully collapsed `p_prime`, `b`, `G'`
@@ -183,7 +183,7 @@ fn parallel_generator_collapse<C: CurveAffine>(g: &mut [C], challenge: C::Scalar
         let g_hi = &g_hi[start..];
         let mut tmp = Vec::with_capacity(g_lo.len());
         for (g_lo, g_hi) in g_lo.iter().zip(g_hi.iter()) {
-            tmp.push(g_lo.to_curve() + &(*g_hi * challenge));
+            tmp.push(g_lo.to_curve() + (*g_hi * challenge));
         }
         C::Curve::batch_normalize(&tmp, g_lo);
     });

--- a/crates/ragu_pcd/src/ipa/verifier.rs
+++ b/crates/ragu_pcd/src/ipa/verifier.rs
@@ -1,0 +1,171 @@
+use alloc::{vec, vec::Vec};
+
+use ff::{Field, PrimeField};
+use pasta_curves::group::Curve;
+use ragu_arithmetic::{CurveAffine, PoseidonPermutation, mul as best_multiexp};
+use ragu_core::{
+    Result,
+    drivers::emulator::{Emulator, Wireless},
+    maybe::{Always, Maybe},
+};
+use ragu_primitives::{Element, GadgetExt};
+
+use super::{IpaProof, Params, MSM, absorb_point};
+use crate::internal::transcript::Transcript;
+
+/// A guard returned by the verifier
+#[derive(Debug, Clone)]
+pub struct Guard<'a, C: CurveAffine> {
+    msm: MSM<'a, C>,
+    neg_c: C::Scalar,
+    u: Vec<C::Scalar>,
+}
+
+/// An accumulator instance consisting of an evaluation claim and a proof.
+#[derive(Debug, Clone)]
+pub struct Accumulator<C: CurveAffine> {
+    /// The claimed output of the linear-time polycommit opening protocol
+    pub g: C,
+
+    /// A vector of challenges u_0, ..., u_{k - 1} sampled by the verifier, to
+    /// be used in computing G'_0.
+    pub u: Vec<C::Scalar>,
+}
+
+impl<'a, C: CurveAffine> Guard<'a, C> {
+    /// Lets caller supply the challenges and obtain an MSM with updated
+    /// scalars and points.
+    pub fn use_challenges(mut self) -> MSM<'a, C> {
+        let s = compute_s(&self.u, self.neg_c);
+        self.msm.add_to_g_scalars(&s);
+
+        self.msm
+    }
+
+    /// Lets caller supply the purported G point and simply appends
+    /// [-c] G to return an updated MSM.
+    pub fn use_g(mut self, g: C) -> (MSM<'a, C>, Accumulator<C>) {
+        self.msm.append_term(self.neg_c, g);
+
+        let accumulator = Accumulator { g, u: self.u };
+
+        (self.msm, accumulator)
+    }
+
+    /// Computes G = ⟨s, params.g⟩
+    pub fn compute_g(&self) -> C {
+        let s = compute_s(&self.u, C::Scalar::ONE);
+
+        best_multiexp(&s, &self.msm.params.g).to_affine()
+    }
+}
+
+/// Checks to see if the proof represented within `transcript` is valid, and a
+/// point `x` that the polynomial commitment `P` opens purportedly to the value
+/// `v`. The provided `msm` should evaluate to the commitment `P` being opened.
+pub fn verify_proof<'a, 'dr, C, P>(
+    params: &'a Params<C>,
+    mut msm: MSM<'a, C>,
+    dr: &mut Emulator<Wireless<Always<()>, C::Scalar>>,
+    transcript: &mut Transcript<'dr, Emulator<Wireless<Always<()>, C::Scalar>>, P>,
+    proof: &IpaProof<C>,
+    x: C::Scalar,
+    v: C::Scalar,
+) -> Result<Guard<'a, C>>
+where
+    C: CurveAffine,
+    C::Base: PrimeField,
+    C::Scalar: PrimeField,
+    P: PoseidonPermutation<C::Scalar>,
+{
+    let k = params.k as usize;
+
+    // P' = P - [v] G_0 + [ξ] S
+    msm.add_constant_term(-v); // add [-v] G_0
+    let s_poly_commitment = proof.s_commitment;
+    absorb_point(dr, transcript, &s_poly_commitment)?;
+    let xi = *transcript.challenge(dr)?.value().take();
+    msm.append_term(xi, s_poly_commitment);
+
+    let z = *transcript.challenge(dr)?.value().take();
+
+    let mut rounds = Vec::with_capacity(k);
+    for j in 0..k {
+        // Read L and R from the proof and write them to the transcript
+        let (l, r) = proof.rounds[j];
+        absorb_point(dr, transcript, &l)?;
+        absorb_point(dr, transcript, &r)?;
+
+        let u_j = *transcript.challenge(dr)?.value().take();
+        let u_j_inv = u_j.invert().unwrap(); // TODO, bubble this up
+
+        rounds.push((l, r, u_j, u_j_inv));
+    }
+
+    // This is the left-hand side of the verifier equation.
+    // P' + \sum([u_j^{-1}] L_j) + \sum([u_j] R_j)
+    let mut u = Vec::with_capacity(k);
+    for (l, r, u_j, u_j_inv) in rounds {
+        msm.append_term(u_j_inv, l);
+        msm.append_term(u_j, r);
+
+        u.push(u_j);
+    }
+
+    // Our goal is to check that the left hand side of the verifier
+    // equation
+    //     P' + \sum([u_j^{-1}] L_j) + \sum([u_j] R_j)
+    // equals (given b = \mathbf{b}_0, and the prover's values c, f),
+    // the right-hand side
+    //   = [c] (G'_0 + [b * z] U) + [f] W
+    // Subtracting the right-hand side from both sides we get
+    //   P' + \sum([u_j^{-1}] L_j) + \sum([u_j] R_j)
+    //   + [-c] G'_0 + [-cbz] U + [-f] W
+    //   = 0
+    //
+    // Note that the guard returned from this function does not include
+    // the [-c]G'_0 term.
+
+    let c = proof.c;
+    let neg_c = -c;
+    let f = proof.f;
+    Element::constant(dr, c).write(dr, transcript)?;
+    Element::constant(dr, f).write(dr, transcript)?;
+    let b = compute_b(x, &u);
+
+    msm.add_to_u_scalar(neg_c * &b * &z);
+    msm.add_to_w_scalar(-f);
+
+    let guard = Guard { msm, neg_c, u };
+
+    Ok(guard)
+}
+
+/// Computes $\prod\limits_{i=0}^{k-1} (1 + u_{k - 1 - i} x^{2^i})$.
+fn compute_b<F: Field>(x: F, u: &[F]) -> F {
+    let mut tmp = F::ONE;
+    let mut cur = x;
+    for u_j in u.iter().rev() {
+        tmp *= F::ONE + &(*u_j * &cur);
+        cur *= cur;
+    }
+    tmp
+}
+
+/// Computes the coefficients of $g(X) = \prod\limits_{i=0}^{k-1} (1 + u_{k - 1 - i} X^{2^i})$.
+fn compute_s<F: Field>(u: &[F], init: F) -> Vec<F> {
+    assert!(!u.is_empty());
+    let mut v = vec![F::ZERO; 1 << u.len()];
+    v[0] = init;
+
+    for (len, u_j) in u.iter().rev().enumerate().map(|(i, u_j)| (1 << i, u_j)) {
+        let (left, right) = v.split_at_mut(len);
+        let right = &mut right[0..len];
+        right.copy_from_slice(left);
+        for v in right {
+            *v *= u_j;
+        }
+    }
+
+    v
+}

--- a/crates/ragu_pcd/src/ipa/verifier.rs
+++ b/crates/ragu_pcd/src/ipa/verifier.rs
@@ -10,7 +10,7 @@ use ragu_core::{
 };
 use ragu_primitives::{Element, GadgetExt};
 
-use super::{IpaProof, Params, MSM, absorb_point};
+use super::{IpaProof, MSM, Params, absorb_point};
 use crate::internal::transcript::Transcript;
 
 /// A guard returned by the verifier
@@ -133,7 +133,7 @@ where
     Element::constant(dr, f).write(dr, transcript)?;
     let b = compute_b(x, &u);
 
-    msm.add_to_u_scalar(neg_c * &b * &z);
+    msm.add_to_u_scalar(neg_c * b * z);
     msm.add_to_w_scalar(-f);
 
     let guard = Guard { msm, neg_c, u };
@@ -146,7 +146,7 @@ fn compute_b<F: Field>(x: F, u: &[F]) -> F {
     let mut tmp = F::ONE;
     let mut cur = x;
     for u_j in u.iter().rev() {
-        tmp *= F::ONE + &(*u_j * &cur);
+        tmp *= F::ONE + (*u_j * cur);
         cur *= cur;
     }
     tmp

--- a/crates/ragu_pcd/src/lib.rs
+++ b/crates/ragu_pcd/src/lib.rs
@@ -27,6 +27,7 @@ extern crate std;
 mod fuse;
 pub mod header;
 mod internal;
+pub mod ipa;
 mod proof;
 pub mod step;
 mod verify;
@@ -35,6 +36,7 @@ use alloc::collections::BTreeMap;
 use core::{any::TypeId, cell::OnceCell, marker::PhantomData};
 
 use header::Header;
+pub use ipa::{CompressedProof, IpaProof};
 pub use proof::{Pcd, Proof};
 use ragu_arithmetic::Cycle;
 use ragu_circuits::{


### PR DESCRIPTION
Integrates [Halo2's IPA implementation](https://github.com/zcash/halo2/tree/main/halo2_proofs/src/poly/commitment) adapted for Ragu's API (port mostly lifts the original structure, and no batch verifier), and wraps the IPA prover and verifier with `compress` and `verify_compressed` utilities. It takes an uncompressed accumulator (NARK), compresses it into an `IpaProof` and stores inside `CompressedProof`, and then the compressed proof is verified via IPA verifier. This represents the IPA foundation which is the final layer that the in-circuit SNARK compression reductions will feed into.

It's currently naively checking just the P polynomial opening: `P(u) = v`. **Update:** Our decomposition trick for reducing the revdot claim into a polynomial query is deffered here, and rebasing with a clean commit history accordingly (preliminary work in https://github.com/tachyon-zcash/ragu/pull/667).