### PR TITLE
chore: add deepwiki badge for auto-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ---
 
-# `ragu` ![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg) [![codecov](https://codecov.io/gh/tachyon-zcash/ragu/graph/badge.svg?token=HJARL1P2O4)](https://codecov.io/gh/tachyon-zcash/ragu)
+# `ragu` ![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg) [![codecov](https://codecov.io/gh/tachyon-zcash/ragu/graph/badge.svg?token=HJARL1P2O4)](https://codecov.io/gh/tachyon-zcash/ragu)[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tachyon-zcash/ragu)
 
 **Ragu** is a Rust-language [proof-carrying data (PCD)](https://ic-people.epfl.ch/~achiesa/docs/CT10.pdf) framework that implements a modified version of the ECDLP-based recursive SNARK construction from [Halo [BGH19]](https://eprint.iacr.org/2019/1021). Ragu does not require a trusted setup. Developed for [Project Tachyon](https://tachyon.z.cash/) and compatible with the [Pasta curves](https://electriccoin.co/blog/the-pasta-curves-for-halo-2-and-beyond/) employed in [Zcash](https://z.cash/), Ragu targets performance and feature support that is competitive with other ECC-based [accumulation](https://eprint.iacr.org/2020/499)/[folding](https://eprint.iacr.org/2021/370) schemes without complicated circuit arithmetizations.
 


### PR DESCRIPTION
I was experimenting with Deepwiki: https://deepwiki.com/tachyon-zcash/ragu/1-overview, it's quite a nice knowledge base for asking questions against. 

This PR adds a badge which triggers auto-update on Devin's end. 

Here's what I did locally: 

- add MCP server ([doc](https://docs.devin.ai/work-with-devin/deepwiki-mcp#for-claude-code)): `claude mcp add -s user -t http deepwiki https://mcp.deepwiki.com/mcp`
- in my local `CLAUDE.md` specify a default, (other knowledge base can be explicitly referenced `Ask @deepwiki:zcash/halo2: <question>`)

```
Follow these for MCP tools:

- **Deepwiki**:
  - by default (when unspecified), the target is `tachyon-zcash/ragu`
```
