### PR TITLE
chore(gadgets): `Bound` type alias

### DIFF
--- a/book/src/guide/gadgets/gadgetkind.md
+++ b/book/src/guide/gadgets/gadgetkind.md
@@ -29,6 +29,11 @@ of [`GadgetKind`][gadgetkind-trait] to specify how a concrete
 associated type `Kind` that relates back to its corresponding
 [`GadgetKind`][gadgetkind-trait] implementation.
 
+## The `Bound` Type Alias
+
+The [`Bound<'dr, D, K>`][bound-alias] type alias is shorthand for
+`<K as GadgetKind<F>>::Rebind<'dr, D>`.
+
 ## `map_gadget`
 
 Thanks to the strict requirements on implementations of
@@ -71,6 +76,7 @@ see it.
 
 [gadget-trait]: ragu_core::gadgets::Gadget
 [gadgetkind-trait]: ragu_core::gadgets::GadgetKind
+[bound-alias]: ragu_core::gadgets::Bound
 [driver-trait]: ragu_core::drivers::Driver
 [enforce-equal]: ragu_core::gadgets::GadgetKind::enforce_equal_gadget
 [fromdriver-trait]: ragu_core::drivers::FromDriver

--- a/book/src/guide/getting_started.md
+++ b/book/src/guide/getting_started.md
@@ -61,7 +61,7 @@ types:
 
 ```rust
 use ff::Field;
-use ragu_core::{Result, drivers::{Driver, DriverValue}, gadgets::{GadgetKind, Kind}, maybe::Maybe};
+use ragu_core::{Result, drivers::{Driver, DriverValue}, gadgets::{Bound, Kind}, maybe::Maybe};
 use ragu_pcd::header::{Header, Suffix};
 use ragu_primitives::Element;
 use ragu_primitives::poseidon::Sponge;
@@ -77,7 +77,7 @@ impl<F: Field> Header<F> for LeafNode {
     fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
         dr: &mut D,
         witness: DriverValue<D, Self::Data<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, Self::Output>> {
         Element::alloc(dr, witness)  // Convert to circuit element
     }
 }
@@ -93,7 +93,7 @@ impl<F: Field> Header<F> for InternalNode {
     fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
         dr: &mut D,
         witness: DriverValue<D, Self::Data<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, Self::Output>> {
         Element::alloc(dr, witness)
     }
 }

--- a/book/src/guide/writing_circuits.md
+++ b/book/src/guide/writing_circuits.md
@@ -164,7 +164,7 @@ impl<F: Field> Header<F> for LeafNode {
     fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
         dr: &mut D,
         witness: DriverValue<D, Self::Data<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, Self::Output>> {
         Element::alloc(dr, witness)  // How to convert data to gadget
     }
 }

--- a/crates/ragu_circuits/src/lib.rs
+++ b/crates/ragu_circuits/src/lib.rs
@@ -35,7 +35,7 @@ use ff::Field;
 use ragu_core::{
     Error, Result,
     drivers::{Driver, DriverValue},
-    gadgets::GadgetKind,
+    gadgets::Bound,
 };
 use ragu_primitives::io::Write;
 
@@ -91,7 +91,7 @@ pub trait Circuit<F: Field>: Sized + Send + Sync {
         &self,
         dr: &mut D,
         instance: DriverValue<D, Self::Instance<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::Output>>
     where
         Self: 'dr;
 
@@ -104,7 +104,7 @@ pub trait Circuit<F: Field>: Sized + Send + Sync {
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'source>>,
     ) -> Result<(
-        <Self::Output as GadgetKind<F>>::Rebind<'dr, D>,
+        Bound<'dr, D, Self::Output>,
         DriverValue<D, Self::Aux<'source>>,
     )>
     where

--- a/crates/ragu_circuits/src/metrics.rs
+++ b/crates/ragu_circuits/src/metrics.rs
@@ -9,7 +9,7 @@ use ragu_arithmetic::Coeff;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverTypes, emulator::Emulator},
-    gadgets::GadgetKind,
+    gadgets::{Bound, GadgetKind},
     maybe::Empty,
     routines::Routine,
 };
@@ -90,8 +90,8 @@ impl<'dr, F: Field> Driver<'dr> for Counter<F> {
     fn routine<Ro: Routine<Self::F> + 'dr>(
         &mut self,
         routine: Ro,
-        input: <Ro::Input as GadgetKind<Self::F>>::Rebind<'dr, Self>,
-    ) -> Result<<Ro::Output as GadgetKind<Self::F>>::Rebind<'dr, Self>> {
+        input: Bound<'dr, Self, Ro::Input>,
+    ) -> Result<Bound<'dr, Self, Ro::Output>> {
         self.with_fresh_b(|this| {
             let mut dummy = Emulator::wireless();
             let dummy_input = Ro::Input::map_gadget(&input, &mut dummy)?;

--- a/crates/ragu_circuits/src/polynomials/txz.rs
+++ b/crates/ragu_circuits/src/polynomials/txz.rs
@@ -4,7 +4,7 @@ use ff::Field;
 use ragu_core::{
     Error, Result,
     drivers::{Driver, DriverValue},
-    gadgets::{GadgetKind, Kind},
+    gadgets::{Bound, Kind},
     maybe::Maybe,
     routines::{Prediction, Routine},
 };
@@ -43,9 +43,9 @@ impl<F: Field, R: Rank> Routine<F> for Evaluate<R> {
     fn execute<'dr, D: Driver<'dr, F = F>>(
         &self,
         dr: &mut D,
-        input: <Self::Input as GadgetKind<F>>::Rebind<'dr, D>,
+        input: Bound<'dr, D, Self::Input>,
         aux: DriverValue<D, Self::Aux<'dr>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, Self::Output>> {
         let x = input.0;
         let z = input.1;
 
@@ -87,10 +87,8 @@ impl<F: Field, R: Rank> Routine<F> for Evaluate<R> {
     fn predict<'dr, D: Driver<'dr, F = F>>(
         &self,
         dr: &mut D,
-        input: &<Self::Input as GadgetKind<F>>::Rebind<'dr, D>,
-    ) -> Result<
-        Prediction<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>, DriverValue<D, Self::Aux<'dr>>>,
-    > {
+        input: &Bound<'dr, D, Self::Input>,
+    ) -> Result<Prediction<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'dr>>>> {
         let n = 1u64 << R::log2_n();
 
         // Compute inversions once and store as aux data to accelerate execution

--- a/crates/ragu_circuits/src/rx.rs
+++ b/crates/ragu_circuits/src/rx.rs
@@ -8,7 +8,7 @@ use ragu_arithmetic::Coeff;
 use ragu_core::{
     Error, Result,
     drivers::{Driver, DriverTypes, emulator::Emulator},
-    gadgets::GadgetKind,
+    gadgets::{Bound, GadgetKind},
     maybe::{Always, Maybe, MaybeKind},
     routines::Routine,
 };
@@ -78,8 +78,8 @@ impl<'a, F: Field, R: Rank> Driver<'a> for Evaluator<'a, F, R> {
     fn routine<Ro: Routine<Self::F> + 'a>(
         &mut self,
         routine: Ro,
-        input: <Ro::Input as GadgetKind<Self::F>>::Rebind<'a, Self>,
-    ) -> Result<<Ro::Output as GadgetKind<Self::F>>::Rebind<'a, Self>> {
+        input: Bound<'a, Self, Ro::Input>,
+    ) -> Result<Bound<'a, Self, Ro::Output>> {
         self.with_fresh_b(|this| {
             let mut dummy = Emulator::wireless();
             let dummy_input = Ro::Input::map_gadget(&input, &mut dummy)?;

--- a/crates/ragu_circuits/src/s/sx.rs
+++ b/crates/ragu_circuits/src/s/sx.rs
@@ -67,7 +67,7 @@ use ragu_arithmetic::Coeff;
 use ragu_core::{
     Error, Result,
     drivers::{Driver, DriverTypes, emulator::Emulator},
-    gadgets::GadgetKind,
+    gadgets::{Bound, GadgetKind},
     maybe::Empty,
     routines::Routine,
 };
@@ -258,8 +258,8 @@ impl<'dr, F: Field, R: Rank> Driver<'dr> for Evaluator<F, R> {
     fn routine<Ro: Routine<Self::F> + 'dr>(
         &mut self,
         routine: Ro,
-        input: <Ro::Input as GadgetKind<Self::F>>::Rebind<'dr, Self>,
-    ) -> Result<<Ro::Output as GadgetKind<Self::F>>::Rebind<'dr, Self>> {
+        input: Bound<'dr, Self, Ro::Input>,
+    ) -> Result<Bound<'dr, Self, Ro::Output>> {
         self.with_fresh_b(|this| {
             let mut dummy = Emulator::wireless();
             let dummy_input = Ro::Input::map_gadget(&input, &mut dummy)?;

--- a/crates/ragu_circuits/src/s/sxy.rs
+++ b/crates/ragu_circuits/src/s/sxy.rs
@@ -53,7 +53,7 @@ use ragu_arithmetic::Coeff;
 use ragu_core::{
     Error, Result,
     drivers::{Driver, DriverTypes, emulator::Emulator},
-    gadgets::GadgetKind,
+    gadgets::{Bound, GadgetKind},
     maybe::Empty,
     routines::Routine,
 };
@@ -240,8 +240,8 @@ impl<'dr, F: Field, R: Rank> Driver<'dr> for Evaluator<F, R> {
     fn routine<Ro: Routine<Self::F> + 'dr>(
         &mut self,
         routine: Ro,
-        input: <Ro::Input as GadgetKind<Self::F>>::Rebind<'dr, Self>,
-    ) -> Result<<Ro::Output as GadgetKind<Self::F>>::Rebind<'dr, Self>> {
+        input: Bound<'dr, Self, Ro::Input>,
+    ) -> Result<Bound<'dr, Self, Ro::Output>> {
         self.with_fresh_b(|this| {
             let mut dummy = Emulator::wireless();
             let dummy_input = Ro::Input::map_gadget(&input, &mut dummy)?;

--- a/crates/ragu_circuits/src/s/sy.rs
+++ b/crates/ragu_circuits/src/s/sy.rs
@@ -71,7 +71,7 @@ use ragu_arithmetic::Coeff;
 use ragu_core::{
     Error, Result,
     drivers::{Driver, DriverTypes, LinearExpression, emulator::Emulator},
-    gadgets::GadgetKind,
+    gadgets::{Bound, GadgetKind},
     maybe::Empty,
     routines::Routine,
 };
@@ -601,8 +601,8 @@ impl<'table, 'sy, F: Field, R: Rank> Driver<'table> for Evaluator<'table, 'sy, F
     fn routine<Ro: Routine<Self::F> + 'table>(
         &mut self,
         routine: Ro,
-        input: <Ro::Input as GadgetKind<Self::F>>::Rebind<'table, Self>,
-    ) -> Result<<Ro::Output as GadgetKind<Self::F>>::Rebind<'table, Self>> {
+        input: Bound<'table, Self, Ro::Input>,
+    ) -> Result<Bound<'table, Self, Ro::Output>> {
         self.with_fresh_b(|this| {
             let mut dummy = Emulator::wireless();
             let dummy_input = Ro::Input::map_gadget(&input, &mut dummy)?;

--- a/crates/ragu_circuits/src/staging/builder.rs
+++ b/crates/ragu_circuits/src/staging/builder.rs
@@ -45,7 +45,7 @@ use ragu_core::{
         Driver, DriverValue, FromDriver,
         emulator::{Emulator, Wireless},
     },
-    gadgets::{Consistent, Gadget, GadgetKind},
+    gadgets::{Bound, Consistent, Gadget},
     maybe::Empty,
 };
 
@@ -128,9 +128,9 @@ impl<'dr, D: Driver<'dr>, R: Rank, S: Stage<D::F, R> + 'dr> StageGuard<'dr, D, R
         self,
         dr: &mut D,
         witness: DriverValue<D, S::Witness<'source>>,
-    ) -> Result<<S::OutputKind as GadgetKind<D::F>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, S::OutputKind>>
     where
-        <S::OutputKind as GadgetKind<D::F>>::Rebind<'dr, D>: Consistent<'dr, D>,
+        Bound<'dr, D, S::OutputKind>: Consistent<'dr, D>,
     {
         let output = self.unenforced_inner(witness)?;
         output.enforce_consistent(dr)?;
@@ -141,7 +141,7 @@ impl<'dr, D: Driver<'dr>, R: Rank, S: Stage<D::F, R> + 'dr> StageGuard<'dr, D, R
     fn unenforced_inner<'source: 'dr>(
         self,
         witness: DriverValue<D, S::Witness<'source>>,
-    ) -> Result<<S::OutputKind as GadgetKind<D::F>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, S::OutputKind>> {
         let mut emulator: Emulator<Wireless<D::MaybeKind, D::F>> = Emulator::wireless();
         let computed_gadget = self.stage.witness(&mut emulator, witness)?;
 
@@ -162,7 +162,7 @@ impl<'dr, D: Driver<'dr>, R: Rank, S: Stage<D::F, R> + 'dr> StageGuard<'dr, D, R
         self,
         _dr: &mut D,
         witness: DriverValue<D, S::Witness<'source>>,
-    ) -> Result<<S::OutputKind as GadgetKind<D::F>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, S::OutputKind>> {
         self.unenforced_inner(witness)
     }
 }

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -225,7 +225,7 @@ mod tests {
     use ragu_core::{
         Result,
         drivers::{Driver, DriverValue, LinearExpression, emulator::Emulator},
-        gadgets::{Consistent, Gadget, GadgetKind},
+        gadgets::{Bound, Consistent, Gadget},
         maybe::Maybe,
     };
     use ragu_pasta::{EpAffine, Fp, Fq};
@@ -252,7 +252,7 @@ mod tests {
             &self,
             _: &mut D,
             _: DriverValue<D, Self::Instance<'source>>,
-        ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+        ) -> Result<Bound<'dr, D, Self::Output>> {
             Ok(())
         }
 
@@ -261,7 +261,7 @@ mod tests {
             dr: &mut D,
             _: DriverValue<D, Self::Witness<'source>>,
         ) -> Result<(
-            <Self::Output as GadgetKind<F>>::Rebind<'dr, D>,
+            Bound<'dr, D, Self::Output>,
             DriverValue<D, Self::Aux<'source>>,
         )> {
             let reserved = self.skip_multiplications + self.num_multiplications + 1;
@@ -312,7 +312,7 @@ mod tests {
                 &self,
                 dr: &mut D,
                 witness: DriverValue<D, Self::Witness<'source>>,
-            ) -> Result<<Self::OutputKind as GadgetKind<Fp>>::Rebind<'dr, D>>
+            ) -> Result<Bound<'dr, D, Self::OutputKind>>
             where
                 Self: 'dr,
             {
@@ -337,7 +337,7 @@ mod tests {
                 &self,
                 dr: &mut D,
                 witness: DriverValue<D, Self::Witness<'source>>,
-            ) -> Result<<Self::OutputKind as GadgetKind<Fp>>::Rebind<'dr, D>>
+            ) -> Result<Bound<'dr, D, Self::OutputKind>>
             where
                 Self: 'dr,
             {
@@ -554,7 +554,7 @@ mod tests {
             &self,
             dr: &mut D,
             witness: DriverValue<D, Self::Witness<'source>>,
-        ) -> Result<<Self::OutputKind as GadgetKind<Fp>>::Rebind<'dr, D>>
+        ) -> Result<Bound<'dr, D, Self::OutputKind>>
         where
             Self: 'dr,
         {

--- a/crates/ragu_circuits/src/staging/mod.rs
+++ b/crates/ragu_circuits/src/staging/mod.rs
@@ -119,7 +119,7 @@ use ff::Field;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue, emulator::Emulator},
-    gadgets::GadgetKind,
+    gadgets::{Bound, GadgetKind},
     maybe::{Always, MaybeKind},
 };
 use ragu_primitives::io::Write;
@@ -152,7 +152,7 @@ pub trait Stage<F: Field, R: Rank> {
         &self,
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'source>>,
-    ) -> Result<<Self::OutputKind as GadgetKind<F>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::OutputKind>>
     where
         Self: 'dr;
 
@@ -178,7 +178,7 @@ impl<F: Field, R: Rank> Stage<F, R> for () {
         &self,
         _: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
-    ) -> Result<<Self::OutputKind as GadgetKind<F>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::OutputKind>>
     where
         Self: 'dr,
     {
@@ -230,7 +230,7 @@ pub trait MultiStageCircuit<F: Field, R: Rank>: Sized + Send + Sync {
         &self,
         dr: &mut D,
         instance: DriverValue<D, Self::Instance<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::Output>>
     where
         Self: 'dr;
 
@@ -243,7 +243,7 @@ pub trait MultiStageCircuit<F: Field, R: Rank>: Sized + Send + Sync {
         dr: StageBuilder<'a, 'dr, D, R, (), Self::Last>,
         witness: DriverValue<D, Self::Witness<'source>>,
     ) -> Result<(
-        <Self::Output as GadgetKind<F>>::Rebind<'dr, D>,
+        Bound<'dr, D, Self::Output>,
         DriverValue<D, Self::Aux<'source>>,
     )>
     where
@@ -291,7 +291,7 @@ impl<F: Field, R: Rank, S: MultiStageCircuit<F, R>> Circuit<F> for MultiStage<F,
         &self,
         dr: &mut D,
         instance: DriverValue<D, S::Instance<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::Output>>
     where
         Self: 'dr,
     {
@@ -302,10 +302,7 @@ impl<F: Field, R: Rank, S: MultiStageCircuit<F, R>> Circuit<F> for MultiStage<F,
         &self,
         dr: &mut D,
         witness: DriverValue<D, S::Witness<'source>>,
-    ) -> Result<(
-        <Self::Output as GadgetKind<F>>::Rebind<'dr, D>,
-        DriverValue<D, S::Aux<'source>>,
-    )>
+    ) -> Result<(Bound<'dr, D, Self::Output>, DriverValue<D, S::Aux<'source>>)>
     where
         Self: 'dr,
     {

--- a/crates/ragu_circuits/src/test_fixtures/mod.rs
+++ b/crates/ragu_circuits/src/test_fixtures/mod.rs
@@ -9,7 +9,7 @@ use ff::Field;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue, LinearExpression},
-    gadgets::{GadgetKind, Kind},
+    gadgets::{Bound, Kind},
     maybe::Maybe,
 };
 use ragu_primitives::Element;
@@ -30,7 +30,7 @@ impl<F: Field> Circuit<F> for MySimpleCircuit {
         &self,
         dr: &mut D,
         instance: DriverValue<D, Self::Instance<'instance>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, Self::Output>> {
         let c = Element::alloc(dr, instance.view().map(|v| v.0))?;
         let d = Element::alloc(dr, instance.view().map(|v| v.1))?;
 
@@ -42,7 +42,7 @@ impl<F: Field> Circuit<F> for MySimpleCircuit {
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'witness>>,
     ) -> Result<(
-        <Self::Output as GadgetKind<F>>::Rebind<'dr, D>,
+        Bound<'dr, D, Self::Output>,
         DriverValue<D, Self::Aux<'witness>>,
     )> {
         let a = Element::alloc(dr, witness.view().map(|w| w.0))?;
@@ -82,7 +82,7 @@ impl<F: Field> Circuit<F> for SquareCircuit {
         &self,
         dr: &mut D,
         instance: DriverValue<D, Self::Instance<'instance>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, Self::Output>> {
         Element::alloc(dr, instance)
     }
 
@@ -91,7 +91,7 @@ impl<F: Field> Circuit<F> for SquareCircuit {
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'witness>>,
     ) -> Result<(
-        <Self::Output as GadgetKind<F>>::Rebind<'dr, D>,
+        Bound<'dr, D, Self::Output>,
         DriverValue<D, Self::Aux<'witness>>,
     )> {
         let mut a = Element::alloc(dr, witness)?;

--- a/crates/ragu_circuits/src/tests/mod.rs
+++ b/crates/ragu_circuits/src/tests/mod.rs
@@ -4,7 +4,7 @@ use ff::Field;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue, LinearExpression},
-    gadgets::{GadgetKind, Kind},
+    gadgets::{Bound, Kind},
     maybe::Maybe,
 };
 use ragu_pasta::Fp;
@@ -35,7 +35,7 @@ impl Circuit<Fp> for SquareCircuit {
         &self,
         dr: &mut D,
         instance: DriverValue<D, Self::Instance<'instance>>,
-    ) -> Result<<Self::Output as GadgetKind<Fp>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, Self::Output>> {
         Element::alloc(dr, instance)
     }
 
@@ -44,7 +44,7 @@ impl Circuit<Fp> for SquareCircuit {
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'witness>>,
     ) -> Result<(
-        <Self::Output as GadgetKind<Fp>>::Rebind<'dr, D>,
+        Bound<'dr, D, Self::Output>,
         DriverValue<D, Self::Aux<'witness>>,
     )> {
         let mut a = Element::alloc(dr, witness)?;
@@ -98,7 +98,7 @@ fn test_simple_circuit() {
             &self,
             dr: &mut D,
             instance: DriverValue<D, Self::Instance<'instance>>,
-        ) -> Result<<Self::Output as GadgetKind<Fp>>::Rebind<'dr, D>> {
+        ) -> Result<Bound<'dr, D, Self::Output>> {
             let c = Element::alloc(dr, instance.view().map(|v| v.0))?;
             let d = Element::alloc(dr, instance.view().map(|v| v.1))?;
 
@@ -110,7 +110,7 @@ fn test_simple_circuit() {
             dr: &mut D,
             witness: DriverValue<D, Self::Witness<'witness>>,
         ) -> Result<(
-            <Self::Output as GadgetKind<Fp>>::Rebind<'dr, D>,
+            Bound<'dr, D, Self::Output>,
             DriverValue<D, Self::Aux<'witness>>,
         )> {
             let a = Element::alloc(dr, witness.view().map(|w| w.0))?;
@@ -204,9 +204,9 @@ impl Routine<Fp> for TestRoutine {
     fn execute<'dr, D: Driver<'dr, F = Fp>>(
         &self,
         dr: &mut D,
-        _input: <Self::Input as GadgetKind<Fp>>::Rebind<'dr, D>,
+        _input: Bound<'dr, D, Self::Input>,
         aux: DriverValue<D, Self::Aux<'dr>>,
-    ) -> Result<<Self::Output as GadgetKind<Fp>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, Self::Output>> {
         let precomputed_value = aux.take();
         let element_from_aux = Element::alloc(dr, D::just(|| precomputed_value))?;
         let other = Element::alloc(dr, D::just(|| Fp::from(5u64)))?;
@@ -217,13 +217,8 @@ impl Routine<Fp> for TestRoutine {
     fn predict<'dr, D: Driver<'dr, F = Fp>>(
         &self,
         _dr: &mut D,
-        _input: &<Self::Input as GadgetKind<Fp>>::Rebind<'dr, D>,
-    ) -> Result<
-        Prediction<
-            <Self::Output as GadgetKind<Fp>>::Rebind<'dr, D>,
-            DriverValue<D, Self::Aux<'dr>>,
-        >,
-    > {
+        _input: &Bound<'dr, D, Self::Input>,
+    ) -> Result<Prediction<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'dr>>>> {
         Ok(Prediction::Unknown(D::just(|| Fp::from(10u64))))
     }
 }

--- a/crates/ragu_circuits/src/trivial.rs
+++ b/crates/ragu_circuits/src/trivial.rs
@@ -8,7 +8,7 @@ use ff::Field;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::GadgetKind,
+    gadgets::Bound,
 };
 
 impl<F: Field> Circuit<F> for () {
@@ -21,7 +21,7 @@ impl<F: Field> Circuit<F> for () {
         &self,
         _: &mut D,
         _: DriverValue<D, Self::Instance<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::Output>>
     where
         Self: 'dr,
     {
@@ -33,7 +33,7 @@ impl<F: Field> Circuit<F> for () {
         _: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
     ) -> Result<(
-        <Self::Output as GadgetKind<F>>::Rebind<'dr, D>,
+        Bound<'dr, D, Self::Output>,
         DriverValue<D, Self::Aux<'source>>,
     )>
     where

--- a/crates/ragu_core/src/drivers.rs
+++ b/crates/ragu_core/src/drivers.rs
@@ -53,7 +53,7 @@ use ragu_arithmetic::Coeff;
 
 use crate::{
     Result,
-    gadgets::GadgetKind,
+    gadgets::{Bound, GadgetKind},
     maybe::{Maybe, MaybeKind},
     routines::Routine,
 };
@@ -195,8 +195,8 @@ pub trait Driver<'dr>: DriverTypes<ImplWire = Self::Wire, ImplField = Self::F> +
     fn routine<R: Routine<Self::F> + 'dr>(
         &mut self,
         routine: R,
-        input: <R::Input as GadgetKind<Self::F>>::Rebind<'dr, Self>,
-    ) -> Result<<R::Output as GadgetKind<Self::F>>::Rebind<'dr, Self>> {
+        input: Bound<'dr, Self, R::Input>,
+    ) -> Result<Bound<'dr, Self, R::Output>> {
         let mut dummy = emulator::Emulator::wireless();
         let dummy_input = R::Input::map_gadget(&input, &mut dummy)?;
         let aux = routine.predict(&mut dummy, &dummy_input)?.into_aux();

--- a/crates/ragu_core/src/drivers/emulator.rs
+++ b/crates/ragu_core/src/drivers/emulator.rs
@@ -74,7 +74,7 @@ use core::marker::PhantomData;
 use crate::{
     Result,
     drivers::{Coeff, DirectSum, Driver, DriverTypes, FromDriver, LinearExpression},
-    gadgets::{Gadget, GadgetKind},
+    gadgets::{Bound, Gadget, GadgetKind},
     maybe::{Always, Empty, MaybeKind},
     routines::{Prediction, Routine},
 };
@@ -326,8 +326,8 @@ impl<'dr, M: MaybeKind, F: Field> Driver<'dr> for Emulator<Wireless<M, F>> {
     fn routine<R: Routine<Self::F> + 'dr>(
         &mut self,
         routine: R,
-        input: <R::Input as GadgetKind<Self::F>>::Rebind<'dr, Self>,
-    ) -> Result<<R::Output as GadgetKind<Self::F>>::Rebind<'dr, Self>> {
+        input: Bound<'dr, Self, R::Input>,
+    ) -> Result<Bound<'dr, Self, R::Output>> {
         short_circuit_routine(self, routine, input)
     }
 }
@@ -376,8 +376,8 @@ impl<'dr, F: Field> Driver<'dr> for Emulator<Wired<F>> {
     fn routine<R: Routine<Self::F> + 'dr>(
         &mut self,
         routine: R,
-        input: <R::Input as GadgetKind<Self::F>>::Rebind<'dr, Self>,
-    ) -> Result<<R::Output as GadgetKind<Self::F>>::Rebind<'dr, Self>> {
+        input: Bound<'dr, Self, R::Input>,
+    ) -> Result<Bound<'dr, Self, R::Output>> {
         short_circuit_routine(self, routine, input)
     }
 }
@@ -388,8 +388,8 @@ impl<'dr, F: Field> Driver<'dr> for Emulator<Wired<F>> {
 fn short_circuit_routine<'dr, D: Driver<'dr>, R: Routine<D::F> + 'dr>(
     dr: &mut D,
     routine: R,
-    input: <R::Input as GadgetKind<D::F>>::Rebind<'dr, D>,
-) -> Result<<R::Output as GadgetKind<D::F>>::Rebind<'dr, D>> {
+    input: Bound<'dr, D, R::Input>,
+) -> Result<Bound<'dr, D, R::Output>> {
     match routine.predict(dr, &input)? {
         Prediction::Known(output, _) => Ok(output),
         Prediction::Unknown(aux) => routine.execute(dr, input, aux),

--- a/crates/ragu_core/src/gadgets.rs
+++ b/crates/ragu_core/src/gadgets.rs
@@ -89,6 +89,10 @@ use super::{
     drivers::{Driver, FromDriver},
 };
 
+/// Alias for the concrete rebinding of a [`GadgetKind`] `K` to a driver `D`. This simplifies
+/// the common pattern of accessing `<K as GadgetKind<F>>::Rebind<'dr, D>`.
+pub type Bound<'dr, D, K> = <K as GadgetKind<<D as Driver<'dr>>::F>>::Rebind<'dr, D>;
+
 /// An abstract data type (parameterized by a [`Driver`] type) which
 /// encapsulates wires allocated by the driver along with any corresponding
 /// witness information.
@@ -114,7 +118,7 @@ pub trait Gadget<'dr, D: Driver<'dr>>: Clone {
     fn map<'new_dr, ND: FromDriver<'dr, 'new_dr, D>>(
         &self,
         ndr: &mut ND,
-    ) -> Result<<Self::Kind as GadgetKind<D::F>>::Rebind<'new_dr, ND::NewDriver>> {
+    ) -> Result<Bound<'new_dr, ND::NewDriver, Self::Kind>> {
         Self::Kind::map_gadget(self, ndr)
     }
 

--- a/crates/ragu_core/src/routines.rs
+++ b/crates/ragu_core/src/routines.rs
@@ -11,7 +11,7 @@ use ff::Field;
 use crate::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::GadgetKind,
+    gadgets::{Bound, GadgetKind},
 };
 
 /// Sections of a circuit that take a [`Gadget`](crate::gadgets::Gadget) as
@@ -44,9 +44,9 @@ pub trait Routine<F: Field>: Clone + Send {
     fn execute<'dr, D: Driver<'dr, F = F>>(
         &self,
         dr: &mut D,
-        input: <Self::Input as GadgetKind<F>>::Rebind<'dr, D>,
+        input: Bound<'dr, D, Self::Input>,
         aux: DriverValue<D, Self::Aux<'dr>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>>;
+    ) -> Result<Bound<'dr, D, Self::Output>>;
 
     /// Routines can offer to predict their outputs given their inputs, which
     /// drivers can leverage to skip actual execution or perform it in a
@@ -56,10 +56,8 @@ pub trait Routine<F: Field>: Clone + Send {
     fn predict<'dr, D: Driver<'dr, F = F>>(
         &self,
         dr: &mut D,
-        input: &<Self::Input as GadgetKind<F>>::Rebind<'dr, D>,
-    ) -> Result<
-        Prediction<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>, DriverValue<D, Self::Aux<'dr>>>,
-    >;
+        input: &Bound<'dr, D, Self::Input>,
+    ) -> Result<Prediction<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'dr>>>>;
 }
 
 /// Describes the result of a routine's [`predict`](Routine::predict) method.

--- a/crates/ragu_macros/src/derive/gadgetwrite.rs
+++ b/crates/ragu_macros/src/derive/gadgetwrite.rs
@@ -126,7 +126,7 @@ pub fn derive(
             #[automatically_derived]
             impl #gadget_kind_generic_params #ragu_primitives_path::io::Write<#driverfield_ident> for #struct_ident #kind_subst_arguments {
                 fn write_gadget<#driver_lifetime, #driver_ident: #ragu_core_path::drivers::Driver<#driver_lifetime, F = #driverfield_ident>, B: #ragu_primitives_path::io::Buffer<#driver_lifetime, #driver_ident> >(
-                    this: &<Self as #ragu_core_path::gadgets::GadgetKind<#driverfield_ident>>::Rebind<#driver_lifetime, #driver_ident>,
+                    this: &#ragu_core_path::gadgets::Bound<#driver_lifetime, #driver_ident, Self>,
                     dr: &mut #driver_ident,
                     buf: &mut B
                 ) -> #ragu_core_path::Result<()> {
@@ -167,7 +167,7 @@ fn test_gadget_serialize_derive() {
                 for MyGadget<'static, ::core::marker::PhantomData< DriverField >, C, N>
             {
                 fn write_gadget<'my_dr, MyD: ::ragu_core::drivers::Driver<'my_dr, F = DriverField>, B: ::ragu_primitives::io::Buffer<'my_dr, MyD> >(
-                    this: &<Self as ::ragu_core::gadgets::GadgetKind<DriverField>>::Rebind<'my_dr, MyD>,
+                    this: &::ragu_core::gadgets::Bound<'my_dr, MyD, Self>,
                     dr: &mut MyD,
                     buf: &mut B
                 ) -> ::ragu_core::Result<()> {

--- a/crates/ragu_pcd/src/circuits/native/compute_v.rs
+++ b/crates/ragu_pcd/src/circuits/native/compute_v.rs
@@ -51,7 +51,7 @@ use ragu_circuits::{
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::GadgetKind,
+    gadgets::Bound,
     maybe::Maybe,
 };
 use ragu_primitives::{Element, Endoscalar, GadgetExt};
@@ -129,7 +129,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> MultiStageCircuit<C::CircuitFi
         &self,
         _: &mut D,
         _: DriverValue<D, Self::Instance<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<C::CircuitField>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::Output>>
     where
         Self: 'dr,
     {
@@ -141,7 +141,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> MultiStageCircuit<C::CircuitFi
         builder: StageBuilder<'a, 'dr, D, R, (), Self::Last>,
         witness: DriverValue<D, Self::Witness<'source>>,
     ) -> Result<(
-        <Self::Output as GadgetKind<C::CircuitField>>::Rebind<'dr, D>,
+        Bound<'dr, D, Self::Output>,
         DriverValue<D, Self::Aux<'source>>,
     )>
     where

--- a/crates/ragu_pcd/src/circuits/native/full_collapse.rs
+++ b/crates/ragu_pcd/src/circuits/native/full_collapse.rs
@@ -54,7 +54,7 @@ use ragu_circuits::{
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::GadgetKind,
+    gadgets::Bound,
     maybe::Maybe,
 };
 
@@ -126,7 +126,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         &self,
         _: &mut D,
         _: DriverValue<D, Self::Instance<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<C::CircuitField>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::Output>>
     where
         Self: 'dr,
     {
@@ -138,7 +138,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         builder: StageBuilder<'a, 'dr, D, R, (), Self::Last>,
         witness: DriverValue<D, Self::Witness<'source>>,
     ) -> Result<(
-        <Self::Output as GadgetKind<C::CircuitField>>::Rebind<'dr, D>,
+        Bound<'dr, D, Self::Output>,
         DriverValue<D, Self::Aux<'source>>,
     )>
     where

--- a/crates/ragu_pcd/src/circuits/native/hashes_1.rs
+++ b/crates/ragu_pcd/src/circuits/native/hashes_1.rs
@@ -80,7 +80,7 @@ use ragu_circuits::{
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::{Gadget, GadgetKind, Kind},
+    gadgets::{Bound, Gadget, Kind},
     maybe::Maybe,
 };
 use ragu_primitives::{
@@ -192,7 +192,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         &self,
         _: &mut D,
         _: DriverValue<D, Self::Instance<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<C::CircuitField>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::Output>>
     where
         Self: 'dr,
     {
@@ -204,7 +204,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         builder: StageBuilder<'a, 'dr, D, R, (), Self::Last>,
         witness: DriverValue<D, Self::Witness<'source>>,
     ) -> Result<(
-        <Self::Output as GadgetKind<C::CircuitField>>::Rebind<'dr, D>,
+        Bound<'dr, D, Self::Output>,
         DriverValue<D, Self::Aux<'source>>,
     )>
     where

--- a/crates/ragu_pcd/src/circuits/native/hashes_2.rs
+++ b/crates/ragu_pcd/src/circuits/native/hashes_2.rs
@@ -66,7 +66,7 @@ use ragu_circuits::{
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::GadgetKind,
+    gadgets::Bound,
     maybe::Maybe,
 };
 use ragu_primitives::{GadgetExt, poseidon::Sponge};
@@ -138,7 +138,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         &self,
         _: &mut D,
         _: DriverValue<D, Self::Instance<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<C::CircuitField>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::Output>>
     where
         Self: 'dr,
     {
@@ -150,7 +150,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         builder: StageBuilder<'a, 'dr, D, R, (), Self::Last>,
         witness: DriverValue<D, Self::Witness<'source>>,
     ) -> Result<(
-        <Self::Output as GadgetKind<C::CircuitField>>::Rebind<'dr, D>,
+        Bound<'dr, D, Self::Output>,
         DriverValue<D, Self::Aux<'source>>,
     )>
     where

--- a/crates/ragu_pcd/src/circuits/native/partial_collapse.rs
+++ b/crates/ragu_pcd/src/circuits/native/partial_collapse.rs
@@ -61,7 +61,7 @@ use ragu_circuits::{
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::{Gadget, GadgetKind},
+    gadgets::{Bound, Gadget},
     maybe::Maybe,
 };
 use ragu_primitives::{Element, vec::FixedVec};
@@ -126,7 +126,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         &self,
         _: &mut D,
         _: DriverValue<D, Self::Instance<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<C::CircuitField>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::Output>>
     where
         Self: 'dr,
     {
@@ -138,7 +138,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         builder: StageBuilder<'a, 'dr, D, R, (), Self::Last>,
         witness: DriverValue<D, Self::Witness<'source>>,
     ) -> Result<(
-        <Self::Output as GadgetKind<C::CircuitField>>::Rebind<'dr, D>,
+        Bound<'dr, D, Self::Output>,
         DriverValue<D, Self::Aux<'source>>,
     )>
     where

--- a/crates/ragu_pcd/src/circuits/native/stages/error_m.rs
+++ b/crates/ragu_pcd/src/circuits/native/stages/error_m.rs
@@ -7,7 +7,7 @@ use ragu_circuits::{polynomials::Rank, staging};
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::{Consistent, Gadget, GadgetKind, Kind},
+    gadgets::{Bound, Consistent, Gadget, Kind},
     maybe::Maybe,
 };
 use ragu_primitives::{
@@ -62,7 +62,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         &self,
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'source>>,
-    ) -> Result<<Self::OutputKind as GadgetKind<C::CircuitField>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::OutputKind>>
     where
         Self: 'dr,
     {

--- a/crates/ragu_pcd/src/circuits/native/stages/error_n.rs
+++ b/crates/ragu_pcd/src/circuits/native/stages/error_n.rs
@@ -7,7 +7,7 @@ use ragu_circuits::{polynomials::Rank, staging};
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::{Consistent, Gadget, GadgetKind, Kind},
+    gadgets::{Bound, Consistent, Gadget, Kind},
     maybe::Maybe,
 };
 use ragu_primitives::{
@@ -127,7 +127,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         &self,
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'source>>,
-    ) -> Result<<Self::OutputKind as GadgetKind<C::CircuitField>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::OutputKind>>
     where
         Self: 'dr,
     {

--- a/crates/ragu_pcd/src/circuits/native/stages/eval.rs
+++ b/crates/ragu_pcd/src/circuits/native/stages/eval.rs
@@ -6,7 +6,7 @@ use ragu_circuits::{polynomials::Rank, staging};
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::{Gadget, GadgetKind, Kind},
+    gadgets::{Bound, Gadget, Kind},
     maybe::Maybe,
 };
 use ragu_primitives::{Element, io::Write};
@@ -187,7 +187,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> staging::Stage<C::CircuitField
         &self,
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'source>>,
-    ) -> Result<<Self::OutputKind as GadgetKind<C::CircuitField>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::OutputKind>>
     where
         Self: 'dr,
     {

--- a/crates/ragu_pcd/src/circuits/native/stages/mod.rs
+++ b/crates/ragu_pcd/src/circuits/native/stages/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod tests {
     use ragu_circuits::{polynomials::Rank, staging::Stage};
     use ragu_core::{
         drivers::emulator::{Emulator, Wireless},
-        gadgets::{Gadget, GadgetKind},
+        gadgets::{Bound, Gadget},
         maybe::Empty,
     };
 
@@ -25,7 +25,7 @@ pub(crate) mod tests {
         F: PrimeField,
         R: Rank,
         S: Stage<F, R>,
-        for<'dr> <S::OutputKind as GadgetKind<F>>::Rebind<'dr, Emulator<Wireless<Empty, F>>>:
+        for<'dr> Bound<'dr, Emulator<Wireless<Empty, F>>, S::OutputKind>:
             Gadget<'dr, Emulator<Wireless<Empty, F>>>,
     {
         let mut emulator = Emulator::counter();

--- a/crates/ragu_pcd/src/circuits/native/stages/preamble.rs
+++ b/crates/ragu_pcd/src/circuits/native/stages/preamble.rs
@@ -7,7 +7,7 @@ use ragu_circuits::{polynomials::Rank, staging};
 use ragu_core::{
     Error, Result,
     drivers::{Driver, DriverValue},
-    gadgets::{Consistent, Gadget, GadgetKind, Kind},
+    gadgets::{Bound, Consistent, Gadget, Kind},
     maybe::Maybe,
 };
 use ragu_primitives::{
@@ -262,7 +262,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> staging::Stage<C::CircuitField
         &self,
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'source>>,
-    ) -> Result<<Self::OutputKind as GadgetKind<C::CircuitField>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::OutputKind>>
     where
         Self: 'dr,
     {

--- a/crates/ragu_pcd/src/circuits/native/stages/query.rs
+++ b/crates/ragu_pcd/src/circuits/native/stages/query.rs
@@ -23,7 +23,7 @@ use ragu_circuits::{
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::{Gadget, GadgetKind, Kind},
+    gadgets::{Bound, Gadget, Kind},
     maybe::Maybe,
 };
 use ragu_primitives::Element;
@@ -377,7 +377,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> staging::Stage<C::CircuitField
         &self,
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'source>>,
-    ) -> Result<<Self::OutputKind as GadgetKind<C::CircuitField>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::OutputKind>>
     where
         Self: 'dr,
     {

--- a/crates/ragu_pcd/src/circuits/native/unified.rs
+++ b/crates/ragu_pcd/src/circuits/native/unified.rs
@@ -23,7 +23,7 @@ use ragu_circuits::polynomials::Rank;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::{Consistent, Gadget, GadgetKind, Kind},
+    gadgets::{Bound, Consistent, Gadget, Kind},
     maybe::Maybe,
 };
 use ragu_primitives::{Element, Point, io::Write};
@@ -360,7 +360,7 @@ impl<'a, 'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>> OutputBuilder<'a, '
         self,
         dr: &mut D,
         instance: &DriverValue<D, &'a Instance<C>>,
-    ) -> Result<<InternalOutputKind<C> as GadgetKind<D::F>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, InternalOutputKind<C>>> {
         let zero = Element::zero(dr);
         Ok(WithSuffix::new(self.finish_no_suffix(dr, instance)?, zero))
     }

--- a/crates/ragu_pcd/src/circuits/nested/stages/mod.rs
+++ b/crates/ragu_pcd/src/circuits/nested/stages/mod.rs
@@ -32,7 +32,7 @@ macro_rules! define_nested_stage {
             use ragu_core::{
                 Result,
                 drivers::{Driver, DriverValue},
-                gadgets::{Gadget, GadgetKind, Kind},
+                gadgets::{Bound, Gadget, Kind},
                 maybe::Maybe,
             };
             use ragu_primitives::{Point, io::Write};
@@ -78,7 +78,7 @@ macro_rules! define_nested_stage {
                     &self,
                     dr: &mut D,
                     witness: DriverValue<D, Self::Witness<'source>>,
-                ) -> Result<<Self::OutputKind as GadgetKind<C::Base>>::Rebind<'dr, D>>
+                ) -> Result<Bound<'dr, D, Self::OutputKind>>
                 where
                     Self: 'dr,
                 {

--- a/crates/ragu_pcd/src/circuits/nested/stages/preamble.rs
+++ b/crates/ragu_pcd/src/circuits/nested/stages/preamble.rs
@@ -9,7 +9,7 @@ use crate::Proof;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::{Gadget, GadgetKind, Kind},
+    gadgets::{Bound, Gadget, Kind},
     maybe::Maybe,
 };
 use ragu_primitives::{Point, io::Write};
@@ -129,7 +129,7 @@ impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stag
         &self,
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'source>>,
-    ) -> Result<<Self::OutputKind as GadgetKind<C::Base>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::OutputKind>>
     where
         Self: 'dr,
     {

--- a/crates/ragu_pcd/src/components/endoscalar.rs
+++ b/crates/ragu_pcd/src/components/endoscalar.rs
@@ -26,7 +26,7 @@ use ragu_circuits::{
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::{Gadget, GadgetKind, Kind},
+    gadgets::{Bound, Gadget, Kind},
     maybe::Maybe,
 };
 use ragu_primitives::{
@@ -80,7 +80,7 @@ impl<F: Field, R: Rank> Stage<F, R> for EndoscalarStage {
         &self,
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'source>>,
-    ) -> Result<<Self::OutputKind as GadgetKind<F>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::OutputKind>>
     where
         Self: 'dr,
     {
@@ -183,7 +183,7 @@ impl<C: CurveAffine, R: Rank, const NUM_POINTS: usize> Stage<C::Base, R>
         &self,
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'source>>,
-    ) -> Result<<Self::OutputKind as GadgetKind<C::Base>>::Rebind<'dr, D>>
+    ) -> Result<Bound<'dr, D, Self::OutputKind>>
     where
         Self: 'dr,
     {
@@ -262,7 +262,7 @@ impl<C: CurveAffine, R: Rank, const NUM_POINTS: usize> MultiStageCircuit<C::Base
         &self,
         _dr: &mut D,
         _instance: DriverValue<D, Self::Instance<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<C::Base>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, Self::Output>> {
         Ok(())
     }
 
@@ -271,7 +271,7 @@ impl<C: CurveAffine, R: Rank, const NUM_POINTS: usize> MultiStageCircuit<C::Base
         dr: StageBuilder<'a, 'dr, D, R, (), Self::Last>,
         witness: DriverValue<D, Self::Witness<'source>>,
     ) -> Result<(
-        <Self::Output as GadgetKind<C::Base>>::Rebind<'dr, D>,
+        Bound<'dr, D, Self::Output>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let (endoscalar_guard, dr) = dr.add_stage::<EndoscalarStage>()?;

--- a/crates/ragu_pcd/src/header.rs
+++ b/crates/ragu_pcd/src/header.rs
@@ -5,7 +5,7 @@ use ff::Field;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::GadgetKind,
+    gadgets::Bound,
 };
 use ragu_primitives::io::Write;
 
@@ -92,7 +92,7 @@ pub trait Header<F: Field>: Send + Sync + Any {
     fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
         dr: &mut D,
         witness: DriverValue<D, Self::Data<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>>;
+    ) -> Result<Bound<'dr, D, Self::Output>>;
 }
 
 /// Trivial header that encodes no data.
@@ -105,7 +105,7 @@ impl<F: Field> Header<F> for () {
     fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
         _: &mut D,
         _: DriverValue<D, Self::Data<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, Self::Output>> {
         Ok(())
     }
 }

--- a/crates/ragu_pcd/src/step/internal/adapter.rs
+++ b/crates/ragu_pcd/src/step/internal/adapter.rs
@@ -3,7 +3,7 @@ use ragu_circuits::{Circuit, polynomials::Rank};
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::{GadgetKind, Kind},
+    gadgets::{Bound, Kind},
     maybe::Maybe,
 };
 use ragu_primitives::{
@@ -66,7 +66,7 @@ impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Circuit<C::Circuit
         &self,
         _: &mut D,
         _: DriverValue<D, Self::Instance<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<C::CircuitField>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, Self::Output>> {
         unreachable!("k(Y) is computed manually for ragu_pcd circuit implementations")
     }
 
@@ -75,7 +75,7 @@ impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Circuit<C::Circuit
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'source>>,
     ) -> Result<(
-        <Self::Output as GadgetKind<C::CircuitField>>::Rebind<'dr, D>,
+        Bound<'dr, D, Self::Output>,
         DriverValue<D, Self::Aux<'source>>,
     )>
     where
@@ -118,7 +118,7 @@ mod tests {
     use ragu_circuits::polynomials::R;
     use ragu_core::{
         drivers::emulator::Emulator,
-        gadgets::Kind,
+        gadgets::{Bound, Kind},
         maybe::{Always, Maybe, MaybeKind},
     };
     use ragu_pasta::{Fp, Pasta};
@@ -136,7 +136,7 @@ mod tests {
         fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
             dr: &mut D,
             witness: DriverValue<D, Self::Data<'source>>,
-        ) -> Result<<Self::Output as GadgetKind<Fp>>::Rebind<'dr, D>> {
+        ) -> Result<Bound<'dr, D, Self::Output>> {
             Element::alloc(dr, witness)
         }
     }

--- a/crates/ragu_pcd/src/step/internal/padded.rs
+++ b/crates/ragu_pcd/src/step/internal/padded.rs
@@ -2,7 +2,7 @@ use ff::{Field, PrimeField};
 use ragu_core::{
     Result,
     drivers::Driver,
-    gadgets::{Gadget, GadgetKind, Kind},
+    gadgets::{Bound, Gadget, GadgetKind, Kind},
 };
 use ragu_primitives::{
     Element, GadgetExt,
@@ -40,7 +40,7 @@ pub(crate) fn for_header<
     D: Driver<'dr, F: PrimeField>,
 >(
     dr: &mut D,
-    gadget: <H::Output as GadgetKind<D::F>>::Rebind<'dr, D>,
+    gadget: Bound<'dr, D, H::Output>,
 ) -> Result<Padded<'dr, D, H::Output, HEADER_SIZE>> {
     let padded_content = PaddedContent { gadget };
     let suffix = Element::constant(dr, D::F::from(H::SUFFIX.get()));

--- a/crates/ragu_pcd/src/step/internal/rerandomize.rs
+++ b/crates/ragu_pcd/src/step/internal/rerandomize.rs
@@ -79,7 +79,7 @@ fn test_rerandomize_consistency() {
     use ragu_core::{
         Result,
         drivers::{Driver, DriverValue},
-        gadgets::{GadgetKind, Kind},
+        gadgets::{Bound, Kind},
         maybe::Maybe,
     };
     use ragu_pasta::{Fp, Pasta};
@@ -96,7 +96,7 @@ fn test_rerandomize_consistency() {
         fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
             dr: &mut D,
             witness: DriverValue<D, Self::Data<'source>>,
-        ) -> Result<<Self::Output as GadgetKind<Fp>>::Rebind<'dr, D>> {
+        ) -> Result<Bound<'dr, D, Self::Output>> {
             Element::alloc(dr, witness)
         }
     }
@@ -109,7 +109,7 @@ fn test_rerandomize_consistency() {
         fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
             dr: &mut D,
             witness: DriverValue<D, Self::Data<'source>>,
-        ) -> Result<<Self::Output as GadgetKind<Fp>>::Rebind<'dr, D>> {
+        ) -> Result<Bound<'dr, D, Self::Output>> {
             let (a, b) = witness.cast();
             let a = Element::alloc(dr, a)?;
             let b = Element::alloc(dr, b)?;

--- a/crates/ragu_pcd/src/test_fixtures/nontrivial.rs
+++ b/crates/ragu_pcd/src/test_fixtures/nontrivial.rs
@@ -5,7 +5,7 @@ use ragu_arithmetic::Cycle;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::{GadgetKind, Kind},
+    gadgets::{Bound, Kind},
     maybe::Maybe,
 };
 use ragu_primitives::{Element, poseidon::Sponge};
@@ -25,7 +25,7 @@ impl<F: Field> Header<F> for LeafNode {
     fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
         dr: &mut D,
         witness: DriverValue<D, Self::Data<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, Self::Output>> {
         Element::alloc(dr, witness)
     }
 }
@@ -40,7 +40,7 @@ impl<F: Field> Header<F> for InternalNode {
     fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
         dr: &mut D,
         witness: DriverValue<D, Self::Data<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, Self::Output>> {
         Element::alloc(dr, witness)
     }
 }

--- a/crates/ragu_pcd/tests/registration_errors.rs
+++ b/crates/ragu_pcd/tests/registration_errors.rs
@@ -3,7 +3,7 @@ use ragu_circuits::polynomials::R;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::GadgetKind,
+    gadgets::Bound,
 };
 use ragu_pasta::Pasta;
 use ragu_pcd::step::{Encoded, Index, Step};
@@ -26,7 +26,7 @@ impl<F: Field> Header<F> for HSuffixA {
     fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
         _: &mut D,
         _: DriverValue<D, Self::Data<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, Self::Output>> {
         Ok(())
     }
 }
@@ -38,7 +38,7 @@ impl<F: Field> Header<F> for HSuffixB {
     fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
         _: &mut D,
         _: DriverValue<D, Self::Data<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, Self::Output>> {
         Ok(())
     }
 }
@@ -50,7 +50,7 @@ impl<F: Field> Header<F> for HSuffixAOther {
     fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
         _: &mut D,
         _: DriverValue<D, Self::Data<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, Self::Output>> {
         Ok(())
     }
 }

--- a/crates/ragu_pcd/tests/rerandomization.rs
+++ b/crates/ragu_pcd/tests/rerandomization.rs
@@ -4,7 +4,7 @@ use ragu_circuits::polynomials::R;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::{GadgetKind, Kind},
+    gadgets::{Bound, Kind},
     maybe::Maybe,
 };
 use ragu_pasta::{Fp, Pasta};
@@ -27,7 +27,7 @@ impl<F: Field> Header<F> for HeaderA {
     fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
         _: &mut D,
         _: DriverValue<D, Self::Data<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, Self::Output>> {
         Ok(())
     }
 }
@@ -42,7 +42,7 @@ impl Header<Fp> for HeaderWithData {
     fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
         dr: &mut D,
         witness: DriverValue<D, Self::Data<'source>>,
-    ) -> Result<<Self::Output as GadgetKind<Fp>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, Self::Output>> {
         Element::alloc(dr, witness)
     }
 }

--- a/crates/ragu_primitives/src/poseidon.rs
+++ b/crates/ragu_primitives/src/poseidon.rs
@@ -9,7 +9,7 @@ use ragu_arithmetic::Coeff;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::{Consistent, Gadget, GadgetKind},
+    gadgets::{Bound, Consistent, Gadget},
     routines::{Prediction, Routine},
 };
 
@@ -351,9 +351,9 @@ impl<F: Field, P: ragu_arithmetic::PoseidonPermutation<F>> Routine<F> for Permut
     fn execute<'dr, D: Driver<'dr, F = F>>(
         &self,
         dr: &mut D,
-        mut state: <Self::Input as GadgetKind<F>>::Rebind<'dr, D>,
+        mut state: Bound<'dr, D, Self::Input>,
         _: DriverValue<D, Self::Aux<'dr>>,
-    ) -> Result<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>> {
+    ) -> Result<Bound<'dr, D, Self::Output>> {
         let mut rcs = self.params.round_constants();
 
         let mut round = |dr: &mut D, elems| {
@@ -379,10 +379,8 @@ impl<F: Field, P: ragu_arithmetic::PoseidonPermutation<F>> Routine<F> for Permut
     fn predict<'dr, D: Driver<'dr, F = F>>(
         &self,
         _: &mut D,
-        _: &<Self::Input as GadgetKind<F>>::Rebind<'dr, D>,
-    ) -> Result<
-        Prediction<<Self::Output as GadgetKind<F>>::Rebind<'dr, D>, DriverValue<D, Self::Aux<'dr>>>,
-    > {
+        _: &Bound<'dr, D, Self::Input>,
+    ) -> Result<Prediction<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'dr>>>> {
         Ok(Prediction::Unknown(D::just(|| ())))
     }
 }

--- a/crates/ragu_primitives/src/promotion.rs
+++ b/crates/ragu_primitives/src/promotion.rs
@@ -6,7 +6,7 @@ use ragu_arithmetic::Coeff;
 use ragu_core::{
     Result,
     drivers::{Driver, DriverTypes, DriverValue, FromDriver},
-    gadgets::{Gadget, GadgetKind},
+    gadgets::{Bound, Gadget, GadgetKind},
     maybe::Empty,
 };
 
@@ -108,11 +108,11 @@ impl<'dr, 'new_dr, D: Driver<'dr>, F: FromDriver<'dr, 'new_dr, D>>
 /// has no witness data, so it cannot meaningfully enforce consistency. Promote
 /// the gadget first, then call `enforce_consistent` on the result.
 pub struct Demoted<'dr, D: Driver<'dr>, G: Gadget<'dr, D>> {
-    gadget: <G::Kind as GadgetKind<D::F>>::Rebind<'dr, DemotedDriver<'dr, D>>,
+    gadget: Bound<'dr, DemotedDriver<'dr, D>, G::Kind>,
 }
 
 impl<'dr, D: Driver<'dr>, G: Gadget<'dr, D>> Deref for Demoted<'dr, D, G> {
-    type Target = <G::Kind as GadgetKind<D::F>>::Rebind<'dr, DemotedDriver<'dr, D>>;
+    type Target = Bound<'dr, DemotedDriver<'dr, D>, G::Kind>;
 
     fn deref(&self) -> &Self::Target {
         &self.gadget

--- a/crates/ragu_primitives/src/simulator.rs
+++ b/crates/ragu_primitives/src/simulator.rs
@@ -8,7 +8,7 @@ use ragu_arithmetic::Coeff;
 use ragu_core::{
     Error, Result,
     drivers::{DirectSum, Driver, DriverTypes},
-    gadgets::{Gadget, GadgetKind},
+    gadgets::{Bound, Gadget},
     maybe::{Always, MaybeKind},
     routines::{Prediction, Routine},
 };
@@ -137,8 +137,8 @@ impl<'dr, F: Field> Driver<'dr> for Simulator<F> {
     fn routine<R: Routine<Self::F> + 'dr>(
         &mut self,
         routine: R,
-        input: <R::Input as GadgetKind<Self::F>>::Rebind<'dr, Self>,
-    ) -> Result<<R::Output as GadgetKind<Self::F>>::Rebind<'dr, Self>> {
+        input: Bound<'dr, Self, R::Input>,
+    ) -> Result<Bound<'dr, Self, R::Output>> {
         let mut tmp = self.clone();
         match routine.predict(&mut tmp, &input)? {
             Prediction::Known(output, aux) => {


### PR DESCRIPTION
References https://github.com/tachyon-zcash/ragu/issues/475. Introduces `pub type Bound<'dr, D, K>` type alias for `<K as GadgetKind<<D as Driver<'dr>>::F>>::Rebind<'dr, D>`, replacing verbose UFCS syntax at call sites. It's named `Bound` to indicate the result of rebinding a `GadgetKind` to a driver.
