### PR TITLE
bump to rand 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,10 +96,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "derive_more"
@@ -141,18 +167,18 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 [[package]]
 name = "ff"
 version = "0.14.0-pre.0"
-source = "git+https://github.com/ebfull/ff?rev=e46e1d268bc026708c8ddeb2d49766ea49f9e70e#e46e1d268bc026708c8ddeb2d49766ea49f9e70e"
+source = "git+https://github.com/ebfull/ff?branch=release-0.14.0-with-rand-0.10#f4ca7c23e6ea693b13aba0c690ad7c43852c561c"
 dependencies = [
  "bitvec",
  "ff_derive",
- "rand_core",
+ "rand_core 0.10.0",
  "subtle",
 ]
 
 [[package]]
 name = "ff_derive"
 version = "0.14.0-pre.0"
-source = "git+https://github.com/ebfull/ff?rev=e46e1d268bc026708c8ddeb2d49766ea49f9e70e#e46e1d268bc026708c8ddeb2d49766ea49f9e70e"
+source = "git+https://github.com/ebfull/ff?branch=release-0.14.0-with-rand-0.10#f4ca7c23e6ea693b13aba0c690ad7c43852c561c"
 dependencies = [
  "addchain",
  "num-bigint",
@@ -168,6 +194,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "funty"
@@ -188,13 +220,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core 0.10.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "group"
 version = "0.14.0-pre.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff6a0b2dd4b981b1ae9e3e6830ab146771f3660d31d57bafd9018805a91b0f1"
+source = "git+https://github.com/ebfull/group?branch=release-0.14.0-with-rand-0.10#5f5c693275598d7885827e153c21ff99c60e18f3"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.10.0",
  "subtle",
 ]
 
@@ -237,9 +282,30 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
@@ -248,7 +314,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -267,6 +335,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +351,12 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -321,13 +401,13 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 [[package]]
 name = "pasta_curves"
 version = "0.5.1"
-source = "git+https://github.com/ebfull/pasta_curves?rev=32152d552b1c39fb3ffab8f0d8646f946c4adecc#32152d552b1c39fb3ffab8f0d8646f946c4adecc"
+source = "git+https://github.com/ebfull/pasta_curves?branch=ff-0.14-with-rand-0.10#ad4c7a24d9b0829f9da5f305aab6b4ab97a97900"
 dependencies = [
  "blake2b_simd",
  "ff",
  "group",
  "lazy_static",
- "rand",
+ "rand 0.10.0",
  "static_assertions",
  "subtle",
 ]
@@ -339,6 +419,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -391,7 +481,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
+ "rand 0.9.2",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -447,7 +537,7 @@ dependencies = [
  "pasta_curves",
  "proptest",
  "ragu_macros",
- "rand",
+ "rand 0.10.0",
 ]
 
 [[package]]
@@ -464,7 +554,7 @@ dependencies = [
  "ragu_pasta",
  "ragu_primitives",
  "ragu_testing",
- "rand",
+ "rand 0.10.0",
 ]
 
 [[package]]
@@ -477,7 +567,7 @@ dependencies = [
  "ragu_arithmetic",
  "ragu_macros",
  "ragu_pasta",
- "rand",
+ "rand 0.10.0",
  "thiserror",
 ]
 
@@ -524,7 +614,7 @@ dependencies = [
  "ragu_pasta",
  "ragu_primitives",
  "ragu_testing",
- "rand",
+ "rand 0.10.0",
 ]
 
 [[package]]
@@ -538,7 +628,7 @@ dependencies = [
  "ragu_core",
  "ragu_macros",
  "ragu_pasta",
- "rand",
+ "rand 0.10.0",
  "thiserror",
 ]
 
@@ -552,7 +642,7 @@ dependencies = [
  "ragu_core",
  "ragu_pcd",
  "ragu_primitives",
- "rand",
+ "rand 0.10.0",
 ]
 
 [[package]]
@@ -562,7 +652,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -572,7 +673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -581,8 +682,14 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_xorshift"
@@ -590,7 +697,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -724,7 +831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -793,6 +900,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -808,6 +921,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -839,6 +995,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ repository = "https://github.com/tachyon-zcash/ragu"
 ff = { version = "0.14.0-pre.0", default-features = false }
 group = { version = "0.14.0-pre.0", default-features = false }
 pasta_curves = "0.5.1"
-rand = "0.9"
+rand = "0.10"
 lazy_static = "1.5.0"
 proptest = "1.7.0"
 gungraun = "0.17.0"
@@ -75,13 +75,22 @@ blake2b_simd = "1.0"
 # that updates `addchain` to use `num_bigint 0.4`
 addchain = { git = "https://github.com/ebfull/addchain", rev = "da4099a81bc29c895f3ca0ebcaae21c860494c12" }
 
-# `ebfull/ff` branch `release-0.14.0` is a fork of
+# `ebfull/ff` branch `release-0.14.0-with-rand-0.10` is a fork of
 # https://github.com/zkcrypto/ff/pull/130
 # which updates `ff` to bump `num-bigint` and `syn`
+# then merges https://github.com/zkcrypto/ff/pull/149
 # dependencies to align with our local usage in `ragu_macros`
-ff = { git = "https://github.com/ebfull/ff", rev = "e46e1d268bc026708c8ddeb2d49766ea49f9e70e" }
+ff = { git = "https://github.com/ebfull/ff", branch = "release-0.14.0-with-rand-0.10" }
 
-# `ebfull/pasta_curves` branch `ff-0.14` is a replica of
+# `ebfull/group` branch `release-0.14.0-with-rand-0.10` is a fork of
+# https://github.com/zkcrypto/group/pull/63
+# which updates `group` to bump `ff` to `0.14` (as well as other
+# changes, including bumping to `rand 0.9`)
+# then merges https://github.com/zkcrypto/group/pull/71
+group = { git = "https://github.com/ebfull/group", branch = "release-0.14.0-with-rand-0.10" }
+
+# `ebfull/pasta_curves` branch `ff-0.14-with-rand-0.10` is a replica of
 # https://github.com/zcash/pasta_curves/pull/86
 # that updates `pasta_curves` to use `ff`/`group` `0.14.0-pre.0`
-pasta_curves = { git = "https://github.com/ebfull/pasta_curves", rev = "32152d552b1c39fb3ffab8f0d8646f946c4adecc" }
+# then bumps to `rand 0.9`.
+pasta_curves = { git = "https://github.com/ebfull/pasta_curves", branch = "ff-0.14-with-rand-0.10" }

--- a/crates/ragu_arithmetic/src/uendo.rs
+++ b/crates/ragu_arithmetic/src/uendo.rs
@@ -9,6 +9,7 @@ use core::{
     fmt::{self, Debug},
     ops::{BitAnd, BitOr, BitOrAssign, Shl, ShlAssign, Shr},
 };
+use rand::RngExt;
 
 const BITS: usize = 136;
 const LIMBS: usize = BITS.div_ceil(64);

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -230,7 +230,7 @@ mod tests {
     };
     use ragu_pasta::{EpAffine, Fp, Fq};
     use ragu_primitives::{Element, Endoscalar, Point, io::Write};
-    use rand::Rng;
+    use rand::RngExt;
 
     use crate::{
         CircuitExt, CircuitObject, metrics, polynomials::Rank, registry, s::sy,

--- a/crates/ragu_pcd/src/components/endoscalar.rs
+++ b/crates/ragu_pcd/src/components/endoscalar.rs
@@ -340,7 +340,7 @@ mod tests {
     };
     use ragu_pasta::{Ep, EpAffine, Fp, Fq};
     use ragu_primitives::{Endoscalar, vec::Len};
-    use rand::Rng;
+    use rand::RngExt;
 
     type R = polynomials::ProductionRank;
 

--- a/crates/ragu_pcd/src/components/fold_revdot.rs
+++ b/crates/ragu_pcd/src/components/fold_revdot.rs
@@ -702,7 +702,7 @@ mod tests {
     #[test]
     fn test_cost_formulas() -> Result<()> {
         fn verify<const M: usize, const N: usize>() -> Result<()> {
-            let rng = rand::rngs::StdRng::from_os_rng();
+            let rng = rand::rngs::StdRng::from_rng(&mut rand::rng());
             let sim = Simulator::simulate(rng, |dr, mut rng| {
                 let mu = Element::alloc(dr, rng.view_mut().map(Fp::random))?;
                 let nu = Element::alloc(dr, rng.view_mut().map(Fp::random))?;

--- a/crates/ragu_primitives/benches/setup/mod.rs
+++ b/crates/ragu_primitives/benches/setup/mod.rs
@@ -8,7 +8,7 @@ use ragu_pasta::{EpAffine, Fp, Fq, Pasta, PoseidonFp};
 use ragu_primitives::poseidon::Sponge;
 use ragu_primitives::{Boolean, Element, Endoscalar, Point};
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 
 pub type BenchEmu = Emulator<Wireless<Always<()>, Fp>>;
 

--- a/crates/ragu_primitives/src/endoscalar.rs
+++ b/crates/ragu_primitives/src/endoscalar.rs
@@ -252,7 +252,7 @@ mod tests {
     use ragu_arithmetic::{CurveAffine, CurveExt, Uendo};
     use ragu_core::Result;
     use ragu_pasta::{EpAffine, Fp};
-    use rand::Rng;
+    use rand::RngExt;
 
     use crate::Simulator;
 


### PR DESCRIPTION
See also #487.

Duplicates remaining:

* Unfortunately, `proptest` hasn't been updated for `rand 0.10` yet. (zebra has an even worse issue with duplicate `rand` usage)
* Also, `wasmparser` uses an older version of `hashbrown`, so we're stuck with the duplicates. (zebra has same issue)

Other than that, looks to be pretty close to what Zebra has to deal with right now.