### PR TITLE
Replace FreshB with PairAllocatedDriver subtrait

### DIFF
--- a/crates/ragu_circuits/src/metrics.rs
+++ b/crates/ragu_circuits/src/metrics.rs
@@ -59,16 +59,8 @@ impl<'dr, F: Field> Driver<'dr> for Counter<F> {
     type Wire = ();
     const ONE: Self::Wire = ();
 
-    fn alloc(&mut self, _: impl Fn() -> Result<Coeff<Self::F>>) -> Result<Self::Wire> {
-        if self.available_b {
-            self.available_b = false;
-            Ok(())
-        } else {
-            self.available_b = true;
-            self.mul(|| unreachable!())?;
-
-            Ok(())
-        }
+    fn alloc(&mut self, value: impl Fn() -> Result<Coeff<Self::F>>) -> Result<Self::Wire> {
+        PairAllocatedDriver::alloc(self, value)
     }
 
     fn mul(

--- a/crates/ragu_circuits/src/rx.rs
+++ b/crates/ragu_circuits/src/rx.rs
@@ -25,6 +25,13 @@ impl<'a, F: Field, R: Rank> PairAllocatedDriver<'a> for Evaluator<'a, F, R> {
     fn available_b(&mut self) -> &mut Option<usize> {
         &mut self.available_b
     }
+
+    // rx::Evaluator's mul *does* call its value closure to write witness data,
+    // so the trait default (which passes `|| unreachable!()`) would panic.
+    // Forward to Driver::alloc instead.
+    fn alloc(&mut self, value: impl Fn() -> Result<Coeff<Self::F>>) -> Result<Self::Wire> {
+        Driver::alloc(self, value)
+    }
 }
 
 impl<F: Field, R: Rank> DriverTypes for Evaluator<'_, F, R> {

--- a/crates/ragu_circuits/src/s/sx.rs
+++ b/crates/ragu_circuits/src/s/sx.rs
@@ -179,15 +179,8 @@ impl<'dr, F: Field, R: Rank> Driver<'dr> for Evaluator<F, R> {
     const ONE: Self::Wire = WireEval::One;
 
     /// Allocates a wire using paired allocation.
-    fn alloc(&mut self, _: impl Fn() -> Result<Coeff<Self::F>>) -> Result<Self::Wire> {
-        if let Some(monomial) = self.available_b.take() {
-            Ok(monomial)
-        } else {
-            let (a, b, _) = self.mul(|| unreachable!())?;
-            self.available_b = Some(b);
-
-            Ok(a)
-        }
+    fn alloc(&mut self, value: impl Fn() -> Result<Coeff<Self::F>>) -> Result<Self::Wire> {
+        PairAllocatedDriver::alloc(self, value)
     }
 
     /// Consumes a multiplication gate, returning evaluated monomials for $(a, b, c)$.

--- a/crates/ragu_circuits/src/s/sxy.rs
+++ b/crates/ragu_circuits/src/s/sxy.rs
@@ -161,15 +161,8 @@ impl<'dr, F: Field, R: Rank> Driver<'dr> for Evaluator<F, R> {
     const ONE: Self::Wire = WireEval::One;
 
     /// Allocates a wire using paired allocation.
-    fn alloc(&mut self, _: impl Fn() -> Result<Coeff<Self::F>>) -> Result<Self::Wire> {
-        if let Some(wire) = self.available_b.take() {
-            Ok(wire)
-        } else {
-            let (a, b, _) = self.mul(|| unreachable!())?;
-            self.available_b = Some(b);
-
-            Ok(a)
-        }
+    fn alloc(&mut self, value: impl Fn() -> Result<Coeff<Self::F>>) -> Result<Self::Wire> {
+        PairAllocatedDriver::alloc(self, value)
     }
 
     /// Consumes a multiplication gate, returning evaluated monomials for $(a, b, c)$.

--- a/crates/ragu_circuits/src/s/sy.rs
+++ b/crates/ragu_circuits/src/s/sy.rs
@@ -505,18 +505,8 @@ impl<'table, 'sy, F: Field, R: Rank> Driver<'table> for Evaluator<'table, 'sy, F
     };
 
     /// Allocates a wire using paired allocation.
-    ///
-    /// Returns either a stashed $b$ wire from a previous gate, or allocates a
-    /// new gate and stashes its $b$ wire for the next call.
-    fn alloc(&mut self, _: impl Fn() -> Result<Coeff<Self::F>>) -> Result<Self::Wire> {
-        if let Some(wire) = self.available_b.take() {
-            Ok(wire)
-        } else {
-            let (a, b, _) = self.mul(|| unreachable!())?;
-            self.available_b = Some(b);
-
-            Ok(a)
-        }
+    fn alloc(&mut self, value: impl Fn() -> Result<Coeff<Self::F>>) -> Result<Self::Wire> {
+        PairAllocatedDriver::alloc(self, value)
     }
 
     /// Consumes a multiplication gate, returning wire handles for $(a, b, c)$.


### PR DESCRIPTION
A follow-up of 465, addressing my own comment: https://github.com/tachyon-zcash/ragu/pull/465#discussion_r2812352274

To conform to the default implementation of `PairAllocatedDriver` for `rx::Evaluator` and `metric::Counter`, had to change their `available_b()` return type to be exactly `Option<Self::Wire>`, but these should be semantic changes only, no effect on performance or logic correctness. 

This is just an alternative option, feel free to close it if you disagree.