### PR TITLE
structural hash as registry digest

### DIFF
--- a/crates/ragu_circuits/src/lib.rs
+++ b/crates/ragu_circuits/src/lib.rs
@@ -200,6 +200,12 @@ pub trait CircuitObject<F: Field, R: Rank>: Send + Sync {
     ///
     /// This captures wire identities and scalar coefficients without evaluating
     /// the polynomial.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the underlying synthesis exceeds the multiplication or linear
+    /// constraint bounds — which cannot happen for circuits that successfully
+    /// passed through [`CircuitExt::into_object`].
     fn hash(&self, state: &mut blake2b_simd::State)
     where
         F: ff::PrimeField;

--- a/crates/ragu_circuits/src/lib.rs
+++ b/crates/ragu_circuits/src/lib.rs
@@ -143,6 +143,13 @@ pub trait CircuitExt<F: Field>: Circuit<F> {
                 s::sy::eval(&self.circuit, y, key, self.metrics.num_linear_constraints)
                     .expect("should succeed if metrics succeeded")
             }
+            fn hash(&self, state: &mut blake2b_simd::State)
+            where
+                F: ff::PrimeField,
+            {
+                s::hash::eval::<_, _, R>(&self.circuit, state)
+                    .expect("should succeed if metrics succeeded")
+            }
             fn constraint_counts(&self) -> (usize, usize) {
                 (
                     self.metrics.num_multiplication_constraints,
@@ -187,6 +194,15 @@ pub trait CircuitObject<F: Field, R: Rank>: Send + Sync {
 
     /// Computes the polynomial restriction $s(X, y)$ for some $y \in \mathbb{F}$.
     fn sy(&self, y: F, key: &registry::Key<F>) -> structured::Polynomial<F, R>;
+
+    /// Hashes the structural identity of this circuit's wiring polynomial into
+    /// the provided BLAKE2b state.
+    ///
+    /// This captures wire identities and scalar coefficients without evaluating
+    /// the polynomial.
+    fn hash(&self, state: &mut blake2b_simd::State)
+    where
+        F: ff::PrimeField;
 
     /// Returns the number of constraints: `(multiplication, linear)`.
     fn constraint_counts(&self) -> (usize, usize);

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -231,30 +231,29 @@ impl<'params, F: PrimeField, R: Rank> RegistryBuilder<'params, F, R> {
 /// recursive verifier. Ragu avoids preprocessing by design, and does not use
 /// verification keys, which suggests an alternative solution.
 ///
-/// # Binding a polynomial through its evaluation
+/// # Binding through structural hashing
 ///
-/// Polynomials of bounded degree are overdetermined by their evaluation at a
-/// sufficient number of distinct points. Starting from public constants, we
-/// iteratively evaluate $e_i = m(w_i, x_i, y_i)$ where each evaluation point
-/// $(w_{i+1}, x_{i+1}, y_{i+1})$ is seeded by hashing the prior evaluation $e_i$.
-/// The final evaluation serves as the binding key.
+/// The registry key is derived by hashing the symbolic structure of each
+/// circuit's wiring polynomial — the wire identities and scalar coefficients
+/// that define the constraint system — directly into BLAKE2b. Each wire
+/// identity (`WireIndex`) uniquely maps to a monomial in the polynomial, so
+/// two circuits with distinct coefficient matrices produce distinct hash
+/// inputs with certainty.
 ///
-/// The number of iterations must exceed the degrees of freedom an adversary
-/// could exploit to adaptively modify circuits.
-/// See [#78] for the security argument.
+/// This is unconditionally binding: no evaluation at random points is needed,
+/// and no Schwartz-Zippel argument is required. The binding holds against
+/// adaptive adversaries, limited only by BLAKE2b collision resistance
+/// ($2^{-128}$ security).
 ///
-/// # Break self-reference without preprocessing
+/// # Breaking self-reference without preprocessing
 ///
-/// Now with a binding evaluation `e_d`, which is the registry [`Key`], we can
-/// break the self-reference more elegantly without preprocessing or reliance on
-/// public inputs.
-///
-/// Concretely, we retroactively inject the registry key into each member circuit
-/// of `m` as a special wire `key_wire`, enforced by a simple linear constraint
-/// `key_wire = k`. This binds each circuit's wiring polynomial to the registry
-/// polynomial, and thus the entire registry polynomial to the Fiat-Shamir
-/// transcript without self-reference. The key randomizes the wiring polynomial
-/// directly.
+/// The key is excluded from the hash since it doesn't exist during derivation.
+/// After computing the key, it is retroactively injected into each member
+/// circuit of $m$ as a special wire `key_wire`, enforced by a simple linear
+/// constraint `key_wire = k`. This binds each circuit's wiring polynomial to
+/// the registry polynomial, and thus the entire registry polynomial to the
+/// Fiat-Shamir transcript without self-reference. The key randomizes the
+/// wiring polynomial directly.
 ///
 /// The key is computed during [`RegistryBuilder::finalize`] and used during
 /// polynomial evaluations of [`CircuitObject`].
@@ -447,45 +446,32 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
 }
 
 impl<F: PrimeField + FromUniformBytes<64>, R: Rank> Registry<'_, F, R> {
-    /// Compute a digest of this registry using BLAKE2b.
+    /// Compute a digest of this registry by hashing the structural identity of
+    /// each circuit's wiring polynomial.
+    ///
+    /// Rather than evaluating the registry polynomial at random points (which
+    /// requires a Schwartz-Zippel argument), this method directly hashes the
+    /// symbolic wire identities and scalar coefficients that define each
+    /// circuit. Two registries with distinct coefficient matrices produce
+    /// distinct hash inputs with certainty. Combined with BLAKE2b collision
+    /// resistance, the key is unconditionally binding.
     fn compute_registry_digest(&self) -> F {
         let mut hasher = Params::new().personal(b"ragu_registry___").to_state();
 
-        let field_from_hash = |digest_state: &blake2b_simd::Hash, index: u8| {
-            F::from_uniform_bytes(
-                Params::new()
-                    .personal(b"ragu_registry___")
-                    .to_state()
-                    .update(digest_state.as_bytes())
-                    .update(&[index])
-                    .finalize()
-                    .as_array(),
-            )
-        };
+        // Hash circuit count for domain separation.
+        hasher.update(&(self.circuits.len() as u64).to_le_bytes());
 
-        // Placeholder "nothing-up-my-sleeve challenges" (small primes).
-        let mut w = F::from(2u64);
-        let mut x = F::from(3u64);
-        let mut y = F::from(5u64);
+        for (i, circuit) in self.circuits.iter().enumerate() {
+            // Fold on W: hash the circuit's domain element.
+            let j = bitreverse(i as u32, self.domain.log2_n()) as usize;
+            let omega_j = self.domain.omega().pow([j as u64]);
+            hasher.update(omega_j.to_repr().as_ref());
 
-        // FIXME(security): 6 iterations is insufficient to fully bind the registry
-        // polynomial. This should be increased to a value that overdetermines the
-        // polynomial (exceeds the degrees of freedom an adversary could exploit).
-        // Currently limited by registry evaluation performance; See #78 and #316.
-        for _ in 0..6 {
-            let eval = self.wxy(w, x, y);
-            hasher.update(eval.to_repr().as_ref());
-
-            let digest_state = hasher.finalize();
-            w = field_from_hash(&digest_state, 0);
-            x = field_from_hash(&digest_state, 1);
-            y = field_from_hash(&digest_state, 2);
-
-            hasher = Params::new().personal(b"ragu_registry___").to_state();
-            hasher.update(digest_state.as_bytes());
+            // Hash intrinsic circuit structure.
+            circuit.hash(&mut hasher);
         }
 
-        field_from_hash(&hasher.finalize(), 0)
+        F::from_uniform_bytes(hasher.finalize().as_array())
     }
 }
 

--- a/crates/ragu_circuits/src/s/common.rs
+++ b/crates/ragu_circuits/src/s/common.rs
@@ -7,10 +7,11 @@
 //! immediate field element results, they can share the same wire representation
 //! types defined here.
 //!
-//! In contrast, [`sy`] requires deferred computation through a virtual wire
-//! system with reference counting, because $s(X, y)$ coefficients cannot be
-//! computed in streaming order during synthesis (see [`sy`] module
-//! documentation).
+//! In contrast, [`sy`] and [`hash`] represent wires as symbolic indices rather
+//! than evaluated field elements, and both use [`WireIndex`] from this module.
+//! [`sy`] requires deferred computation through a virtual wire system with
+//! reference counting, because $s(X, y)$ coefficients cannot be computed in
+//! streaming order during synthesis (see [`sy`] module documentation).
 //!
 //! ### Immediate Evaluation
 //!
@@ -30,9 +31,10 @@
 //! [`sx`]: super::sx
 //! [`sxy`]: super::sxy
 //! [`sy`]: super::sy
+//! [`hash`]: super::hash
 //! [`Driver::ONE`]: ragu_core::drivers::Driver::ONE
 
-use ff::Field;
+use ff::{Field, PrimeField};
 use ragu_arithmetic::Coeff;
 use ragu_core::drivers::LinearExpression;
 
@@ -56,6 +58,39 @@ pub(crate) enum WireIndex {
     B(usize),
     C(usize),
     Virtual(usize),
+}
+
+/// Hashes a [`WireIndex`] into the BLAKE2b state.
+///
+/// Encodes the wire type as a single discriminant byte followed by the gate
+/// or virtual wire index as a little-endian `u64`.
+pub(crate) fn hash_wire_index(state: &mut blake2b_simd::State, wire: &WireIndex) {
+    match wire {
+        WireIndex::A(g) => {
+            state.update(&[0]);
+            state.update(&(*g as u64).to_le_bytes());
+        }
+        WireIndex::B(g) => {
+            state.update(&[1]);
+            state.update(&(*g as u64).to_le_bytes());
+        }
+        WireIndex::C(g) => {
+            state.update(&[2]);
+            state.update(&(*g as u64).to_le_bytes());
+        }
+        WireIndex::Virtual(id) => {
+            state.update(&[3]);
+            state.update(&(*id as u64).to_le_bytes());
+        }
+    }
+}
+
+/// Hashes a [`Coeff`] value into the BLAKE2b state.
+///
+/// Converts the coefficient to its canonical field element representation
+/// and hashes the raw bytes.
+pub(crate) fn hash_coeff<F: PrimeField>(state: &mut blake2b_simd::State, coeff: &Coeff<F>) {
+    state.update(coeff.value().to_repr().as_ref());
 }
 
 /// Represents a wire's evaluated monomial during polynomial synthesis.

--- a/crates/ragu_circuits/src/s/common.rs
+++ b/crates/ragu_circuits/src/s/common.rs
@@ -36,6 +36,28 @@ use ff::Field;
 use ragu_arithmetic::Coeff;
 use ragu_core::drivers::LinearExpression;
 
+/// An index identifying a wire in evaluators that track symbolic wire identity.
+///
+/// Used by the [`sy`] and [`hash`] evaluators to represent wires as indices
+/// rather than evaluated monomials.
+///
+/// # Variants
+///
+/// - `A(i)`, `B(i)`, `C(i)` — Allocated wires from gate $i$, corresponding to
+///   the $a$, $b$, $c$ wires respectively.
+///
+/// - `Virtual(i)` — A virtual wire (linear combination).
+///
+/// [`sy`]: super::sy
+/// [`hash`]: super::hash
+#[derive(Copy, Clone)]
+pub(crate) enum WireIndex {
+    A(usize),
+    B(usize),
+    C(usize),
+    Virtual(usize),
+}
+
 /// Represents a wire's evaluated monomial during polynomial synthesis.
 ///
 /// In the wiring polynomial $s(X, Y)$, each wire corresponds to a monomial

--- a/crates/ragu_circuits/src/s/hash.rs
+++ b/crates/ragu_circuits/src/s/hash.rs
@@ -1,0 +1,370 @@
+//! Streaming structural hash of the wiring polynomial $s(X, Y)$.
+//!
+//! This module provides [`eval`], which hashes the symbolic structure of a
+//! circuit's wiring polynomial into a BLAKE2b state. Unlike the other `s/`
+//! evaluators which compute polynomial values at specific points, this module
+//! captures the polynomial's *identity* — which wires appear in each
+//! constraint, with which scalar coefficients — for use in registry key
+//! derivation.
+//!
+//! # Design
+//!
+//! The hasher driver assigns each wire a **symbolic identity** via
+//! [`WireIndex`] (wire type + gate index) and hashes these identities
+//! alongside their scalar coefficients.
+//!
+//! For each circuit synthesis, the hash captures:
+//! - For each [`add()`](ragu_core::drivers::Driver::add): sentinel + virtual
+//!   wire ID + collected `(wire_id, effective_coeff)` pairs
+//! - For each [`enforce_zero()`](ragu_core::drivers::Driver::enforce_zero):
+//!   sentinel + collected `(wire_id, effective_coeff)` pairs
+//!
+//! # Binding Argument
+//!
+//! Each `(WireIndex, scalar)` pair uniquely identifies one monomial coefficient
+//! of the constraint polynomial. Two circuits with distinct coefficient
+//! matrices produce **distinct hash inputs** with certainty. Combined with
+//! BLAKE2b collision resistance, the resulting key is unconditionally binding.
+//!
+//! [`WireIndex`]: super::common::WireIndex
+
+use ff::PrimeField;
+use ragu_arithmetic::Coeff;
+use ragu_core::{
+    Error, Result,
+    drivers::{Driver, DriverTypes, LinearExpression, emulator::Emulator},
+    gadgets::{Bound, GadgetKind},
+    maybe::Empty,
+    routines::Routine,
+};
+use ragu_primitives::GadgetExt;
+
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+
+// Re-export WireIndex for use by other crate modules (e.g., staging/mask.rs).
+pub(crate) use super::common::WireIndex;
+
+use super::DriverExt;
+use crate::{Circuit, FreshB, polynomials::Rank};
+
+/// Sentinel byte for [`Driver::enforce_zero`] constraints.
+pub(crate) const SENTINEL_ENFORCE: [u8; 1] = [0xEE];
+
+/// Sentinel byte for [`Driver::add`] virtual wire definitions.
+const SENTINEL_ADD: [u8; 1] = [0xAD];
+
+/// Hashes a [`WireIndex`] into the BLAKE2b state.
+///
+/// Encodes the wire type as a single discriminant byte followed by the gate
+/// or virtual wire index as a little-endian `u32`.
+pub(crate) fn hash_wire_index(state: &mut blake2b_simd::State, wire: &WireIndex) {
+    match wire {
+        WireIndex::A(g) => {
+            state.update(&[0]);
+            state.update(&(*g as u32).to_le_bytes());
+        }
+        WireIndex::B(g) => {
+            state.update(&[1]);
+            state.update(&(*g as u32).to_le_bytes());
+        }
+        WireIndex::C(g) => {
+            state.update(&[2]);
+            state.update(&(*g as u32).to_le_bytes());
+        }
+        WireIndex::Virtual(id) => {
+            state.update(&[3]);
+            state.update(&(*id as u32).to_le_bytes());
+        }
+    }
+}
+
+/// Hashes a [`Coeff`] value into the BLAKE2b state.
+///
+/// Converts the coefficient to its canonical field element representation
+/// and hashes the raw bytes.
+pub(crate) fn hash_coeff<F: PrimeField>(state: &mut blake2b_simd::State, coeff: &Coeff<F>) {
+    state.update(coeff.value().to_repr().as_ref());
+}
+
+/// Collects wire references and coefficients for hashing.
+///
+/// Follows the same pattern as `sy::TermCollector` but stores terms for
+/// hashing rather than deferred polynomial resolution.
+struct HashTerms<F: ff::Field> {
+    terms: Vec<(WireIndex, Coeff<F>)>,
+    gain: Coeff<F>,
+}
+
+impl<F: ff::Field> HashTerms<F> {
+    fn new() -> Self {
+        HashTerms {
+            terms: Vec::new(),
+            gain: Coeff::One,
+        }
+    }
+}
+
+impl<F: PrimeField> LinearExpression<WireIndex, F> for HashTerms<F> {
+    fn add_term(mut self, wire: &WireIndex, coeff: Coeff<F>) -> Self {
+        self.terms.push((*wire, coeff * self.gain));
+        self
+    }
+
+    fn gain(mut self, coeff: Coeff<F>) -> Self {
+        self.gain = self.gain * coeff;
+        self
+    }
+}
+
+/// A [`Driver`] that hashes the structural identity of a circuit's wiring
+/// polynomial into a BLAKE2b state.
+///
+/// Instead of evaluating the polynomial at any point, this driver captures
+/// the symbolic wire identities and scalar coefficients that define the
+/// polynomial's structure.
+struct Hasher<'a, F, R> {
+    /// Mutable reference to the running BLAKE2b hash state.
+    state: &'a mut blake2b_simd::State,
+
+    /// Number of multiplication gates consumed so far.
+    multiplication_constraints: usize,
+
+    /// Number of linear constraints processed so far.
+    linear_constraints: usize,
+
+    /// Counter for assigning virtual wire IDs.
+    next_virtual_id: usize,
+
+    /// Stashed $b$ wire from paired allocation.
+    available_b: Option<WireIndex>,
+
+    _marker: PhantomData<(F, R)>,
+}
+
+impl<F: PrimeField, R: Rank> FreshB<Option<WireIndex>> for Hasher<'_, F, R> {
+    fn available_b(&mut self) -> &mut Option<WireIndex> {
+        &mut self.available_b
+    }
+}
+
+impl<F: PrimeField, R: Rank> DriverTypes for Hasher<'_, F, R> {
+    type MaybeKind = Empty;
+    type LCadd = HashTerms<F>;
+    type LCenforce = HashTerms<F>;
+    type ImplField = F;
+    type ImplWire = WireIndex;
+}
+
+impl<'dr, F: PrimeField, R: Rank> Driver<'dr> for Hasher<'dr, F, R> {
+    type F = F;
+    type Wire = WireIndex;
+
+    const ONE: Self::Wire = WireIndex::C(0);
+
+    fn alloc(&mut self, _: impl Fn() -> Result<Coeff<Self::F>>) -> Result<Self::Wire> {
+        if let Some(wire) = self.available_b.take() {
+            Ok(wire)
+        } else {
+            let (a, b, _) = self.mul(|| unreachable!())?;
+            self.available_b = Some(b);
+            Ok(a)
+        }
+    }
+
+    fn mul(
+        &mut self,
+        _: impl Fn() -> Result<(Coeff<F>, Coeff<F>, Coeff<F>)>,
+    ) -> Result<(Self::Wire, Self::Wire, Self::Wire)> {
+        let index = self.multiplication_constraints;
+        if index == R::n() {
+            return Err(Error::MultiplicationBoundExceeded(R::n()));
+        }
+        self.multiplication_constraints += 1;
+
+        Ok((
+            WireIndex::A(index),
+            WireIndex::B(index),
+            WireIndex::C(index),
+        ))
+    }
+
+    fn add(&mut self, lc: impl Fn(Self::LCadd) -> Self::LCadd) -> Self::Wire {
+        let terms = lc(HashTerms::new());
+        let id = self.next_virtual_id;
+        self.next_virtual_id += 1;
+
+        // Hash: sentinel + virtual ID + terms
+        self.state.update(&SENTINEL_ADD);
+        self.state.update(&(id as u32).to_le_bytes());
+        for (wire, coeff) in &terms.terms {
+            hash_wire_index(self.state, wire);
+            hash_coeff::<F>(self.state, coeff);
+        }
+
+        WireIndex::Virtual(id)
+    }
+
+    fn enforce_zero(&mut self, lc: impl Fn(Self::LCenforce) -> Self::LCenforce) -> Result<()> {
+        let q = self.linear_constraints;
+        if q == R::num_coeffs() {
+            return Err(Error::LinearBoundExceeded(R::num_coeffs()));
+        }
+        self.linear_constraints += 1;
+
+        let terms = lc(HashTerms::new());
+
+        // Hash: sentinel + terms
+        self.state.update(&SENTINEL_ENFORCE);
+        for (wire, coeff) in &terms.terms {
+            hash_wire_index(self.state, wire);
+            hash_coeff::<F>(self.state, coeff);
+        }
+
+        Ok(())
+    }
+
+    fn routine<Ro: Routine<Self::F> + 'dr>(
+        &mut self,
+        routine: Ro,
+        input: Bound<'dr, Self, Ro::Input>,
+    ) -> Result<Bound<'dr, Self, Ro::Output>> {
+        self.with_fresh_b(|this| {
+            let mut dummy = Emulator::wireless();
+            let dummy_input = Ro::Input::map_gadget(&input, &mut dummy)?;
+            let aux = routine.predict(&mut dummy, &dummy_input)?.into_aux();
+            routine.execute(this, input, aux)
+        })
+    }
+}
+
+/// Hashes the structural identity of a circuit's wiring polynomial into the
+/// provided BLAKE2b state.
+///
+/// This function runs circuit synthesis with the [`Hasher`] driver, which
+/// records wire identities and scalar coefficients rather than evaluating
+/// the polynomial.
+///
+/// # Arguments
+///
+/// - `circuit`: The circuit whose structure to hash.
+/// - `state`: The BLAKE2b state to hash into.
+pub fn eval<F: PrimeField, C: Circuit<F>, R: Rank>(
+    circuit: &C,
+    state: &mut blake2b_simd::State,
+) -> Result<()> {
+    let mut hasher = Hasher::<F, R> {
+        state,
+        multiplication_constraints: 0,
+        linear_constraints: 0,
+        next_virtual_id: 0,
+        available_b: None,
+        _marker: PhantomData,
+    };
+
+    let mut outputs = Vec::new();
+    let (io, _) = circuit.witness(&mut hasher, Empty)?;
+    io.write(&mut hasher, &mut outputs)?;
+
+    hasher.enforce_public_outputs(outputs.iter().map(|output| output.wire()))?;
+    hasher.enforce_one()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use blake2b_simd::Params;
+    use proptest::prelude::*;
+    use ragu_pasta::Fp;
+
+    use crate::{
+        CircuitExt, CircuitObject,
+        polynomials::{R, Rank},
+        staging::mask::StageMask,
+        tests::SquareCircuit,
+    };
+
+    type TestRank = R<8>;
+
+    fn circuit_digest<C: crate::Circuit<Fp>>(circuit: &C) -> blake2b_simd::Hash {
+        let mut state = Params::new().to_state();
+        super::eval::<Fp, _, TestRank>(circuit, &mut state).unwrap();
+        state.finalize()
+    }
+
+    fn object_digest(obj: &dyn CircuitObject<Fp, TestRank>) -> blake2b_simd::Hash {
+        let mut state = Params::new().to_state();
+        obj.hash(&mut state);
+        state.finalize()
+    }
+
+    // --- Binding: equal circuits hash equally, distinct circuits hash distinctly ---
+
+    proptest! {
+        #[test]
+        fn binding(i in 0usize..20, j in 0usize..20) {
+            let a = circuit_digest(&SquareCircuit { times: i });
+            let b = circuit_digest(&SquareCircuit { times: j });
+            if i == j {
+                prop_assert_eq!(a, b);
+            } else {
+                prop_assert_ne!(a, b);
+            }
+        }
+    }
+
+    // --- ProcessedCircuit hash matches hash::eval ---
+
+    #[test]
+    fn processed_circuit_matches_eval() {
+        for times in [0, 1, 2, 5, 10] {
+            let circuit = SquareCircuit { times };
+            let object = circuit.into_object::<TestRank>().unwrap();
+            assert_eq!(
+                circuit_digest(&SquareCircuit { times }),
+                object_digest(&*object),
+                "mismatch for SquareCircuit {{ times: {} }}",
+                times
+            );
+        }
+    }
+
+    // --- StageMask hand-rolled hash matches hash::eval ---
+
+    #[test]
+    fn stage_mask_handrolled_matches_driver() {
+        for skip in 0..5 {
+            for num in 0..(TestRank::n() - skip - 1) {
+                let mask = StageMask::<TestRank>::new(skip, num).unwrap();
+                assert_eq!(
+                    circuit_digest(&mask),
+                    object_digest(&mask),
+                    "StageMask hash mismatch for skip={}, num={}",
+                    skip,
+                    num
+                );
+            }
+        }
+    }
+
+    // --- StageMask binding ---
+
+    proptest! {
+        #[test]
+        fn stage_mask_binding(
+            s1 in 0..TestRank::n(), n1 in 0..TestRank::n(),
+            s2 in 0..TestRank::n(), n2 in 0..TestRank::n(),
+        ) {
+            prop_assume!(s1 + n1 < TestRank::n());
+            prop_assume!(s2 + n2 < TestRank::n());
+            prop_assume!((s1, n1) != (s2, n2));
+            // When num=0, all skip values produce identical constraints (every
+            // non-ONE gate is constrained), so the hashes are legitimately equal.
+            prop_assume!(n1 > 0 || n2 > 0);
+
+            let a = object_digest(&StageMask::<TestRank>::new(s1, n1).unwrap());
+            let b = object_digest(&StageMask::<TestRank>::new(s2, n2).unwrap());
+            prop_assert_ne!(a, b);
+        }
+    }
+}

--- a/crates/ragu_circuits/src/s/mod.rs
+++ b/crates/ragu_circuits/src/s/mod.rs
@@ -60,6 +60,8 @@
 //! * [`sx`]: Evaluates $s(X, Y)$ at $X = x$ for some $x \in \mathbb{F}$.
 //! * [`sy`]: Evaluates $s(X, Y)$ at $Y = y$ for some $y \in \mathbb{F}$.
 //! * [`sxy`]: Evaluates $s(X, Y)$ at $(x, y)$ for some $x, y \in \mathbb{F}$.
+//! * [`hash`]: Hashes the symbolic structure of $s(X, Y)$ — wire indices and
+//!   scalar coefficients — into a BLAKE2b state for registry key derivation.
 //!
 //! [`Driver`]: ragu_core::drivers::Driver
 //! [`Routine`]: ragu_core::routines::Routine

--- a/crates/ragu_circuits/src/s/mod.rs
+++ b/crates/ragu_circuits/src/s/mod.rs
@@ -73,6 +73,7 @@ use ragu_core::{
 };
 
 mod common;
+pub(crate) mod hash;
 pub mod sx;
 pub mod sxy;
 pub mod sy;

--- a/crates/ragu_circuits/src/s/sy.rs
+++ b/crates/ragu_circuits/src/s/sy.rs
@@ -80,36 +80,12 @@ use ragu_primitives::GadgetExt;
 use alloc::{vec, vec::Vec};
 use core::cell::RefCell;
 
-use super::DriverExt;
+use super::{DriverExt, common::WireIndex};
 use crate::{
     Circuit, FreshB,
     polynomials::{Rank, structured},
     registry,
 };
-
-/// An index identifying a wire in the evaluator.
-///
-/// During $s(X, y)$ evaluation, wires are either *allocated* (from
-/// multiplication gates) or *virtual* (from linear combinations via
-/// [`Driver::add`]).
-///
-/// # Variants
-///
-/// - `A(i)`, `B(i)`, `C(i)` — Allocated wires from gate $i$, corresponding to
-///   the $a$, $b$, $c$ wires respectively. Values are written directly to the
-///   backward view when resolved.
-///
-/// - `Virtual(i)` — A virtual wire (linear combination) at index $i$ in the
-///   [`VirtualTable`]. Uses reference counting for deferred resolution.
-///
-/// [`Driver::add`]: ragu_core::drivers::Driver::add
-#[derive(Copy, Clone)]
-enum WireIndex {
-    A(usize),
-    B(usize),
-    C(usize),
-    Virtual(usize),
-}
 
 /// A handle to a wire in the $s(X, y)$ evaluator.
 ///

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -211,10 +211,12 @@ impl<F: Field, R: Rank> CircuitObject<F, R> for StageMask<R> {
 
     /// Hashes the structural identity of this stage mask's wiring polynomial.
     ///
-    /// Reproduces what the [`hash::Hasher`](crate::s::hash) driver would
-    /// produce for an equivalent circuit synthesis, but without running the
-    /// full driver machinery. Each non-multiplied gate contributes 3
-    /// single-term enforce_zero constraints (one each for the a, b, c wires).
+    /// Reproduces what [`hash::eval`](crate::s::hash::eval) produces for an
+    /// equivalent circuit synthesis, but without running the full driver
+    /// machinery. Each non-multiplied gate contributes 3 single-term
+    /// `enforce_zero` constraints (one each for the `a`, `b`, `c` wires).
+    /// No [`Driver::add`](ragu_core::drivers::Driver::add) calls are made
+    /// during synthesis, so no virtual wire sentinel bytes are emitted.
     fn hash(&self, state: &mut blake2b_simd::State)
     where
         F: ff::PrimeField,

--- a/crates/ragu_pcd/src/circuits/tests.rs
+++ b/crates/ragu_pcd/src/circuits/tests.rs
@@ -168,7 +168,7 @@ fn test_native_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fp!(0x0400166defd8dc2be663e17219897561e58fc170d60d7cc195c756c560a8d5af);
+    let expected = fp!(0x28176366992c6ce0ad3620d56aa4f5bab116ab671eebd8b0c3010e7499bce4d0);
 
     assert_eq!(
         app.native_registry.key().value(),
@@ -192,7 +192,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x024c9dfb5b4a790e1198a4fe8a12e63b06e6217491c89674adb77f179ba6f893);
+    let expected = fq!(0x39a6c0c4812d3664132d3db9a49ee8a20da840200ae1e135b4fda0115f1ef96d);
 
     assert_eq!(
         app.nested_registry.key().value(),

--- a/crates/ragu_pcd/src/circuits/tests.rs
+++ b/crates/ragu_pcd/src/circuits/tests.rs
@@ -168,7 +168,7 @@ fn test_native_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fp!(0x000c5762bc28cd8fc9d33c2e131f2b3cc9d3d5a88b236fc4ae9dd7cda157ec09);
+    let expected = fp!(0x0400166defd8dc2be663e17219897561e58fc170d60d7cc195c756c560a8d5af);
 
     assert_eq!(
         app.native_registry.key().value(),
@@ -192,7 +192,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x181619952c660871c9da859f63dfb88c3dc783f339ce481122cffd10ba1a719f);
+    let expected = fq!(0x024c9dfb5b4a790e1198a4fe8a12e63b06e6217491c89674adb77f179ba6f893);
 
     assert_eq!(
         app.nested_registry.key().value(),


### PR DESCRIPTION
As mentioned in https://github.com/tachyon-zcash/ragu/issues/78#issuecomment-3885588746:

> Concretely, we need to increase the current iteration from 6 to 4n+1, so that the vanishing polynomial of degree 4n-1 doesn't exist.
Given the computation load, I think it's reasonable to consider changing to key = blake2b(m(X)) by directly hashing the coefficients of m(X) instead of using evaluations to bind it.

This PR attempts to introduce a `Hasher` driver under `s/hash.rs` to stream through the circuit logic and hash the structure in a binding digest as the registry key.