### PR TITLE
refactor: use conditional_select in Point endo/negate

### DIFF
--- a/crates/ragu_pcd/src/circuits/tests.rs
+++ b/crates/ragu_pcd/src/circuits/tests.rs
@@ -192,7 +192,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x181619952c660871c9da859f63dfb88c3dc783f339ce481122cffd10ba1a719f);
+    let expected = fq!(0x245758c98f3c46ca03bfafe1bb50c38d0dcaed48231fd7547f40e3b208e67729);
 
     assert_eq!(
         app.nested_registry.key().value(),


### PR DESCRIPTION
refactored `conditional_endo` and `conditional_negate` in the Point gadget API to use `Boolean::conditional_select` instead of hand-rolled inline arithmetic...

closes #294