### PR TITLE
chore(bench): gungraun flamegraph support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,8 +246,7 @@ dependencies = [
 [[package]]
 name = "gungraun"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b247b47ec86130ed355045982783d4666f32045e397a4547bbb6793cd53e940f"
+source = "git+https://github.com/turbocrime/gungraun?branch=fix%2Fflamegraph#20a17226e6d9657a00c57446f8467bbe01536722"
 dependencies = [
  "bincode",
  "derive_more",
@@ -258,8 +257,7 @@ dependencies = [
 [[package]]
 name = "gungraun-macros"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b605e561ccca36d68ebacd387751f2d58cf65202b781bb4a9029951dd3a66d"
+source = "git+https://github.com/turbocrime/gungraun?branch=fix%2Fflamegraph#20a17226e6d9657a00c57446f8467bbe01536722"
 dependencies = [
  "derive_more",
  "proc-macro-error2",
@@ -274,8 +272,7 @@ dependencies = [
 [[package]]
 name = "gungraun-runner"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0ae6c9fe670d3d77f5576be41568ebf1733e5873c6ca85ff3b85848a31ac76"
+source = "git+https://github.com/turbocrime/gungraun?branch=fix%2Fflamegraph#20a17226e6d9657a00c57446f8467bbe01536722"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,3 +94,8 @@ group = { git = "https://github.com/ebfull/group", branch = "release-0.14.0-with
 # that updates `pasta_curves` to use `ff`/`group` `0.14.0-pre.0`
 # then bumps to `rand 0.9`.
 pasta_curves = { git = "https://github.com/ebfull/pasta_curves", branch = "ff-0.14-with-rand-0.10" }
+
+# `turbocrime/gungraun` branch `fix/flamegraph` fixes flamegraph generation:
+# proper DFS call-graph traversal instead of broken BinaryHeap greedy approach,
+# correct recursion measurement, and restored sentinel behavior.
+gungraun = { git = "https://github.com/turbocrime/gungraun", branch = "fix/flamegraph" }

--- a/crates/ragu_arithmetic/benches/arithmetic.rs
+++ b/crates/ragu_arithmetic/benches/arithmetic.rs
@@ -1,6 +1,17 @@
 mod setup;
 
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::{
+    Callgrind, FlamegraphConfig, LibraryBenchmarkConfig, library_benchmark,
+    library_benchmark_group, main,
+};
+
+fn bench_config() -> LibraryBenchmarkConfig {
+    let mut callgrind = Callgrind::default();
+    if std::env::var("RAGU_FLAMEGRAPH").is_ok() {
+        callgrind.flamegraph(FlamegraphConfig::default());
+    }
+    LibraryBenchmarkConfig::default().tool(callgrind).clone()
+}
 use pasta_curves::{EpAffine, Fp, Fq};
 use ragu_arithmetic::{Domain, dot, eval, factor, geosum, mul, poly_with_roots};
 use setup::{f, setup_domain_ell, setup_domain_fft, setup_rng, setup_with_rng, vec_affine, vec_f};
@@ -97,6 +108,7 @@ library_benchmark_group!(
 );
 
 main!(
+    config = bench_config();
     library_benchmark_groups = msm_ops,
     domain_ops,
     poly_ops,

--- a/crates/ragu_circuits/benches/circuits.rs
+++ b/crates/ragu_circuits/benches/circuits.rs
@@ -4,7 +4,18 @@ mod setup;
 
 use std::hint::black_box;
 
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::{
+    Callgrind, FlamegraphConfig, LibraryBenchmarkConfig, library_benchmark,
+    library_benchmark_group, main,
+};
+
+fn bench_config() -> LibraryBenchmarkConfig {
+    let mut callgrind = Callgrind::default();
+    if std::env::var("RAGU_FLAMEGRAPH").is_ok() {
+        callgrind.flamegraph(FlamegraphConfig::default());
+    }
+    LibraryBenchmarkConfig::default().tool(callgrind).clone()
+}
 use ragu_arithmetic::Cycle;
 use ragu_circuits::polynomials::{ProductionRank, TestRank, structured, unstructured};
 use ragu_circuits::registry::{Registry, RegistryBuilder};
@@ -161,6 +172,7 @@ library_benchmark_group!(
 );
 
 main!(
+    config = bench_config();
     library_benchmark_groups = poly_commits,
     poly_ops,
     circuit_synthesis,

--- a/crates/ragu_pcd/benches/pcd.rs
+++ b/crates/ragu_pcd/benches/pcd.rs
@@ -2,7 +2,18 @@
 
 mod setup;
 
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::{
+    Callgrind, FlamegraphConfig, LibraryBenchmarkConfig, library_benchmark,
+    library_benchmark_group, main,
+};
+
+fn bench_config() -> LibraryBenchmarkConfig {
+    let mut callgrind = Callgrind::default();
+    if std::env::var("RAGU_FLAMEGRAPH").is_ok() {
+        callgrind.flamegraph(FlamegraphConfig::default());
+    }
+    LibraryBenchmarkConfig::default().tool(callgrind).clone()
+}
 use ragu_arithmetic::Cycle;
 use ragu_circuits::polynomials::ProductionRank;
 use ragu_pasta::{Fp, Pasta};
@@ -131,4 +142,7 @@ library_benchmark_group!(
     benchmarks = verify_leaf, verify_node, rerandomize
 );
 
-main!(library_benchmark_groups = app_setup, app_proof, app_verify);
+main!(
+    config = bench_config();
+    library_benchmark_groups = app_setup, app_proof, app_verify
+);

--- a/crates/ragu_primitives/benches/primitives.rs
+++ b/crates/ragu_primitives/benches/primitives.rs
@@ -2,7 +2,18 @@
 
 mod setup;
 
-use gungraun::{library_benchmark, library_benchmark_group, main};
+use gungraun::{
+    Callgrind, FlamegraphConfig, LibraryBenchmarkConfig, library_benchmark,
+    library_benchmark_group, main,
+};
+
+fn bench_config() -> LibraryBenchmarkConfig {
+    let mut callgrind = Callgrind::default();
+    if std::env::var("RAGU_FLAMEGRAPH").is_ok() {
+        callgrind.flamegraph(FlamegraphConfig::default());
+    }
+    LibraryBenchmarkConfig::default().tool(callgrind).clone()
+}
 use ragu_pasta::{EpAffine, Fp, PoseidonFp};
 use ragu_primitives::poseidon::Sponge;
 use ragu_primitives::{Boolean, Element, Endoscalar, Point, multiadd, multipack};
@@ -167,6 +178,7 @@ library_benchmark_group!(
 );
 
 main!(
+    config = bench_config();
     library_benchmark_groups = element_ops,
     point_ops,
     boolean_ops,


### PR DESCRIPTION
References https://github.com/tachyon-zcash/ragu/issues/21; for testing purposes, this integrates support for generating flamegraphs locally via `RAGU_FLAMEGRAPH=1 just bench`, and targets https://github.com/turbocrime/gungraun/tree/fix/flamegraph which (maybe?) fixes upstream gungraun 0.17.0 (which currently breaks flamegraphs, reference this issue: https://github.com/gungraun/gungraun/issues/523). the environment variable ensures it doesn't run in CI, where it would crash due to exceeding memory limits. 

**Update:** this also doesn't seem to work and searching through iai-callgrinds commit history suggests they've always had broken flamegraphs. cc @turbocrime  

--------------

<img width="1724" height="877" alt="Screenshot 2026-02-23 at 8 00 22 PM" src="https://github.com/user-attachments/assets/058b3fbd-82fe-4793-8312-624e052c72d2" />
