### PR TITLE
chore(bench): flamegraph profiling via cargo-flamegraph and perf

### DIFF
--- a/justfile
+++ b/justfile
@@ -67,7 +67,7 @@ _bench_macos *ARGS:
     docker attach --no-stdin $container
 
 _bench_linux *ARGS: _gungraun_setup
-    cargo bench --workspace --all-features {{ARGS}}
+    cargo bench --workspace --all-features --bench arithmetic --bench circuits --bench pcd --bench primitives {{ARGS}}
 
 # generate flamegraph in target/*.svg
 flamegraph PACKAGE GROUP TARGET *ARGS:


### PR DESCRIPTION
References https://github.com/tachyon-zcash/ragu/issues/21. Instead of the approach in https://github.com/tachyon-zcash/ragu/pull/506 (which tries to structurally fix gungraun flamegraphs and doesn't currently work), this implements flamegraph support for profiling individual gungraun benchmarks. It runs the gungraun bench binary directly under [perf](https://www.brendangregg.com/perf.html) (Linux kernel profiler) via [cargo flamegraph](https://crates.io/crates/flamegraph), bypassing gungraun-runner's valgrind orchestration, so any benchmark listed in a `library_benchmark_group!` can be targeted by name. Integrating into CI will [exceed memory limits](https://github.com/tachyon-zcash/ragu/issues/21#issuecomment-3929213537), so this profiling can be invoked a as discretionary local workflow for dev purposes.

---------

**Usage:** `just flamegraph <package> <target>` (eg. `just flamegraph ragu_pcd fuse` and `open target/flamegraph-profile_fuse.svg`) 

<img width="1721" height="899" alt="Screenshot 2026-02-23 at 8 23 18 PM" src="https://github.com/user-attachments/assets/fad98f63-6095-487c-babf-d6f806939369" />
