### PR TITLE
primitives: Sendable wrapper

### DIFF
--- a/crates/ragu_primitives/src/lib.rs
+++ b/crates/ragu_primitives/src/lib.rs
@@ -22,6 +22,7 @@ pub mod io;
 mod point;
 pub mod poseidon;
 pub mod promotion;
+mod sendable;
 mod simulator;
 mod util;
 pub mod vec;
@@ -35,6 +36,7 @@ pub use boolean::{Boolean, multipack};
 pub use element::{Element, multiadd};
 pub use endoscalar::{Endoscalar, extract_endoscalar, lift_endoscalar};
 pub use point::Point;
+pub use sendable::Sendable;
 pub use simulator::Simulator;
 
 /// Primitive extension trait for all gadgets.
@@ -51,6 +53,16 @@ pub trait GadgetExt<'dr, D: Driver<'dr>>: Gadget<'dr, D> {
     /// Demote this gadget by stripping its witness data.
     fn demote(&self) -> Result<Demoted<'dr, D, Self>> {
         Demoted::new(self)
+    }
+
+    /// Wrap this gadget in [`Sendable`], asserting it is [`Send`].
+    ///
+    /// This is only available when `D::Wire: Send`.
+    fn sendable(self) -> Sendable<Self>
+    where
+        D::Wire: Send,
+    {
+        Sendable::new::<D>(self)
     }
 }
 

--- a/crates/ragu_primitives/src/sendable.rs
+++ b/crates/ragu_primitives/src/sendable.rs
@@ -1,0 +1,50 @@
+use ragu_core::drivers::Driver;
+use ragu_core::gadgets::Gadget;
+
+/// A wrapper that asserts its contents are [`Send`].
+///
+/// This type can only be constructed (via [`new`](Sendable::new)) when
+/// `D::Wire: Send`, which — together with the safety contract of
+/// [`GadgetKind`](ragu_core::gadgets::GadgetKind) — guarantees the wrapped
+/// gadget is `Send`.
+pub struct Sendable<G>(G);
+
+impl<G> Sendable<G> {
+    /// Wraps a gadget in `Sendable`, asserting it is [`Send`].
+    ///
+    /// The `D::Wire: Send` bound, combined with the safety contract of
+    /// [`GadgetKind`](ragu_core::gadgets::GadgetKind) (which requires that
+    /// `D::Wire: Send` implies `Rebind<'dr, D>: Send`), guarantees the
+    /// wrapped gadget is actually `Send`.
+    pub fn new<'dr, D: Driver<'dr>>(gadget: G) -> Self
+    where
+        G: Gadget<'dr, D>,
+        D::Wire: Send,
+    {
+        Sendable(gadget)
+    }
+
+    /// Unwraps the `Sendable`, returning the inner gadget.
+    pub fn into_inner(self) -> G {
+        self.0
+    }
+}
+
+/// Safety: `Sendable<G>` can only be constructed when `D::Wire: Send`, and the
+/// safety contract of `GadgetKind` guarantees that `D::Wire: Send` implies the
+/// gadget (its `Rebind`) is `Send`.
+unsafe impl<G> Send for Sendable<G> {}
+
+impl<G: Clone> Clone for Sendable<G> {
+    fn clone(&self) -> Self {
+        Sendable(self.0.clone())
+    }
+}
+
+impl<G> core::ops::Deref for Sendable<G> {
+    type Target = G;
+
+    fn deref(&self) -> &G {
+        &self.0
+    }
+}


### PR DESCRIPTION
This restores an API that existed long ago in the library: a wrapper type that allows gadgets to cross thread boundaries safely by leveraging `GadgetKind`'s API guarantees (and in particular, its safety guarantees). This is needed for #63.