### PR TITLE
feat(pcd): add fuse criterion bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,8 +812,10 @@ dependencies = [
 name = "ragu_pcd"
 version = "0.0.0"
 dependencies = [
+ "criterion",
  "ff",
  "gungraun",
+ "maybe-rayon",
  "pasta_curves",
  "ragu_arithmetic",
  "ragu_circuits",

--- a/crates/ragu_pcd/Cargo.toml
+++ b/crates/ragu_pcd/Cargo.toml
@@ -27,6 +27,7 @@ all-features = true
 
 [features]
 default = []
+multicore = ["maybe-rayon/threads", "ragu_arithmetic/multicore", "ragu_circuits/multicore"]
 
 [lib]
 bench = false
@@ -34,6 +35,7 @@ bench = false
 [dependencies]
 ragu_arithmetic = { path = "../ragu_arithmetic", version = "0.0.0" }
 ff = { workspace = true }
+maybe-rayon = { workspace = true }
 pasta_curves = { workspace = true }
 ragu_circuits = { path = "../ragu_circuits", version = "0.0.0" }
 ragu_core = { path = "../ragu_core", version = "0.0.0" }
@@ -41,10 +43,16 @@ ragu_primitives = { path = "../ragu_primitives", version = "0.0.0" }
 rand = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 ragu_pasta = { path = "../ragu_pasta", version = "0.0.0", features = ["baked"] }
 gungraun = { workspace = true }
 ragu_testing = { path = "../ragu_testing", version = "0.0.0" }
 
 [[bench]]
 name = "pcd"
+harness = false
+
+[[bench]]
+name = "fuse_criterion"
+path = "benches/criterion/fuse.rs"
 harness = false

--- a/crates/ragu_pcd/benches/criterion/fuse.rs
+++ b/crates/ragu_pcd/benches/criterion/fuse.rs
@@ -1,0 +1,59 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use ragu_arithmetic::Cycle;
+use ragu_circuits::polynomials::ProductionRank;
+use ragu_pasta::{Fp, Pasta};
+use ragu_pcd::ApplicationBuilder;
+use ragu_testing::pcd::nontrivial;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+fn fuse_bench(c: &mut Criterion) {
+    let pasta = Pasta::baked();
+    let poseidon_params = Pasta::circuit_poseidon(pasta);
+
+    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+        .register(nontrivial::WitnessLeaf { poseidon_params })
+        .unwrap()
+        .register(nontrivial::Hash2 { poseidon_params })
+        .unwrap()
+        .finalize(pasta)
+        .unwrap();
+
+    let mut rng = StdRng::seed_from_u64(1234);
+
+    let (proof1, aux1) = app
+        .seed(
+            &mut rng,
+            nontrivial::WitnessLeaf { poseidon_params },
+            Fp::from(1u64),
+        )
+        .unwrap();
+    let leaf1 = proof1.carry::<nontrivial::LeafNode>(aux1);
+
+    let (proof2, aux2) = app
+        .seed(
+            &mut rng,
+            nontrivial::WitnessLeaf { poseidon_params },
+            Fp::from(2u64),
+        )
+        .unwrap();
+    let leaf2 = proof2.carry::<nontrivial::LeafNode>(aux2);
+
+    c.bench_function("fuse", |b| {
+        b.iter_batched(
+            || (leaf1.clone(), leaf2.clone(), StdRng::seed_from_u64(5678)),
+            |(l1, l2, mut rng)| {
+                app.fuse(&mut rng, nontrivial::Hash2 { poseidon_params }, (), l1, l2)
+                    .unwrap()
+            },
+            criterion::BatchSize::PerIteration,
+        );
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = fuse_bench
+}
+criterion_main!(benches);


### PR DESCRIPTION
This adds a criterion bench to measure wall-clock time between sequential and parallel fuse. In thinking about https://github.com/tachyon-zcash/ragu/issues/333, I realized this actually wouldn't offer much benefit because you can only apply this base-point read amortization for MSMs clustered in a _single_ stage, and this only partially benefits some stages. Instead, I tried parallelizing the MSM calls in the prover, but realized our [existing](https://github.com/tachyon-zcash/ragu/pull/510) window-level parallelism within each MSM already likely saturates a normal devices available cores. Halo2 also doesn't implement a multi-core prover (batching MSMs calls) because their prover is seemingly fast enough.

`cargo bench --bench fuse_criterion -p ragu_pcd`
`cargo bench --bench fuse_criterion -p ragu_pcd --features multicore`

-----------

**sequential** 

<img width="665" height="82" alt="Screenshot 2026-03-07 at 7 24 21 PM" src="https://github.com/user-attachments/assets/0fc4045b-2f42-47d7-b8e8-1cd03673282f" />

**Intra-MSM parallelism**

<img width="843" height="70" alt="Screenshot 2026-03-08 at 9 12 44 AM" src="https://github.com/user-attachments/assets/6713abb2-d025-4e55-a1ef-d62ecc4dcae0" />

**Inter-MSM parallelism**

<img width="831" height="107" alt="Screenshot 2026-03-08 at 9 12 48 AM" src="https://github.com/user-attachments/assets/10ee8f0c-77a3-446b-b359-58216f40b266" />
