### PR TITLE
chore: integrate tropes.xyz anti-patterns into book review policies

### DIFF
--- a/.claude/book-review/formatting.md
+++ b/.claude/book-review/formatting.md
@@ -107,3 +107,13 @@ sentence or clause boundaries. Sentences flow together continuously; a line brea
 may land mid-sentence. In math-heavy paragraphs, short inline math tokens wrap
 like ordinary words; only long expressions that would overflow need standalone
 line treatment.
+
+## Typography and Decoration
+
+- Do not begin every bullet in a list with a bolded phrase. If you need
+  bullets, let the content carry the list — not typographic decoration.
+  (Bold-prefixed definition lists like `**Term:** definition` are fine;
+  the anti-pattern is gratuitous bolding of the first word of each item.)
+- Do not use unicode arrows (→), curly quotes, or other characters that
+  require special input. Use plain text equivalents (->), straight
+  quotes, and standard punctuation.

--- a/.claude/book-review/grammar.md
+++ b/.claude/book-review/grammar.md
@@ -14,6 +14,8 @@ all project prose), the following book-specific rules apply.
 
 - Address the reader as "we" when walking through constructions together. Use
   "you" for direct instructions in the user guide.
+- Do not adopt a teacher-student tone. Cut "Let's break this down",
+  "Let's unpack this", "Let's explore", and "Let's dive in".
 
 ## Sentence Structure
 
@@ -22,3 +24,15 @@ all project prose), the following book-specific rules apply.
   contrast after a comma — e.g., "X suffices for A, but B requires Y"
   rather than "While X suffices for A, B requires Y." Temporal "while"
   (meaning "during the time that") is fine.
+- Do not frame points as "It's not X — it's Y" for false profundity. One
+  such construction in a piece can work; repeating the pattern is a flag.
+- Do not build fake tension by negating two things before landing a
+  point ("Not a bug. Not a feature. A fundamental design flaw.").
+- Do not pose rhetorical questions nobody asked and immediately answer
+  them ("The result? Devastating."). State the point directly.
+- Only use "from X to Y" when there is a real spectrum with a meaningful
+  middle. Don't dress up a pair of loosely related things as a range.
+- Do not append a trailing present-participle phrase to inject shallow
+  significance ("contributing to the region's rich cultural heritage").
+  If an observation needs significance tacked on, rewrite it to speak
+  for itself.

--- a/.claude/book-review/prose.md
+++ b/.claude/book-review/prose.md
@@ -30,3 +30,65 @@ consistency, capitalization, etc.), the following book-specific rules apply.
 - Each paragraph should connect to the preceding one. Flag abrupt topic shifts
   with no connecting logic.
 - Section transitions should give the reader a reason to keep reading.
+
+## Tone
+
+- Do not use false-suspense transitions to manufacture drama before an
+  unremarkable point. Cut "Here's the kicker", "Here's the thing",
+  "Here's where it gets interesting", and "Here's what most people miss".
+- Only reach for analogy when it is genuinely more illuminating than
+  the direct explanation. Don't assume the reader needs a metaphor
+  ("Think of it like a highway system for data").
+- Do not open an argument by asking the reader to imagine an appealing
+  future ("Imagine a world where..."). Make the argument directly.
+- Do not perform self-awareness. Simulated candor — pretending to break
+  the fourth wall or admit a bias — reads as hollow unless it is
+  specific and has stakes.
+- Do not cite unnamed authorities ("Experts argue...", "Industry reports
+  suggest..."). If you can't name the source, don't invoke it.
+- Do not coin compound labels ("supervision paradox", "acceleration
+  trap") and treat them as established terms. Name things precisely, or
+  make the argument without the label.
+- Match the stakes of claims to what is actually being demonstrated.
+  Don't inflate every argument to world-historical scale ("will define
+  the next era of computing").
+
+## Paragraph Patterns
+
+One instance of any pattern below might be fine. Flag when a pattern
+repeats or when several appear together.
+
+- Do not use a string of very short sentences or fragments as standalone
+  paragraphs to manufacture emphasis. This is an inhuman cadence — use
+  it sparingly and deliberately, not as a default rhythm.
+- Do not follow a claim with a stream of verbless gerund fragments as
+  standalone sentences ("Fixing small bugs. Writing straightforward
+  features. Implementing well-defined tickets.").
+- Do not repeat the same sentence opening multiple times in quick
+  succession (anaphora). One deliberate use can be effective; a string
+  of "They could..." clauses is not.
+- One rule-of-three (tricolon) is elegant. Do not stack multiple
+  tricolons back-to-back.
+- If you're writing a list, write a list. Don't disguise it as prose by
+  wrapping each item in a paragraph beginning "The first...", "The
+  second...", "The third...".
+
+## Composition
+
+- Do not summarize every section before and after writing it, and do not
+  restate at the document level what was just said at the section level.
+- Introduce a metaphor, use it, then move on. Don't return to the same
+  metaphor throughout an entire piece.
+- One well-chosen historical analogy is stronger than five weak ones. Do
+  not rapid-fire a list of historical companies or tech revolutions to
+  build authority.
+- Do not restate a single argument in ten different ways across
+  thousands of words. If the point is made, move forward or stop.
+- Do not repeat entire paragraphs or sections verbatim within the same
+  piece.
+- Do not announce the conclusion. End the piece — don't label the
+  ending. Cut "In conclusion", "To sum up", and "In summary".
+- Do not follow the formula of acknowledging problems only to
+  immediately dismiss them with an optimistic pivot ("Despite these
+  challenges, the initiative continues to thrive"). If there are real
+  challenges, engage with them.

--- a/.claude/book-review/standards.md
+++ b/.claude/book-review/standards.md
@@ -89,6 +89,10 @@ Specific anti-patterns to avoid:
   noun with a demonstrative that refers back to items named in the preceding
   clause (e.g., "these primitives" after "wires and witness data") is
   standard prose, not an inconsistency. Do not flag these.
+- **Trope rules are density-sensitive.** Many anti-trope rules (in
+  grammar.md and prose.md) flag patterns that are acceptable in
+  isolation. Flag them when they repeat within a section or when
+  several appear together — not on a single occurrence.
 
 ## Deferred Issues
 

--- a/.claude/review-shared/writing.md
+++ b/.claude/review-shared/writing.md
@@ -17,8 +17,12 @@ code-review) layer additional rules on top of these.
 
 - Avoid "simply", "just", "obviously", "clearly". If something is obvious, it
   doesn't need a comment. If it isn't obvious, these words are dishonest.
+  This extends to indirect assertions of clarity — "the reality is simpler",
+  "history is unambiguous". Don't tell the reader your point is clear;
+  demonstrate it.
 - "Note that" is almost always filler. Delete it and the sentence usually
-  improves.
+  improves. The same applies to "It's worth noting", "It bears mentioning",
+  "Importantly", "Interestingly", and "Notably".
 - "In fact" and "in theory" are filler or hedging. If the statement is
   factual, it stands on its own; if it is theoretical, qualify it with the
   actual limitation. "Arguably" hedges a claim the author should either
@@ -32,6 +36,20 @@ code-review) layer additional rules on top of these.
   actual benefit. "So they can represent wires in whatever way suits their
   context" → "so they can represent wires in an efficient way that suits their
   context."
+- Avoid overused LLM vocabulary: "delve", "certainly", "utilize", "leverage"
+  (verb), "robust", "streamline", "harness". These words are not inherently
+  wrong, but their overuse by language models has made them conspicuous.
+
+## Inflated Language
+
+- Don't reach for adverbs like "quietly", "deeply", "fundamentally", or
+  "remarkably" to make mundane descriptions feel significant. If something
+  is important, the sentence should show it without adverbial signaling.
+- Prefer plain nouns over grandiose ones. Avoid "tapestry", "landscape",
+  "paradigm", "synergy", and "ecosystem" (when used loosely) as vague
+  filler. Name the actual thing.
+- Prefer "is" or "are" over pompous substitutes like "serves as", "stands
+  as", "marks", or "represents" when the simpler verb suffices.
 
 ## Sentence Structure
 


### PR DESCRIPTION
Stolen from https://gist.github.com/abuisman/05c766310cae4725914cd414639f3780 and integrated into our `book-review`.