### PR TITLE
test: add proptest scaffolding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,6 +831,7 @@ dependencies = [
  "ff",
  "group",
  "gungraun",
+ "proptest",
  "ragu_arithmetic",
  "ragu_core",
  "ragu_macros",

--- a/crates/ragu_arithmetic/src/domain.rs
+++ b/crates/ragu_arithmetic/src/domain.rs
@@ -276,6 +276,32 @@ fn test_contains() {
     assert!(!domain.contains(F::DELTA));
 }
 
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use pasta_curves::Fp as F;
+    use proptest::prelude::*;
+
+    fn arb_fe() -> impl Strategy<Value = F> {
+        (any::<u64>(), any::<u64>())
+            .prop_map(|(a, b)| F::from(a) + F::from(b) * F::MULTIPLICATIVE_GENERATOR)
+    }
+
+    proptest! {
+        #[test]
+        fn fft_ifft_roundtrip(log2_n in 1u32..=8, seed in arb_fe()) {
+            let domain = Domain::<F>::new(log2_n);
+            let coeffs: Vec<F> = (0..domain.n())
+                .map(|i| seed * F::from((i + 1) as u64))
+                .collect();
+            let mut buf = coeffs.clone();
+            domain.fft(&mut buf);
+            domain.ifft(&mut buf);
+            prop_assert_eq!(buf, coeffs);
+        }
+    }
+}
+
 #[test]
 #[should_panic]
 fn test_domain_exceeds_max_boundary_panics() {

--- a/crates/ragu_arithmetic/src/util.rs
+++ b/crates/ragu_arithmetic/src/util.rs
@@ -458,6 +458,54 @@ fn test_poly_with_roots() {
     assert_eq!(constant_poly, vec![F::ONE]);
 }
 
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use pasta_curves::Fp as F;
+    use proptest::prelude::*;
+
+    fn arb_fe() -> impl Strategy<Value = F> {
+        (any::<u64>(), any::<u64>())
+            .prop_map(|(a, b)| F::from(a) + F::from(b) * F::MULTIPLICATIVE_GENERATOR)
+    }
+
+    proptest! {
+        #[test]
+        fn eval_dot_equivalence(x in arb_fe(), coeffs in proptest::collection::vec(arb_fe(), 1..32)) {
+            let mut powers = Vec::with_capacity(coeffs.len());
+            let mut p = F::ONE;
+            for _ in 0..coeffs.len() {
+                powers.push(p);
+                p *= x;
+            }
+            prop_assert_eq!(dot(powers.iter(), coeffs.iter()), eval(&coeffs, x));
+        }
+
+        #[test]
+        fn factor_quotient_identity(
+            p in proptest::collection::vec(arb_fe(), 2..16),
+            b in arb_fe(),
+            y in arb_fe(),
+        ) {
+            let q = factor(p.iter().copied(), b);
+            let lhs = eval(&p, y);
+            let rhs = eval(&q, y) * (y - b) + eval(&p, b);
+            prop_assert_eq!(lhs, rhs);
+        }
+
+        #[test]
+        fn geosum_matches_naive(r in arb_fe(), m in 1usize..64) {
+            let mut naive = F::ZERO;
+            let mut power = F::ONE;
+            for _ in 0..m {
+                naive += power;
+                power *= r;
+            }
+            prop_assert_eq!(geosum(r, m), naive);
+        }
+    }
+}
+
 #[test]
 fn test_mul() {
     use pasta_curves::group::{Curve, prime::PrimeCurveAffine};

--- a/crates/ragu_core/src/maybe/mod.rs
+++ b/crates/ragu_core/src/maybe/mod.rs
@@ -485,4 +485,27 @@ mod tests {
     fn test_empty_is_zst() {
         assert_eq!(core::mem::size_of::<Empty>(), 0);
     }
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        proptest! {
+            #[test]
+            fn always_map_identity(v in 0usize..10000) {
+                let original = Always::<()>::just(|| v);
+                let mapped = Always::<()>::just(|| v).map(|x| x);
+                prop_assert_eq!(original.take(), mapped.take());
+            }
+
+            #[test]
+            fn always_map_composition(v in 0usize..10000) {
+                let f = |x: usize| x.wrapping_mul(3);
+                let g = |x: usize| x.wrapping_add(7);
+                let chained = Always::<()>::just(|| v).map(f).map(g).take();
+                let composed = Always::<()>::just(|| v).map(|x| g(f(x))).take();
+                prop_assert_eq!(chained, composed);
+            }
+        }
+    }
 }

--- a/crates/ragu_primitives/Cargo.toml
+++ b/crates/ragu_primitives/Cargo.toml
@@ -45,6 +45,7 @@ rand = { workspace = true }
 group = { workspace = true }
 ragu_pasta = { path = "../ragu_pasta", version = "0.0.0", features = ["baked"] }
 gungraun = { workspace = true }
+proptest = { workspace = true }
 
 [[bench]]
 name = "primitives"

--- a/crates/ragu_primitives/src/boolean.rs
+++ b/crates/ragu_primitives/src/boolean.rs
@@ -422,6 +422,70 @@ mod tests {
     }
 }
 
+#[cfg(test)]
+mod proptests {
+    use alloc::format;
+
+    use super::*;
+    use proptest::prelude::*;
+    use ragu_core::maybe::Maybe;
+
+    type F = ragu_pasta::Fp;
+    type Simulator = crate::Simulator<F>;
+
+    fn arb_fe() -> impl Strategy<Value = F> {
+        (any::<u64>(), any::<u64>())
+            .prop_map(|(a, b)| F::from(a) + F::from(b) * F::MULTIPLICATIVE_GENERATOR)
+    }
+
+    proptest! {
+        #[test]
+        fn boolean_and_idempotent(a_val in proptest::bool::ANY) {
+            let mut actual = None;
+            Simulator::simulate(a_val, |dr, witness| {
+                let a = Boolean::alloc(dr, witness)?;
+                let result = a.and(dr, &a)?;
+                actual = Some(result.value().take());
+                Ok(())
+            }).map_err(|e| TestCaseError::fail(format!("{e:?}")))?;
+            prop_assert_eq!(actual, Some(a_val));
+        }
+
+        #[test]
+        fn boolean_and_complement(a_val in proptest::bool::ANY) {
+            let mut actual = None;
+            Simulator::simulate(a_val, |dr, witness| {
+                let a = Boolean::alloc(dr, witness)?;
+                let not_a = a.not(dr);
+                let result = a.and(dr, &not_a)?;
+                actual = Some(result.value().take());
+                Ok(())
+            }).map_err(|e| TestCaseError::fail(format!("{e:?}")))?;
+            prop_assert_eq!(actual, Some(false));
+        }
+
+        #[test]
+        fn conditional_select_correctness(
+            cond in proptest::bool::ANY,
+            a_fe in arb_fe(),
+            b_fe in arb_fe(),
+        ) {
+            let expected = if cond { b_fe } else { a_fe };
+            let mut actual = None;
+            Simulator::simulate((cond, a_fe, b_fe), |dr, witness| {
+                let (c, a, b) = witness.cast();
+                let c = Boolean::alloc(dr, c)?;
+                let a = Element::alloc(dr, a)?;
+                let b = Element::alloc(dr, b)?;
+                let result = c.conditional_select(dr, &a, &b)?;
+                actual = Some(*result.value().take());
+                Ok(())
+            }).map_err(|e| TestCaseError::fail(format!("{e:?}")))?;
+            prop_assert_eq!(actual, Some(expected));
+        }
+    }
+}
+
 #[test]
 fn test_multipack_vector() -> Result<()> {
     use alloc::{vec, vec::Vec};

--- a/crates/ragu_primitives/src/element.rs
+++ b/crates/ragu_primitives/src/element.rs
@@ -415,6 +415,60 @@ pub fn multiadd<'dr, D: Driver<'dr>>(
     Element::promote(wire, value)
 }
 
+#[cfg(test)]
+mod proptests {
+    use alloc::format;
+
+    use super::*;
+    use ff::PrimeField;
+    use proptest::prelude::*;
+    use ragu_core::maybe::Maybe;
+
+    type F = ragu_pasta::Fp;
+    type Simulator = crate::Simulator<F>;
+
+    fn arb_fe() -> impl Strategy<Value = F> {
+        (any::<u64>(), any::<u64>())
+            .prop_map(|(a, b)| F::from(a) + F::from(b) * F::MULTIPLICATIVE_GENERATOR)
+    }
+
+    proptest! {
+        #[test]
+        fn element_add_sub_roundtrip(a_fe in arb_fe(), b_fe in arb_fe()) {
+            let mut actual = None;
+            Simulator::simulate((a_fe, b_fe), |dr, witness| {
+                let (a, b) = witness.cast();
+                let a = Element::alloc(dr, a)?;
+                let b = Element::alloc(dr, b)?;
+                let sum = a.add(dr, &b);
+                let result = sum.sub(dr, &b);
+                actual = Some(*result.value().take());
+                Ok(())
+            }).map_err(|e| TestCaseError::fail(format!("{e:?}")))?;
+            prop_assert_eq!(actual, Some(a_fe));
+        }
+
+        #[test]
+        fn element_mul_commutative(a_fe in arb_fe(), b_fe in arb_fe()) {
+            let mut actual = None;
+            Simulator::simulate((a_fe, b_fe), |dr, witness| {
+                let (a, b) = witness.cast();
+                let a = Element::alloc(dr, a)?;
+                let b = Element::alloc(dr, b)?;
+                let ab = a.mul(dr, &b)?;
+                let ba = b.mul(dr, &a)?;
+                actual = Some((*ab.value().take(), *ba.value().take()));
+                Ok(())
+            }).map_err(|e| TestCaseError::fail(format!("{e:?}")))?;
+            if let Some((ab, ba)) = actual {
+                prop_assert_eq!(ab, ba);
+            } else {
+                return Err(TestCaseError::fail("missing simulated result"));
+            }
+        }
+    }
+}
+
 #[test]
 fn test_div_nonzero() -> Result<()> {
     type F = ragu_pasta::Fp;


### PR DESCRIPTION
Summary
  - Add `proptest` dev-dependency to `ragu_primitives`
  - Add 11 new proptests across 3 crates covering algebraic identities, round-trips, and gadget correctness
  - Consolidate `arb_fe()` strategy pattern using full-field coverage

New proptests

  | Crate | Test | Property |
  |---|---|---|
  | `ragu_arithmetic` | `eval_dot_equivalence` | `dot(powers(x), coeffs) == eval(coeffs, x)` |
  | `ragu_arithmetic` | `factor_quotient_identity` | `eval(q, y) * (y - b) + eval(p, b) == eval(p, y)` |
  | `ragu_arithmetic` | `geosum_matches_naive` | Fast geosum matches naive summation |
  | `ragu_arithmetic` | `fft_ifft_roundtrip` | `ifft(fft(coeffs)) == coeffs` |
  | `ragu_core` | `always_map_identity` | `v.map(id) == v` (functor identity) |
  | `ragu_core` | `always_map_composition` | `v.map(f).map(g) == v.map(g∘f)` (functor composition) |
  | `ragu_primitives` | `boolean_and_idempotent` | `a AND a == a` |
  | `ragu_primitives` | `boolean_and_complement` | `a AND (NOT a) == false` |
  | `ragu_primitives` | `conditional_select_correctness` | Returns `b` when true, `a` when false |
  | `ragu_primitives` | `element_add_sub_roundtrip` | `(a + b) - b == a` |
  | `ragu_primitives` | `element_mul_commutative` | `a * b == b * a` |

Reference #523 