### PR TITLE
Refactor: drop 'source lifetime

### DIFF
--- a/crates/ragu_pcd/benches/pcd.rs
+++ b/crates/ragu_pcd/benches/pcd.rs
@@ -69,8 +69,8 @@ fn seed(
 fn fuse(
     (app, leaf1, leaf2, poseidon_params, mut rng): (
         Application<'static, Pasta, ProductionRank, 4>,
-        Pcd<'static, Pasta, ProductionRank, nontrivial::LeafNode>,
-        Pcd<'static, Pasta, ProductionRank, nontrivial::LeafNode>,
+        Pcd<Pasta, ProductionRank, nontrivial::LeafNode>,
+        Pcd<Pasta, ProductionRank, nontrivial::LeafNode>,
         &'static <Pasta as Cycle>::CircuitPoseidon,
         StdRng,
     ),
@@ -95,7 +95,7 @@ library_benchmark_group!(
 fn verify_leaf(
     (app, leaf, mut rng): (
         Application<'static, Pasta, ProductionRank, 4>,
-        Pcd<'static, Pasta, ProductionRank, nontrivial::LeafNode>,
+        Pcd<Pasta, ProductionRank, nontrivial::LeafNode>,
         StdRng,
     ),
 ) {
@@ -107,7 +107,7 @@ fn verify_leaf(
 fn verify_node(
     (app, node, mut rng): (
         Application<'static, Pasta, ProductionRank, 4>,
-        Pcd<'static, Pasta, ProductionRank, nontrivial::InternalNode>,
+        Pcd<Pasta, ProductionRank, nontrivial::InternalNode>,
         StdRng,
     ),
 ) {
@@ -119,7 +119,7 @@ fn verify_node(
 fn rerandomize(
     (app, node, mut rng): (
         Application<'static, Pasta, ProductionRank, 4>,
-        Pcd<'static, Pasta, ProductionRank, nontrivial::InternalNode>,
+        Pcd<Pasta, ProductionRank, nontrivial::InternalNode>,
         StdRng,
     ),
 ) {

--- a/crates/ragu_pcd/benches/setup/mod.rs
+++ b/crates/ragu_pcd/benches/setup/mod.rs
@@ -51,8 +51,8 @@ pub fn setup_seed() -> (
 
 pub fn setup_fuse() -> (
     Application<'static, Pasta, ProductionRank, 4>,
-    Pcd<'static, Pasta, ProductionRank, nontrivial::LeafNode>,
-    Pcd<'static, Pasta, ProductionRank, nontrivial::LeafNode>,
+    Pcd<Pasta, ProductionRank, nontrivial::LeafNode>,
+    Pcd<Pasta, ProductionRank, nontrivial::LeafNode>,
     &'static <Pasta as Cycle>::CircuitPoseidon,
     StdRng,
 ) {
@@ -79,7 +79,7 @@ pub fn setup_fuse() -> (
 
 pub fn setup_verify_leaf() -> (
     Application<'static, Pasta, ProductionRank, 4>,
-    Pcd<'static, Pasta, ProductionRank, nontrivial::LeafNode>,
+    Pcd<Pasta, ProductionRank, nontrivial::LeafNode>,
     StdRng,
 ) {
     let (app, poseidon_params, mut rng) = setup_seed();
@@ -97,7 +97,7 @@ pub fn setup_verify_leaf() -> (
 
 pub fn setup_verify_node() -> (
     Application<'static, Pasta, ProductionRank, 4>,
-    Pcd<'static, Pasta, ProductionRank, nontrivial::InternalNode>,
+    Pcd<Pasta, ProductionRank, nontrivial::InternalNode>,
     StdRng,
 ) {
     let (app, poseidon_params, mut rng) = setup_seed();

--- a/crates/ragu_pcd/src/fuse/_01_application.rs
+++ b/crates/ragu_pcd/src/fuse/_01_application.rs
@@ -22,13 +22,13 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         rng: &mut RNG,
         step: S,
         witness: S::Witness<'source>,
-        left: Pcd<'source, C, R, S::Left>,
-        right: Pcd<'source, C, R, S::Right>,
+        left: Pcd<C, R, S::Left>,
+        right: Pcd<C, R, S::Right>,
     ) -> Result<(
         Proof<C, R>,
         Proof<C, R>,
         proof::Application<C, R>,
-        <S::Output as Header<C::CircuitField>>::Data<'source>,
+        <S::Output as Header<C::CircuitField>>::Data,
         S::Aux<'source>,
     )> {
         let (left_proof, left_data) = left.into_parts();

--- a/crates/ragu_pcd/src/fuse/mod.rs
+++ b/crates/ragu_pcd/src/fuse/mod.rs
@@ -51,9 +51,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         rng: &mut RNG,
         step: S,
         witness: S::Witness<'source>,
-        left: Pcd<'source, C, R, S::Left>,
-        right: Pcd<'source, C, R, S::Right>,
-    ) -> Result<(Pcd<'source, C, R, S::Output>, S::Aux<'source>)> {
+        left: Pcd<C, R, S::Left>,
+        right: Pcd<C, R, S::Right>,
+    ) -> Result<(Pcd<C, R, S::Output>, S::Aux<'source>)> {
         let (left, right, application, application_data, application_aux) =
             self.compute_application_proof(rng, step, witness, left, right)?;
 

--- a/crates/ragu_pcd/src/header.rs
+++ b/crates/ragu_pcd/src/header.rs
@@ -84,15 +84,15 @@ pub trait Header<F: Field>: Send + Sync + Any {
     const SUFFIX: Suffix;
 
     /// The data needed to encode a header.
-    type Data<'source>: Send + Clone;
+    type Data: Send + Clone;
 
     /// The output gadget that encodes the data for this header.
     type Output: Write<F>;
 
     /// Encode some data into a gadget representing this header.
-    fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
+    fn encode<'dr, D: Driver<'dr, F = F>>(
         dr: &mut D,
-        witness: DriverValue<D, Self::Data<'source>>,
+        witness: DriverValue<D, Self::Data>,
     ) -> Result<Bound<'dr, D, Self::Output>>;
 }
 
@@ -100,12 +100,12 @@ pub trait Header<F: Field>: Send + Sync + Any {
 impl<F: Field> Header<F> for () {
     const SUFFIX: Suffix = Suffix::internal(1);
 
-    type Data<'source> = ();
+    type Data = ();
     type Output = ();
 
-    fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
+    fn encode<'dr, D: Driver<'dr, F = F>>(
         _: &mut D,
-        _: DriverValue<D, Self::Data<'source>>,
+        _: DriverValue<D, Self::Data>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         Ok(())
     }

--- a/crates/ragu_pcd/src/internal/native/stages/preamble.rs
+++ b/crates/ragu_pcd/src/internal/native/stages/preamble.rs
@@ -193,14 +193,11 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usiz
 
     /// Allocate ProofInputs from a proof reference and some unprocessed header
     /// data.
-    pub fn alloc_for_verify<'source, R: Rank, H: Header<C::CircuitField>>(
+    pub fn alloc_for_verify<R: Rank, H: Header<C::CircuitField>>(
         dr: &mut D,
         proof: DriverValue<D, &Proof<C, R>>,
-        header_data: DriverValue<D, H::Data<'source>>,
-    ) -> Result<Self>
-    where
-        'source: 'dr,
-    {
+        header_data: DriverValue<D, H::Data>,
+    ) -> Result<Self> {
         let header_data = D::try_just(|| {
             use ragu_core::drivers::emulator::{Emulator, Wireless};
             let emulator = &mut Emulator::<Wireless<D::MaybeKind, D::F>>::wireless();

--- a/crates/ragu_pcd/src/lib.rs
+++ b/crates/ragu_pcd/src/lib.rs
@@ -197,7 +197,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         rng: &mut RNG,
         step: S,
         witness: S::Witness<'source>,
-    ) -> Result<(Pcd<'source, C, R, S::Output>, S::Aux<'source>)> {
+    ) -> Result<(Pcd<C, R, S::Output>, S::Aux<'source>)> {
         self.fuse(rng, step, witness, self.trivial_pcd(), self.trivial_pcd())
     }
 
@@ -209,7 +209,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
     ///
     /// The proof is lazily created on first use and cached; subsequent calls
     /// return the same (non-random) proof.
-    fn seeded_trivial_pcd<'source, RNG: CryptoRng>(&self, rng: &mut RNG) -> Pcd<'source, C, R, ()> {
+    fn seeded_trivial_pcd<RNG: CryptoRng>(&self, rng: &mut RNG) -> Pcd<C, R, ()> {
         self.seeded_trivial
             .get_or_init(|| {
                 self.seed(rng, step::internal::trivial::Trivial::new(), ())
@@ -229,11 +229,11 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
     /// is valid for the same [`Header`] but reveals nothing else about the
     /// original proof. As a result, [`Application::verify`] should produce the
     /// same result on the provided `pcd` as it would the output of this method.
-    pub fn rerandomize<'source, RNG: CryptoRng, H: Header<C::CircuitField>>(
+    pub fn rerandomize<RNG: CryptoRng, H: Header<C::CircuitField>>(
         &self,
-        pcd: Pcd<'source, C, R, H>,
+        pcd: Pcd<C, R, H>,
         rng: &mut RNG,
-    ) -> Result<Pcd<'source, C, R, H>> {
+    ) -> Result<Pcd<C, R, H>> {
         // Seed a trivial proof for rerandomization.
         // TODO: this is a temporary hack that allows the base case logic to be simple
         let seeded_trivial = self.seeded_trivial_pcd(rng);

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -26,14 +26,14 @@ use crate::internal::nested::NUM_ENDOSCALING_POINTS;
 
 /// Represents proof-carrying data, a recursive proof for the correctness of
 /// some accompanying data.
-pub struct Pcd<'source, C: Cycle, R: Rank, H: Header<C::CircuitField>> {
+pub struct Pcd<C: Cycle, R: Rank, H: Header<C::CircuitField>> {
     proof: Proof<C, R>,
-    data: H::Data<'source>,
+    data: H::Data,
 }
 
-impl<'source, C: Cycle, R: Rank, H: Header<C::CircuitField>> Pcd<'source, C, R, H> {
+impl<C: Cycle, R: Rank, H: Header<C::CircuitField>> Pcd<C, R, H> {
     /// Returns a reference to the data that the proof accompanies.
-    pub fn data(&self) -> &H::Data<'source> {
+    pub fn data(&self) -> &H::Data {
         &self.data
     }
 
@@ -44,12 +44,12 @@ impl<'source, C: Cycle, R: Rank, H: Header<C::CircuitField>> Pcd<'source, C, R, 
 
     /// Consumes the proof-carrying data and returns the proof and data
     /// separately.
-    pub(crate) fn into_parts(self) -> (Proof<C, R>, H::Data<'source>) {
+    pub(crate) fn into_parts(self) -> (Proof<C, R>, H::Data) {
         (self.proof, self.data)
     }
 }
 
-impl<C: Cycle, R: Rank, H: Header<C::CircuitField>> Clone for Pcd<'_, C, R, H> {
+impl<C: Cycle, R: Rank, H: Header<C::CircuitField>> Clone for Pcd<C, R, H> {
     fn clone(&self) -> Self {
         Pcd {
             proof: self.proof.clone(),
@@ -77,7 +77,7 @@ pub struct Proof<C: Cycle, R: Rank> {
 
 impl<C: Cycle, R: Rank> Proof<C, R> {
     /// Augment a recursive proof with some data, described by a [`Header`].
-    pub fn carry<H: Header<C::CircuitField>>(self, data: H::Data<'_>) -> Pcd<'_, C, R, H> {
+    pub fn carry<H: Header<C::CircuitField>>(self, data: H::Data) -> Pcd<C, R, H> {
         Pcd { proof: self, data }
     }
 
@@ -113,7 +113,7 @@ impl<C: Cycle, R: Rank> Proof<C, R> {
 }
 
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, HEADER_SIZE> {
-    pub(crate) fn trivial_pcd<'source>(&self) -> Pcd<'source, C, R, ()> {
+    pub(crate) fn trivial_pcd(&self) -> Pcd<C, R, ()> {
         self.trivial_proof().carry(())
     }
 

--- a/crates/ragu_pcd/src/step/encoder.rs
+++ b/crates/ragu_pcd/src/step/encoder.rs
@@ -108,10 +108,7 @@ impl<'dr, D: Driver<'dr, F: PrimeField>, H: Header<D::F>, const HEADER_SIZE: usi
     ///
     /// This is the standard encoding method used by most Steps. The gadget structure
     /// is preserved and will be serialized with padding during the write phase.
-    pub fn new<'source: 'dr>(
-        dr: &mut D,
-        witness: DriverValue<D, H::Data<'source>>,
-    ) -> Result<Self> {
+    pub fn new(dr: &mut D, witness: DriverValue<D, H::Data>) -> Result<Self> {
         Ok(Encoded::from_gadget(H::encode(dr, witness)?))
     }
 
@@ -124,10 +121,7 @@ impl<'dr, D: Driver<'dr, F: PrimeField>, H: Header<D::F>, const HEADER_SIZE: usi
     ///
     /// The tradeoff: less efficient (requires emulation + serialization) but achieves
     /// circuit uniformity across different header types.
-    pub(crate) fn new_uniform<'source: 'dr>(
-        dr: &mut D,
-        witness: DriverValue<D, H::Data<'source>>,
-    ) -> Result<Self> {
+    pub(crate) fn new_uniform(dr: &mut D, witness: DriverValue<D, H::Data>) -> Result<Self> {
         let mut emulator: Emulator<Wireless<D::MaybeKind, _>> = Emulator::wireless();
         let gadget = H::encode(&mut emulator, witness)?;
         let gadget = padded::for_header::<H, HEADER_SIZE, _>(&mut emulator, gadget)?;
@@ -157,12 +151,12 @@ mod tests {
 
     impl Header<Fp> for SingleHeader {
         const SUFFIX: Suffix = Suffix::new(100);
-        type Data<'source> = Fp;
+        type Data = Fp;
         type Output = Kind![Fp; Element<'_, _>];
 
-        fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        fn encode<'dr, D: Driver<'dr, F = Fp>>(
             dr: &mut D,
-            witness: DriverValue<D, Self::Data<'source>>,
+            witness: DriverValue<D, Self::Data>,
         ) -> Result<Bound<'dr, D, Self::Output>> {
             Element::alloc(dr, witness)
         }
@@ -172,12 +166,12 @@ mod tests {
 
     impl Header<Fp> for PairHeader {
         const SUFFIX: Suffix = Suffix::new(101);
-        type Data<'source> = (Fp, Fp);
+        type Data = (Fp, Fp);
         type Output = Kind![Fp; (Element<'_, _>, Element<'_, _>)];
 
-        fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        fn encode<'dr, D: Driver<'dr, F = Fp>>(
             dr: &mut D,
-            witness: DriverValue<D, Self::Data<'source>>,
+            witness: DriverValue<D, Self::Data>,
         ) -> Result<Bound<'dr, D, Self::Output>> {
             let (a, b) = witness.cast();
             Ok((Element::alloc(dr, a)?, Element::alloc(dr, b)?))

--- a/crates/ragu_pcd/src/step/internal/adapter.rs
+++ b/crates/ragu_pcd/src/step/internal/adapter.rs
@@ -46,11 +46,11 @@ impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Circuit<C::Circuit
     type Instance<'source> = (
         FixedVec<C::CircuitField, ConstLen<HEADER_SIZE>>,
         FixedVec<C::CircuitField, ConstLen<HEADER_SIZE>>,
-        <S::Output as Header<C::CircuitField>>::Data<'source>,
+        <S::Output as Header<C::CircuitField>>::Data,
     );
     type Witness<'source> = (
-        <S::Left as Header<C::CircuitField>>::Data<'source>,
-        <S::Right as Header<C::CircuitField>>::Data<'source>,
+        <S::Left as Header<C::CircuitField>>::Data,
+        <S::Right as Header<C::CircuitField>>::Data,
         S::Witness<'source>,
     );
     type Output = Kind![C::CircuitField; FixedVec<Element<'_, _>, TripleConstLen<HEADER_SIZE>>];
@@ -59,7 +59,7 @@ impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Circuit<C::Circuit
             FixedVec<C::CircuitField, ConstLen<HEADER_SIZE>>,
             FixedVec<C::CircuitField, ConstLen<HEADER_SIZE>>,
         ),
-        <S::Output as Header<C::CircuitField>>::Data<'source>,
+        <S::Output as Header<C::CircuitField>>::Data,
         S::Aux<'source>,
     );
 
@@ -135,12 +135,12 @@ mod tests {
 
     impl Header<Fp> for TestHeader {
         const SUFFIX: Suffix = Suffix::new(50);
-        type Data<'source> = Fp;
+        type Data = Fp;
         type Output = Kind![Fp; Element<'_, _>];
 
-        fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        fn encode<'dr, D: Driver<'dr, F = Fp>>(
             dr: &mut D,
-            witness: DriverValue<D, Self::Data<'source>>,
+            witness: DriverValue<D, Self::Data>,
         ) -> Result<Bound<'dr, D, Self::Output>> {
             Element::alloc(dr, witness)
         }

--- a/crates/ragu_pcd/src/step/internal/rerandomize.rs
+++ b/crates/ragu_pcd/src/step/internal/rerandomize.rs
@@ -45,7 +45,7 @@ impl<C: Cycle, H: Header<C::CircuitField>> Step<C> for Rerandomize<H> {
         &self,
         dr: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
-        left: DriverValue<D, H::Data<'source>>,
+        left: DriverValue<D, H::Data>,
         right: DriverValue<D, ()>,
     ) -> Result<(
         (
@@ -53,7 +53,7 @@ impl<C: Cycle, H: Header<C::CircuitField>> Step<C> for Rerandomize<H> {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         // Use uniform encoding for left to ensure circuit uniformity across header types
@@ -94,11 +94,11 @@ fn test_rerandomize_consistency() {
     struct Single;
     impl Header<Fp> for Single {
         const SUFFIX: Suffix = Suffix::new(0);
-        type Data<'source> = Fp;
+        type Data = Fp;
         type Output = Kind![Fp; Element<'_, _>];
-        fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        fn encode<'dr, D: Driver<'dr, F = Fp>>(
             dr: &mut D,
-            witness: DriverValue<D, Self::Data<'source>>,
+            witness: DriverValue<D, Self::Data>,
         ) -> Result<Bound<'dr, D, Self::Output>> {
             Element::alloc(dr, witness)
         }
@@ -107,11 +107,11 @@ fn test_rerandomize_consistency() {
     struct Pair;
     impl Header<Fp> for Pair {
         const SUFFIX: Suffix = Suffix::new(1);
-        type Data<'source> = (Fp, Fp);
+        type Data = (Fp, Fp);
         type Output = Kind![Fp; (Element<'_, _>, Element<'_, _>)];
-        fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        fn encode<'dr, D: Driver<'dr, F = Fp>>(
             dr: &mut D,
-            witness: DriverValue<D, Self::Data<'source>>,
+            witness: DriverValue<D, Self::Data>,
         ) -> Result<Bound<'dr, D, Self::Output>> {
             let (a, b) = witness.cast();
             let a = Element::alloc(dr, a)?;

--- a/crates/ragu_pcd/src/step/internal/trivial.rs
+++ b/crates/ragu_pcd/src/step/internal/trivial.rs
@@ -44,7 +44,7 @@ impl<C: Cycle> Step<C> for Trivial {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;

--- a/crates/ragu_pcd/src/step/mod.rs
+++ b/crates/ragu_pcd/src/step/mod.rs
@@ -175,15 +175,15 @@ pub trait Step<C: Cycle>: Sized + Send + Sync {
         &self,
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'source>>,
-        left: DriverValue<D, <Self::Left as Header<C::CircuitField>>::Data<'source>>,
-        right: DriverValue<D, <Self::Right as Header<C::CircuitField>>::Data<'source>>,
+        left: DriverValue<D, <Self::Left as Header<C::CircuitField>>::Data>,
+        right: DriverValue<D, <Self::Right as Header<C::CircuitField>>::Data>,
     ) -> Result<(
         (
             Encoded<'dr, D, Self::Left, HEADER_SIZE>,
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )>
     where

--- a/crates/ragu_pcd/src/verify.rs
+++ b/crates/ragu_pcd/src/verify.rs
@@ -24,7 +24,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
     /// Verifies some [`Pcd`] for the provided [`Header`].
     pub fn verify<RNG: CryptoRng, H: Header<C::CircuitField>>(
         &self,
-        pcd: &Pcd<'_, C, R, H>,
+        pcd: &Pcd<C, R, H>,
         mut rng: RNG,
     ) -> Result<bool> {
         // Sample verification challenges w, y, and z.

--- a/crates/ragu_pcd/tests/registration_errors.rs
+++ b/crates/ragu_pcd/tests/registration_errors.rs
@@ -21,11 +21,11 @@ struct HSuffixAOther;
 
 impl<F: Field> Header<F> for HSuffixA {
     const SUFFIX: Suffix = Suffix::new(0);
-    type Data<'source> = ();
+    type Data = ();
     type Output = ();
-    fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
+    fn encode<'dr, D: Driver<'dr, F = F>>(
         _: &mut D,
-        _: DriverValue<D, Self::Data<'source>>,
+        _: DriverValue<D, Self::Data>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         Ok(())
     }
@@ -33,11 +33,11 @@ impl<F: Field> Header<F> for HSuffixA {
 
 impl<F: Field> Header<F> for HSuffixB {
     const SUFFIX: Suffix = Suffix::new(1);
-    type Data<'source> = ();
+    type Data = ();
     type Output = ();
-    fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
+    fn encode<'dr, D: Driver<'dr, F = F>>(
         _: &mut D,
-        _: DriverValue<D, Self::Data<'source>>,
+        _: DriverValue<D, Self::Data>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         Ok(())
     }
@@ -45,11 +45,11 @@ impl<F: Field> Header<F> for HSuffixB {
 
 impl<F: Field> Header<F> for HSuffixAOther {
     const SUFFIX: Suffix = Suffix::new(0); // duplicate suffix
-    type Data<'source> = ();
+    type Data = ();
     type Output = ();
-    fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
+    fn encode<'dr, D: Driver<'dr, F = F>>(
         _: &mut D,
-        _: DriverValue<D, Self::Data<'source>>,
+        _: DriverValue<D, Self::Data>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         Ok(())
     }
@@ -76,7 +76,7 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step0 {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;
@@ -108,7 +108,7 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step1 {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;
@@ -140,7 +140,7 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step1Dup {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;

--- a/crates/ragu_pcd/tests/rerandomization.rs
+++ b/crates/ragu_pcd/tests/rerandomization.rs
@@ -22,11 +22,11 @@ struct HeaderA;
 
 impl<F: Field> Header<F> for HeaderA {
     const SUFFIX: Suffix = Suffix::new(0);
-    type Data<'source> = ();
+    type Data = ();
     type Output = ();
-    fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
+    fn encode<'dr, D: Driver<'dr, F = F>>(
         _: &mut D,
-        _: DriverValue<D, Self::Data<'source>>,
+        _: DriverValue<D, Self::Data>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         Ok(())
     }
@@ -37,11 +37,11 @@ struct HeaderWithData;
 
 impl Header<Fp> for HeaderWithData {
     const SUFFIX: Suffix = Suffix::new(2);
-    type Data<'source> = Fp;
+    type Data = Fp;
     type Output = Kind![Fp; Element<'_, _>];
-    fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+    fn encode<'dr, D: Driver<'dr, F = Fp>>(
         dr: &mut D,
-        witness: DriverValue<D, Self::Data<'source>>,
+        witness: DriverValue<D, Self::Data>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         Element::alloc(dr, witness)
     }
@@ -68,7 +68,7 @@ impl Step<Pasta> for StepWithData {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<Fp>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;
@@ -99,7 +99,7 @@ impl<C: Cycle> Step<C> for Step0 {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;
@@ -129,7 +129,7 @@ impl<C: Cycle> Step<C> for Step1 {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;

--- a/crates/ragu_testing/src/pcd/nontrivial.rs
+++ b/crates/ragu_testing/src/pcd/nontrivial.rs
@@ -18,12 +18,12 @@ pub struct LeafNode;
 
 impl<F: Field> Header<F> for LeafNode {
     const SUFFIX: Suffix = Suffix::new(0);
-    type Data<'source> = F;
+    type Data = F;
     type Output = Kind![F; Element<'_, _>];
 
-    fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
+    fn encode<'dr, D: Driver<'dr, F = F>>(
         dr: &mut D,
-        witness: DriverValue<D, Self::Data<'source>>,
+        witness: DriverValue<D, Self::Data>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         Element::alloc(dr, witness)
     }
@@ -33,12 +33,12 @@ pub struct InternalNode;
 
 impl<F: Field> Header<F> for InternalNode {
     const SUFFIX: Suffix = Suffix::new(1);
-    type Data<'source> = F;
+    type Data = F;
     type Output = Kind![F; Element<'_, _>];
 
-    fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
+    fn encode<'dr, D: Driver<'dr, F = F>>(
         dr: &mut D,
-        witness: DriverValue<D, Self::Data<'source>>,
+        witness: DriverValue<D, Self::Data>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         Element::alloc(dr, witness)
     }
@@ -68,7 +68,7 @@ impl<C: Cycle> Step<C> for Hash2<'_, C> {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )>
     where
@@ -112,7 +112,7 @@ impl<C: Cycle> Step<C> for WitnessLeaf<'_, C> {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )>
     where


### PR DESCRIPTION
Blocked by #535, 
(will rebase the only new commit [6b2e3d8](https://github.com/tachyon-zcash/ragu/pull/561/commits/6b2e3d8271d1bd8307aaa4344c56f8d210af61c2) once 535 is merged)

Suggested by @ebfull in https://github.com/tachyon-zcash/ragu/pull/535#pullrequestreview-3904501261:

The 'source lifetime on `Header::Data` (and transitively `Step::Witness`, `Step::Aux`, Circuit GATs, `Pcd`) was never used by any implementation — all Data types were owned (`(), Fp, Arc<...>`). The `Send + Clone` bound on `Data` already made pure borrowing impractical, so the lifetime was purely phantom.

This PR removed the `'source` lifetime and simplify the type of relevant struct and traits throughout all crates. 