### PR TITLE
chore(pcd): remove deadcode attribute

### DIFF
--- a/crates/ragu_pcd/src/proof/components.rs
+++ b/crates/ragu_pcd/src/proof/components.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use ff::Field;
 use ragu_arithmetic::Cycle;
 use ragu_circuits::{


### PR DESCRIPTION
stale `#![allow(dead_code)]`