### PR TITLE
chore(pcd): preallocate buffer in fuse stage

### DIFF
--- a/crates/ragu_pcd/src/fuse/_08_f.rs
+++ b/crates/ragu_pcd/src/fuse/_08_f.rs
@@ -155,7 +155,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             ));
         }
 
-        let mut coeffs = Vec::new();
+        let mut coeffs = Vec::with_capacity(R::num_coeffs());
         let (first, rest) = iters.split_first_mut().unwrap();
         for val in first.by_ref() {
             let c = rest


### PR DESCRIPTION
Low hanging fruit which preallocates the coefficient vector with `Vec::with_capacity(R::num_coeffs())` to avoid repeated reallocations. Without it, the vector grows through doublings (each copying a larger buffer).