### PR TITLE
perf: Use lazy Montgomery reduction during revdot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,6 +845,7 @@ dependencies = [
  "group",
  "gungraun",
  "maybe-rayon",
+ "pasta_curves",
  "proptest",
  "ragu_arithmetic",
  "ragu_core",

--- a/crates/ragu_arithmetic/src/lib.rs
+++ b/crates/ragu_arithmetic/src/lib.rs
@@ -83,7 +83,10 @@ pub use coeff::Coeff;
 pub use domain::Domain;
 use ff::{Field, FromUniformBytes, WithSmallOrderMulGroup};
 pub use fft::{Ring, bitreverse};
-pub use pasta_curves::arithmetic::{Coordinates, CurveAffine, CurveExt};
+pub use pasta_curves::{
+    arithmetic::{Coordinates, CurveAffine, CurveExt},
+    deferred::DeferredField,
+};
 /// Converts a 256-bit integer literal into the little endian `[u64; 4]`
 /// representation that e.g. [`Fp::from_raw`](pasta_curves::Fp::from_raw) or
 /// [`Fp::pow`](pasta_curves::Fp::pow) need as input. This makes constants
@@ -113,10 +116,10 @@ pub use util::{
 pub trait Cycle: Copy + Clone + Default + Send + Sync + 'static {
     /// The field that circuit developers will primarily work with, and the
     /// scalar field of the [`HostCurve`](Cycle::HostCurve).
-    type CircuitField: WithSmallOrderMulGroup<3> + FromUniformBytes<64>;
+    type CircuitField: WithSmallOrderMulGroup<3> + FromUniformBytes<64> + DeferredField;
 
     /// The scalar field of the [`NestedCurve`](Cycle::NestedCurve).
-    type ScalarField: WithSmallOrderMulGroup<3> + FromUniformBytes<64>;
+    type ScalarField: WithSmallOrderMulGroup<3> + FromUniformBytes<64> + DeferredField;
 
     /// The nested curve that applications typically use for asymmetric keys,
     /// signatures, and other cryptographic primitives. (This is the Pallas

--- a/crates/ragu_circuits/Cargo.toml
+++ b/crates/ragu_circuits/Cargo.toml
@@ -33,6 +33,7 @@ ragu_arithmetic = { path = "../ragu_arithmetic", version = "0.0.0" }
 blake2b_simd = { workspace = true }
 ff = { workspace = true }
 group = { workspace = true }
+pasta_curves = { workspace = true }
 ragu_core = { path = "../ragu_core", version = "0.0.0" }
 ragu_primitives = { path = "../ragu_primitives", version = "0.0.0" }
 rand = { workspace = true }

--- a/crates/ragu_circuits/src/polynomials/sparse/mod.rs
+++ b/crates/ragu_circuits/src/polynomials/sparse/mod.rs
@@ -50,7 +50,7 @@ use alloc::vec::Vec;
 use core::{borrow::Borrow, marker::PhantomData};
 
 use ff::Field;
-use ragu_arithmetic::CurveAffine;
+use ragu_arithmetic::{CurveAffine, DeferredField};
 use rand::CryptoRng;
 
 use super::Rank;
@@ -397,10 +397,15 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     /// Computes $\sum\_{k} \text{self}\[k\] \cdot \text{other}\[4n - 1 - k\]$.
     ///
     /// Uses a two-pointer merge over both block lists for $O(\text{nnz})$
-    /// time.
-    pub fn revdot(&self, other: &Self) -> F {
+    /// time. Products are accumulated unreduced via
+    /// [`DeferredField::mul_accumulate`] and a single Montgomery reduction is
+    /// performed at the end.
+    pub fn revdot(&self, other: &Self) -> F
+    where
+        F: DeferredField,
+    {
         let max_deg = R::num_coeffs() - 1;
-        let mut result = F::ZERO;
+        let mut acc = F::Accumulator::default();
 
         let mut a_iter = self.blocks.iter().peekable();
         // Iterating other's blocks in reverse yields ascending reversed-index
@@ -432,7 +437,7 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
                 let b_slice = &b_data[b_idx_lo..=b_idx_hi];
 
                 for (a_val, b_val) in a_slice.iter().zip(b_slice.iter().rev()) {
-                    result += *a_val * *b_val;
+                    F::mul_accumulate(&mut acc, a_val, b_val);
                 }
             }
 
@@ -444,7 +449,7 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
             }
         }
 
-        result
+        F::reduce(acc)
     }
 
     /// Computes a commitment to this polynomial in projective form. Use

--- a/crates/ragu_pcd/src/internal/fold_revdot.rs
+++ b/crates/ragu_pcd/src/internal/fold_revdot.rs
@@ -3,6 +3,7 @@
 use core::{borrow::Borrow, iter, marker::PhantomData};
 
 use ff::Field;
+use ragu_arithmetic::DeferredField;
 use ragu_circuits::{
     horner::Horner,
     polynomials::{Rank, sparse},
@@ -133,7 +134,7 @@ pub fn fold_outer<T: Foldable<F>, F: Field, P: Parameters>(
 ///
 /// This computes off-diagonal revdot products for each group of `Inner`
 /// polynomials, producing `Outer` groups of error terms.
-fn compute_errors_impl<F: Field, R: Rank, Outer: Len, Inner: Len>(
+fn compute_errors_impl<F: DeferredField, R: Rank, Outer: Len, Inner: Len>(
     a: &[impl Borrow<sparse::Polynomial<F, R>>],
     b: &[impl Borrow<sparse::Polynomial<F, R>>],
 ) -> FixedVec<FixedVec<F, NumErrorTerms<Inner>>, Outer> {
@@ -171,7 +172,7 @@ fn compute_errors_impl<F: Field, R: Rank, Outer: Len, Inner: Len>(
 }
 
 /// Inner error terms: `NumGroups` groups of `GroupSize`*(`GroupSize`-1) off-diagonal revdot products.
-pub fn inner_error_terms<F: Field, R: Rank, P: Parameters>(
+pub fn inner_error_terms<F: DeferredField, R: Rank, P: Parameters>(
     a: &[impl Borrow<sparse::Polynomial<F, R>>],
     b: &[impl Borrow<sparse::Polynomial<F, R>>],
 ) -> FixedVec<FixedVec<F, NumErrorTerms<P::GroupSize>>, P::NumGroups> {
@@ -179,7 +180,7 @@ pub fn inner_error_terms<F: Field, R: Rank, P: Parameters>(
 }
 
 /// Outer error terms: `NumGroups`*(`NumGroups`-1) off-diagonal revdot products.
-pub fn outer_error_terms<F: Field, R: Rank, P: Parameters>(
+pub fn outer_error_terms<F: DeferredField, R: Rank, P: Parameters>(
     a: &[impl Borrow<sparse::Polynomial<F, R>>],
     b: &[impl Borrow<sparse::Polynomial<F, R>>],
 ) -> FixedVec<F, NumErrorTerms<P::NumGroups>> {


### PR DESCRIPTION
Close #579, Pair with https://github.com/ebfull/pasta_curves/pull/1.
subsume changes in ILP improvement in #574 (cc @TalDerei, but feel free to merge that in, it's originally orthogonal improvements, but it's clearer for me to just follow the same inspiration here and break up into 4 `n`-sized revdot)

The benchmark verifies **a 47% improvement on `revdot`** against `main`:

```
circuits::poly_ops::revdot revdot:setup_rng((rand_structured_poly, rand_structured_p...
  Instructions:                     1093515|2075253              (-47.3069%) [-1.89778x]
  L1 Hits:                          1315245|2395959              (-45.1057%) [-1.82168x]
  LL Hits:                             8256|8243                 (+0.15771%) [+1.00158x]
  RAM Hits:                              63|80                   (-21.2500%) [-1.26984x]
  Total read+write:                 1323564|2404282              (-44.9497%) [-1.81652x]
  Estimated Cycles:                 1358730|2439974              (-44.3138%) [-1.79578x]

```