### PR TITLE
Single responsibility claim order

### DIFF
--- a/crates/ragu_pcd/src/fuse/_05_error_n.rs
+++ b/crates/ragu_pcd/src/fuse/_05_error_n.rs
@@ -23,6 +23,7 @@ use rand::CryptoRng;
 use crate::{
     Application,
     internal::{
+        claims::KySource,
         fold_revdot, native,
         native::stages::error_n::{ChildKyValues, KyValues},
         nested,
@@ -86,7 +87,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                 let nu = Element::alloc(dr, nu)?;
 
                 // Build k(y) values in claim order.
-                let ky = native::claims::TwoProofKySource {
+                let ky_source = native::claims::TwoProofKySource {
                     left_raw_c: preamble.left.unified.c.clone(),
                     right_raw_c: preamble.right.unified.c.clone(),
                     left_app: left_application_ky.clone(),
@@ -97,7 +98,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                     right_unified: right_unified_ky.clone(),
                     zero: Element::zero(dr),
                 };
-                let mut ky = native::claims::ky_values(&ky);
+                let mut ky = ky_source.padded_ky_values();
 
                 let fold_products = fold_revdot::FoldProducts::new(dr, &mu, &nu)?;
 

--- a/crates/ragu_pcd/src/internal/claims.rs
+++ b/crates/ragu_pcd/src/internal/claims.rs
@@ -55,6 +55,40 @@ pub trait Source {
     fn app_circuits(&self) -> impl Iterator<Item = Self::AppCircuitId>;
 }
 
+/// Either a per-proof value iterator or a single zero.
+pub(crate) enum KyIter<A, B> {
+    Value(A),
+    Zero(B),
+}
+
+impl<T, A: Iterator<Item = T>, B: Iterator<Item = T>> Iterator for KyIter<A, B> {
+    type Item = T;
+    fn next(&mut self) -> Option<T> {
+        match self {
+            Self::Value(a) => a.next(),
+            Self::Zero(b) => b.next(),
+        }
+    }
+}
+
+/// Trait for providing $k(y)$ values for claim verification.
+pub(crate) trait KySource {
+    /// The $k(y)$ value type.
+    type Item: Clone;
+
+    /// Returns $k(y)$ values in claim order.
+    fn ky_values(&self) -> impl Iterator<Item = Self::Item>;
+
+    /// The zero value for stage claims.
+    fn zero(&self) -> Self::Item;
+
+    /// Returns $k(y)$ values in claim order, followed by infinite zeros.
+    fn padded_ky_values(&self) -> impl Iterator<Item = Self::Item> {
+        let zero = self.zero();
+        self.ky_values().chain(core::iter::repeat(zero))
+    }
+}
+
 /// Processor that builds polynomial vectors for revdot claims.
 ///
 /// Accumulates (a, b) polynomial pairs for each claim type, using

--- a/crates/ragu_pcd/src/internal/native/circuits/partial_collapse.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/partial_collapse.rs
@@ -68,11 +68,12 @@ use ragu_primitives::{Element, vec::FixedVec};
 
 use core::marker::PhantomData;
 
-use super::super::claims::{TwoProofKySource, ky_values};
+use super::super::claims::TwoProofKySource;
 use super::super::{
     stages::{error_m as native_error_m, error_n as native_error_n, preamble as native_preamble},
     unified::{self, OutputBuilder},
 };
+use crate::internal::claims::KySource;
 use crate::internal::fold_revdot;
 
 /// Circuit that verifies layer 1 of the two-layer revdot reduction.
@@ -158,12 +159,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         let nu = unified_output.nu.read(dr)?;
         let fold_products = fold_revdot::FoldProducts::new(dr, &mu, &nu)?;
 
-        // Assemble k(y) values from multiple sources. The ordering must match
-        // claims's iteration order for correct folding correspondence.
-        // Sources include:
-        // - Child c values from preamble (the children's final revdot claims)
-        // - Application and unified k(y) evaluations from error_n
-        let ky = TwoProofKySource {
+        // Assemble k(y) values in claim_order() sequence.
+        let ky_source = TwoProofKySource {
             left_raw_c: preamble.left.unified.c.clone(),
             right_raw_c: preamble.right.unified.c.clone(),
             left_app: error_n.left.application.clone(),
@@ -174,7 +171,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
             right_unified: error_n.right.unified.clone(),
             zero: Element::zero(dr),
         };
-        let mut ky = ky_values(&ky);
+        let mut ky = ky_source.padded_ky_values();
 
         // Verify each group's layer 1 reduction. For each group, fold the
         // error_m terms with the corresponding k(y) values and enforce the

--- a/crates/ragu_pcd/src/internal/native/claims.rs
+++ b/crates/ragu_pcd/src/internal/native/claims.rs
@@ -11,7 +11,7 @@
 //! - [`build`]: Orchestrates claim building in unified order
 
 use alloc::borrow::Cow;
-use core::iter::{once, repeat_n};
+use core::iter::once;
 
 use ff::PrimeField;
 use ragu_circuits::{
@@ -23,24 +23,90 @@ use ragu_core::drivers::Driver;
 use ragu_primitives::Element;
 
 use super::{InternalCircuitIndex, RxComponent, RxIndex};
-use crate::internal::claims::{Builder, Source, sum_polynomials};
+use crate::internal::claims::{Builder, KyIter, KySource, Source, sum_polynomials};
 
-/// Number of circuits using unified $k(y)$ in [`build`].
-///
-/// These circuits use [`unified::InternalOutputKind`]:
-/// [`hashes_2`], [`partial_collapse`], [`full_collapse`], [`compute_v`].
-///
-/// Note: [`hashes_1`] separately uses `unified_bridge_ky` because its public
-/// inputs include child proof headers (see [`hashes_1::Output`]).
-///
-/// [`hashes_1`]: crate::internal::native::circuits::hashes_1
-/// [`hashes_1::Output`]: crate::internal::native::circuits::hashes_1::Output
-/// [`hashes_2`]: crate::internal::native::circuits::hashes_2
-/// [`partial_collapse`]: crate::internal::native::circuits::partial_collapse
-/// [`full_collapse`]: crate::internal::native::circuits::full_collapse
-/// [`compute_v`]: crate::internal::native::circuits::compute_v
-/// [`unified::InternalOutputKind`]: crate::internal::native::unified::InternalOutputKind
-const NUM_UNIFIED_CIRCUITS: usize = 4;
+/// Which $k(y)$ group a claim belongs to.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum KyKind {
+    Raw,
+    Application,
+    UnifiedBridge,
+    Unified,
+    Zero,
+}
+
+/// Canonical claim ordering, shared by [`build`] and [`KyValues::into_values`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ClaimOrder {
+    Raw,
+    Application,
+    Internal(InternalCircuitIndex),
+}
+
+impl ClaimOrder {
+    pub(crate) fn ky_kind(&self) -> KyKind {
+        match self {
+            Self::Raw => KyKind::Raw,
+            Self::Application => KyKind::Application,
+            Self::Internal(id) => {
+                use InternalCircuitIndex::*;
+                match id {
+                    Hashes1Circuit => KyKind::UnifiedBridge,
+                    Hashes2Circuit
+                    | PartialCollapseCircuit
+                    | FullCollapseCircuit
+                    | ComputeVCircuit => KyKind::Unified,
+                    PreambleStage | ErrorMStage | ErrorNStage | QueryStage | EvalStage
+                    | ErrorMFinalStaged | ErrorNFinalStaged | EvalFinalStaged => KyKind::Zero,
+                }
+            }
+        }
+    }
+}
+
+/// Returns the canonical claim ordering: raw, application, then all internal circuits.
+pub(crate) fn claim_order() -> impl Iterator<Item = ClaimOrder> {
+    once(ClaimOrder::Raw)
+        .chain(once(ClaimOrder::Application))
+        .chain(
+            InternalCircuitIndex::ALL
+                .iter()
+                .copied()
+                .map(ClaimOrder::Internal),
+        )
+}
+
+/// Per-group $k(y)$ iterators, flattened in [`claim_order`] sequence.
+pub(crate) struct KyValues<I: Iterator> {
+    pub(crate) raw: I,
+    pub(crate) application: I,
+    pub(crate) unified_bridge: I,
+    pub(crate) unified: I,
+    pub(crate) zero: I::Item,
+}
+
+impl<I: Clone + Iterator> KyValues<I>
+where
+    I::Item: Clone,
+{
+    /// Flatten into $k(y)$ values in [`claim_order`] sequence.
+    pub(crate) fn into_values(self) -> impl Iterator<Item = I::Item> {
+        let KyValues {
+            raw,
+            application,
+            unified_bridge,
+            unified,
+            zero,
+        } = self;
+        claim_order().flat_map(move |order| match order.ky_kind() {
+            KyKind::Raw => KyIter::Value(raw.clone()),
+            KyKind::Application => KyIter::Value(application.clone()),
+            KyKind::UnifiedBridge => KyIter::Value(unified_bridge.clone()),
+            KyKind::Unified => KyIter::Value(unified.clone()),
+            KyKind::Zero => KyIter::Zero(once(zero.clone())),
+        })
+    }
+}
 
 /// Trait that processes claim values into accumulated outputs.
 ///
@@ -115,13 +181,13 @@ impl<'m, 'rx, F: PrimeField, R: Rank> Processor<&'rx structured::Polynomial<F, R
 
 /// Build claims in unified interleaved order from a source.
 ///
-/// The ordering is: for each claim type, add claims for all proofs before
-/// moving to the next claim type. This produces an interleaved order:
-/// `[L_raw, R_raw, L_app, R_app, L_h1, R_h1, ...]` for two-proof sources.
+/// The ordering is driven by [`claim_order`]: for each claim type, add claims
+/// for all proofs before moving to the next claim type. This produces an
+/// interleaved order: `[L_raw, R_raw, L_app, R_app, L_h1, R_h1, ...]` for
+/// two-proof sources.
 ///
-/// This ordering must match the $k(y)$ ordering in
-/// [`partial_collapse`](crate::internal::native::circuits::partial_collapse)
-/// and `compute_errors_n` in the fuse implementation.
+/// This ordering must match the $k(y)$ ordering produced by
+/// [`KyValues::into_values`], which is also driven by [`claim_order`].
 pub fn build<S, P>(source: &S, processor: &mut P) -> Result<()>
 where
     S: Source<RxComponent = RxComponent>,
@@ -130,148 +196,113 @@ where
     use RxComponent::*;
     use RxIndex::*;
 
-    // Raw claims (interleaved per proof)
-    for (a, b) in source.rx(AbA).zip(source.rx(AbB)) {
-        processor.raw_claim(a, b);
-    }
-
-    // App circuits (interleaved per proof)
-    for (app_id, rx) in source.app_circuits().zip(source.rx(Rx(Application))) {
-        processor.circuit(app_id, rx);
-    }
-
-    // Internal circuits and stages in canonical order.
-    for &id in &InternalCircuitIndex::ALL {
-        use InternalCircuitIndex::*;
-        match id {
-            // hashes_1: Hashes1 + Preamble + ErrorN
-            Hashes1Circuit => {
-                for ((h1, pre), en) in source
-                    .rx(Rx(Hashes1))
-                    .zip(source.rx(Rx(Preamble)))
-                    .zip(source.rx(Rx(ErrorN)))
-                {
-                    processor.internal_circuit(id, [h1, pre, en].into_iter());
+    for order in claim_order() {
+        match order {
+            ClaimOrder::Raw => {
+                for (a, b) in source.rx(AbA).zip(source.rx(AbB)) {
+                    processor.raw_claim(a, b);
                 }
             }
-
-            // hashes_2: Hashes2 + ErrorN
-            Hashes2Circuit => {
-                for (h2, en) in source.rx(Rx(Hashes2)).zip(source.rx(Rx(ErrorN))) {
-                    processor.internal_circuit(id, [h2, en].into_iter());
+            ClaimOrder::Application => {
+                for (app_id, rx) in source.app_circuits().zip(source.rx(Rx(Application))) {
+                    processor.circuit(app_id, rx);
                 }
             }
+            ClaimOrder::Internal(id) => {
+                use InternalCircuitIndex::*;
+                match id {
+                    // hashes_1: Hashes1 + Preamble + ErrorN
+                    Hashes1Circuit => {
+                        for ((h1, pre), en) in source
+                            .rx(Rx(Hashes1))
+                            .zip(source.rx(Rx(Preamble)))
+                            .zip(source.rx(Rx(ErrorN)))
+                        {
+                            processor.internal_circuit(id, [h1, pre, en].into_iter());
+                        }
+                    }
 
-            // partial_collapse: PartialCollapse + Preamble + ErrorM + ErrorN
-            PartialCollapseCircuit => {
-                for (((pc, pre), em), en) in source
-                    .rx(Rx(PartialCollapse))
-                    .zip(source.rx(Rx(Preamble)))
-                    .zip(source.rx(Rx(ErrorM)))
-                    .zip(source.rx(Rx(ErrorN)))
-                {
-                    processor.internal_circuit(id, [pc, pre, em, en].into_iter());
+                    // hashes_2: Hashes2 + ErrorN
+                    Hashes2Circuit => {
+                        for (h2, en) in source.rx(Rx(Hashes2)).zip(source.rx(Rx(ErrorN))) {
+                            processor.internal_circuit(id, [h2, en].into_iter());
+                        }
+                    }
+
+                    // partial_collapse: PartialCollapse + Preamble + ErrorM + ErrorN
+                    PartialCollapseCircuit => {
+                        for (((pc, pre), em), en) in source
+                            .rx(Rx(PartialCollapse))
+                            .zip(source.rx(Rx(Preamble)))
+                            .zip(source.rx(Rx(ErrorM)))
+                            .zip(source.rx(Rx(ErrorN)))
+                        {
+                            processor.internal_circuit(id, [pc, pre, em, en].into_iter());
+                        }
+                    }
+
+                    // full_collapse: FullCollapse + Preamble + ErrorN
+                    FullCollapseCircuit => {
+                        for ((fc, pre), en) in source
+                            .rx(Rx(FullCollapse))
+                            .zip(source.rx(Rx(Preamble)))
+                            .zip(source.rx(Rx(ErrorN)))
+                        {
+                            processor.internal_circuit(id, [fc, pre, en].into_iter());
+                        }
+                    }
+
+                    // compute_v: ComputeV + Preamble + Query + Eval
+                    ComputeVCircuit => {
+                        for (((cv, pre), q), e) in source
+                            .rx(Rx(ComputeV))
+                            .zip(source.rx(Rx(Preamble)))
+                            .zip(source.rx(Rx(Query)))
+                            .zip(source.rx(Rx(Eval)))
+                        {
+                            processor.internal_circuit(id, [cv, pre, q, e].into_iter());
+                        }
+                    }
+
+                    // Native stages (aggregated across all proofs)
+                    PreambleStage => {
+                        processor.stage(id, source.rx(Rx(Preamble)))?;
+                    }
+                    ErrorMStage => {
+                        processor.stage(id, source.rx(Rx(ErrorM)))?;
+                    }
+                    ErrorNStage => {
+                        processor.stage(id, source.rx(Rx(ErrorN)))?;
+                    }
+                    QueryStage => {
+                        processor.stage(id, source.rx(Rx(Query)))?;
+                    }
+                    EvalStage => {
+                        processor.stage(id, source.rx(Rx(Eval)))?;
+                    }
+
+                    // Final stage masks
+                    ErrorMFinalStaged => {
+                        processor.stage(id, source.rx(Rx(PartialCollapse)))?;
+                    }
+                    ErrorNFinalStaged => {
+                        processor.stage(
+                            id,
+                            source
+                                .rx(Rx(Hashes1))
+                                .chain(source.rx(Rx(Hashes2)))
+                                .chain(source.rx(Rx(FullCollapse))),
+                        )?;
+                    }
+                    EvalFinalStaged => {
+                        processor.stage(id, source.rx(Rx(ComputeV)))?;
+                    }
                 }
-            }
-
-            // full_collapse: FullCollapse + Preamble + ErrorN
-            FullCollapseCircuit => {
-                for ((fc, pre), en) in source
-                    .rx(Rx(FullCollapse))
-                    .zip(source.rx(Rx(Preamble)))
-                    .zip(source.rx(Rx(ErrorN)))
-                {
-                    processor.internal_circuit(id, [fc, pre, en].into_iter());
-                }
-            }
-
-            // compute_v: ComputeV + Preamble + Query + Eval
-            ComputeVCircuit => {
-                for (((cv, pre), q), e) in source
-                    .rx(Rx(ComputeV))
-                    .zip(source.rx(Rx(Preamble)))
-                    .zip(source.rx(Rx(Query)))
-                    .zip(source.rx(Rx(Eval)))
-                {
-                    processor.internal_circuit(id, [cv, pre, q, e].into_iter());
-                }
-            }
-
-            // Native stages (aggregated across all proofs)
-            PreambleStage => {
-                processor.stage(id, source.rx(Rx(Preamble)))?;
-            }
-            ErrorMStage => {
-                processor.stage(id, source.rx(Rx(ErrorM)))?;
-            }
-            ErrorNStage => {
-                processor.stage(id, source.rx(Rx(ErrorN)))?;
-            }
-            QueryStage => {
-                processor.stage(id, source.rx(Rx(Query)))?;
-            }
-            EvalStage => {
-                processor.stage(id, source.rx(Rx(Eval)))?;
-            }
-
-            // Final stage masks
-            ErrorMFinalStaged => {
-                processor.stage(id, source.rx(Rx(PartialCollapse)))?;
-            }
-            ErrorNFinalStaged => {
-                processor.stage(
-                    id,
-                    source
-                        .rx(Rx(Hashes1))
-                        .chain(source.rx(Rx(Hashes2)))
-                        .chain(source.rx(Rx(FullCollapse))),
-                )?;
-            }
-            EvalFinalStaged => {
-                processor.stage(id, source.rx(Rx(ComputeV)))?;
             }
         }
     }
 
     Ok(())
-}
-
-/// Trait for providing $k(y)$ values for claim verification.
-pub trait KySource {
-    /// The $k(y)$ value type.
-    type Ky: Clone;
-
-    /// Iterator over raw_c values (the c from AB proof / preamble unified).
-    fn raw_c(&self) -> impl Iterator<Item = Self::Ky>;
-
-    /// Iterator over application circuit $k(y)$ values.
-    fn application_ky(&self) -> impl Iterator<Item = Self::Ky>;
-
-    /// Iterator over unified bridge $k(y)$ values.
-    fn unified_bridge_ky(&self) -> impl Iterator<Item = Self::Ky>;
-
-    /// Base iterator over unified $k(y)$ values.
-    ///
-    /// Will be repeated [`NUM_UNIFIED_CIRCUITS`] times.
-    /// The `+ Clone` bound is required for `repeat_n` in [`ky_values`].
-    fn unified_ky(&self) -> impl Iterator<Item = Self::Ky> + Clone;
-
-    /// The zero value for stage claims.
-    fn zero(&self) -> Self::Ky;
-}
-
-/// Build an iterator over $k(y)$ values in claim order.
-///
-/// Chains the $k(y)$ sources in the order required by [`build`],
-/// with `unified_ky` repeated [`NUM_UNIFIED_CIRCUITS`] times,
-/// followed by infinite zeros for stage claims.
-pub fn ky_values<S: KySource>(source: &S) -> impl Iterator<Item = S::Ky> {
-    source
-        .raw_c()
-        .chain(source.application_ky())
-        .chain(source.unified_bridge_ky())
-        .chain(repeat_n(source.unified_ky(), NUM_UNIFIED_CIRCUITS).flatten())
-        .chain(core::iter::repeat(source.zero()))
 }
 
 pub struct TwoProofKySource<'dr, D: Driver<'dr>> {
@@ -287,22 +318,19 @@ pub struct TwoProofKySource<'dr, D: Driver<'dr>> {
 }
 
 impl<'dr, D: Driver<'dr>> KySource for TwoProofKySource<'dr, D> {
-    type Ky = Element<'dr, D>;
+    type Item = Element<'dr, D>;
 
-    fn raw_c(&self) -> impl Iterator<Item = Element<'dr, D>> {
-        once(self.left_raw_c.clone()).chain(once(self.right_raw_c.clone()))
-    }
-
-    fn application_ky(&self) -> impl Iterator<Item = Element<'dr, D>> {
-        once(self.left_app.clone()).chain(once(self.right_app.clone()))
-    }
-
-    fn unified_bridge_ky(&self) -> impl Iterator<Item = Element<'dr, D>> {
-        once(self.left_bridge.clone()).chain(once(self.right_bridge.clone()))
-    }
-
-    fn unified_ky(&self) -> impl Iterator<Item = Element<'dr, D>> + Clone {
-        once(self.left_unified.clone()).chain(once(self.right_unified.clone()))
+    fn ky_values(&self) -> impl Iterator<Item = Element<'dr, D>> {
+        let pair =
+            |l: &Element<'dr, D>, r: &Element<'dr, D>| once(l.clone()).chain(once(r.clone()));
+        KyValues {
+            raw: pair(&self.left_raw_c, &self.right_raw_c),
+            application: pair(&self.left_app, &self.right_app),
+            unified_bridge: pair(&self.left_bridge, &self.right_bridge),
+            unified: pair(&self.left_unified, &self.right_unified),
+            zero: self.zero.clone(),
+        }
+        .into_values()
     }
 
     fn zero(&self) -> Element<'dr, D> {

--- a/crates/ragu_pcd/src/internal/nested/claims.rs
+++ b/crates/ragu_pcd/src/internal/nested/claims.rs
@@ -16,7 +16,52 @@ use ragu_circuits::polynomials::{Rank, structured};
 use ragu_core::Result;
 
 use super::InternalCircuitIndex;
-use crate::internal::claims::{Builder, Source, sum_polynomials};
+use crate::internal::claims::{Builder, KyIter, Source, sum_polynomials};
+
+/// Canonical claim ordering for nested claims.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ClaimOrder {
+    EndoscalingStep(u32),
+    Stage(InternalCircuitIndex),
+}
+
+/// Returns the canonical nested claim ordering: steps then stages.
+pub(crate) fn claim_order() -> impl Iterator<Item = ClaimOrder> {
+    use super::NUM_ENDOSCALING_POINTS;
+    use crate::internal::endoscalar::NumStepsLen;
+    use ragu_primitives::vec::Len;
+
+    let num_steps = NumStepsLen::<NUM_ENDOSCALING_POINTS>::len();
+
+    (0..num_steps)
+        .map(|step| ClaimOrder::EndoscalingStep(step as u32))
+        .chain([
+            ClaimOrder::Stage(InternalCircuitIndex::EndoscalarStage),
+            ClaimOrder::Stage(InternalCircuitIndex::PointsStage),
+            ClaimOrder::Stage(InternalCircuitIndex::PointsFinalStaged),
+        ])
+}
+
+/// Per-group $k(y)$ iterators for nested claims, flattened in [`claim_order`]
+/// sequence.
+pub(crate) struct KyValues<I: Iterator> {
+    pub(crate) circuit: I,
+    pub(crate) zero: I::Item,
+}
+
+impl<I: Clone + Iterator> KyValues<I>
+where
+    I::Item: Clone,
+{
+    /// Flatten into $k(y)$ values in [`claim_order`] sequence.
+    pub(crate) fn into_values(self) -> impl Iterator<Item = I::Item> {
+        let KyValues { circuit, zero } = self;
+        claim_order().flat_map(move |order| match order {
+            ClaimOrder::EndoscalingStep(_) => KyIter::Value(circuit.clone()),
+            ClaimOrder::Stage(_) => KyIter::Zero(core::iter::once(zero.clone())),
+        })
+    }
+}
 
 /// Enum identifying which nested field rx polynomial to retrieve from a proof.
 #[derive(Clone, Copy, Debug)]
@@ -67,13 +112,14 @@ impl<'m, 'rx, F: PrimeField, R: Rank> Processor<&'rx structured::Polynomial<F, R
 
 /// Build nested claims in unified interleaved order from a source.
 ///
-/// The ordering is:
+/// The ordering is driven by [`claim_order`]:
 /// 1. Circuit checks ($k(y) = 1$): [`EndoscalingStep`](InternalCircuitIndex::EndoscalingStep)
 ///    for each step, interleaved across proofs
 /// 2. Stage checks ($k(y) = 0$): [`EndoscalarStage`](InternalCircuitIndex::EndoscalarStage),
 ///    [`PointsStage`](InternalCircuitIndex::PointsStage), `PointsFinalStaged`
 ///
-/// This ordering must match the ky_elements ordering from [`ky_values`].
+/// This ordering must match the $k(y)$ ordering produced by
+/// [`KyValues::into_values`], which is also driven by [`claim_order`].
 pub fn build<S, P>(source: &S, processor: &mut P) -> Result<()>
 where
     S: Source<RxComponent = RxComponent>,
@@ -85,68 +131,39 @@ where
 
     let num_steps = NumStepsLen::<NUM_ENDOSCALING_POINTS>::len();
 
-    use RxComponent::*;
-
-    // 1. Circuit checks FIRST (k(y) = 1)
-    // Process all EndoscalingStep circuits (interleaved across proofs)
-    // Each circuit claim needs: step_rx + endoscalar_rx + points_rx
-    for step in 0..num_steps {
-        for ((step_rx, endo_rx), pts_rx) in source
-            .rx(EndoscalingStep(step as u32))
-            .zip(source.rx(EndoscalarStage))
-            .zip(source.rx(PointsStage))
-        {
-            processor.internal_circuit(
-                InternalCircuitIndex::EndoscalingStep(step as u32),
-                [step_rx, endo_rx, pts_rx].into_iter(),
-            );
+    for order in claim_order() {
+        match order {
+            ClaimOrder::EndoscalingStep(step) => {
+                for ((step_rx, endo_rx), pts_rx) in source
+                    .rx(RxComponent::EndoscalingStep(step))
+                    .zip(source.rx(RxComponent::EndoscalarStage))
+                    .zip(source.rx(RxComponent::PointsStage))
+                {
+                    processor.internal_circuit(
+                        InternalCircuitIndex::EndoscalingStep(step),
+                        [step_rx, endo_rx, pts_rx].into_iter(),
+                    );
+                }
+            }
+            ClaimOrder::Stage(id) => {
+                use InternalCircuitIndex::*;
+                match id {
+                    EndoscalarStage => {
+                        processor.stage(id, source.rx(RxComponent::EndoscalarStage))?;
+                    }
+                    PointsStage => {
+                        processor.stage(id, source.rx(RxComponent::PointsStage))?;
+                    }
+                    PointsFinalStaged => {
+                        let final_rxs = (0..num_steps)
+                            .flat_map(|step| source.rx(RxComponent::EndoscalingStep(step as u32)));
+                        processor.stage(id, final_rxs)?;
+                    }
+                    _ => unreachable!(),
+                }
+            }
         }
     }
 
-    // 2. Stage checks SECOND (k(y) = 0)
-    processor.stage(
-        InternalCircuitIndex::EndoscalarStage,
-        source.rx(EndoscalarStage),
-    )?;
-
-    processor.stage(InternalCircuitIndex::PointsStage, source.rx(PointsStage))?;
-
-    // PointsFinalStaged - final stage check
-    // Aggregates all EndoscalingStep rxs from all proofs
-    {
-        let final_rxs = (0..num_steps).flat_map(|step| source.rx(EndoscalingStep(step as u32)));
-        processor.stage(InternalCircuitIndex::PointsFinalStaged, final_rxs)?;
-    }
-
     Ok(())
-}
-
-/// Trait for providing $k(y)$ values for nested claim verification.
-pub trait KySource {
-    /// The $k(y)$ value type.
-    type Ky: Clone;
-
-    /// Returns 1 for circuit checks.
-    fn one(&self) -> Self::Ky;
-
-    /// Returns 0 for stage checks.
-    fn zero(&self) -> Self::Ky;
-}
-
-/// Build an iterator over $k(y)$ values in nested claim order.
-///
-/// Returns:
-/// - `num_steps` ones (for EndoscalingStep circuit checks, single-proof verification)
-/// - Infinite zeros (for stage checks)
-pub fn ky_values<S: KySource>(source: &S) -> impl Iterator<Item = S::Ky> {
-    use super::NUM_ENDOSCALING_POINTS;
-    use crate::internal::endoscalar::NumStepsLen;
-    use ragu_primitives::vec::Len;
-
-    let num_steps = NumStepsLen::<NUM_ENDOSCALING_POINTS>::len();
-
-    // Circuit checks: k(y) = 1 (for single-proof, num_circuit_claims = num_steps)
-    core::iter::repeat_n(source.one(), num_steps)
-        // Stage checks: k(y) = 0 (infinite, matches how native does it)
-        .chain(core::iter::repeat(source.zero()))
 }

--- a/crates/ragu_pcd/src/internal/nested/mod.rs
+++ b/crates/ragu_pcd/src/internal/nested/mod.rs
@@ -29,7 +29,7 @@ pub const NUM_ENDOSCALING_POINTS: usize = 37;
 /// Index of internal nested circuits registered into the registry.
 ///
 /// These correspond to the circuit objects registered in [`register_all`].
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum InternalCircuitIndex {
     /// `EndoscalingStep` circuit at given step.
     EndoscalingStep(u32),

--- a/crates/ragu_pcd/src/verify.rs
+++ b/crates/ragu_pcd/src/verify.rs
@@ -20,6 +20,9 @@ use crate::{
     internal::{native::claims as native_claims, nested::claims as nested_claims},
 };
 
+// Import KySource trait so `.padded_ky_values()` is available in `verify`.
+use crate::internal::claims::KySource as _;
+
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
     /// Verifies some [`Pcd`] for the provided [`Header`].
     pub fn verify<RNG: CryptoRng, H: Header<C::CircuitField>>(
@@ -80,7 +83,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                 unified_ky,
             };
 
-            native::ky_values(&ky_source)
+            ky_source
+                .padded_ky_values()
                 .zip(builder.a.iter().zip(builder.b.iter()))
                 .all(|(ky, (a, b))| a.revdot(b) == ky)
         };
@@ -95,7 +99,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             nested_claims::build(&nested_source, &mut nested_builder)?;
 
             let ky_source = nested::SingleProofKySource::<C::ScalarField>::new();
-            nested::ky_values(&ky_source)
+            ky_source
+                .padded_ky_values()
                 .zip(nested_builder.a.iter().zip(nested_builder.b.iter()))
                 .all(|(ky, (a, b))| a.revdot(b) == ky)
         };
@@ -137,10 +142,10 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
 
 mod native {
     use super::*;
+    use crate::internal::claims::KySource;
     use crate::internal::claims::Source;
-    use crate::internal::native::{RxComponent, claims::KySource};
-
-    pub use crate::internal::native::claims::ky_values;
+    use crate::internal::native::RxComponent;
+    use crate::internal::native::claims::KyValues;
 
     pub struct SingleProofSource<'rx, C: Cycle, R: Rank> {
         pub proof: &'rx Proof<C, R>,
@@ -169,22 +174,17 @@ mod native {
     }
 
     impl<F: Field> KySource for SingleProofKySource<F> {
-        type Ky = F;
+        type Item = F;
 
-        fn raw_c(&self) -> impl Iterator<Item = F> {
-            once(self.raw_c)
-        }
-
-        fn application_ky(&self) -> impl Iterator<Item = F> {
-            once(self.application_ky)
-        }
-
-        fn unified_bridge_ky(&self) -> impl Iterator<Item = F> {
-            once(self.unified_bridge_ky)
-        }
-
-        fn unified_ky(&self) -> impl Iterator<Item = F> + Clone {
-            once(self.unified_ky)
+        fn ky_values(&self) -> impl Iterator<Item = F> {
+            KyValues {
+                raw: once(self.raw_c),
+                application: once(self.application_ky),
+                unified_bridge: once(self.unified_bridge_ky),
+                unified: once(self.unified_ky),
+                zero: F::ZERO,
+            }
+            .into_values()
         }
 
         fn zero(&self) -> F {
@@ -195,10 +195,9 @@ mod native {
 
 mod nested {
     use super::*;
+    use crate::internal::claims::KySource;
     use crate::internal::claims::Source;
-    use crate::internal::nested::claims::{KySource, RxComponent};
-
-    pub use crate::internal::nested::claims::ky_values;
+    use crate::internal::nested::claims::{KyValues, RxComponent};
 
     /// Source for nested field rx polynomials for single-proof verification.
     pub struct SingleProofSource<'rx, C: Cycle, R: Rank> {
@@ -235,10 +234,14 @@ mod nested {
     }
 
     impl<F: Field> KySource for SingleProofKySource<F> {
-        type Ky = F;
+        type Item = F;
 
-        fn one(&self) -> F {
-            F::ONE
+        fn ky_values(&self) -> impl Iterator<Item = F> {
+            KyValues {
+                circuit: once(F::ONE),
+                zero: F::ZERO,
+            }
+            .into_values()
         }
 
         fn zero(&self) -> F {


### PR DESCRIPTION
Here's my stab at #566. (only the ky/claimer part, since that PR contains changes for orthogonal issue like `circuit.is_registered()` check)

Instead of tracking `num_stages` to assert ky value alignment, I'd like a centrally declared claim order that is singularly responsible for the order in both `build()` and `ky_values()`. 

### Problem Statement

`build()` and `ky_values()` must iterate claims in the same order. Previously they were independent functions that implicitly agreed; if they drifted, verification would fail silently. Now both are driven by `claim_order(),` making drift impossible.

### Changes Made

- Add `ClaimOrder` + `KyKind` enums (native) and `ClaimOrder` enum (nested) that define canonical claim iteration order
- Add `KyValues<I>` structs that flatten per-group iterators in `claim_order()` sequence via `into_values()`
- Add shared `KySource` trait `(internal/claims.rs)` with `ky_values()` and `padded_ky_values()` provided method
- Rewrite `build()` in both native and nested to iterate `claim_order()`
- Delete `NUM_UNIFIED_CIRCUITS` constant