### PR TITLE
Header macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,6 +732,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ragu_app"
+version = "0.0.0"
+dependencies = [
+ "ff",
+ "group",
+ "ragu_arithmetic",
+ "ragu_circuits",
+ "ragu_core",
+ "ragu_macros",
+ "ragu_pasta",
+ "ragu_pcd",
+ "ragu_primitives",
+ "rand 0.10.0",
+]
+
+[[package]]
 name = "ragu_arithmetic"
 version = "0.0.0"
 dependencies = [
@@ -786,13 +802,16 @@ version = "0.0.0"
 name = "ragu_macros"
 version = "0.0.0"
 dependencies = [
+ "heck",
  "num-bigint",
  "num-traits",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
+ "ragu_app",
  "ragu_arithmetic",
  "ragu_core",
+ "ragu_pcd",
  "ragu_primitives",
  "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ ragu_pcd = { path = "crates/ragu_pcd", version = "0.0.0" }
 
 [workspace]
 members = [
+  "crates/ragu_app",
   "crates/ragu_arithmetic",
   "crates/ragu_circuits",
   "crates/ragu_core",

--- a/crates/ragu_app/Cargo.toml
+++ b/crates/ragu_app/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "ragu_app"
+description = "Developer APIs for building a PCD application"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+
+documentation = "https://docs.rs/ragu_app"
+categories = ["cryptography", "mathematics", "algorithms", "science", "no-std"]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--html-in-header", "katex-header.html"]
+all-features = true
+
+[lib]
+bench = false
+
+[dependencies]
+ff = { workspace = true }
+rand = { workspace = true }
+ragu_arithmetic = { path = "../ragu_arithmetic", version = "0.0.0" }
+ragu_circuits = { path = "../ragu_circuits", version = "0.0.0" }
+ragu_core = { path = "../ragu_core", version = "0.0.0" }
+ragu_macros = { path = "../ragu_macros", version = "0.0.0" }
+ragu_pcd = { path = "../ragu_pcd", version = "0.0.0" }
+ragu_primitives = { path = "../ragu_primitives", version = "0.0.0" }
+
+[dev-dependencies]
+group = { workspace = true }
+ragu_pasta = { path = "../ragu_pasta", version = "0.0.0", features = ["baked"] }

--- a/crates/ragu_app/src/lib.rs
+++ b/crates/ragu_app/src/lib.rs
@@ -27,11 +27,12 @@ pub use ragu_core::{
     drivers::{Driver, DriverValue},
     gadgets::Bound,
 };
-pub use ragu_macros::application;
+pub use ragu_macros::{application, header};
 pub use ragu_pcd::header::Header;
 pub use ragu_primitives::io::Write;
 
-/// Re-exports used by `#[application]` generated code. Not public API.
+/// Re-exports used by `#[application]` and `#[header]` generated code.
+/// Not public API.
 #[doc(hidden)]
 pub mod __macro_internal {
     pub use ::ff::Field;
@@ -40,7 +41,7 @@ pub mod __macro_internal {
     pub use ragu_core::{
         Result,
         drivers::{Driver, DriverValue},
-        gadgets::Bound,
+        gadgets::{Bound, Kind},
     };
     pub use ragu_pcd::{
         Application, ApplicationBuilder, Pcd,
@@ -52,8 +53,62 @@ pub mod __macro_internal {
 /// Simplified header trait for application developers.
 ///
 /// Unlike [`ragu_pcd::header::Header`], this trait has no `const SUFFIX`.
-/// The `#[application]` macro generates the full [`ragu_pcd::header::Header`]
-/// impl with auto-assigned suffix values based on declaration order.
+/// The [`#[application]`](macro@application) macro generates the full
+/// [`ragu_pcd::header::Header`] impl with auto-assigned suffix values based
+/// on declaration order.
+///
+/// # Using `#[header]` for single-gadget headers
+///
+/// Most headers allocate a single gadget from their witness data. For these
+/// cases, the [`#[header]`](macro@header) attribute macro generates the entire
+/// `HeaderContent` implementation automatically:
+///
+/// ```ignore
+/// use ragu_app::header;
+/// use ragu_primitives::Element;
+///
+/// /// A leaf node carrying a hashed field element.
+/// #[header(data = F, gadget = Element)]
+/// pub struct LeafNode;
+/// ```
+///
+/// This generates a generic `impl<F: Field> HeaderContent<F>` where `encode()`
+/// calls `Element::alloc(dr, witness)`. When the gadget carries additional
+/// type parameters — such as a curve type — `data` alone cannot serve as the
+/// field parameter. In that case, provide an explicit `field`:
+///
+/// ```ignore
+/// use ragu_app::header;
+/// use ragu_primitives::Point;
+///
+/// /// A header carrying a curve point.
+/// #[header(data = EpAffine, gadget = Point<EpAffine>, field = Fp)]
+/// pub struct ScaledPoint;
+/// ```
+///
+/// # Manual implementation
+///
+/// Implement `HeaderContent` manually when `encode()` computes a derived value
+/// from the witness data rather than encoding it directly — for example,
+/// encoding a Merkle root from a full Merkle tree:
+///
+/// ```ignore
+/// pub struct MerkleRoot;
+///
+/// impl<F: Field> HeaderContent<F> for MerkleRoot {
+///     // encode() receives the full tree but only commits the root hash.
+///     type Data = MerkleTree<F>;
+///     type Output = Kind![F; Element<'_, _>];
+///
+///     fn encode<'dr, D: Driver<'dr, F = F>>(
+///         dr: &mut D,
+///         witness: DriverValue<D, Self::Data>,
+///     ) -> Result<Bound<'dr, D, Self::Output>> {
+///         let root = witness.map(|tree| tree.root());
+///         Element::alloc(dr, root)
+///     }
+/// }
+/// ```
 pub trait HeaderContent<F: Field>: Send + Sync + 'static {
     /// The data needed to encode a header.
     type Data: Send + Clone;

--- a/crates/ragu_app/src/lib.rs
+++ b/crates/ragu_app/src/lib.rs
@@ -1,0 +1,111 @@
+//! Developer APIs for PCD applications using Ragu.
+//!
+//! This crate provides simplified [`Step`] and [`HeaderContent`] traits that
+//! application developers implement. The `#[application]` proc-macro (from
+//! `ragu_macros`) then generates:
+//!
+//! - [`ragu_pcd::header::Header`] impls with auto-assigned `const SUFFIX`
+//!   values from each [`HeaderContent`] impl
+//! - [`ragu_pcd::step::Step`] impls with `const INDEX` and `Encoded` bridging
+//!   from each [`Step`] impl
+//! - A wrapper struct with typed `build()`/`seed()`/`fuse()`/`verify()`/
+//!   `rerandomize()` methods
+
+#![no_std]
+#![allow(clippy::type_complexity)]
+#![deny(unsafe_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
+#![deny(missing_docs)]
+#![doc(html_favicon_url = "https://tachyon.z.cash/assets/ragu/v1/favicon-32x32.png")]
+#![doc(html_logo_url = "https://tachyon.z.cash/assets/ragu/v1/rustdoc-128x128.png")]
+
+pub use ff::Field;
+pub use ragu_arithmetic::Cycle;
+pub use ragu_circuits::polynomials::Rank;
+pub use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue},
+    gadgets::Bound,
+};
+pub use ragu_macros::application;
+pub use ragu_pcd::header::Header;
+pub use ragu_primitives::io::Write;
+
+/// Re-exports used by `#[application]` generated code. Not public API.
+#[doc(hidden)]
+pub mod __macro_internal {
+    pub use ::ff::Field;
+    pub use ::rand::CryptoRng;
+    pub use ragu_circuits::polynomials::Rank;
+    pub use ragu_core::{
+        Result,
+        drivers::{Driver, DriverValue},
+        gadgets::Bound,
+    };
+    pub use ragu_pcd::{
+        Application, ApplicationBuilder, Pcd,
+        header::{Header, Suffix},
+        step::{Encoded, Index, Step as PcdStep},
+    };
+}
+
+/// Simplified header trait for application developers.
+///
+/// Unlike [`ragu_pcd::header::Header`], this trait has no `const SUFFIX`.
+/// The `#[application]` macro generates the full [`ragu_pcd::header::Header`]
+/// impl with auto-assigned suffix values based on declaration order.
+pub trait HeaderContent<F: Field>: Send + Sync + 'static {
+    /// The data needed to encode a header.
+    type Data: Send + Clone;
+
+    /// The output gadget that encodes the data for this header.
+    type Output: Write<F>;
+
+    /// Encode some data into a gadget representing this header.
+    fn encode<'dr, D: Driver<'dr, F = F>>(
+        dr: &mut D,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>>;
+}
+
+/// Simplified step trait for application developers.
+///
+/// Unlike [`ragu_pcd::step::Step`], this trait has no `const INDEX` and works
+/// with pre-encoded header gadgets (`&Bound<...>`) instead of raw `Encoded`
+/// types. The `#[application]` macro generates the full [`ragu_pcd::step::Step`]
+/// impl that bridges between this trait and the internal encoding layer.
+pub trait Step<C: Cycle>: Sized + Send + Sync {
+    /// The witness data needed to construct a proof for this step.
+    type Witness: Send;
+
+    /// The "left" header expected during this step.
+    type Left: Header<C::CircuitField>;
+
+    /// The "right" header expected during this step.
+    type Right: Header<C::CircuitField>;
+
+    /// The header produced during this step.
+    type Output: Header<C::CircuitField>;
+
+    /// Auxiliary information produced during circuit synthesis that may be
+    /// used to pipeline witness data to future steps.
+    type Aux: Send;
+
+    /// Constrain this step. Receives pre-encoded left/right header gadgets.
+    ///
+    /// Returns the output header gadget, the output data to carry in the
+    /// resulting PCD, and any auxiliary witness data.
+    fn synthesize<'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Self::Witness>,
+        left: &Bound<'dr, D, <Self::Left as Header<C::CircuitField>>::Output>,
+        right: &Bound<'dr, D, <Self::Right as Header<C::CircuitField>>::Output>,
+    ) -> Result<(
+        Bound<'dr, D, <Self::Output as Header<C::CircuitField>>::Output>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
+        DriverValue<D, Self::Aux>,
+    )>
+    where
+        Self: 'dr;
+}

--- a/crates/ragu_app/tests/example.rs
+++ b/crates/ragu_app/tests/example.rs
@@ -1,8 +1,7 @@
-use ff::Field;
 use group::prime::PrimeCurveAffine;
-use ragu_app::{Bound, Cycle, Driver, DriverValue, Header, HeaderContent, Result, application};
+use ragu_app::{Bound, Cycle, Driver, DriverValue, Header, Result, application, header};
 use ragu_circuits::polynomials::ProductionRank;
-use ragu_core::{gadgets::Kind, maybe::Maybe};
+use ragu_core::maybe::Maybe;
 use ragu_pasta::{EpAffine, Fp, Pasta};
 use ragu_primitives::{Element, Endoscalar, Point, poseidon::Sponge};
 use rand::SeedableRng;
@@ -13,49 +12,16 @@ use rand::rngs::StdRng;
 // ==========================================================================
 
 /// Header for a hashed leaf value.
+#[header(data = F, gadget = Element)]
 pub struct LeafNode;
 
-impl<F: Field> HeaderContent<F> for LeafNode {
-    type Data = F;
-    type Output = Kind![F; Element<'_, _>];
-
-    fn encode<'dr, D: Driver<'dr, F = F>>(
-        dr: &mut D,
-        witness: DriverValue<D, Self::Data>,
-    ) -> Result<Bound<'dr, D, Self::Output>> {
-        Element::alloc(dr, witness)
-    }
-}
-
 /// Header for a hash node whose value serves as an endoscalar source.
+#[header(data = F, gadget = Element)]
 pub struct ExponentNode;
 
-impl<F: Field> HeaderContent<F> for ExponentNode {
-    type Data = F;
-    type Output = Kind![F; Element<'_, _>];
-
-    fn encode<'dr, D: Driver<'dr, F = F>>(
-        dr: &mut D,
-        witness: DriverValue<D, Self::Data>,
-    ) -> Result<Bound<'dr, D, Self::Output>> {
-        Element::alloc(dr, witness)
-    }
-}
-
 /// Header carrying a scaled curve point.
+#[header(data = EpAffine, gadget = Point<EpAffine>, field = Fp)]
 pub struct ScaledPoint;
-
-impl HeaderContent<Fp> for ScaledPoint {
-    type Data = EpAffine;
-    type Output = Kind![Fp; Point<'_, _, EpAffine>];
-
-    fn encode<'dr, D: Driver<'dr, F = Fp>>(
-        dr: &mut D,
-        witness: DriverValue<D, Self::Data>,
-    ) -> Result<Bound<'dr, D, Self::Output>> {
-        Point::alloc(dr, witness)
-    }
-}
 
 // ==========================================================================
 // Steps

--- a/crates/ragu_app/tests/example.rs
+++ b/crates/ragu_app/tests/example.rs
@@ -192,13 +192,13 @@ impl ragu_app::Step<Pasta> for Endoscale {
 /// ```
 #[application]
 pub enum ExampleApp<'params, C: Cycle> {
-    #[step(left = (), right = (), output = LeafNode)]
+    #[step(output = LeafNode)]
     WitnessLeaf(WitnessLeaf<'params, C>),
 
-    #[step(left = LeafNode, right = LeafNode, output = ExponentNode)]
+    #[step(output = ExponentNode)]
     Hash2(Hash2<'params, C>),
 
-    #[step(left = ExponentNode, right = (), output = ScaledPoint)]
+    #[step(output = ScaledPoint)]
     Endoscale(Endoscale),
 }
 

--- a/crates/ragu_app/tests/example.rs
+++ b/crates/ragu_app/tests/example.rs
@@ -1,0 +1,260 @@
+use ff::Field;
+use group::prime::PrimeCurveAffine;
+use ragu_app::{Bound, Cycle, Driver, DriverValue, Header, HeaderContent, Result, application};
+use ragu_circuits::polynomials::ProductionRank;
+use ragu_core::{gadgets::Kind, maybe::Maybe};
+use ragu_pasta::{EpAffine, Fp, Pasta};
+use ragu_primitives::{Element, Endoscalar, Point, poseidon::Sponge};
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+// ==========================================================================
+// Headers
+// ==========================================================================
+
+/// Header for a hashed leaf value.
+pub struct LeafNode;
+
+impl<F: Field> HeaderContent<F> for LeafNode {
+    type Data = F;
+    type Output = Kind![F; Element<'_, _>];
+
+    fn encode<'dr, D: Driver<'dr, F = F>>(
+        dr: &mut D,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, witness)
+    }
+}
+
+/// Header for a hash node whose value serves as an endoscalar source.
+pub struct ExponentNode;
+
+impl<F: Field> HeaderContent<F> for ExponentNode {
+    type Data = F;
+    type Output = Kind![F; Element<'_, _>];
+
+    fn encode<'dr, D: Driver<'dr, F = F>>(
+        dr: &mut D,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, witness)
+    }
+}
+
+/// Header carrying a scaled curve point.
+pub struct ScaledPoint;
+
+impl HeaderContent<Fp> for ScaledPoint {
+    type Data = EpAffine;
+    type Output = Kind![Fp; Point<'_, _, EpAffine>];
+
+    fn encode<'dr, D: Driver<'dr, F = Fp>>(
+        dr: &mut D,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Point::alloc(dr, witness)
+    }
+}
+
+// ==========================================================================
+// Steps
+// ==========================================================================
+
+/// Hash a witness field element to produce a leaf.
+pub struct WitnessLeaf<'params, C: Cycle> {
+    pub poseidon_params: &'params C::CircuitPoseidon,
+}
+
+impl<C: Cycle> ragu_app::Step<C> for WitnessLeaf<'_, C> {
+    type Witness = C::CircuitField;
+    type Left = ();
+    type Right = ();
+    type Output = LeafNode;
+    type Aux = ();
+
+    fn synthesize<'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Self::Witness>,
+        _left: &Bound<'dr, D, <Self::Left as Header<C::CircuitField>>::Output>,
+        _right: &Bound<'dr, D, <Self::Right as Header<C::CircuitField>>::Output>,
+    ) -> Result<(
+        Bound<'dr, D, <Self::Output as Header<C::CircuitField>>::Output>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
+        DriverValue<D, Self::Aux>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let leaf = Element::alloc(dr, witness)?;
+        let mut sponge = Sponge::new(dr, self.poseidon_params);
+        sponge.absorb(dr, &leaf)?;
+        let output = sponge.squeeze(dr)?;
+        let output_data = output.value().map(|v| *v);
+        Ok((output, output_data, D::unit()))
+    }
+}
+
+/// Hash two leaf children into an internal node.
+pub struct Hash2<'params, C: Cycle> {
+    pub poseidon_params: &'params C::CircuitPoseidon,
+}
+
+impl<C: Cycle> ragu_app::Step<C> for Hash2<'_, C> {
+    type Witness = ();
+    type Left = LeafNode;
+    type Right = LeafNode;
+    type Output = ExponentNode;
+    type Aux = ();
+
+    fn synthesize<'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
+        &self,
+        dr: &mut D,
+        _witness: DriverValue<D, Self::Witness>,
+        left: &Bound<'dr, D, <Self::Left as Header<C::CircuitField>>::Output>,
+        right: &Bound<'dr, D, <Self::Right as Header<C::CircuitField>>::Output>,
+    ) -> Result<(
+        Bound<'dr, D, <Self::Output as Header<C::CircuitField>>::Output>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
+        DriverValue<D, Self::Aux>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let mut sponge = Sponge::new(dr, self.poseidon_params);
+        sponge.absorb(dr, left)?;
+        sponge.absorb(dr, right)?;
+        let output = sponge.squeeze(dr)?;
+        let output_data = output.value().map(|v| *v);
+        Ok((output, output_data, D::unit()))
+    }
+}
+
+/// Extract an endoscalar from the internal node hash and perform
+/// endoscalar group scaling on the generator point.
+pub struct Endoscale;
+
+impl ragu_app::Step<Pasta> for Endoscale {
+    type Witness = ();
+    type Left = ExponentNode;
+    type Right = ();
+    type Output = ScaledPoint;
+    type Aux = ();
+
+    fn synthesize<'dr, D: Driver<'dr, F = Fp>, const HEADER_SIZE: usize>(
+        &self,
+        dr: &mut D,
+        _witness: DriverValue<D, Self::Witness>,
+        left: &Bound<'dr, D, <Self::Left as Header<Fp>>::Output>,
+        _right: &Bound<'dr, D, <Self::Right as Header<Fp>>::Output>,
+    ) -> Result<(
+        Bound<'dr, D, <Self::Output as Header<Fp>>::Output>,
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux>,
+    )>
+    where
+        Self: 'dr,
+    {
+        // Extract endoscalar from the internal node's hash element.
+        let endo = Endoscalar::extract(dr, left.clone())?;
+
+        // Create a constant generator point on the nested curve.
+        let point = Point::<D, EpAffine>::constant(dr, EpAffine::generator())?;
+
+        // Perform endoscalar group scaling.
+        let scaled = endo.group_scale(dr, &point)?;
+
+        let output_data = scaled.value();
+        Ok((scaled, output_data, D::unit()))
+    }
+}
+
+// ==========================================================================
+// Application
+// ==========================================================================
+
+/// Example PCD application demonstrating a three-step pipeline:
+/// Poseidon hashing, Merkle-style merging, and endoscalar group scaling.
+///
+/// ```text
+/// WitnessLeaf  WitnessLeaf
+///     |            |
+/// [LeafNode]   [LeafNode]
+///       \        /
+///          Hash2
+///            |
+///     [ExponentNode]  [trivial right]
+///            \         /
+///             Endoscale
+///                 |
+///           [ScaledPoint]
+/// ```
+#[application]
+pub enum ExampleApp<'params, C: Cycle> {
+    #[step(left = (), right = (), output = LeafNode)]
+    WitnessLeaf(WitnessLeaf<'params, C>),
+
+    #[step(left = LeafNode, right = LeafNode, output = ExponentNode)]
+    Hash2(Hash2<'params, C>),
+
+    #[step(left = ExponentNode, right = (), output = ScaledPoint)]
+    Endoscale(Endoscale),
+}
+
+#[test]
+fn example_pipeline() -> Result<()> {
+    let pasta = Pasta::baked();
+    let poseidon = Pasta::circuit_poseidon(pasta);
+
+    let app = ExampleApp::<Pasta, ProductionRank, 4>::build(
+        pasta,
+        WitnessLeaf {
+            poseidon_params: poseidon,
+        },
+        Hash2 {
+            poseidon_params: poseidon,
+        },
+        Endoscale,
+    )?;
+
+    let mut rng = StdRng::seed_from_u64(5678);
+
+    // Create two leaves.
+    let (leaf1, _) = app.seed(
+        &mut rng,
+        WitnessLeaf {
+            poseidon_params: poseidon,
+        },
+        Fp::from(100u64),
+    )?;
+    assert!(app.verify(&leaf1, &mut rng)?);
+
+    let (leaf2, _) = app.seed(
+        &mut rng,
+        WitnessLeaf {
+            poseidon_params: poseidon,
+        },
+        Fp::from(200u64),
+    )?;
+    assert!(app.verify(&leaf2, &mut rng)?);
+
+    // Hash the two leaves into an internal node.
+    let (internal, _) = app.fuse(
+        &mut rng,
+        Hash2 {
+            poseidon_params: poseidon,
+        },
+        (),
+        leaf1,
+        leaf2,
+    )?;
+    assert!(app.verify(&internal, &mut rng)?);
+
+    // Extract endoscalar from the hash and scale the generator.
+    let trivial = app.trivial_pcd(&mut rng);
+    let (scaled, _) = app.fuse(&mut rng, Endoscale, (), internal, trivial)?;
+    assert!(app.verify(&scaled, &mut rng)?);
+
+    Ok(())
+}

--- a/crates/ragu_macros/Cargo.toml
+++ b/crates/ragu_macros/Cargo.toml
@@ -24,12 +24,14 @@ quote = "1.0.40"
 proc-macro2 = "1.0.95"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
+heck = "0.5.0"
 proc-macro-crate = "3.3.0"
 
 [dependencies.syn]
 version = "2.0.101"
+features = ["full"]
 # Helpful for debugging:
-# features = ["full", "extra-traits"]
+# features = ["extra-traits"]
 
 [dev-dependencies]
 
@@ -37,6 +39,8 @@ version = "2.0.101"
 # when building doc tests that invoke derive macros inside the derive macro's
 # actual documentation. Also, this allows us to have compilation errors if paths
 # change where macros are ultimately re-exported downstream.
+ragu_app = { path = "../ragu_app", version = "0.0.0" }
 ragu_arithmetic = { path = "../ragu_arithmetic", version = "0.0.0" }
 ragu_core = { path = "../ragu_core", version = "0.0.0" }
+ragu_pcd = { path = "../ragu_pcd", version = "0.0.0" }
 ragu_primitives = { path = "../ragu_primitives", version = "0.0.0" }

--- a/crates/ragu_macros/src/lib.rs
+++ b/crates/ragu_macros/src/lib.rs
@@ -17,7 +17,7 @@ mod proc;
 mod substitution;
 
 use proc_macro::TokenStream;
-use syn::{DeriveInput, ItemEnum, LitInt, parse_macro_input};
+use syn::{DeriveInput, ItemEnum, ItemStruct, LitInt, parse_macro_input};
 
 use helpers::macro_body;
 
@@ -113,18 +113,48 @@ use ragu_pcd as _;
 ///
 /// ```ignore
 /// #[application]
-/// pub enum MerkleTree<C: Cycle> {
-///     #[step(left = (), right = (), output = LeafNode)]
-///     WitnessLeaf(WitnessLeaf<'_, C>),
+/// pub enum MerkleTree<'params, C: Cycle> {
+///     #[step(output = LeafNode)]
+///     WitnessLeaf(WitnessLeaf<'params, C>),
 ///
-///     #[step(left = LeafNode, right = LeafNode, output = InternalNode)]
-///     Hash2(Hash2<'_, C>),
+///     #[step(output = InternalNode)]
+///     Hash2(Hash2<'params, C>),
 /// }
 /// ```
 #[proc_macro_attribute]
 pub fn application(_attr: TokenStream, input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemEnum);
     macro_body(|| proc::application::evaluate(input))
+}
+
+/// Attribute macro for generating single-gadget `HeaderContent` implementations.
+///
+/// For headers where `encode()` allocates a single gadget directly from
+/// witness data, this macro generates the full `HeaderContent` implementation.
+///
+/// # Attributes
+///
+/// - `data`: The witness data type (required).
+/// - `gadget`: The gadget type to allocate (required).
+/// - `field`: The field type for a concrete impl (optional; when omitted,
+///   `data` is used as a generic field type parameter).
+///
+/// # Example
+///
+/// ```ignore
+/// // Generic: F is both the field type and the witness data type
+/// #[header(data = F, gadget = Element)]
+/// pub struct LeafNode;
+///
+/// // Concrete: data is a curve point, field is explicit
+/// #[header(data = EpAffine, gadget = Point<EpAffine>, field = Fp)]
+/// pub struct ScaledPoint;
+/// ```
+#[proc_macro_attribute]
+pub fn header(attr: TokenStream, input: TokenStream) -> TokenStream {
+    let attr = parse_macro_input!(attr as proc::header::HeaderAttr);
+    let input = parse_macro_input!(input as ItemStruct);
+    macro_body(|| proc::header::evaluate(attr, input))
 }
 
 #[cfg(test)]

--- a/crates/ragu_macros/src/lib.rs
+++ b/crates/ragu_macros/src/lib.rs
@@ -17,7 +17,7 @@ mod proc;
 mod substitution;
 
 use proc_macro::TokenStream;
-use syn::{DeriveInput, LitInt, parse_macro_input};
+use syn::{DeriveInput, ItemEnum, LitInt, parse_macro_input};
 
 use helpers::macro_body;
 
@@ -93,6 +93,38 @@ pub fn derive_consistent(input: TokenStream) -> TokenStream {
         let ragu_primitives_path = path_resolution::RaguPrimitivesPath::resolve()?;
         derive::consistent::derive(input, ragu_core_path, ragu_primitives_path)
     })
+}
+
+#[cfg(test)]
+#[allow(unused_imports)]
+use ragu_app as _;
+
+#[cfg(test)]
+#[allow(unused_imports)]
+use ragu_pcd as _;
+
+/// Attribute macro for defining a PCD application.
+///
+/// Generates `ragu_pcd::Header` impls (with `const SUFFIX`),
+/// `ragu_pcd::Step` impls (with `const INDEX`), and a wrapper struct
+/// with `build()`/`seed()`/`fuse()`/`verify()`/`rerandomize()` methods.
+///
+/// # Example
+///
+/// ```ignore
+/// #[application]
+/// pub enum MerkleTree<C: Cycle> {
+///     #[step(left = (), right = (), output = LeafNode)]
+///     WitnessLeaf(WitnessLeaf<'_, C>),
+///
+///     #[step(left = LeafNode, right = LeafNode, output = InternalNode)]
+///     Hash2(Hash2<'_, C>),
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn application(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemEnum);
+    macro_body(|| proc::application::evaluate(input))
 }
 
 #[cfg(test)]

--- a/crates/ragu_macros/src/path_resolution.rs
+++ b/crates/ragu_macros/src/path_resolution.rs
@@ -11,10 +11,19 @@ use quote::{ToTokens, format_ident};
 use syn::{Error, Ident, Path, Result, parse_quote};
 
 #[derive(Clone)]
+pub struct RaguAppPath(Path);
+
+#[derive(Clone)]
 pub struct RaguCorePath(Path);
 
 #[derive(Clone)]
 pub struct RaguPrimitivesPath(Path);
+
+impl ToTokens for RaguAppPath {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        self.0.to_tokens(tokens)
+    }
+}
 
 impl ToTokens for RaguCorePath {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
@@ -28,6 +37,12 @@ impl ToTokens for RaguPrimitivesPath {
     }
 }
 
+impl Default for RaguAppPath {
+    fn default() -> Self {
+        Self(parse_quote! { ::ragu_app })
+    }
+}
+
 impl Default for RaguCorePath {
     fn default() -> Self {
         Self(parse_quote! { ::ragu_core })
@@ -38,6 +53,23 @@ impl Default for RaguPrimitivesPath {
     fn default() -> Self {
         Self(parse_quote! { ::ragu_primitives })
     }
+}
+
+fn ragu_app_path() -> Result<Path> {
+    Ok(match (crate_name("ragu_app"), crate_name("ragu")) {
+        (Ok(FoundCrate::Itself), _) => parse_quote! { ::ragu_app },
+        (_, Ok(FoundCrate::Itself)) => parse_quote! { ::ragu::app },
+        (Ok(FoundCrate::Name(name)), _) | (Err(_), Ok(FoundCrate::Name(name))) => {
+            let name: Ident = format_ident!("{}", name);
+            parse_quote! { ::#name }
+        }
+        _ => {
+            return Err(Error::new(
+                Span::call_site(),
+                "Failed to find ragu/ragu_app crate. Ensure it is included in your Cargo.toml.",
+            ));
+        }
+    })
 }
 
 fn ragu_core_path() -> Result<Path> {
@@ -76,6 +108,12 @@ fn ragu_primitives_path() -> Result<Path> {
             ));
         }
     })
+}
+
+impl RaguAppPath {
+    pub fn resolve() -> Result<Self> {
+        ragu_app_path().map(Self)
+    }
 }
 
 impl RaguCorePath {

--- a/crates/ragu_macros/src/proc/application.rs
+++ b/crates/ragu_macros/src/proc/application.rs
@@ -320,16 +320,16 @@ fn generate_step_impls(
             {
                 const INDEX: #prelude::Index = #prelude::Index::new(#index);
 
-                type Witness = <#step_ty as #app::Step<#cycle>>::Witness;
+                type Witness<'source> = <#step_ty as #app::Step<#cycle>>::Witness;
                 type Left = <#step_ty as #app::Step<#cycle>>::Left;
                 type Right = <#step_ty as #app::Step<#cycle>>::Right;
                 type Output = <#step_ty as #app::Step<#cycle>>::Output;
-                type Aux = <#step_ty as #app::Step<#cycle>>::Aux;
+                type Aux<'source> = <#step_ty as #app::Step<#cycle>>::Aux;
 
-                fn witness<'dr, __D: #prelude::Driver<'dr, F = #cycle::CircuitField>, const HEADER_SIZE: usize>(
+                fn witness<'dr, 'source: 'dr, __D: #prelude::Driver<'dr, F = #cycle::CircuitField>, const HEADER_SIZE: usize>(
                     &self,
                     dr: &mut __D,
-                    witness: #prelude::DriverValue<__D, Self::Witness>,
+                    witness: #prelude::DriverValue<__D, Self::Witness<'source>>,
                     left: #prelude::DriverValue<
                         __D,
                         <Self::Left as #prelude::Header<#cycle::CircuitField>>::Data,
@@ -348,7 +348,7 @@ fn generate_step_impls(
                         __D,
                         <Self::Output as #prelude::Header<#cycle::CircuitField>>::Data,
                     >,
-                    #prelude::DriverValue<__D, Self::Aux>,
+                    #prelude::DriverValue<__D, Self::Aux<'source>>,
                 )>
                 where
                     Self: 'dr,
@@ -585,24 +585,24 @@ fn generate_wrapper(
             }
 
             /// Seed a new computation by running a step with trivial inputs.
-            #vis fn seed<__RNG: #prelude::CryptoRng, __S: #prelude::PcdStep<#cycle, Left = (), Right = ()>>(
+            #vis fn seed<'source, __RNG: #prelude::CryptoRng, __S: #prelude::PcdStep<#cycle, Left = (), Right = ()>>(
                 &self,
                 rng: &mut __RNG,
                 step: __S,
-                witness: __S::Witness,
-            ) -> #prelude::Result<(#prelude::Pcd<#cycle, __R, __S::Output>, __S::Aux)> {
+                witness: __S::Witness<'source>,
+            ) -> #prelude::Result<(#prelude::Pcd<#cycle, __R, __S::Output>, __S::Aux<'source>)> {
                 self.inner.seed(rng, step, witness)
             }
 
             /// Fuse two pieces of proof-carrying data using a step.
-            #vis fn fuse<__RNG: #prelude::CryptoRng, __S: #prelude::PcdStep<#cycle>>(
+            #vis fn fuse<'source, __RNG: #prelude::CryptoRng, __S: #prelude::PcdStep<#cycle>>(
                 &self,
                 rng: &mut __RNG,
                 step: __S,
-                witness: __S::Witness,
+                witness: __S::Witness<'source>,
                 left: #prelude::Pcd<#cycle, __R, __S::Left>,
                 right: #prelude::Pcd<#cycle, __R, __S::Right>,
-            ) -> #prelude::Result<(#prelude::Pcd<#cycle, __R, __S::Output>, __S::Aux)> {
+            ) -> #prelude::Result<(#prelude::Pcd<#cycle, __R, __S::Output>, __S::Aux<'source>)> {
                 self.inner.fuse(rng, step, witness, left, right)
             }
 

--- a/crates/ragu_macros/src/proc/application.rs
+++ b/crates/ragu_macros/src/proc/application.rs
@@ -24,10 +24,10 @@ use crate::path_resolution::RaguAppPath;
 /// ```ignore
 /// #[application]
 /// enum MyApp<'param, C: Cycle> {
-///    #[step(left = (), right = (), output = LeafNode)]
+///    #[step(output = LeafNode)]
 ///    WitnessLeaf(WitnessLeaf<'params, C>),
 ///
-///    #[step(left = LeafNode, right = LeafNode, output = HashNode)]
+///    #[step(output = HashNode)]
 ///    Hash2(Hash2<'params, C>),
 /// }
 pub fn evaluate(input: ItemEnum) -> Result<TokenStream> {
@@ -92,17 +92,18 @@ pub fn evaluate(input: ItemEnum) -> Result<TokenStream> {
 // ---------------------------------------------------------------------------
 
 /// Parsed `#[step(...)]` attribute on a variant.
-/// Expected format: `#[step(left = Type, right = Type, output = Type)]`
+/// Expected format: `#[step(output = Type)]`
+///
+/// Only the `output` header type is required — left/right are inferred from
+/// the `ragu_app::Step` trait implementation. The macro needs `output` to
+/// collect unique header types for suffix assignment (proc-macros can't
+/// resolve associated types).
 struct StepAttr {
-    left: Type,
-    right: Type,
     output: Type,
 }
 
 impl Parse for StepAttr {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
-        let mut left = None;
-        let mut right = None;
         let mut output = None;
 
         while !input.is_empty() {
@@ -111,8 +112,6 @@ impl Parse for StepAttr {
             let ty: Type = input.parse()?;
 
             match ident.to_string().as_str() {
-                "left" => left = Some(ty),
-                "right" => right = Some(ty),
                 "output" => output = Some(ty),
                 other => {
                     return Err(Error::new(
@@ -128,9 +127,6 @@ impl Parse for StepAttr {
         }
 
         Ok(StepAttr {
-            left: left.ok_or_else(|| Error::new(input.span(), "missing `left` in #[step(...)]"))?,
-            right: right
-                .ok_or_else(|| Error::new(input.span(), "missing `right` in #[step(...)]"))?,
             output: output
                 .ok_or_else(|| Error::new(input.span(), "missing `output` in #[step(...)]"))?,
         })
@@ -174,19 +170,18 @@ fn extract_variant_type(variant: &Variant) -> Result<Type> {
     }
 }
 
-/// Collect unique non-unit header types from step attributes, preserving
-/// first-appearance order (which determines suffix assignment).
+/// Collect unique non-unit header types from step `output` attributes,
+/// preserving first-appearance order (which determines suffix assignment).
 fn collect_unique_headers(variants: &[ParsedVariant]) -> Vec<Type> {
     let mut seen = BTreeSet::new();
     let mut headers = Vec::new();
     for v in variants {
-        for ty in [&v.step_attr.left, &v.step_attr.right, &v.step_attr.output] {
-            if is_unit_type(ty) {
-                continue;
-            }
-            if seen.insert(quote!(#ty).to_string()) {
-                headers.push(ty.clone());
-            }
+        let ty = &v.step_attr.output;
+        if is_unit_type(ty) {
+            continue;
+        }
+        if seen.insert(quote!(#ty).to_string()) {
+            headers.push(ty.clone());
         }
     }
     headers
@@ -278,20 +273,26 @@ fn type_args_with(generics: &Generics, extra: TokenStream) -> TokenStream {
 /// user's `ragu_app::Step::synthesize` (which works with pre-encoded `&Bound`
 /// gadgets), then wraps the output via `Encoded::from_gadget`.
 ///
+/// Associated types (`Left`, `Right`, `Output`) are delegated to the
+/// `ragu_app::Step` trait — the macro doesn't need to know them.
+///
 /// # Example
 ///
-/// For variant `#[step(left = LeafNode, right = LeafNode, output = ExponentNode)]
-/// Hash2(Hash2<'p, C>)` at index 1:
+/// For variant `#[step(output = ExponentNode)] Hash2(Hash2<'p, C>)` at index 1:
 ///
 /// ```ignore
 /// impl<'p, C: Cycle> PcdStep<C> for Hash2<'p, C>
 /// where
-///     Hash2<'p, C>: ragu_app::Step<C, Left = LeafNode, Right = LeafNode, Output = ExponentNode>,
-///     LeafNode: Header<C::CircuitField>,
-///     ExponentNode: Header<C::CircuitField>,
+///     Hash2<'p, C>: ragu_app::Step<C>,
+///     <Hash2<'p, C> as ragu_app::Step<C>>::Left: Header<C::CircuitField>,
+///     <Hash2<'p, C> as ragu_app::Step<C>>::Right: Header<C::CircuitField>,
+///     <Hash2<'p, C> as ragu_app::Step<C>>::Output: Header<C::CircuitField>,
 /// {
 ///     const INDEX: Index = Index::new(1);
-///     // ... type aliases and witness() bridging impl
+///     type Left = <Hash2<'p, C> as ragu_app::Step<C>>::Left;
+///     type Right = <Hash2<'p, C> as ragu_app::Step<C>>::Right;
+///     type Output = <Hash2<'p, C> as ragu_app::Step<C>>::Output;
+///     // ... witness() bridging impl
 /// }
 /// ```
 fn generate_step_impls(
@@ -308,28 +309,21 @@ fn generate_step_impls(
     for v in variants {
         let step_ty = &v.step_ty;
         let index = v.index;
-        let left_ty = &v.step_attr.left;
-        let right_ty = &v.step_attr.right;
-        let output_ty = &v.step_attr.output;
 
         impls.extend(quote! {
             impl<#(#enum_params),*> #prelude::PcdStep<#cycle> for #step_ty
             where
-                #step_ty: #app::Step<#cycle,
-                    Left = #left_ty,
-                    Right = #right_ty,
-                    Output = #output_ty,
-                >,
-                #left_ty: #prelude::Header<#cycle::CircuitField>,
-                #right_ty: #prelude::Header<#cycle::CircuitField>,
-                #output_ty: #prelude::Header<#cycle::CircuitField>,
+                #step_ty: #app::Step<#cycle>,
+                <#step_ty as #app::Step<#cycle>>::Left: #prelude::Header<#cycle::CircuitField>,
+                <#step_ty as #app::Step<#cycle>>::Right: #prelude::Header<#cycle::CircuitField>,
+                <#step_ty as #app::Step<#cycle>>::Output: #prelude::Header<#cycle::CircuitField>,
             {
                 const INDEX: #prelude::Index = #prelude::Index::new(#index);
 
                 type Witness = <#step_ty as #app::Step<#cycle>>::Witness;
-                type Left = #left_ty;
-                type Right = #right_ty;
-                type Output = #output_ty;
+                type Left = <#step_ty as #app::Step<#cycle>>::Left;
+                type Right = <#step_ty as #app::Step<#cycle>>::Right;
+                type Output = <#step_ty as #app::Step<#cycle>>::Output;
                 type Aux = <#step_ty as #app::Step<#cycle>>::Aux;
 
                 fn witness<'dr, __D: #prelude::Driver<'dr, F = #cycle::CircuitField>, const HEADER_SIZE: usize>(
@@ -467,10 +461,10 @@ fn generate_header_impls(
 /// ```ignore
 /// #[application]
 /// pub enum ExampleApp<'params, C: Cycle> {
-///     #[step(left = (), right = (), output = LeafNode)]
+///     #[step(output = LeafNode)]
 ///     WitnessLeaf(WitnessLeaf<'params, C>),
 ///
-///     #[step(left = LeafNode, right = LeafNode, output = ExponentNode)]
+///     #[step(output = ExponentNode)]
 ///     Hash2(Hash2<'params, C>),
 /// }
 /// ```
@@ -494,8 +488,8 @@ fn generate_header_impls(
 ///     // conditional on `ragu_app::Step<C>`. Without these, non-generic
 ///     // steps (e.g. `Endoscale: Step<Pasta>`) fail to resolve for
 ///     // generic `C`.
-///     WitnessLeaf<'params, C>: Step<C, Left = (), Right = (), Output = LeafNode>,
-///     Hash2<'params, C>: Step<C, Left = LeafNode, Right = LeafNode, Output = ExponentNode>,
+///     WitnessLeaf<'params, C>: Step<C>,
+///     Hash2<'params, C>: Step<C>,
 /// {
 ///     pub fn build(
 ///         params: &'params C::Params,
@@ -555,17 +549,16 @@ fn generate_wrapper(
         .map(|h| quote!(#h: #prelude::Header<#cycle::CircuitField>))
         .collect();
 
-    // Where clause: each step type must impl `ragu_app::Step<C>` with matching
-    // associated types. Required so `.register()` in `build()` can resolve the
-    // generated `PcdStep<C>` impl (which is conditional on this bound).
+    // Where clause: each step type must impl `ragu_app::Step<C>`.
+    // Required so `.register()` in `build()` can resolve the generated
+    // `PcdStep<C>` impl (which is conditional on this bound). Without these,
+    // non-generic steps (e.g. `Endoscale: Step<Pasta>`) fail to resolve for
+    // generic `C`.
     let step_bounds: Vec<_> = variants
         .iter()
         .map(|v| {
             let step_ty = &v.step_ty;
-            let left = &v.step_attr.left;
-            let right = &v.step_attr.right;
-            let output = &v.step_attr.output;
-            quote!(#step_ty: #app::Step<#cycle, Left = #left, Right = #right, Output = #output>)
+            quote!(#step_ty: #app::Step<#cycle>)
         })
         .collect();
 

--- a/crates/ragu_macros/src/proc/application.rs
+++ b/crates/ragu_macros/src/proc/application.rs
@@ -1,0 +1,642 @@
+//! Implementation of the `#[application]` proc-macro.
+//!
+//! Parses an enum annotated with `#[application]` and generates:
+//! - `ragu_pcd::step::Step` impls (with `const INDEX`) bridging from `ragu_app::Step`
+//! - A wrapper struct with typed `build()`/`seed()`/`fuse()`/`verify()`/`rerandomize()`
+//! - Compile-time assertions for header suffix uniqueness
+
+use std::collections::BTreeSet;
+
+use heck::ToSnakeCase;
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{
+    Attribute, Error, Fields, GenericParam, Generics, Ident, ItemEnum, Result, Token, Type,
+    Variant, Visibility, parse::Parse, parse::ParseStream,
+};
+
+use crate::path_resolution::RaguAppPath;
+
+/// Main entry point for the `#[application]` macro.
+///
+/// # Example
+///
+/// ```ignore
+/// #[application]
+/// enum MyApp<'param, C: Cycle> {
+///    #[step(left = (), right = (), output = LeafNode)]
+///    WitnessLeaf(WitnessLeaf<'params, C>),
+///
+///    #[step(left = LeafNode, right = LeafNode, output = HashNode)]
+///    Hash2(Hash2<'params, C>),
+/// }
+pub fn evaluate(input: ItemEnum) -> Result<TokenStream> {
+    let app = RaguAppPath::resolve()?;
+
+    let vis = &input.vis;
+    let enum_ident = &input.ident;
+    let enum_generics = &input.generics;
+    let cycle = find_cycle_param(enum_generics)?;
+    let params_lt = find_params_lifetime(enum_generics)?;
+
+    // Parse all variants, each variant is a step type with a #[step(...)] attribute.
+    // The variant name (e.g. `WitnessLeaf`) is used as the `build()` parameter name
+    // (converted to snake_case); the inner type is the actual Step implementor.
+    let mut variants = Vec::new();
+    for (index, variant) in input.variants.iter().enumerate() {
+        let step_attr = parse_step_attr(&variant.attrs)?;
+        let step_ty = extract_variant_type(variant)?;
+        variants.push(ParsedVariant {
+            name: variant.ident.clone(),
+            step_ty,
+            step_attr,
+            index,
+        });
+    }
+
+    if variants.is_empty() {
+        return Err(Error::new_spanned(
+            &input,
+            "application must have at least one step",
+        ));
+    }
+
+    // Collect unique headers for suffix/Header impl generation.
+    let headers = collect_unique_headers(&variants);
+    // All generated code references items through `ragu_app::__macro_internal`.
+    let prelude = quote!(#app::__macro_internal);
+
+    let header_impls = generate_header_impls(&headers, &app, &prelude);
+    let step_impls = generate_step_impls(&variants, enum_generics, &cycle, &app, &prelude)?;
+    let wrapper = generate_wrapper(
+        vis,
+        enum_ident,
+        enum_generics,
+        &cycle,
+        &params_lt,
+        &variants,
+        &headers,
+        &app,
+        &prelude,
+    )?;
+
+    Ok(quote! {
+        #header_impls
+        #step_impls
+        #wrapper
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Parsing helpers
+// ---------------------------------------------------------------------------
+
+/// Parsed `#[step(...)]` attribute on a variant.
+/// Expected format: `#[step(left = Type, right = Type, output = Type)]`
+struct StepAttr {
+    left: Type,
+    right: Type,
+    output: Type,
+}
+
+impl Parse for StepAttr {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let mut left = None;
+        let mut right = None;
+        let mut output = None;
+
+        while !input.is_empty() {
+            let ident: Ident = input.parse()?;
+            input.parse::<Token![=]>()?;
+            let ty: Type = input.parse()?;
+
+            match ident.to_string().as_str() {
+                "left" => left = Some(ty),
+                "right" => right = Some(ty),
+                "output" => output = Some(ty),
+                other => {
+                    return Err(Error::new(
+                        ident.span(),
+                        format!("unknown attribute `{other}`"),
+                    ));
+                }
+            }
+
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            }
+        }
+
+        Ok(StepAttr {
+            left: left.ok_or_else(|| Error::new(input.span(), "missing `left` in #[step(...)]"))?,
+            right: right
+                .ok_or_else(|| Error::new(input.span(), "missing `right` in #[step(...)]"))?,
+            output: output
+                .ok_or_else(|| Error::new(input.span(), "missing `output` in #[step(...)]"))?,
+        })
+    }
+}
+
+/// A parsed enum variant: its name (used for `build()` param naming),
+/// inner step type, step attribute, and declaration index.
+struct ParsedVariant {
+    /// Variant name (e.g. `WitnessLeaf`), used to derive the `build()` parameter
+    /// name via snake_case conversion (e.g. `witness_leaf`).
+    name: Ident,
+    step_ty: Type,
+    step_attr: StepAttr,
+    index: usize,
+}
+
+/// Extract the `#[step(...)]` attribute from a variant's attributes.
+fn parse_step_attr(attrs: &[Attribute]) -> Result<StepAttr> {
+    for attr in attrs {
+        if attr.path().is_ident("step") {
+            return attr.parse_args::<StepAttr>();
+        }
+    }
+    Err(Error::new(
+        proc_macro2::Span::call_site(),
+        "missing #[step(...)] attribute on variant",
+    ))
+}
+
+/// Extract the inner type from a tuple variant with exactly one unnamed field.
+fn extract_variant_type(variant: &Variant) -> Result<Type> {
+    match &variant.fields {
+        Fields::Unnamed(fields) if fields.unnamed.len() == 1 => {
+            Ok(fields.unnamed.first().unwrap().ty.clone())
+        }
+        _ => Err(Error::new_spanned(
+            variant,
+            "application variants must be tuple variants with exactly one field",
+        )),
+    }
+}
+
+/// Collect unique non-unit header types from step attributes, preserving
+/// first-appearance order (which determines suffix assignment).
+fn collect_unique_headers(variants: &[ParsedVariant]) -> Vec<Type> {
+    let mut seen = BTreeSet::new();
+    let mut headers = Vec::new();
+    for v in variants {
+        for ty in [&v.step_attr.left, &v.step_attr.right, &v.step_attr.output] {
+            if is_unit_type(ty) {
+                continue;
+            }
+            if seen.insert(quote!(#ty).to_string()) {
+                headers.push(ty.clone());
+            }
+        }
+    }
+    headers
+}
+
+fn is_unit_type(ty: &Type) -> bool {
+    matches!(ty, Type::Tuple(t) if t.elems.is_empty())
+}
+
+// ---------------------------------------------------------------------------
+// Generics helpers
+// ---------------------------------------------------------------------------
+
+/// Extract the Cycle type parameter ident from the enum's generics.
+fn find_cycle_param(generics: &Generics) -> Result<Ident> {
+    generics
+        .params
+        .iter()
+        .find_map(|p| match p {
+            GenericParam::Type(t) => Some(t.ident.clone()),
+            _ => None,
+        })
+        .ok_or_else(|| Error::new_spanned(generics, "expected a Cycle type parameter on the enum"))
+}
+
+/// Get the lifetime from enum generics to use as 'params for Application.
+fn find_params_lifetime(generics: &Generics) -> Result<syn::Lifetime> {
+    generics
+        .params
+        .iter()
+        .find_map(|p| match p {
+            GenericParam::Lifetime(lt) => Some(lt.lifetime.clone()),
+            _ => None,
+        })
+        .ok_or_else(|| {
+            Error::new_spanned(
+                generics,
+                "application enum must have a lifetime parameter (e.g., `'params`)",
+            )
+        })
+}
+
+/// Build the impl generic params: enum generics (with bounds) + extra params.
+fn impl_generics_with(generics: &Generics, extra: TokenStream) -> TokenStream {
+    let params: Vec<_> = generics.params.iter().collect();
+    if params.is_empty() {
+        extra
+    } else {
+        quote!(#(#params),*, #extra)
+    }
+}
+
+/// Build type arguments from enum generics (just names, no bounds) + extra args.
+fn type_args_with(generics: &Generics, extra: TokenStream) -> TokenStream {
+    let args: Vec<TokenStream> = generics
+        .params
+        .iter()
+        .map(|p| match p {
+            GenericParam::Lifetime(lt) => {
+                let lt = &lt.lifetime;
+                quote!(#lt)
+            }
+            GenericParam::Type(t) => {
+                let ident = &t.ident;
+                quote!(#ident)
+            }
+            GenericParam::Const(c) => {
+                let ident = &c.ident;
+                quote!(#ident)
+            }
+        })
+        .collect();
+    if args.is_empty() {
+        extra
+    } else {
+        quote!(#(#args),*, #extra)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Code generation
+// ---------------------------------------------------------------------------
+
+/// Generate `ragu_pcd::step::Step` impls that bridge from `ragu_app::Step`.
+///
+/// For each variant at position `i`, generates an impl of `PcdStep<C>` on the
+/// inner step type with `const INDEX = Index::new(i)`. The generated `witness()`
+/// method encodes left/right headers via `Encoded::new`, delegates to the
+/// user's `ragu_app::Step::synthesize` (which works with pre-encoded `&Bound`
+/// gadgets), then wraps the output via `Encoded::from_gadget`.
+///
+/// # Example
+///
+/// For variant `#[step(left = LeafNode, right = LeafNode, output = ExponentNode)]
+/// Hash2(Hash2<'p, C>)` at index 1:
+///
+/// ```ignore
+/// impl<'p, C: Cycle> PcdStep<C> for Hash2<'p, C>
+/// where
+///     Hash2<'p, C>: ragu_app::Step<C, Left = LeafNode, Right = LeafNode, Output = ExponentNode>,
+///     LeafNode: Header<C::CircuitField>,
+///     ExponentNode: Header<C::CircuitField>,
+/// {
+///     const INDEX: Index = Index::new(1);
+///     // ... type aliases and witness() bridging impl
+/// }
+/// ```
+fn generate_step_impls(
+    variants: &[ParsedVariant],
+    enum_generics: &Generics,
+    cycle: &Ident,
+    app: &RaguAppPath,
+    prelude: &TokenStream,
+) -> Result<TokenStream> {
+    let mut impls = TokenStream::new();
+
+    let enum_params: Vec<_> = enum_generics.params.iter().collect();
+
+    for v in variants {
+        let step_ty = &v.step_ty;
+        let index = v.index;
+        let left_ty = &v.step_attr.left;
+        let right_ty = &v.step_attr.right;
+        let output_ty = &v.step_attr.output;
+
+        impls.extend(quote! {
+            impl<#(#enum_params),*> #prelude::PcdStep<#cycle> for #step_ty
+            where
+                #step_ty: #app::Step<#cycle,
+                    Left = #left_ty,
+                    Right = #right_ty,
+                    Output = #output_ty,
+                >,
+                #left_ty: #prelude::Header<#cycle::CircuitField>,
+                #right_ty: #prelude::Header<#cycle::CircuitField>,
+                #output_ty: #prelude::Header<#cycle::CircuitField>,
+            {
+                const INDEX: #prelude::Index = #prelude::Index::new(#index);
+
+                type Witness = <#step_ty as #app::Step<#cycle>>::Witness;
+                type Left = #left_ty;
+                type Right = #right_ty;
+                type Output = #output_ty;
+                type Aux = <#step_ty as #app::Step<#cycle>>::Aux;
+
+                fn witness<'dr, __D: #prelude::Driver<'dr, F = #cycle::CircuitField>, const HEADER_SIZE: usize>(
+                    &self,
+                    dr: &mut __D,
+                    witness: #prelude::DriverValue<__D, Self::Witness>,
+                    left: #prelude::DriverValue<
+                        __D,
+                        <Self::Left as #prelude::Header<#cycle::CircuitField>>::Data,
+                    >,
+                    right: #prelude::DriverValue<
+                        __D,
+                        <Self::Right as #prelude::Header<#cycle::CircuitField>>::Data,
+                    >,
+                ) -> #prelude::Result<(
+                    (
+                        #prelude::Encoded<'dr, __D, Self::Left, HEADER_SIZE>,
+                        #prelude::Encoded<'dr, __D, Self::Right, HEADER_SIZE>,
+                        #prelude::Encoded<'dr, __D, Self::Output, HEADER_SIZE>,
+                    ),
+                    #prelude::DriverValue<
+                        __D,
+                        <Self::Output as #prelude::Header<#cycle::CircuitField>>::Data,
+                    >,
+                    #prelude::DriverValue<__D, Self::Aux>,
+                )>
+                where
+                    Self: 'dr,
+                {
+                    let left_enc = #prelude::Encoded::new(dr, left)?;
+                    let right_enc = #prelude::Encoded::new(dr, right)?;
+
+                    // Helper to propagate HEADER_SIZE to synthesize.
+                    fn call_synthesize<'dr, __C2: #app::Cycle, __D2: #prelude::Driver<'dr, F = __C2::CircuitField>, __S2, const HS: usize>(
+                        step: &__S2,
+                        dr: &mut __D2,
+                        witness: #prelude::DriverValue<__D2, __S2::Witness>,
+                        left: &#prelude::Bound<'dr, __D2, <__S2::Left as #prelude::Header<__C2::CircuitField>>::Output>,
+                        right: &#prelude::Bound<'dr, __D2, <__S2::Right as #prelude::Header<__C2::CircuitField>>::Output>,
+                    ) -> #prelude::Result<(
+                        #prelude::Bound<'dr, __D2, <__S2::Output as #prelude::Header<__C2::CircuitField>>::Output>,
+                        #prelude::DriverValue<__D2, <__S2::Output as #prelude::Header<__C2::CircuitField>>::Data>,
+                        #prelude::DriverValue<__D2, __S2::Aux>,
+                    )>
+                    where
+                        __S2: #app::Step<__C2> + 'dr,
+                    {
+                        __S2::synthesize::<__D2, HS>(step, dr, witness, left, right)
+                    }
+
+                    let (output_gadget, output_data, aux) =
+                        call_synthesize::<#cycle, __D, #step_ty, HEADER_SIZE>(
+                            self,
+                            dr,
+                            witness,
+                            left_enc.as_gadget(),
+                            right_enc.as_gadget(),
+                        )?;
+
+                    let output_enc = #prelude::Encoded::from_gadget(output_gadget);
+                    Ok(((left_enc, right_enc, output_enc), output_data, aux))
+                }
+            }
+        });
+    }
+
+    Ok(impls)
+}
+
+/// Generate `ragu_pcd::header::Header` impls from `ragu_app::HeaderContent` impls.
+///
+/// Each unique non-unit header type gets an auto-assigned `const SUFFIX` based
+/// on its first-appearance order across all `#[step(...)]` attributes. The unit
+/// type `()` already has a blanket `Header` impl and is skipped.
+///
+/// # Example
+///
+/// Given headers `[LeafNode, ExponentNode, ScaledPoint]` (collected in order):
+///
+/// ```ignore
+/// impl<F: Field> Header<F> for LeafNode
+/// where LeafNode: HeaderContent<F> {
+///     const SUFFIX: Suffix = Suffix::new(0);
+///     // ... delegates Data/Output/encode to HeaderContent
+/// }
+/// impl<F: Field> Header<F> for ExponentNode
+/// where ExponentNode: HeaderContent<F> {
+///     const SUFFIX: Suffix = Suffix::new(1);
+///     // ...
+/// }
+/// impl<F: Field> Header<F> for ScaledPoint
+/// where ScaledPoint: HeaderContent<F> {
+///     const SUFFIX: Suffix = Suffix::new(2);
+///     // ...
+/// }
+/// ```
+fn generate_header_impls(
+    headers: &[Type],
+    app: &RaguAppPath,
+    prelude: &TokenStream,
+) -> TokenStream {
+    let mut impls = TokenStream::new();
+
+    for (i, header_ty) in headers.iter().enumerate() {
+        impls.extend(quote! {
+            impl<__F: #prelude::Field> #prelude::Header<__F> for #header_ty
+            where
+                #header_ty: #app::HeaderContent<__F>,
+            {
+                const SUFFIX: #prelude::Suffix = #prelude::Suffix::new(#i);
+
+                type Data = <#header_ty as #app::HeaderContent<__F>>::Data;
+                type Output = <#header_ty as #app::HeaderContent<__F>>::Output;
+
+                fn encode<'dr, __D: #prelude::Driver<'dr, F = __F>>(
+                    dr: &mut __D,
+                    witness: #prelude::DriverValue<__D, Self::Data>,
+                ) -> #prelude::Result<#prelude::Bound<'dr, __D, Self::Output>> {
+                    <#header_ty as #app::HeaderContent<__F>>::encode(dr, witness)
+                }
+            }
+        });
+    }
+
+    impls
+}
+
+/// Generate the wrapper struct and its `build`/`seed`/`fuse`/`verify`/
+/// `rerandomize`/`trivial_pcd` methods.
+///
+/// # Example transformation
+///
+/// Given the input enum (after parsing):
+///
+/// ```ignore
+/// #[application]
+/// pub enum ExampleApp<'params, C: Cycle> {
+///     #[step(left = (), right = (), output = LeafNode)]
+///     WitnessLeaf(WitnessLeaf<'params, C>),
+///
+///     #[step(left = LeafNode, right = LeafNode, output = ExponentNode)]
+///     Hash2(Hash2<'params, C>),
+/// }
+/// ```
+///
+/// This function generates:
+///
+/// ```ignore
+/// pub struct ExampleApp<'params, C: Cycle, __R: Rank, const HEADER_SIZE: usize> {
+///     inner: Application<'params, C, __R, HEADER_SIZE>,
+/// }
+///
+/// impl<'params, C: Cycle, __R: Rank, const HEADER_SIZE: usize>
+///     ExampleApp<'params, C, __R, HEADER_SIZE>
+/// where
+///     // Header bounds — needed so non-generic headers (e.g. `ScaledPoint:
+///     // Header<Fp>`) gate the impl to compatible cycles.
+///     LeafNode: Header<C::CircuitField>,
+///     ExponentNode: Header<C::CircuitField>,
+///     // Step bounds — needed because `build()` calls `.register()` which
+///     // requires `PcdStep<C>`, and the generated `PcdStep` impls are
+///     // conditional on `ragu_app::Step<C>`. Without these, non-generic
+///     // steps (e.g. `Endoscale: Step<Pasta>`) fail to resolve for
+///     // generic `C`.
+///     WitnessLeaf<'params, C>: Step<C, Left = (), Right = (), Output = LeafNode>,
+///     Hash2<'params, C>: Step<C, Left = LeafNode, Right = LeafNode, Output = ExponentNode>,
+/// {
+///     pub fn build(
+///         params: &'params C::Params,
+///         witness_leaf: WitnessLeaf<'params, C>,  // snake_case of variant name
+///         hash2: Hash2<'params, C>,
+///     ) -> Result<Self> { /* registers each step then finalizes */ }
+///
+///     pub fn seed(...)  -> Result<(Pcd<..., S::Output>, S::Aux)> { ... }
+///     pub fn fuse(...)  -> Result<(Pcd<..., S::Output>, S::Aux)> { ... }
+///     pub fn verify(...) -> Result<bool> { ... }
+///     pub fn rerandomize(...) -> Result<Pcd<..., H>> { ... }
+///     pub fn trivial_pcd(...) -> Pcd<..., ()> { ... }
+/// }
+/// ```
+#[allow(clippy::too_many_arguments)]
+fn generate_wrapper(
+    vis: &Visibility,
+    enum_ident: &Ident,
+    enum_generics: &Generics,
+    cycle: &Ident,
+    params_lt: &syn::Lifetime,
+    variants: &[ParsedVariant],
+    headers: &[Type],
+    app: &RaguAppPath,
+    prelude: &TokenStream,
+) -> Result<TokenStream> {
+    // `build()` parameters: one per variant, snake_case name with the step type.
+    // e.g. `WitnessLeaf(WitnessLeaf<'p, C>)` → `witness_leaf: WitnessLeaf<'p, C>`
+    let build_params: Vec<_> = variants
+        .iter()
+        .map(|v| {
+            let name = format_ident!("{}", v.name.to_string().to_snake_case());
+            let ty = &v.step_ty;
+            quote!(#name: #ty)
+        })
+        .collect();
+
+    // Chained `.register(step)?` calls inside `build()`, one per variant.
+    let register_calls: Vec<_> = variants
+        .iter()
+        .map(|v| {
+            let name = format_ident!("{}", v.name.to_string().to_snake_case());
+            quote!(.register(#name)?)
+        })
+        .collect();
+
+    // Struct/impl generics: enum's own params + `__R: Rank, const HEADER_SIZE: usize`.
+    let impl_gen = impl_generics_with(
+        enum_generics,
+        quote!(__R: #prelude::Rank, const HEADER_SIZE: usize),
+    );
+    let struct_args = type_args_with(enum_generics, quote!(__R, HEADER_SIZE));
+
+    // Where clause: each unique header must impl `Header<C::CircuitField>`.
+    let header_bounds: Vec<_> = headers
+        .iter()
+        .map(|h| quote!(#h: #prelude::Header<#cycle::CircuitField>))
+        .collect();
+
+    // Where clause: each step type must impl `ragu_app::Step<C>` with matching
+    // associated types. Required so `.register()` in `build()` can resolve the
+    // generated `PcdStep<C>` impl (which is conditional on this bound).
+    let step_bounds: Vec<_> = variants
+        .iter()
+        .map(|v| {
+            let step_ty = &v.step_ty;
+            let left = &v.step_attr.left;
+            let right = &v.step_attr.right;
+            let output = &v.step_attr.output;
+            quote!(#step_ty: #app::Step<#cycle, Left = #left, Right = #right, Output = #output>)
+        })
+        .collect();
+
+    Ok(quote! {
+        /// Generated application wrapper.
+        #vis struct #enum_ident<#impl_gen> {
+            inner: #prelude::Application<#params_lt, #cycle, __R, HEADER_SIZE>,
+        }
+
+        impl<#impl_gen> #enum_ident<#struct_args>
+        where
+            #(#header_bounds,)*
+            #(#step_bounds,)*
+        {
+            /// Build the application by registering all steps.
+            #vis fn build(
+                params: &#params_lt #cycle::Params,
+                #(#build_params),*
+            ) -> #prelude::Result<Self> {
+                let inner = #prelude::ApplicationBuilder::<#cycle, __R, HEADER_SIZE>::new()
+                    #(#register_calls)*
+                    .finalize(params)?;
+                Ok(Self { inner })
+            }
+
+            /// Seed a new computation by running a step with trivial inputs.
+            #vis fn seed<__RNG: #prelude::CryptoRng, __S: #prelude::PcdStep<#cycle, Left = (), Right = ()>>(
+                &self,
+                rng: &mut __RNG,
+                step: __S,
+                witness: __S::Witness,
+            ) -> #prelude::Result<(#prelude::Pcd<#cycle, __R, __S::Output>, __S::Aux)> {
+                self.inner.seed(rng, step, witness)
+            }
+
+            /// Fuse two pieces of proof-carrying data using a step.
+            #vis fn fuse<__RNG: #prelude::CryptoRng, __S: #prelude::PcdStep<#cycle>>(
+                &self,
+                rng: &mut __RNG,
+                step: __S,
+                witness: __S::Witness,
+                left: #prelude::Pcd<#cycle, __R, __S::Left>,
+                right: #prelude::Pcd<#cycle, __R, __S::Right>,
+            ) -> #prelude::Result<(#prelude::Pcd<#cycle, __R, __S::Output>, __S::Aux)> {
+                self.inner.fuse(rng, step, witness, left, right)
+            }
+
+            /// Verify proof-carrying data.
+            #vis fn verify<__RNG: #prelude::CryptoRng, __H: #prelude::Header<#cycle::CircuitField>>(
+                &self,
+                pcd: &#prelude::Pcd<#cycle, __R, __H>,
+                rng: __RNG,
+            ) -> #prelude::Result<bool> {
+                self.inner.verify(pcd, rng)
+            }
+
+            /// Rerandomize proof-carrying data.
+            #vis fn rerandomize<__RNG: #prelude::CryptoRng, __H: #prelude::Header<#cycle::CircuitField>>(
+                &self,
+                pcd: #prelude::Pcd<#cycle, __R, __H>,
+                rng: &mut __RNG,
+            ) -> #prelude::Result<#prelude::Pcd<#cycle, __R, __H>> {
+                self.inner.rerandomize(pcd, rng)
+            }
+
+            /// Returns a seeded trivial PCD with no header data, suitable
+            /// as a placeholder input for steps that only use one of their
+            /// two inputs.
+            #vis fn trivial_pcd<__RNG: #prelude::CryptoRng>(&self, rng: &mut __RNG) -> #prelude::Pcd<#cycle, __R, ()> {
+                self.inner.seeded_trivial_pcd(rng)
+            }
+        }
+    })
+}

--- a/crates/ragu_macros/src/proc/header.rs
+++ b/crates/ragu_macros/src/proc/header.rs
@@ -1,0 +1,217 @@
+//! Implementation of the `#[header]` proc-macro.
+//!
+//! Generates a `HeaderContent` implementation for single-gadget headers where
+//! `encode()` calls `Gadget::alloc(dr, witness)`.
+//!
+//! # Modes
+//!
+//! - **Generic** (`#[header(data = F, gadget = Element)]`): `data` doubles as
+//!   the field type parameter, producing `impl<F: Field> HeaderContent<F>`.
+//! - **Concrete** (`#[header(data = EpAffine, gadget = Point<EpAffine>, field = Fp)]`):
+//!   an explicit `field` pins the impl to a specific field type.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Error, Ident, ItemStruct, Result, Token, Type, parse::Parse, parse::ParseStream};
+
+use crate::path_resolution::RaguAppPath;
+
+/// Generates the `HeaderContent` impl for a `#[header]`-annotated struct.
+pub fn evaluate(attr: HeaderAttr, item: ItemStruct) -> Result<TokenStream> {
+    let app = RaguAppPath::resolve()?;
+
+    if !item.generics.params.is_empty() || item.generics.where_clause.is_some() {
+        return Err(Error::new_spanned(
+            &item.generics,
+            "#[header] structs must not have generic parameters or where clauses",
+        ));
+    }
+
+    if !matches!(item.fields, syn::Fields::Unit) {
+        return Err(Error::new_spanned(
+            &item.fields,
+            "#[header] structs must be unit structs (no fields)",
+        ));
+    }
+
+    let struct_vis = &item.vis;
+    let struct_ident = &item.ident;
+    let struct_attrs = &item.attrs;
+    let data_ty = &attr.data;
+    let prelude = quote!(#app::__macro_internal);
+    let kind_expr = make_kind_expr(&attr.gadget)?;
+    let gadget_base = extract_base_path(&attr.gadget)?;
+
+    // When `field` is absent, `data` is both the field parameter and the data
+    // type, yielding a generic impl. When present, the impl is concrete.
+    let field_ty = attr.field.as_ref().unwrap_or(data_ty);
+    let impl_generics = if attr.field.is_some() {
+        quote!()
+    } else {
+        quote!(<#data_ty: #prelude::Field>)
+    };
+
+    Ok(quote! {
+        #(#struct_attrs)*
+        #struct_vis struct #struct_ident;
+
+        impl #impl_generics #app::HeaderContent<#field_ty> for #struct_ident {
+            type Data = #data_ty;
+            type Output = #prelude::Kind![#field_ty; #kind_expr];
+
+            fn encode<'dr, __D: #prelude::Driver<'dr, F = #field_ty>>(
+                dr: &mut __D,
+                witness: #prelude::DriverValue<__D, Self::Data>,
+            ) -> #prelude::Result<#prelude::Bound<'dr, __D, Self::Output>> {
+                #gadget_base::alloc(dr, witness)
+            }
+        }
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/// The parsed `#[header(...)]` attribute arguments.
+///
+/// Required: `data` and `gadget`.
+/// Optional: `field` (when absent, `data` is used as both the field type
+/// parameter and the data type, producing a generic `impl<F: Field>`).
+pub struct HeaderAttr {
+    data: Type,
+    gadget: Type,
+    field: Option<Type>,
+}
+
+impl Parse for HeaderAttr {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let mut data = None;
+        let mut gadget = None;
+        let mut field = None;
+
+        while !input.is_empty() {
+            let ident: Ident = input.parse()?;
+            input.parse::<Token![=]>()?;
+            let ty: Type = input.parse()?;
+
+            match ident.to_string().as_str() {
+                "data" => {
+                    if data.is_some() {
+                        return Err(Error::new(
+                            ident.span(),
+                            "duplicate `data` key in #[header(...)]",
+                        ));
+                    }
+                    data = Some(ty);
+                }
+                "gadget" => {
+                    if gadget.is_some() {
+                        return Err(Error::new(
+                            ident.span(),
+                            "duplicate `gadget` key in #[header(...)]",
+                        ));
+                    }
+                    gadget = Some(ty);
+                }
+                "field" => {
+                    if field.is_some() {
+                        return Err(Error::new(
+                            ident.span(),
+                            "duplicate `field` key in #[header(...)]",
+                        ));
+                    }
+                    field = Some(ty);
+                }
+                other => {
+                    return Err(Error::new(
+                        ident.span(),
+                        format!(
+                            "unknown attribute `{other}`, expected `data`, `gadget`, or `field`"
+                        ),
+                    ));
+                }
+            }
+
+            // Consume optional trailing comma.
+            let _ = input.parse::<Token![,]>();
+        }
+
+        Ok(HeaderAttr {
+            data: data
+                .ok_or_else(|| Error::new(input.span(), "missing `data` in #[header(...)]"))?,
+            gadget: gadget
+                .ok_or_else(|| Error::new(input.span(), "missing `gadget` in #[header(...)]"))?,
+            field,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Returns the inner [`syn::TypePath`], or an error if `ty` is not a path type.
+fn as_type_path(ty: &Type) -> Result<&syn::TypePath> {
+    match ty {
+        Type::Path(p) => Ok(p),
+        _ => Err(Error::new_spanned(ty, "expected a path type for gadget")),
+    }
+}
+
+/// Builds the `Kind!` gadget expression by prepending `'_, _` (the lifetime
+/// and driver placeholders) to any existing type arguments.
+///
+/// Assumes all gadgets follow the convention `Gadget<'dr, D: Driver, ...extra>`.
+/// The lifetime and driver slots are filled with `'_, _`; extra user-supplied
+/// type arguments (from the `gadget` attribute) are appended after them.
+///
+/// - `Element`          → `Element<'_, _>`
+/// - `Point<EpAffine>`  → `Point<'_, _, EpAffine>`
+fn make_kind_expr(gadget_ty: &Type) -> Result<TokenStream> {
+    let type_path = as_type_path(gadget_ty)?;
+    let segments = &type_path.path.segments;
+    let last = segments
+        .last()
+        .ok_or_else(|| Error::new_spanned(gadget_ty, "empty path for gadget type"))?;
+
+    let prefix: Vec<_> = segments.iter().take(segments.len() - 1).collect();
+    let base_ident = &last.ident;
+
+    let extra_args: Vec<TokenStream> = match &last.arguments {
+        syn::PathArguments::None => vec![],
+        syn::PathArguments::AngleBracketed(args) => args.args.iter().map(|a| quote!(#a)).collect(),
+        _ => {
+            return Err(Error::new_spanned(
+                gadget_ty,
+                "unexpected parenthesized arguments on gadget type",
+            ));
+        }
+    };
+
+    let prefix_tokens = if prefix.is_empty() {
+        quote!()
+    } else {
+        quote!(#(#prefix)::* ::)
+    };
+
+    if extra_args.is_empty() {
+        Ok(quote!(#prefix_tokens #base_ident<'_, _>))
+    } else {
+        Ok(quote!(#prefix_tokens #base_ident<'_, _, #(#extra_args),*>))
+    }
+}
+
+/// Strips generic arguments from a gadget path for the `::alloc()` call,
+/// preserving the leading `::` and any path qualifiers.
+///
+/// - `Element`         → `Element`
+/// - `Point<EpAffine>` → `Point`
+fn extract_base_path(gadget_ty: &Type) -> Result<TokenStream> {
+    let type_path = as_type_path(gadget_ty)?;
+    let mut path = type_path.path.clone();
+    if let Some(last) = path.segments.last_mut() {
+        last.arguments = syn::PathArguments::None;
+    }
+    Ok(quote!(#path))
+}

--- a/crates/ragu_macros/src/proc/mod.rs
+++ b/crates/ragu_macros/src/proc/mod.rs
@@ -1,3 +1,4 @@
+pub mod application;
 pub mod kind;
 pub mod maybe_cast;
 pub mod repr;

--- a/crates/ragu_macros/src/proc/mod.rs
+++ b/crates/ragu_macros/src/proc/mod.rs
@@ -1,4 +1,5 @@
 pub mod application;
+pub mod header;
 pub mod kind;
 pub mod maybe_cast;
 pub mod repr;

--- a/crates/ragu_pcd/benches/pcd.rs
+++ b/crates/ragu_pcd/benches/pcd.rs
@@ -69,8 +69,8 @@ fn seed(
 fn fuse(
     (app, leaf1, leaf2, poseidon_params, mut rng): (
         Application<'static, Pasta, ProductionRank, 4>,
-        Pcd<'static, Pasta, ProductionRank, nontrivial::LeafNode>,
-        Pcd<'static, Pasta, ProductionRank, nontrivial::LeafNode>,
+        Pcd<Pasta, ProductionRank, nontrivial::LeafNode>,
+        Pcd<Pasta, ProductionRank, nontrivial::LeafNode>,
         &'static <Pasta as Cycle>::CircuitPoseidon,
         StdRng,
     ),
@@ -95,7 +95,7 @@ library_benchmark_group!(
 fn verify_leaf(
     (app, leaf, mut rng): (
         Application<'static, Pasta, ProductionRank, 4>,
-        Pcd<'static, Pasta, ProductionRank, nontrivial::LeafNode>,
+        Pcd<Pasta, ProductionRank, nontrivial::LeafNode>,
         StdRng,
     ),
 ) {
@@ -107,7 +107,7 @@ fn verify_leaf(
 fn verify_node(
     (app, node, mut rng): (
         Application<'static, Pasta, ProductionRank, 4>,
-        Pcd<'static, Pasta, ProductionRank, nontrivial::InternalNode>,
+        Pcd<Pasta, ProductionRank, nontrivial::InternalNode>,
         StdRng,
     ),
 ) {
@@ -119,7 +119,7 @@ fn verify_node(
 fn rerandomize(
     (app, node, mut rng): (
         Application<'static, Pasta, ProductionRank, 4>,
-        Pcd<'static, Pasta, ProductionRank, nontrivial::InternalNode>,
+        Pcd<Pasta, ProductionRank, nontrivial::InternalNode>,
         StdRng,
     ),
 ) {

--- a/crates/ragu_pcd/benches/setup/mod.rs
+++ b/crates/ragu_pcd/benches/setup/mod.rs
@@ -51,8 +51,8 @@ pub fn setup_seed() -> (
 
 pub fn setup_fuse() -> (
     Application<'static, Pasta, ProductionRank, 4>,
-    Pcd<'static, Pasta, ProductionRank, nontrivial::LeafNode>,
-    Pcd<'static, Pasta, ProductionRank, nontrivial::LeafNode>,
+    Pcd<Pasta, ProductionRank, nontrivial::LeafNode>,
+    Pcd<Pasta, ProductionRank, nontrivial::LeafNode>,
     &'static <Pasta as Cycle>::CircuitPoseidon,
     StdRng,
 ) {
@@ -79,7 +79,7 @@ pub fn setup_fuse() -> (
 
 pub fn setup_verify_leaf() -> (
     Application<'static, Pasta, ProductionRank, 4>,
-    Pcd<'static, Pasta, ProductionRank, nontrivial::LeafNode>,
+    Pcd<Pasta, ProductionRank, nontrivial::LeafNode>,
     StdRng,
 ) {
     let (app, poseidon_params, mut rng) = setup_seed();
@@ -97,7 +97,7 @@ pub fn setup_verify_leaf() -> (
 
 pub fn setup_verify_node() -> (
     Application<'static, Pasta, ProductionRank, 4>,
-    Pcd<'static, Pasta, ProductionRank, nontrivial::InternalNode>,
+    Pcd<Pasta, ProductionRank, nontrivial::InternalNode>,
     StdRng,
 ) {
     let (app, poseidon_params, mut rng) = setup_seed();

--- a/crates/ragu_pcd/src/fuse/_01_application.rs
+++ b/crates/ragu_pcd/src/fuse/_01_application.rs
@@ -22,13 +22,13 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         rng: &mut RNG,
         step: S,
         witness: S::Witness<'source>,
-        left: Pcd<'source, C, R, S::Left>,
-        right: Pcd<'source, C, R, S::Right>,
+        left: Pcd<C, R, S::Left>,
+        right: Pcd<C, R, S::Right>,
     ) -> Result<(
         Proof<C, R>,
         Proof<C, R>,
         proof::Application<C, R>,
-        <S::Output as Header<C::CircuitField>>::Data<'source>,
+        <S::Output as Header<C::CircuitField>>::Data,
         S::Aux<'source>,
     )> {
         let (left_proof, left_data) = left.into_parts();

--- a/crates/ragu_pcd/src/fuse/mod.rs
+++ b/crates/ragu_pcd/src/fuse/mod.rs
@@ -51,9 +51,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         rng: &mut RNG,
         step: S,
         witness: S::Witness<'source>,
-        left: Pcd<'source, C, R, S::Left>,
-        right: Pcd<'source, C, R, S::Right>,
-    ) -> Result<(Pcd<'source, C, R, S::Output>, S::Aux<'source>)> {
+        left: Pcd<C, R, S::Left>,
+        right: Pcd<C, R, S::Right>,
+    ) -> Result<(Pcd<C, R, S::Output>, S::Aux<'source>)> {
         let (left, right, application, application_data, application_aux) =
             self.compute_application_proof(rng, step, witness, left, right)?;
 

--- a/crates/ragu_pcd/src/header.rs
+++ b/crates/ragu_pcd/src/header.rs
@@ -84,15 +84,15 @@ pub trait Header<F: Field>: Send + Sync + Any {
     const SUFFIX: Suffix;
 
     /// The data needed to encode a header.
-    type Data<'source>: Send + Clone;
+    type Data: Send + Clone;
 
     /// The output gadget that encodes the data for this header.
     type Output: Write<F>;
 
     /// Encode some data into a gadget representing this header.
-    fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
+    fn encode<'dr, D: Driver<'dr, F = F>>(
         dr: &mut D,
-        witness: DriverValue<D, Self::Data<'source>>,
+        witness: DriverValue<D, Self::Data>,
     ) -> Result<Bound<'dr, D, Self::Output>>;
 }
 
@@ -100,12 +100,12 @@ pub trait Header<F: Field>: Send + Sync + Any {
 impl<F: Field> Header<F> for () {
     const SUFFIX: Suffix = Suffix::internal(1);
 
-    type Data<'source> = ();
+    type Data = ();
     type Output = ();
 
-    fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
+    fn encode<'dr, D: Driver<'dr, F = F>>(
         _: &mut D,
-        _: DriverValue<D, Self::Data<'source>>,
+        _: DriverValue<D, Self::Data>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         Ok(())
     }

--- a/crates/ragu_pcd/src/header.rs
+++ b/crates/ragu_pcd/src/header.rs
@@ -46,7 +46,7 @@ impl Suffix {
 
     /// Obtain this suffix's `u64` value based on whether this represents an
     /// internal or application [`Header`] suffix.
-    pub(crate) fn get(&self) -> u64 {
+    pub const fn get(&self) -> u64 {
         match self.suffix {
             HeaderSuffix::Internal(i) => i as u64,
             HeaderSuffix::Application(i) => (i + NUM_INTERNAL_SUFFIXES as usize) as u64,

--- a/crates/ragu_pcd/src/internal/native/stages/preamble.rs
+++ b/crates/ragu_pcd/src/internal/native/stages/preamble.rs
@@ -193,14 +193,11 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usiz
 
     /// Allocate ProofInputs from a proof reference and some unprocessed header
     /// data.
-    pub fn alloc_for_verify<'source, R: Rank, H: Header<C::CircuitField>>(
+    pub fn alloc_for_verify<R: Rank, H: Header<C::CircuitField>>(
         dr: &mut D,
         proof: DriverValue<D, &Proof<C, R>>,
-        header_data: DriverValue<D, H::Data<'source>>,
-    ) -> Result<Self>
-    where
-        'source: 'dr,
-    {
+        header_data: DriverValue<D, H::Data>,
+    ) -> Result<Self> {
         let header_data = D::try_just(|| {
             use ragu_core::drivers::emulator::{Emulator, Wireless};
             let emulator = &mut Emulator::<Wireless<D::MaybeKind, D::F>>::wireless();

--- a/crates/ragu_pcd/src/lib.rs
+++ b/crates/ragu_pcd/src/lib.rs
@@ -197,7 +197,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         rng: &mut RNG,
         step: S,
         witness: S::Witness<'source>,
-    ) -> Result<(Pcd<'source, C, R, S::Output>, S::Aux<'source>)> {
+    ) -> Result<(Pcd<C, R, S::Output>, S::Aux<'source>)> {
         self.fuse(rng, step, witness, self.trivial_pcd(), self.trivial_pcd())
     }
 
@@ -209,7 +209,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
     ///
     /// The proof is lazily created on first use and cached; subsequent calls
     /// return the same (non-random) proof.
-    fn seeded_trivial_pcd<'source, RNG: CryptoRng>(&self, rng: &mut RNG) -> Pcd<'source, C, R, ()> {
+    fn seeded_trivial_pcd<RNG: CryptoRng>(&self, rng: &mut RNG) -> Pcd<C, R, ()> {
         self.seeded_trivial
             .get_or_init(|| {
                 self.seed(rng, step::internal::trivial::Trivial::new(), ())
@@ -229,11 +229,11 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
     /// is valid for the same [`Header`] but reveals nothing else about the
     /// original proof. As a result, [`Application::verify`] should produce the
     /// same result on the provided `pcd` as it would the output of this method.
-    pub fn rerandomize<'source, RNG: CryptoRng, H: Header<C::CircuitField>>(
+    pub fn rerandomize<RNG: CryptoRng, H: Header<C::CircuitField>>(
         &self,
-        pcd: Pcd<'source, C, R, H>,
+        pcd: Pcd<C, R, H>,
         rng: &mut RNG,
-    ) -> Result<Pcd<'source, C, R, H>> {
+    ) -> Result<Pcd<C, R, H>> {
         // Seed a trivial proof for rerandomization.
         // TODO: this is a temporary hack that allows the base case logic to be simple
         let seeded_trivial = self.seeded_trivial_pcd(rng);

--- a/crates/ragu_pcd/src/lib.rs
+++ b/crates/ragu_pcd/src/lib.rs
@@ -209,7 +209,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
     ///
     /// The proof is lazily created on first use and cached; subsequent calls
     /// return the same (non-random) proof.
-    fn seeded_trivial_pcd<RNG: CryptoRng>(&self, rng: &mut RNG) -> Pcd<C, R, ()> {
+    pub fn seeded_trivial_pcd<RNG: CryptoRng>(&self, rng: &mut RNG) -> Pcd<C, R, ()> {
         self.seeded_trivial
             .get_or_init(|| {
                 self.seed(rng, step::internal::trivial::Trivial::new(), ())

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -26,14 +26,14 @@ use crate::internal::nested::NUM_ENDOSCALING_POINTS;
 
 /// Represents proof-carrying data, a recursive proof for the correctness of
 /// some accompanying data.
-pub struct Pcd<'source, C: Cycle, R: Rank, H: Header<C::CircuitField>> {
+pub struct Pcd<C: Cycle, R: Rank, H: Header<C::CircuitField>> {
     proof: Proof<C, R>,
-    data: H::Data<'source>,
+    data: H::Data,
 }
 
-impl<'source, C: Cycle, R: Rank, H: Header<C::CircuitField>> Pcd<'source, C, R, H> {
+impl<C: Cycle, R: Rank, H: Header<C::CircuitField>> Pcd<C, R, H> {
     /// Returns a reference to the data that the proof accompanies.
-    pub fn data(&self) -> &H::Data<'source> {
+    pub fn data(&self) -> &H::Data {
         &self.data
     }
 
@@ -44,12 +44,12 @@ impl<'source, C: Cycle, R: Rank, H: Header<C::CircuitField>> Pcd<'source, C, R, 
 
     /// Consumes the proof-carrying data and returns the proof and data
     /// separately.
-    pub(crate) fn into_parts(self) -> (Proof<C, R>, H::Data<'source>) {
+    pub(crate) fn into_parts(self) -> (Proof<C, R>, H::Data) {
         (self.proof, self.data)
     }
 }
 
-impl<C: Cycle, R: Rank, H: Header<C::CircuitField>> Clone for Pcd<'_, C, R, H> {
+impl<C: Cycle, R: Rank, H: Header<C::CircuitField>> Clone for Pcd<C, R, H> {
     fn clone(&self) -> Self {
         Pcd {
             proof: self.proof.clone(),
@@ -77,7 +77,7 @@ pub struct Proof<C: Cycle, R: Rank> {
 
 impl<C: Cycle, R: Rank> Proof<C, R> {
     /// Augment a recursive proof with some data, described by a [`Header`].
-    pub fn carry<H: Header<C::CircuitField>>(self, data: H::Data<'_>) -> Pcd<'_, C, R, H> {
+    pub fn carry<H: Header<C::CircuitField>>(self, data: H::Data) -> Pcd<C, R, H> {
         Pcd { proof: self, data }
     }
 
@@ -113,7 +113,7 @@ impl<C: Cycle, R: Rank> Proof<C, R> {
 }
 
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, HEADER_SIZE> {
-    pub(crate) fn trivial_pcd<'source>(&self) -> Pcd<'source, C, R, ()> {
+    pub(crate) fn trivial_pcd(&self) -> Pcd<C, R, ()> {
         self.trivial_proof().carry(())
     }
 

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -113,7 +113,9 @@ impl<C: Cycle, R: Rank> Proof<C, R> {
 }
 
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, HEADER_SIZE> {
-    pub(crate) fn trivial_pcd(&self) -> Pcd<C, R, ()> {
+    /// Returns a trivial PCD with no header data, useful as a placeholder
+    /// input for steps that only use one of their two inputs.
+    pub fn trivial_pcd(&self) -> Pcd<C, R, ()> {
         self.trivial_proof().carry(())
     }
 

--- a/crates/ragu_pcd/src/step/encoder.rs
+++ b/crates/ragu_pcd/src/step/encoder.rs
@@ -108,10 +108,7 @@ impl<'dr, D: Driver<'dr, F: PrimeField>, H: Header<D::F>, const HEADER_SIZE: usi
     ///
     /// This is the standard encoding method used by most Steps. The gadget structure
     /// is preserved and will be serialized with padding during the write phase.
-    pub fn new<'source: 'dr>(
-        dr: &mut D,
-        witness: DriverValue<D, H::Data<'source>>,
-    ) -> Result<Self> {
+    pub fn new(dr: &mut D, witness: DriverValue<D, H::Data>) -> Result<Self> {
         Ok(Encoded::from_gadget(H::encode(dr, witness)?))
     }
 
@@ -124,10 +121,7 @@ impl<'dr, D: Driver<'dr, F: PrimeField>, H: Header<D::F>, const HEADER_SIZE: usi
     ///
     /// The tradeoff: less efficient (requires emulation + serialization) but achieves
     /// circuit uniformity across different header types.
-    pub(crate) fn new_uniform<'source: 'dr>(
-        dr: &mut D,
-        witness: DriverValue<D, H::Data<'source>>,
-    ) -> Result<Self> {
+    pub(crate) fn new_uniform(dr: &mut D, witness: DriverValue<D, H::Data>) -> Result<Self> {
         let mut emulator: Emulator<Wireless<D::MaybeKind, _>> = Emulator::wireless();
         let gadget = H::encode(&mut emulator, witness)?;
         let gadget = padded::for_header::<H, HEADER_SIZE, _>(&mut emulator, gadget)?;
@@ -157,12 +151,12 @@ mod tests {
 
     impl Header<Fp> for SingleHeader {
         const SUFFIX: Suffix = Suffix::new(100);
-        type Data<'source> = Fp;
+        type Data = Fp;
         type Output = Kind![Fp; Element<'_, _>];
 
-        fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        fn encode<'dr, D: Driver<'dr, F = Fp>>(
             dr: &mut D,
-            witness: DriverValue<D, Self::Data<'source>>,
+            witness: DriverValue<D, Self::Data>,
         ) -> Result<Bound<'dr, D, Self::Output>> {
             Element::alloc(dr, witness)
         }
@@ -172,12 +166,12 @@ mod tests {
 
     impl Header<Fp> for PairHeader {
         const SUFFIX: Suffix = Suffix::new(101);
-        type Data<'source> = (Fp, Fp);
+        type Data = (Fp, Fp);
         type Output = Kind![Fp; (Element<'_, _>, Element<'_, _>)];
 
-        fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        fn encode<'dr, D: Driver<'dr, F = Fp>>(
             dr: &mut D,
-            witness: DriverValue<D, Self::Data<'source>>,
+            witness: DriverValue<D, Self::Data>,
         ) -> Result<Bound<'dr, D, Self::Output>> {
             let (a, b) = witness.cast();
             Ok((Element::alloc(dr, a)?, Element::alloc(dr, b)?))

--- a/crates/ragu_pcd/src/step/internal/adapter.rs
+++ b/crates/ragu_pcd/src/step/internal/adapter.rs
@@ -46,11 +46,11 @@ impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Circuit<C::Circuit
     type Instance<'source> = (
         FixedVec<C::CircuitField, ConstLen<HEADER_SIZE>>,
         FixedVec<C::CircuitField, ConstLen<HEADER_SIZE>>,
-        <S::Output as Header<C::CircuitField>>::Data<'source>,
+        <S::Output as Header<C::CircuitField>>::Data,
     );
     type Witness<'source> = (
-        <S::Left as Header<C::CircuitField>>::Data<'source>,
-        <S::Right as Header<C::CircuitField>>::Data<'source>,
+        <S::Left as Header<C::CircuitField>>::Data,
+        <S::Right as Header<C::CircuitField>>::Data,
         S::Witness<'source>,
     );
     type Output = Kind![C::CircuitField; FixedVec<Element<'_, _>, TripleConstLen<HEADER_SIZE>>];
@@ -59,7 +59,7 @@ impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Circuit<C::Circuit
             FixedVec<C::CircuitField, ConstLen<HEADER_SIZE>>,
             FixedVec<C::CircuitField, ConstLen<HEADER_SIZE>>,
         ),
-        <S::Output as Header<C::CircuitField>>::Data<'source>,
+        <S::Output as Header<C::CircuitField>>::Data,
         S::Aux<'source>,
     );
 
@@ -135,12 +135,12 @@ mod tests {
 
     impl Header<Fp> for TestHeader {
         const SUFFIX: Suffix = Suffix::new(50);
-        type Data<'source> = Fp;
+        type Data = Fp;
         type Output = Kind![Fp; Element<'_, _>];
 
-        fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        fn encode<'dr, D: Driver<'dr, F = Fp>>(
             dr: &mut D,
-            witness: DriverValue<D, Self::Data<'source>>,
+            witness: DriverValue<D, Self::Data>,
         ) -> Result<Bound<'dr, D, Self::Output>> {
             Element::alloc(dr, witness)
         }

--- a/crates/ragu_pcd/src/step/internal/rerandomize.rs
+++ b/crates/ragu_pcd/src/step/internal/rerandomize.rs
@@ -45,7 +45,7 @@ impl<C: Cycle, H: Header<C::CircuitField>> Step<C> for Rerandomize<H> {
         &self,
         dr: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
-        left: DriverValue<D, H::Data<'source>>,
+        left: DriverValue<D, H::Data>,
         right: DriverValue<D, ()>,
     ) -> Result<(
         (
@@ -53,7 +53,7 @@ impl<C: Cycle, H: Header<C::CircuitField>> Step<C> for Rerandomize<H> {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         // Use uniform encoding for left to ensure circuit uniformity across header types
@@ -94,11 +94,11 @@ fn test_rerandomize_consistency() {
     struct Single;
     impl Header<Fp> for Single {
         const SUFFIX: Suffix = Suffix::new(0);
-        type Data<'source> = Fp;
+        type Data = Fp;
         type Output = Kind![Fp; Element<'_, _>];
-        fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        fn encode<'dr, D: Driver<'dr, F = Fp>>(
             dr: &mut D,
-            witness: DriverValue<D, Self::Data<'source>>,
+            witness: DriverValue<D, Self::Data>,
         ) -> Result<Bound<'dr, D, Self::Output>> {
             Element::alloc(dr, witness)
         }
@@ -107,11 +107,11 @@ fn test_rerandomize_consistency() {
     struct Pair;
     impl Header<Fp> for Pair {
         const SUFFIX: Suffix = Suffix::new(1);
-        type Data<'source> = (Fp, Fp);
+        type Data = (Fp, Fp);
         type Output = Kind![Fp; (Element<'_, _>, Element<'_, _>)];
-        fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        fn encode<'dr, D: Driver<'dr, F = Fp>>(
             dr: &mut D,
-            witness: DriverValue<D, Self::Data<'source>>,
+            witness: DriverValue<D, Self::Data>,
         ) -> Result<Bound<'dr, D, Self::Output>> {
             let (a, b) = witness.cast();
             let a = Element::alloc(dr, a)?;

--- a/crates/ragu_pcd/src/step/internal/trivial.rs
+++ b/crates/ragu_pcd/src/step/internal/trivial.rs
@@ -44,7 +44,7 @@ impl<C: Cycle> Step<C> for Trivial {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;

--- a/crates/ragu_pcd/src/step/mod.rs
+++ b/crates/ragu_pcd/src/step/mod.rs
@@ -175,15 +175,15 @@ pub trait Step<C: Cycle>: Sized + Send + Sync {
         &self,
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'source>>,
-        left: DriverValue<D, <Self::Left as Header<C::CircuitField>>::Data<'source>>,
-        right: DriverValue<D, <Self::Right as Header<C::CircuitField>>::Data<'source>>,
+        left: DriverValue<D, <Self::Left as Header<C::CircuitField>>::Data>,
+        right: DriverValue<D, <Self::Right as Header<C::CircuitField>>::Data>,
     ) -> Result<(
         (
             Encoded<'dr, D, Self::Left, HEADER_SIZE>,
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )>
     where

--- a/crates/ragu_pcd/src/verify.rs
+++ b/crates/ragu_pcd/src/verify.rs
@@ -24,7 +24,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
     /// Verifies some [`Pcd`] for the provided [`Header`].
     pub fn verify<RNG: CryptoRng, H: Header<C::CircuitField>>(
         &self,
-        pcd: &Pcd<'_, C, R, H>,
+        pcd: &Pcd<C, R, H>,
         mut rng: RNG,
     ) -> Result<bool> {
         // Sample verification challenges w, y, and z.

--- a/crates/ragu_pcd/tests/registration_errors.rs
+++ b/crates/ragu_pcd/tests/registration_errors.rs
@@ -21,11 +21,11 @@ struct HSuffixAOther;
 
 impl<F: Field> Header<F> for HSuffixA {
     const SUFFIX: Suffix = Suffix::new(0);
-    type Data<'source> = ();
+    type Data = ();
     type Output = ();
-    fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
+    fn encode<'dr, D: Driver<'dr, F = F>>(
         _: &mut D,
-        _: DriverValue<D, Self::Data<'source>>,
+        _: DriverValue<D, Self::Data>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         Ok(())
     }
@@ -33,11 +33,11 @@ impl<F: Field> Header<F> for HSuffixA {
 
 impl<F: Field> Header<F> for HSuffixB {
     const SUFFIX: Suffix = Suffix::new(1);
-    type Data<'source> = ();
+    type Data = ();
     type Output = ();
-    fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
+    fn encode<'dr, D: Driver<'dr, F = F>>(
         _: &mut D,
-        _: DriverValue<D, Self::Data<'source>>,
+        _: DriverValue<D, Self::Data>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         Ok(())
     }
@@ -45,11 +45,11 @@ impl<F: Field> Header<F> for HSuffixB {
 
 impl<F: Field> Header<F> for HSuffixAOther {
     const SUFFIX: Suffix = Suffix::new(0); // duplicate suffix
-    type Data<'source> = ();
+    type Data = ();
     type Output = ();
-    fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
+    fn encode<'dr, D: Driver<'dr, F = F>>(
         _: &mut D,
-        _: DriverValue<D, Self::Data<'source>>,
+        _: DriverValue<D, Self::Data>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         Ok(())
     }
@@ -76,7 +76,7 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step0 {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;
@@ -108,7 +108,7 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step1 {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;
@@ -140,7 +140,7 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step1Dup {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;

--- a/crates/ragu_pcd/tests/rerandomization.rs
+++ b/crates/ragu_pcd/tests/rerandomization.rs
@@ -22,11 +22,11 @@ struct HeaderA;
 
 impl<F: Field> Header<F> for HeaderA {
     const SUFFIX: Suffix = Suffix::new(0);
-    type Data<'source> = ();
+    type Data = ();
     type Output = ();
-    fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
+    fn encode<'dr, D: Driver<'dr, F = F>>(
         _: &mut D,
-        _: DriverValue<D, Self::Data<'source>>,
+        _: DriverValue<D, Self::Data>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         Ok(())
     }
@@ -37,11 +37,11 @@ struct HeaderWithData;
 
 impl Header<Fp> for HeaderWithData {
     const SUFFIX: Suffix = Suffix::new(2);
-    type Data<'source> = Fp;
+    type Data = Fp;
     type Output = Kind![Fp; Element<'_, _>];
-    fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+    fn encode<'dr, D: Driver<'dr, F = Fp>>(
         dr: &mut D,
-        witness: DriverValue<D, Self::Data<'source>>,
+        witness: DriverValue<D, Self::Data>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         Element::alloc(dr, witness)
     }
@@ -68,7 +68,7 @@ impl Step<Pasta> for StepWithData {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<Fp>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;
@@ -99,7 +99,7 @@ impl<C: Cycle> Step<C> for Step0 {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;
@@ -129,7 +129,7 @@ impl<C: Cycle> Step<C> for Step1 {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let left = Encoded::new(dr, left)?;

--- a/crates/ragu_testing/src/pcd/nontrivial.rs
+++ b/crates/ragu_testing/src/pcd/nontrivial.rs
@@ -18,12 +18,12 @@ pub struct LeafNode;
 
 impl<F: Field> Header<F> for LeafNode {
     const SUFFIX: Suffix = Suffix::new(0);
-    type Data<'source> = F;
+    type Data = F;
     type Output = Kind![F; Element<'_, _>];
 
-    fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
+    fn encode<'dr, D: Driver<'dr, F = F>>(
         dr: &mut D,
-        witness: DriverValue<D, Self::Data<'source>>,
+        witness: DriverValue<D, Self::Data>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         Element::alloc(dr, witness)
     }
@@ -33,12 +33,12 @@ pub struct InternalNode;
 
 impl<F: Field> Header<F> for InternalNode {
     const SUFFIX: Suffix = Suffix::new(1);
-    type Data<'source> = F;
+    type Data = F;
     type Output = Kind![F; Element<'_, _>];
 
-    fn encode<'dr, 'source: 'dr, D: Driver<'dr, F = F>>(
+    fn encode<'dr, D: Driver<'dr, F = F>>(
         dr: &mut D,
-        witness: DriverValue<D, Self::Data<'source>>,
+        witness: DriverValue<D, Self::Data>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         Element::alloc(dr, witness)
     }
@@ -68,7 +68,7 @@ impl<C: Cycle> Step<C> for Hash2<'_, C> {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )>
     where
@@ -112,7 +112,7 @@ impl<C: Cycle> Step<C> for WitnessLeaf<'_, C> {
             Encoded<'dr, D, Self::Right, HEADER_SIZE>,
             Encoded<'dr, D, Self::Output, HEADER_SIZE>,
         ),
-        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data<'source>>,
+        DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )>
     where


### PR DESCRIPTION
A follow up of #585, (blocked by it)
(Only review [8d9bb19](https://github.com/tachyon-zcash/ragu/pull/586/commits/8d9bb196e04a09994ded5d0a5940af386be2489e) onward, everything prior are from 585)

This PR introduce a new `#[header]` proc-macro that auto generate the `Header` implementation for trivial header (that directly allocate everything in the `H::Data` into its `H::Output` gadget. We still leave the freedom to circuit dev to define their own custom `Header::encode()` logic if needed.