### PR TITLE
chore: expanding lazy mont reduction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,7 +604,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 [[package]]
 name = "pasta_curves"
 version = "0.5.1"
-source = "git+https://github.com/ebfull/pasta_curves?branch=ff-0.14-with-rand-0.10#ad4c7a24d9b0829f9da5f305aab6b4ab97a97900"
+source = "git+https://github.com/alxiong/pasta_curves?branch=v0.5.2-rc.1#59e30c5377191c6ef10f5051c3d95da43eb1081e"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -755,6 +755,7 @@ dependencies = [
  "group",
  "gungraun",
  "maybe-rayon",
+ "pasta_curves",
  "proptest",
  "ragu_arithmetic",
  "ragu_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,4 +101,4 @@ group = { git = "https://github.com/ebfull/group", branch = "release-0.14.0-with
 # https://github.com/zcash/pasta_curves/pull/86
 # that updates `pasta_curves` to use `ff`/`group` `0.14.0-pre.0`
 # then bumps to `rand 0.9`.
-pasta_curves = { git = "https://github.com/ebfull/pasta_curves", branch = "ff-0.14-with-rand-0.10" }
+pasta_curves = { git = "https://github.com/alxiong/pasta_curves", branch = "v0.5.2-rc.1" }

--- a/crates/ragu_arithmetic/src/lib.rs
+++ b/crates/ragu_arithmetic/src/lib.rs
@@ -84,6 +84,7 @@ use ff::{Field, FromUniformBytes, WithSmallOrderMulGroup};
 pub use coeff::Coeff;
 pub use domain::Domain;
 pub use fft::{Ring, bitreverse};
+pub use pasta_curves::MontgomeryRepr;
 pub use pasta_curves::arithmetic::{Coordinates, CurveAffine, CurveExt};
 pub use util::{
     batch_to_affine, dot, eval, factor, factor_iter, geosum, low_u64, mul, poly_with_roots,
@@ -116,10 +117,10 @@ pub use u128 as Uendo;
 pub trait Cycle: Copy + Clone + Default + Send + Sync + 'static {
     /// The field that circuit developers will primarily work with, and the
     /// scalar field of the [`HostCurve`](Cycle::HostCurve).
-    type CircuitField: WithSmallOrderMulGroup<3> + FromUniformBytes<64>;
+    type CircuitField: WithSmallOrderMulGroup<3> + FromUniformBytes<64> + MontgomeryRepr;
 
     /// The scalar field of the [`NestedCurve`](Cycle::NestedCurve).
-    type ScalarField: WithSmallOrderMulGroup<3> + FromUniformBytes<64>;
+    type ScalarField: WithSmallOrderMulGroup<3> + FromUniformBytes<64> + MontgomeryRepr;
 
     /// The nested curve that applications typically use for asymmetric keys,
     /// signatures, and other cryptographic primitives. (This is the Pallas

--- a/crates/ragu_arithmetic/src/util.rs
+++ b/crates/ragu_arithmetic/src/util.rs
@@ -1,5 +1,6 @@
 use ff::{Field, PrimeField};
 use pasta_curves::{
+    MontgomeryRepr,
     arithmetic::CurveAffine,
     group::{Curve, Group},
 };
@@ -45,7 +46,12 @@ where
 /// # Panics
 ///
 /// Panics if the lengths of $\mathbf{a}$ and $\mathbf{b}$ are not equal.
-pub fn dot<'a, F: Field, I1: IntoIterator<Item = &'a F>, I2: IntoIterator<Item = &'a F>>(
+pub fn dot<
+    'a,
+    F: Field + MontgomeryRepr,
+    I1: IntoIterator<Item = &'a F>,
+    I2: IntoIterator<Item = &'a F>,
+>(
     a: I1,
     b: I2,
 ) -> F
@@ -53,13 +59,10 @@ where
     I1::IntoIter: ExactSizeIterator,
     I2::IntoIter: ExactSizeIterator,
 {
-    let a = a.into_iter();
-    let b = b.into_iter();
+    let a: Vec<F> = a.into_iter().copied().collect();
+    let b: Vec<F> = b.into_iter().copied().collect();
     assert_eq!(a.len(), b.len());
-    a.into_iter()
-        .zip(b)
-        .map(|(a, b)| *a * *b)
-        .fold(F::ZERO, |acc, x| acc + x)
+    F::inner_product(&a, &b)
 }
 
 fn factor_iter_inner<F: Field, I: IntoIterator<Item = F>>(a: I, mut b: F) -> impl Iterator<Item = F>

--- a/crates/ragu_circuits/Cargo.toml
+++ b/crates/ragu_circuits/Cargo.toml
@@ -33,6 +33,7 @@ ragu_arithmetic = { path = "../ragu_arithmetic", version = "0.0.0" }
 blake2b_simd = { workspace = true }
 ff = { workspace = true }
 group = { workspace = true }
+pasta_curves = { workspace = true }
 ragu_core = { path = "../ragu_core", version = "0.0.0" }
 ragu_primitives = { path = "../ragu_primitives", version = "0.0.0" }
 rand = { workspace = true }

--- a/crates/ragu_circuits/src/polynomials/structured.rs
+++ b/crates/ragu_circuits/src/polynomials/structured.rs
@@ -2,6 +2,7 @@
 
 use ff::Field;
 use ragu_arithmetic::CurveAffine;
+use ragu_arithmetic::MontgomeryRepr;
 use rand::CryptoRng;
 
 use alloc::vec::Vec;
@@ -121,17 +122,14 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     }
 
     /// Inner product of `self` with the reversed `other`.
-    pub fn revdot(&self, other: &Self) -> F {
-        fn dot<F: Field>(a: &[F], b: &[F]) -> F {
-            a.iter()
-                .zip(b.iter())
-                .fold(F::ZERO, |acc, (a, b)| acc + (*a * *b))
-        }
-
-        dot(&self.u, &other.v)
-            + dot(&self.v, &other.u)
-            + dot(&self.w, &other.d)
-            + dot(&self.d, &other.w)
+    pub fn revdot(&self, other: &Self) -> F
+    where
+        F: MontgomeryRepr,
+    {
+        F::inner_product(&self.u, &other.v)
+            + F::inner_product(&self.v, &other.u)
+            + F::inner_product(&self.w, &other.d)
+            + F::inner_product(&self.d, &other.w)
     }
 
     /// Add the coefficients of `other` to `self`.

--- a/crates/ragu_pcd/src/fuse/_08_f.rs
+++ b/crates/ragu_pcd/src/fuse/_08_f.rs
@@ -166,13 +166,20 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             ));
         }
 
-        let mut coeffs = Vec::with_capacity(R::num_coeffs());
         let (first, rest) = iters.split_first_mut().unwrap();
-        for val in first.by_ref() {
-            let c = rest
-                .iter_mut()
-                .fold(val, |acc, iter| alpha * acc + iter.next().unwrap());
-            coeffs.push(c);
+        let mut coeffs: Vec<_> = first.collect();
+
+        for iter in rest.iter_mut() {
+            for c in coeffs.chunks_exact_mut(4) {
+                let [a, b, c, d] = c else { unreachable!() };
+                *a = alpha * *a + iter.next().unwrap();
+                *b = alpha * *b + iter.next().unwrap();
+                *c = alpha * *c + iter.next().unwrap();
+                *d = alpha * *d + iter.next().unwrap();
+            }
+            for c in coeffs.chunks_exact_mut(4).into_remainder() {
+                *c = alpha * *c + iter.next().unwrap();
+            }
         }
         coeffs.reverse();
 

--- a/crates/ragu_pcd/src/internal/fold_revdot.rs
+++ b/crates/ragu_pcd/src/internal/fold_revdot.rs
@@ -1,6 +1,7 @@
 //! Operations and utilities for reasoning about folded revdot claims.
 
 use ff::Field;
+use ragu_arithmetic::MontgomeryRepr;
 use ragu_circuits::{
     horner::Horner,
     polynomials::{Rank, structured},
@@ -136,7 +137,7 @@ pub fn fold_outer<T: Foldable<F>, F: Field, P: Parameters>(
 ///
 /// This computes off-diagonal revdot products for each group of `Inner`
 /// polynomials, producing `Outer` groups of error terms.
-fn compute_errors_impl<F: Field, R: Rank, Outer: Len, Inner: Len>(
+fn compute_errors_impl<F: Field + MontgomeryRepr, R: Rank, Outer: Len, Inner: Len>(
     a: &[impl Borrow<structured::Polynomial<F, R>>],
     b: &[impl Borrow<structured::Polynomial<F, R>>],
 ) -> FixedVec<FixedVec<F, NumErrorTerms<Inner>>, Outer> {
@@ -174,7 +175,7 @@ fn compute_errors_impl<F: Field, R: Rank, Outer: Len, Inner: Len>(
 }
 
 /// Inner error terms: `NumGroups` groups of `GroupSize`*(`GroupSize`-1) off-diagonal revdot products.
-pub fn inner_error_terms<F: Field, R: Rank, P: Parameters>(
+pub fn inner_error_terms<F: Field + MontgomeryRepr, R: Rank, P: Parameters>(
     a: &[impl Borrow<structured::Polynomial<F, R>>],
     b: &[impl Borrow<structured::Polynomial<F, R>>],
 ) -> FixedVec<FixedVec<F, NumErrorTerms<P::GroupSize>>, P::NumGroups> {
@@ -182,7 +183,7 @@ pub fn inner_error_terms<F: Field, R: Rank, P: Parameters>(
 }
 
 /// Outer error terms: `NumGroups`*(`NumGroups`-1) off-diagonal revdot products.
-pub fn outer_error_terms<F: Field, R: Rank, P: Parameters>(
+pub fn outer_error_terms<F: Field + MontgomeryRepr, R: Rank, P: Parameters>(
     a: &[impl Borrow<structured::Polynomial<F, R>>],
     b: &[impl Borrow<structured::Polynomial<F, R>>],
 ) -> FixedVec<F, NumErrorTerms<P::NumGroups>> {


### PR DESCRIPTION
Builds on https://github.com/tachyon-zcash/ragu/pull/580 by extending `inner_product` usage at callsites. The first commit duplicates that diff and will be subsumed after rebase once @alxiong's PR lands. CI currently failing because of the `needs_reduction` bug identified in https://github.com/zcash/pasta_curves/pull/88. 