### PR TITLE
chore(pcd): parallelize fuse evals

### DIFF
--- a/crates/ragu_arithmetic/src/lib.rs
+++ b/crates/ragu_arithmetic/src/lib.rs
@@ -83,6 +83,10 @@ pub use coeff::Coeff;
 pub use domain::Domain;
 use ff::{Field, FromUniformBytes, WithSmallOrderMulGroup};
 pub use fft::{Ring, bitreverse};
+/// Internal re-export consumed by [`par_join!`]. `par_join!` expands to a path
+/// through `$crate`, so the helper must be reachable at the crate root.
+#[doc(hidden)]
+pub use multicore::join;
 pub use pasta_curves::{
     arithmetic::{Coordinates, CurveAffine, CurveExt},
     deferred::DeferredField,
@@ -103,6 +107,21 @@ pub use u128 as Uendo;
 pub use util::{
     batch_to_affine, dot, eval, factor, factor_iter, geosum, low_u64, mul, poly_with_roots,
 };
+
+/// N-way parallel join for coarse-grained task parallelism.
+///
+/// Like rayon's `join` for more than two closures: nests internally and
+/// flattens the result into a single tuple. Each closure may return a
+/// different type. Supports 2..=4 closures — for higher arities prefer a
+/// data-parallel iterator.
+///
+/// ```
+/// use ragu_arithmetic::par_join;
+///
+/// let (a, b, c) = par_join!(|| 1u32, || "two", || 3.0_f64);
+/// assert_eq!((a, b, c), (1, "two", 3.0));
+/// ```
+pub use crate::__ragu_arithmetic_par_join as par_join;
 
 /// Represents a "cycle" of elliptic curves where the scalar field of one curve
 /// is the base field of the other, and vice-versa.

--- a/crates/ragu_arithmetic/src/lib.rs
+++ b/crates/ragu_arithmetic/src/lib.rs
@@ -107,20 +107,6 @@ pub use util::{
     poly_mul, poly_with_roots,
 };
 
-/// N-way parallel join for coarse-grained task parallelism.
-///
-/// Like [`join`] for more than two closures: nests internally and flattens the
-/// result into a single tuple. Each closure may return a different type.
-/// Supports 2..=4 closures — for higher arities prefer a data-parallel
-/// iterator.
-///
-/// ```
-/// use ragu_arithmetic::par_join;
-///
-/// let (a, b, c) = par_join!(|| 1u32, || "two", || 3.0_f64);
-/// assert_eq!((a, b, c), (1, "two", 3.0));
-/// ```
-pub use crate::__ragu_arithmetic_par_join as par_join;
 use crate::ff::{Field, FromUniformBytes, PrimeFieldBits, WithSmallOrderMulGroup};
 pub use crate::pasta_curves::{
     arithmetic::{Coordinates, CurveAffine, CurveExt},

--- a/crates/ragu_arithmetic/src/lib.rs
+++ b/crates/ragu_arithmetic/src/lib.rs
@@ -90,6 +90,13 @@ pub extern crate rand;
 pub use coeff::Coeff;
 pub use domain::Domain;
 pub use fft::{Ring, bitreverse};
+/// Runs two closures, potentially in parallel, and returns both of their
+/// results. This is the primitive that [`par_join!`] generalizes to more than
+/// two closures.
+///
+/// When the `multicore` feature is disabled the closures simply run in
+/// sequence.
+pub use multicore::join;
 /// Converts a 256-bit integer literal into the little endian `[u64; 4]`
 /// representation that e.g. [`Fp::from_raw`](crate::pasta_curves::Fp::from_raw) or
 /// [`Fp::pow`](crate::pasta_curves::Fp::pow) need as input. This makes constants
@@ -100,6 +107,20 @@ pub use util::{
     poly_mul, poly_with_roots,
 };
 
+/// N-way parallel join for coarse-grained task parallelism.
+///
+/// Like [`join`] for more than two closures: nests internally and flattens the
+/// result into a single tuple. Each closure may return a different type.
+/// Supports 2..=4 closures — for higher arities prefer a data-parallel
+/// iterator.
+///
+/// ```
+/// use ragu_arithmetic::par_join;
+///
+/// let (a, b, c) = par_join!(|| 1u32, || "two", || 3.0_f64);
+/// assert_eq!((a, b, c), (1, "two", 3.0));
+/// ```
+pub use crate::__ragu_arithmetic_par_join as par_join;
 use crate::ff::{Field, FromUniformBytes, PrimeFieldBits, WithSmallOrderMulGroup};
 pub use crate::pasta_curves::{
     arithmetic::{Coordinates, CurveAffine, CurveExt},

--- a/crates/ragu_arithmetic/src/multicore.rs
+++ b/crates/ragu_arithmetic/src/multicore.rs
@@ -1,8 +1,44 @@
+//! Parallel-execution utilities backed by [`maybe_rayon`].
+
 #[cfg(feature = "multicore")]
 pub use maybe_rayon::{current_num_threads, iter::ParallelIterator};
 pub use maybe_rayon::{iter::IntoParallelIterator, join};
 
+/// Returns 1 when the `multicore` feature is disabled.
 #[cfg(not(feature = "multicore"))]
 pub fn current_num_threads() -> usize {
     1
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __ragu_arithmetic_par_join {
+    ($a:expr, $b:expr $(,)?) => {
+        $crate::join($a, $b)
+    };
+    ($a:expr, $b:expr, $c:expr $(,)?) => {{
+        let (a, (b, c)) = $crate::join($a, || $crate::join($b, $c));
+        (a, b, c)
+    }};
+    ($a:expr, $b:expr, $c:expr, $d:expr $(,)?) => {{
+        let ((a, b), (c, d)) = $crate::join(|| $crate::join($a, $b), || $crate::join($c, $d));
+        (a, b, c, d)
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::par_join;
+
+    #[test]
+    fn flattens_to_tuple() {
+        let (a, b) = par_join!(|| 1u32, || "two");
+        assert_eq!((a, b), (1, "two"));
+
+        let (a, b, c) = par_join!(|| 1u32, || "two", || 3.0_f64);
+        assert_eq!((a, b, c), (1, "two", 3.0));
+
+        let (a, b, c, d) = par_join!(|| 1u32, || "two", || 3.0_f64, || 4i64);
+        assert_eq!((a, b, c, d), (1, "two", 3.0, 4));
+    }
 }

--- a/crates/ragu_arithmetic/src/multicore.rs
+++ b/crates/ragu_arithmetic/src/multicore.rs
@@ -33,8 +33,6 @@ macro_rules! par_join {
 
 #[cfg(test)]
 mod tests {
-    use crate::par_join;
-
     #[test]
     fn flattens_to_tuple() {
         let (a, b) = par_join!(|| 1u32, || "two");

--- a/crates/ragu_arithmetic/src/multicore.rs
+++ b/crates/ragu_arithmetic/src/multicore.rs
@@ -10,9 +10,14 @@ pub fn current_num_threads() -> usize {
     1
 }
 
+/// N-way parallel join for coarse-grained task parallelism.
+///
+/// Like [`join`] for more than two closures: nests internally and flattens
+/// the result into a single tuple. Each closure may return a different type.
+/// Supports 2..=4 closures — for higher arities prefer a data-parallel
+/// iterator.
 #[macro_export]
-#[doc(hidden)]
-macro_rules! __ragu_arithmetic_par_join {
+macro_rules! par_join {
     ($a:expr, $b:expr $(,)?) => {
         $crate::join($a, $b)
     };

--- a/crates/ragu_backend/src/lib.rs
+++ b/crates/ragu_backend/src/lib.rs
@@ -6,6 +6,9 @@
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 
+extern crate alloc;
+
+use alloc::vec::Vec;
 use core::fmt::Debug;
 
 use ragu_arithmetic::{
@@ -93,12 +96,48 @@ pub trait Backend: Clone + Copy + Debug + Default + Send + Sync + 'static {
     }
 
     /// Computes the registry restriction $m(W, x, y)$.
+    ///
+    /// Callers that also need the $W$-domain evaluations can reach for
+    /// [`registry_wxy_over_domain`](Self::registry_wxy_over_domain) and
+    /// [`registry_interpolate_xy`](Self::registry_interpolate_xy) directly,
+    /// sharing a single per-circuit pass between the two representations.
+    ///
+    /// # Correctness
+    ///
+    /// Overrides must match [`Registry::xy`] exactly.
     fn registry_xy<F: PrimeField, R: Rank>(
         registry: &Registry<'_, F, R>,
         x: F,
         y: F,
     ) -> sparse::Polynomial<F, R> {
-        registry.xy(x, y)
+        Self::registry_interpolate_xy(registry, Self::registry_wxy_over_domain(registry, x, y))
+    }
+
+    /// Evaluates the registry polynomial over its $W$-domain at $X = x$,
+    /// $Y = y$.
+    ///
+    /// # Correctness
+    ///
+    /// Overrides must match [`Registry::wxy_over_domain`] exactly.
+    fn registry_wxy_over_domain<F: PrimeField, R: Rank>(
+        registry: &Registry<'_, F, R>,
+        x: F,
+        y: F,
+    ) -> Vec<F> {
+        registry.wxy_over_domain(x, y)
+    }
+
+    /// Interpolates $W$-domain evaluations into the monomial-basis polynomial
+    /// $m(W, x, y)$.
+    ///
+    /// # Correctness
+    ///
+    /// Overrides must match [`Registry::interpolate_xy`] exactly.
+    fn registry_interpolate_xy<F: PrimeField, R: Rank>(
+        registry: &Registry<'_, F, R>,
+        evals: Vec<F>,
+    ) -> sparse::Polynomial<F, R> {
+        registry.interpolate_xy(evals)
     }
 
     /// Computes the circuit restriction $s_i(X, y)$ selected by `circuit`.

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -410,32 +410,60 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     }
 
     /// Evaluate the registry polynomial unrestricted at $W$.
+    ///
+    /// Composed of [`wxy_over_domain`](Self::wxy_over_domain) followed by
+    /// [`interpolate_xy`](Self::interpolate_xy). When a caller needs both
+    /// representations, it can call those two methods directly to share a
+    /// single per-circuit pass.
     pub fn xy(&self, x: F, y: F) -> sparse::Polynomial<F, R> {
-        let key_scalar = self.key_sxy(x, y);
-        let mut coeffs = alloc::vec![F::ZERO; R::num_coeffs()];
+        let evals = self.wxy_over_domain(x, y);
+        self.interpolate_xy(evals)
+    }
 
+    /// Evaluate the registry polynomial at every element of its $W$-domain
+    /// with $X = x$, $Y = y$, returning evaluations $m(\omega^j, x, y)$ for
+    /// $j \in [0, n)$.
+    ///
+    /// The returned vector is ordered by $j$, not by circuit index — circuit
+    /// $i$'s value $s\_{i}(x, y) = m(\omega\_{j(i)}, x, y)$ lives at
+    /// `evals[bitreverse(i, log2_n)]`. Domain positions with no registered
+    /// circuit hold only the W-independent key contribution.
+    pub fn wxy_over_domain(&self, x: F, y: F) -> Vec<F> {
+        // The key term k * (XY)^{4n-1} has no W factor, so it adds the same
+        // scalar to every domain evaluation.
+        let key_scalar = self.key_sxy(x, y);
+        let global_xy = crate::staging::mask::global_mask::<F, R>(x, y);
+
+        let mut evals = alloc::vec![key_scalar; self.domain.n()];
         // Masking polynomials return only -notch from sxy(); add the shared
         // global term to each mask slot inline.
-        let global_xy = crate::staging::mask::global_mask::<F, R>(x, y);
         for (i, circuit) in self.circuits.iter().enumerate() {
             let j = bitreverse(i as u32, self.domain.log2_n()) as usize;
             let mut v = circuit.sxy(x, y, &self.floor_plans[i]);
             if circuit.is_mask() {
                 v += global_xy;
             }
-            coeffs[j] = v;
+            evals[j] += v;
         }
+        evals
+    }
 
-        // Convert from the Lagrange basis.
-        let domain = &self.domain;
-        domain.ifft(&mut coeffs[..domain.n()]);
+    /// Interpolate the Lagrange-basis evaluations from
+    /// [`wxy_over_domain`](Self::wxy_over_domain) into the monomial-basis
+    /// polynomial $m(W, x, y)$ via an inverse FFT.
+    ///
+    /// Consumes `evals` and reuses its allocation as the polynomial's
+    /// coefficient buffer. `evals.len()` must equal the registry's domain size.
+    pub fn interpolate_xy(&self, mut evals: Vec<F>) -> sparse::Polynomial<F, R> {
+        assert_eq!(evals.len(), self.domain.n());
+        self.domain.ifft(&mut evals);
+        sparse::Polynomial::from_coeffs(evals)
+    }
 
-        // The key term k * (XY)^{4n-1} has no W factor, so it evaluates to
-        // the same scalar at every domain point. After IFFT the contribution
-        // lives entirely in the W^0 (DC) coefficient.
-        coeffs[0] += key_scalar;
-
-        sparse::Polynomial::from_coeffs(coeffs)
+    /// Returns $\log_2$ of the registry's $W$-domain size (the smallest power
+    /// of two that fits all registered circuits).
+    pub fn log2_domain(&self) -> u32 {
+        self.domain.log2_n()
     }
 
     /// Index the $i$th circuit to field element $\omega^j$ as $w$, and evaluate
@@ -770,6 +798,58 @@ mod tests {
             assert_eq!(wxy_value, wx_poly.eval(y));
 
             w *= registry.domain.omega();
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_wxy_over_domain_consistency() -> Result<()> {
+        // Use a non-power-of-two count so the domain has zero-padded slots.
+        let registry = TestRegistryBuilder::new()
+            .register_circuit(SquareCircuit { times: 2 })?
+            .register_circuit(SquareCircuit { times: 5 })?
+            .register_circuit(SquareCircuit { times: 10 })?
+            .register_circuit(SquareCircuit { times: 11 })?
+            .register_circuit(SquareCircuit { times: 19 })?
+            .finalize()?;
+
+        let x = Fp::random(&mut rand::rng());
+        let y = Fp::random(&mut rand::rng());
+
+        let evals = registry.wxy_over_domain(x, y);
+        let poly = registry.xy(x, y);
+
+        assert_eq!(evals.len(), registry.domain.n());
+
+        // evals[k] must equal m(omega^k, x, y) = poly.eval(omega^k).
+        let mut omega_pow = Fp::ONE;
+        for (k, eval) in evals.iter().enumerate() {
+            assert_eq!(
+                *eval,
+                poly.eval(omega_pow),
+                "evals[{}] should equal poly.eval(omega^{})",
+                k,
+                k
+            );
+            omega_pow *= registry.domain.omega();
+        }
+
+        // For each registered circuit i, its evaluation at omega_j(i) lives
+        // at the bit-reversed domain position.
+        let log2_n = registry.log2_domain();
+        for i in 0..registry.num_circuits() {
+            let k = bitreverse(i as u32, log2_n) as usize;
+            let omega_j = CircuitIndex::new(i).omega_j::<Fp>();
+            assert_eq!(evals[k], poly.eval(omega_j));
+        }
+
+        // interpolate_xy on the evals reproduces xy() (compared via
+        // evaluation at random off-domain points).
+        let interpolated = registry.interpolate_xy(evals);
+        for _ in 0..4 {
+            let probe = Fp::random(&mut rand::rng());
+            assert_eq!(interpolated.eval(probe), poly.eval(probe));
         }
 
         Ok(())

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -469,20 +469,16 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
         self.interpolate_xy(evals)
     }
 
-    /// Evaluate the registry polynomial at every element of its $W$-domain
-    /// with $X = x$, $Y = y$, returning $m(\omega^j, x, y)$ at index $j$ for
-    /// $j \in [0, n)$, where $\omega$ is the domain generator.
+    /// Evaluate the registry polynomial at every element of its $W$-domain,
+    /// returning $m(\omega^j, x, y)$ at index $j$ for $j \in [0, n)$, where
+    /// $\omega$ generates the domain.
     ///
-    /// The vector is indexed by domain position, not by circuit index: circuit
-    /// $i$ occupies position $j = \text{bitreverse}(i, \log\_2 n)$, so its entry
-    /// lives at `evals[bitreverse(i, log2_n)]`. (This agrees with
-    /// [`CircuitIndex::omega_j`], which computes the same point against the
-    /// field's full $2^S$ domain.)
-    ///
-    /// Each entry is the *whole* registry evaluation at that point, not the
-    /// circuit's $s\_i(x, y)$ alone: it also carries the $W$-independent key
-    /// term, plus the shared global term for masking circuits. Domain
-    /// positions with no registered circuit hold the key term only.
+    /// Entries are indexed by domain position: circuit $i$'s evaluation lives
+    /// at $j = \text{bitreverse}(i, \log\_2 n)$, the same point
+    /// [`CircuitIndex::omega_j`] computes against the field's full $2^S$
+    /// domain. Every entry includes the $W$-independent key term (positions
+    /// with no registered circuit hold it alone), and masking circuits also
+    /// carry the shared global term.
     pub fn wxy_over_domain(&self, x: F, y: F) -> Vec<F> {
         // The key term k * (XY)^{4n-1} has no W factor, so it adds the same
         // scalar to every domain evaluation.

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -459,32 +459,60 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     }
 
     /// Evaluate the registry polynomial unrestricted at $W$.
+    ///
+    /// Composed of [`wxy_over_domain`](Self::wxy_over_domain) followed by
+    /// [`interpolate_xy`](Self::interpolate_xy). When a caller needs both
+    /// representations, it can call those two methods directly to share a
+    /// single per-circuit pass.
     pub fn xy(&self, x: F, y: F) -> sparse::Polynomial<F, R> {
-        let key_scalar = self.key_sxy(x, y);
-        let mut coeffs = alloc::vec![F::ZERO; R::num_coeffs()];
+        let evals = self.wxy_over_domain(x, y);
+        self.interpolate_xy(evals)
+    }
 
+    /// Evaluate the registry polynomial at every element of its $W$-domain
+    /// with $X = x$, $Y = y$, returning evaluations $m(\omega^j, x, y)$ for
+    /// $j \in [0, n)$.
+    ///
+    /// The returned vector is ordered by $j$, not by circuit index — circuit
+    /// $i$'s value $s\_{i}(x, y) = m(\omega\_{j(i)}, x, y)$ lives at
+    /// `evals[bitreverse(i, log2_n)]`. Domain positions with no registered
+    /// circuit hold only the W-independent key contribution.
+    pub fn wxy_over_domain(&self, x: F, y: F) -> Vec<F> {
+        // The key term k * (XY)^{4n-1} has no W factor, so it adds the same
+        // scalar to every domain evaluation.
+        let key_scalar = self.key_sxy(x, y);
+        let global_xy = crate::staging::mask::global_mask::<F, R>(x, y);
+
+        let mut evals = alloc::vec![key_scalar; self.domain.n()];
         // Masking polynomials return only -notch from sxy(); add the shared
         // global term to each mask slot inline.
-        let global_xy = crate::staging::mask::global_mask::<F, R>(x, y);
         for (i, circuit) in self.circuits.iter().enumerate() {
             let j = self.bitreversed_index(i);
             let mut v = circuit.sxy(x, y, &self.floor_plans[i]);
             if circuit.is_mask() {
                 v += global_xy;
             }
-            coeffs[j] = v;
+            evals[j] += v;
         }
+        evals
+    }
 
-        // Convert from the Lagrange basis.
-        let domain = &self.domain;
-        domain.ifft(&mut coeffs[..domain.n()]);
+    /// Interpolate the Lagrange-basis evaluations from
+    /// [`wxy_over_domain`](Self::wxy_over_domain) into the monomial-basis
+    /// polynomial $m(W, x, y)$ via an inverse FFT.
+    ///
+    /// Consumes `evals` and reuses its allocation as the polynomial's
+    /// coefficient buffer. `evals.len()` must equal the registry's domain size.
+    pub fn interpolate_xy(&self, mut evals: Vec<F>) -> sparse::Polynomial<F, R> {
+        assert_eq!(evals.len(), self.domain.n());
+        self.domain.ifft(&mut evals);
+        sparse::Polynomial::from_coeffs(evals)
+    }
 
-        // The key term k * (XY)^{4n-1} has no W factor, so it evaluates to
-        // the same scalar at every domain point. After IFFT the contribution
-        // lives entirely in the W^0 (DC) coefficient.
-        coeffs[0] += key_scalar;
-
-        sparse::Polynomial::from_coeffs(coeffs)
+    /// Returns $\log_2$ of the registry's $W$-domain size (the smallest power
+    /// of two that fits all registered circuits).
+    pub fn log2_domain(&self) -> u32 {
+        self.domain.log2_n()
     }
 
     /// Index the $i$th circuit to field element $\omega^j$ as $w$, and evaluate
@@ -860,6 +888,58 @@ mod tests {
             assert_eq!(wxy_value, wx_poly.eval(y));
 
             w *= registry.domain.omega();
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_wxy_over_domain_consistency() -> Result<()> {
+        // Use a non-power-of-two count so the domain has zero-padded slots.
+        let registry = TestRegistryBuilder::new()
+            .register_circuit(SquareCircuit { times: 2 })?
+            .register_circuit(SquareCircuit { times: 5 })?
+            .register_circuit(SquareCircuit { times: 10 })?
+            .register_circuit(SquareCircuit { times: 11 })?
+            .register_circuit(SquareCircuit { times: 19 })?
+            .finalize()?;
+
+        let x = Fp::random(&mut rand::rng());
+        let y = Fp::random(&mut rand::rng());
+
+        let evals = registry.wxy_over_domain(x, y);
+        let poly = registry.xy(x, y);
+
+        assert_eq!(evals.len(), registry.domain.n());
+
+        // evals[k] must equal m(omega^k, x, y) = poly.eval(omega^k).
+        let mut omega_pow = Fp::ONE;
+        for (k, eval) in evals.iter().enumerate() {
+            assert_eq!(
+                *eval,
+                poly.eval(omega_pow),
+                "evals[{}] should equal poly.eval(omega^{})",
+                k,
+                k
+            );
+            omega_pow *= registry.domain.omega();
+        }
+
+        // For each registered circuit i, its evaluation at omega_j(i) lives
+        // at the bit-reversed domain position.
+        let log2_n = registry.log2_domain();
+        for i in 0..registry.num_circuits() {
+            let k = bitreverse(i as u32, log2_n) as usize;
+            let omega_j = CircuitIndex::new(i).omega_j::<Fp>();
+            assert_eq!(evals[k], poly.eval(omega_j));
+        }
+
+        // interpolate_xy on the evals reproduces xy() (compared via
+        // evaluation at random off-domain points).
+        let interpolated = registry.interpolate_xy(evals);
+        for _ in 0..4 {
+            let probe = Fp::random(&mut rand::rng());
+            assert_eq!(interpolated.eval(probe), poly.eval(probe));
         }
 
         Ok(())

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -470,13 +470,19 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     }
 
     /// Evaluate the registry polynomial at every element of its $W$-domain
-    /// with $X = x$, $Y = y$, returning evaluations $m(\omega^j, x, y)$ for
-    /// $j \in [0, n)$.
+    /// with $X = x$, $Y = y$, returning $m(\omega^j, x, y)$ at index $j$ for
+    /// $j \in [0, n)$, where $\omega$ is the domain generator.
     ///
-    /// The returned vector is ordered by $j$, not by circuit index — circuit
-    /// $i$'s value $s\_{i}(x, y) = m(\omega\_{j(i)}, x, y)$ lives at
-    /// `evals[bitreverse(i, log2_n)]`. Domain positions with no registered
-    /// circuit hold only the W-independent key contribution.
+    /// The vector is indexed by domain position, not by circuit index: circuit
+    /// $i$ occupies position $j = \text{bitreverse}(i, \log\_2 n)$, so its entry
+    /// lives at `evals[bitreverse(i, log2_n)]`. (This agrees with
+    /// [`CircuitIndex::omega_j`], which computes the same point against the
+    /// field's full $2^S$ domain.)
+    ///
+    /// Each entry is the *whole* registry evaluation at that point, not the
+    /// circuit's $s\_i(x, y)$ alone: it also carries the $W$-independent key
+    /// term, plus the shared global term for masking circuits. Domain
+    /// positions with no registered circuit hold the key term only.
     pub fn wxy_over_domain(&self, x: F, y: F) -> Vec<F> {
         // The key term k * (XY)^{4n-1} has no W factor, so it adds the same
         // scalar to every domain evaluation.
@@ -501,8 +507,12 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     /// [`wxy_over_domain`](Self::wxy_over_domain) into the monomial-basis
     /// polynomial $m(W, x, y)$ via an inverse FFT.
     ///
-    /// Consumes `evals` and reuses its allocation as the polynomial's
-    /// coefficient buffer. `evals.len()` must equal the registry's domain size.
+    /// `evals` is consumed and transformed in place by the inverse FFT before
+    /// being compressed into sparse block form.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `evals.len()` does not equal the registry's domain size.
     pub fn interpolate_xy(&self, mut evals: Vec<F>) -> sparse::Polynomial<F, R> {
         assert_eq!(evals.len(), self.domain.n());
         self.domain.ifft(&mut evals);
@@ -912,15 +922,13 @@ mod tests {
 
         assert_eq!(evals.len(), registry.domain.n());
 
-        // evals[k] must equal m(omega^k, x, y) = poly.eval(omega^k).
+        // evals[j] must equal m(omega^j, x, y) = poly.eval(omega^j).
         let mut omega_pow = Fp::ONE;
-        for (k, eval) in evals.iter().enumerate() {
+        for (j, eval) in evals.iter().enumerate() {
             assert_eq!(
                 *eval,
                 poly.eval(omega_pow),
-                "evals[{}] should equal poly.eval(omega^{})",
-                k,
-                k
+                "evals[{j}] should equal poly.eval(omega^{j})"
             );
             omega_pow *= registry.domain.omega();
         }
@@ -929,17 +937,19 @@ mod tests {
         // at the bit-reversed domain position.
         let log2_n = registry.log2_domain();
         for i in 0..registry.num_circuits() {
-            let k = bitreverse(i as u32, log2_n) as usize;
+            let j = bitreverse(i as u32, log2_n) as usize;
             let omega_j = CircuitIndex::new(i).omega_j::<Fp>();
-            assert_eq!(evals[k], poly.eval(omega_j));
+            assert_eq!(evals[j], poly.eval(omega_j));
         }
 
-        // interpolate_xy on the evals reproduces xy() (compared via
-        // evaluation at random off-domain points).
+        // interpolate_xy must agree with `wxy`, which reaches the same value
+        // through the independent Lagrange-cache path. Comparing against
+        // `poly` here would be vacuous: `xy` is defined as exactly this
+        // composition, so such an assertion could never fail.
         let interpolated = registry.interpolate_xy(evals);
         for _ in 0..4 {
             let probe = Fp::random(&mut rand::rng());
-            assert_eq!(interpolated.eval(probe), poly.eval(probe));
+            assert_eq!(interpolated.eval(probe), registry.wxy(probe, x, y));
         }
 
         Ok(())

--- a/crates/ragu_pcd/src/fuse/_07_query.rs
+++ b/crates/ragu_pcd/src/fuse/_07_query.rs
@@ -9,7 +9,7 @@
 //! restriction.
 
 use ff::Field;
-use ragu_arithmetic::Cycle;
+use ragu_arithmetic::{Cycle, par_join};
 use ragu_circuits::{polynomials::Rank, staging::StageExt};
 use ragu_core::{Result, drivers::Driver, maybe::Maybe};
 use ragu_primitives::Element;
@@ -43,41 +43,29 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
 
         // Evaluate the registry polynomial at all internal-circuit points and
         // at w concurrently with the left/right child witness construction.
-        let ((fixed_registry, registry_wxy), (left_witness, right_witness)) = maybe_rayon::join(
-            || {
-                (
-                    // TODO: these can all be evaluated at the same time; in fact,
-                    // that's what registry.xy is supposed to allow.
-                    native::InternalCircuitValues::from_fn(|id| {
-                        registry_xy_poly.eval(id.circuit_index().omega_j())
-                    }),
-                    registry_xy_poly.eval(w),
-                )
-            },
-            || {
-                maybe_rayon::join(
-                    || {
-                        native::stages::query::ChildEvaluationsWitness::from_proof(
-                            left,
-                            w,
-                            x,
-                            xz,
-                            &registry_xy_poly,
-                            &registry_wy.poly,
-                        )
-                    },
-                    || {
-                        native::stages::query::ChildEvaluationsWitness::from_proof(
-                            right,
-                            w,
-                            x,
-                            xz,
-                            &registry_xy_poly,
-                            &registry_wy.poly,
-                        )
-                    },
-                )
-            },
+        let (fixed_registry, registry_wxy, left_witness, right_witness) = par_join!(
+            // TODO: these can all be evaluated at the same time; in fact,
+            // that's what registry.xy is supposed to allow.
+            || native::InternalCircuitValues::from_fn(
+                |id| registry_xy_poly.eval(id.circuit_index().omega_j())
+            ),
+            || registry_xy_poly.eval(w),
+            || native::stages::query::ChildEvaluationsWitness::from_proof(
+                left,
+                w,
+                x,
+                xz,
+                &registry_xy_poly,
+                &registry_wy.poly,
+            ),
+            || native::stages::query::ChildEvaluationsWitness::from_proof(
+                right,
+                w,
+                x,
+                xz,
+                &registry_xy_poly,
+                &registry_wy.poly,
+            ),
         );
 
         let query_witness = native::stages::query::Witness {

--- a/crates/ragu_pcd/src/fuse/_07_query.rs
+++ b/crates/ragu_pcd/src/fuse/_07_query.rs
@@ -41,29 +41,50 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
 
         let registry_xy_poly = self.native_registry.xy(x, y);
 
+        // Evaluate the registry polynomial at all internal-circuit points and
+        // at w concurrently with the left/right child witness construction.
+        let ((fixed_registry, registry_wxy), (left_witness, right_witness)) = maybe_rayon::join(
+            || {
+                (
+                    // TODO: these can all be evaluated at the same time; in fact,
+                    // that's what registry.xy is supposed to allow.
+                    native::InternalCircuitValues::from_fn(|id| {
+                        registry_xy_poly.eval(id.circuit_index().omega_j())
+                    }),
+                    registry_xy_poly.eval(w),
+                )
+            },
+            || {
+                maybe_rayon::join(
+                    || {
+                        native::stages::query::ChildEvaluationsWitness::from_proof(
+                            left,
+                            w,
+                            x,
+                            xz,
+                            &registry_xy_poly,
+                            &registry_wy.poly,
+                        )
+                    },
+                    || {
+                        native::stages::query::ChildEvaluationsWitness::from_proof(
+                            right,
+                            w,
+                            x,
+                            xz,
+                            &registry_xy_poly,
+                            &registry_wy.poly,
+                        )
+                    },
+                )
+            },
+        );
+
         let query_witness = native::stages::query::Witness {
-            // TODO: these can all be evaluated at the same time; in fact,
-            // that's what registry.xy is supposed to allow.
-            fixed_registry: native::InternalCircuitValues::from_fn(|id| {
-                registry_xy_poly.eval(id.circuit_index().omega_j())
-            }),
-            registry_wxy: registry_xy_poly.eval(w),
-            left: native::stages::query::ChildEvaluationsWitness::from_proof(
-                left,
-                w,
-                x,
-                xz,
-                &registry_xy_poly,
-                &registry_wy.poly,
-            ),
-            right: native::stages::query::ChildEvaluationsWitness::from_proof(
-                right,
-                w,
-                x,
-                xz,
-                &registry_xy_poly,
-                &registry_wy.poly,
-            ),
+            fixed_registry,
+            registry_wxy,
+            left: left_witness,
+            right: right_witness,
         };
 
         let rx = native::stages::query::Stage::<C, R, HEADER_SIZE>::rx(

--- a/crates/ragu_pcd/src/fuse/_07_query.rs
+++ b/crates/ragu_pcd/src/fuse/_07_query.rs
@@ -9,7 +9,7 @@
 //! restriction.
 
 use ff::Field;
-use ragu_arithmetic::{Cycle, par_join};
+use ragu_arithmetic::{Cycle, bitreverse, par_join};
 use ragu_circuits::{polynomials::Rank, staging::StageExt};
 use ragu_core::{Result, drivers::Driver, maybe::Maybe};
 use ragu_primitives::Element;
@@ -39,16 +39,18 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         let y = *y.value().take();
         let xz = x * *z.value().take();
 
-        let registry_xy_poly = self.native_registry.xy(x, y);
+        let registry_xy_evals = self.native_registry.wxy_over_domain(x, y);
+        let log2_n = self.native_registry.log2_domain();
 
-        // Evaluate the registry polynomial at all internal-circuit points and
-        // at w concurrently with the left/right child witness construction.
-        let (fixed_registry, registry_wxy, left_witness, right_witness) = par_join!(
-            // TODO: these can all be evaluated at the same time; in fact,
-            // that's what registry.xy is supposed to allow.
-            || native::InternalCircuitValues::from_fn(
-                |id| registry_xy_poly.eval(id.circuit_index().omega_j())
-            ),
+        let fixed_registry = native::InternalCircuitValues::from_fn(|id| {
+            let i = usize::from(id.circuit_index()) as u32;
+            registry_xy_evals[bitreverse(i, log2_n) as usize]
+        });
+        let registry_xy_poly = self.native_registry.interpolate_xy(registry_xy_evals);
+
+        // Evaluate the registry polynomial at w concurrently with the
+        // left/right child witness construction.
+        let (registry_wxy, left_witness, right_witness) = par_join!(
             || registry_xy_poly.eval(w),
             || native::stages::query::ChildEvaluationsWitness::from_proof(
                 left,

--- a/crates/ragu_pcd/src/fuse/_07_query.rs
+++ b/crates/ragu_pcd/src/fuse/_07_query.rs
@@ -41,29 +41,50 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, B: crate::SelectableBackend>
 
         let registry_xy_poly = B::registry_xy(&self.native_registry, x, y);
 
+        // Evaluate the registry polynomial at all internal-circuit points and
+        // at w concurrently with the left/right child witness construction.
+        let ((fixed_registry, registry_wxy), (left_witness, right_witness)) = maybe_rayon::join(
+            || {
+                (
+                    // TODO: these can all be evaluated at the same time; in fact,
+                    // that's what registry.xy is supposed to allow.
+                    native::InternalCircuitValues::from_fn(|id| {
+                        B::sparse_eval(&registry_xy_poly, id.circuit_index().omega_j())
+                    }),
+                    B::sparse_eval(&registry_xy_poly, w),
+                )
+            },
+            || {
+                maybe_rayon::join(
+                    || {
+                        native::stages::query::ChildEvaluationsWitness::from_proof::<C, R, B>(
+                            left,
+                            w,
+                            x,
+                            xz,
+                            &registry_xy_poly,
+                            &registry_wy.poly,
+                        )
+                    },
+                    || {
+                        native::stages::query::ChildEvaluationsWitness::from_proof::<C, R, B>(
+                            right,
+                            w,
+                            x,
+                            xz,
+                            &registry_xy_poly,
+                            &registry_wy.poly,
+                        )
+                    },
+                )
+            },
+        );
+
         let query_witness = native::stages::query::Witness {
-            // TODO: these can all be evaluated at the same time; in fact,
-            // that's what registry.xy is supposed to allow.
-            fixed_registry: native::InternalCircuitValues::from_fn(|id| {
-                B::sparse_eval(&registry_xy_poly, id.circuit_index().omega_j())
-            }),
-            registry_wxy: B::sparse_eval(&registry_xy_poly, w),
-            left: native::stages::query::ChildEvaluationsWitness::from_proof::<C, R, B>(
-                left,
-                w,
-                x,
-                xz,
-                &registry_xy_poly,
-                &registry_wy.poly,
-            ),
-            right: native::stages::query::ChildEvaluationsWitness::from_proof::<C, R, B>(
-                right,
-                w,
-                x,
-                xz,
-                &registry_xy_poly,
-                &registry_wy.poly,
-            ),
+            fixed_registry,
+            registry_wxy,
+            left: left_witness,
+            right: right_witness,
         };
 
         let rx = native::stages::query::Stage::<C, R, HEADER_SIZE>::rx(

--- a/crates/ragu_pcd/src/fuse/_07_query.rs
+++ b/crates/ragu_pcd/src/fuse/_07_query.rs
@@ -8,7 +8,7 @@
 //! This phase of the fuse operation is also used to commit to the $m(W, x, y)$
 //! restriction.
 
-use ragu_arithmetic::{Cycle, ff::Field, rand::CryptoRng};
+use ragu_arithmetic::{Cycle, ff::Field, par_join, rand::CryptoRng};
 use ragu_circuits::{polynomials::Rank, staging::StageExt};
 use ragu_core::{Result, drivers::Driver, maybe::Maybe};
 use ragu_primitives::Element;
@@ -43,41 +43,30 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, B: crate::SelectableBackend>
 
         // Evaluate the registry polynomial at all internal-circuit points and
         // at w concurrently with the left/right child witness construction.
-        let ((fixed_registry, registry_wxy), (left_witness, right_witness)) = maybe_rayon::join(
-            || {
-                (
-                    // TODO: these can all be evaluated at the same time; in fact,
-                    // that's what registry.xy is supposed to allow.
-                    native::InternalCircuitValues::from_fn(|id| {
-                        B::sparse_eval(&registry_xy_poly, id.circuit_index().omega_j())
-                    }),
-                    B::sparse_eval(&registry_xy_poly, w),
-                )
-            },
-            || {
-                maybe_rayon::join(
-                    || {
-                        native::stages::query::ChildEvaluationsWitness::from_proof::<C, R, B>(
-                            left,
-                            w,
-                            x,
-                            xz,
-                            &registry_xy_poly,
-                            &registry_wy.poly,
-                        )
-                    },
-                    || {
-                        native::stages::query::ChildEvaluationsWitness::from_proof::<C, R, B>(
-                            right,
-                            w,
-                            x,
-                            xz,
-                            &registry_xy_poly,
-                            &registry_wy.poly,
-                        )
-                    },
-                )
-            },
+        let (fixed_registry, registry_wxy, left_witness, right_witness) = par_join!(
+            // TODO: these can all be evaluated at the same time; in fact,
+            // that's what registry.xy is supposed to allow.
+            || native::InternalCircuitValues::from_fn(|id| B::sparse_eval(
+                &registry_xy_poly,
+                id.circuit_index().omega_j()
+            )),
+            || B::sparse_eval(&registry_xy_poly, w),
+            || native::stages::query::ChildEvaluationsWitness::from_proof::<C, R, B>(
+                left,
+                w,
+                x,
+                xz,
+                &registry_xy_poly,
+                &registry_wy.poly,
+            ),
+            || native::stages::query::ChildEvaluationsWitness::from_proof::<C, R, B>(
+                right,
+                w,
+                x,
+                xz,
+                &registry_xy_poly,
+                &registry_wy.poly,
+            ),
         );
 
         let query_witness = native::stages::query::Witness {

--- a/crates/ragu_pcd/src/fuse/_07_query.rs
+++ b/crates/ragu_pcd/src/fuse/_07_query.rs
@@ -8,7 +8,7 @@
 //! This phase of the fuse operation is also used to commit to the $m(W, x, y)$
 //! restriction.
 
-use ragu_arithmetic::{Cycle, ff::Field, par_join, rand::CryptoRng};
+use ragu_arithmetic::{Cycle, bitreverse, ff::Field, par_join, rand::CryptoRng};
 use ragu_circuits::{polynomials::Rank, staging::StageExt};
 use ragu_core::{Result, drivers::Driver, maybe::Maybe};
 use ragu_primitives::Element;
@@ -39,17 +39,18 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, B: crate::SelectableBackend>
         let y = *y.value().take();
         let xz = x * *z.value().take();
 
-        let registry_xy_poly = B::registry_xy(&self.native_registry, x, y);
+        let registry_xy_evals = B::registry_wxy_over_domain(&self.native_registry, x, y);
+        let log2_n = self.native_registry.log2_domain();
 
-        // Evaluate the registry polynomial at all internal-circuit points and
-        // at w concurrently with the left/right child witness construction.
-        let (fixed_registry, registry_wxy, left_witness, right_witness) = par_join!(
-            // TODO: these can all be evaluated at the same time; in fact,
-            // that's what registry.xy is supposed to allow.
-            || native::InternalCircuitValues::from_fn(|id| B::sparse_eval(
-                &registry_xy_poly,
-                id.circuit_index().omega_j()
-            )),
+        let fixed_registry = native::InternalCircuitValues::from_fn(|id| {
+            let i = usize::from(id.circuit_index()) as u32;
+            registry_xy_evals[bitreverse(i, log2_n) as usize]
+        });
+        let registry_xy_poly = B::registry_interpolate_xy(&self.native_registry, registry_xy_evals);
+
+        // Evaluate the registry polynomial at w concurrently with the
+        // left/right child witness construction.
+        let (registry_wxy, left_witness, right_witness) = par_join!(
             || B::sparse_eval(&registry_xy_poly, w),
             || native::stages::query::ChildEvaluationsWitness::from_proof::<C, R, B>(
                 left,

--- a/crates/ragu_pcd/src/fuse/_09_eval.rs
+++ b/crates/ragu_pcd/src/fuse/_09_eval.rs
@@ -5,7 +5,7 @@
 //! $f(u)$ is derived from the aforementioned evaluations.
 
 use ff::Field;
-use ragu_arithmetic::Cycle;
+use ragu_arithmetic::{Cycle, par_join};
 use ragu_circuits::{polynomials::Rank, staging::StageExt};
 use ragu_core::{Result, drivers::Driver, maybe::Maybe};
 use ragu_primitives::Element;
@@ -30,26 +30,24 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
     {
         let u = *u.value().take();
 
-        // ProofBuilder is not Sync, so re-borrow the read-only polynomials
-        // before the rayon closure captures them.
+        // ProofBuilder contains OnceCell fields and is therefore !Sync.
+        // Extract shared references to the already-set polynomials so the
+        // closures below capture &Polynomial (which is Sync) rather than
+        // &ProofBuilder.
         let native_a_poly = builder.native_a_poly();
         let native_b_poly = builder.native_b_poly();
         let native_registry_xy_poly = builder.native_registry_xy_poly();
 
         // Evaluate left/right child witnesses concurrently with the
         // current-step polynomial evaluations at u.
-        let ((left_witness, right_witness), current) = maybe_rayon::join(
-            || {
-                maybe_rayon::join(
-                    || native::stages::eval::ChildEvaluationsWitness::from_proof(left, u),
-                    || native::stages::eval::ChildEvaluationsWitness::from_proof(right, u),
-                )
-            },
+        let (left_witness, right_witness, current) = par_join!(
+            || native::stages::eval::ChildEvaluationsWitness::from_proof(left, u),
+            || native::stages::eval::ChildEvaluationsWitness::from_proof(right, u),
             || native::stages::eval::CurrentStepWitness {
-                // TODO: the registry evaluations here could _theoretically_ be more
-                // efficient if they're computed simultaneously with assistance
-                // from the registry itself, rather than individually evaluated for
-                // each of these restrictions.
+                // TODO: registry_wx0_poly, registry_wx1_poly, and
+                // registry_wy.poly are each evaluated independently here. A
+                // batched evaluation path (analogous to wxy_over_domain) could
+                // amortize the per-circuit cost across all three.
                 registry_wx0: s_prime.registry_wx0_poly.eval(u),
                 registry_wx1: s_prime.registry_wx1_poly.eval(u),
                 registry_wy: registry_wy.poly.eval(u),

--- a/crates/ragu_pcd/src/fuse/_09_eval.rs
+++ b/crates/ragu_pcd/src/fuse/_09_eval.rs
@@ -44,10 +44,6 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             || native::stages::eval::ChildEvaluationsWitness::from_proof(left, u),
             || native::stages::eval::ChildEvaluationsWitness::from_proof(right, u),
             || native::stages::eval::CurrentStepWitness {
-                // TODO: registry_wx0_poly, registry_wx1_poly, and
-                // registry_wy.poly are each evaluated independently here. A
-                // batched evaluation path (analogous to wxy_over_domain) could
-                // amortize the per-circuit cost across all three.
                 registry_wx0: s_prime.registry_wx0_poly.eval(u),
                 registry_wx1: s_prime.registry_wx1_poly.eval(u),
                 registry_wy: registry_wy.poly.eval(u),

--- a/crates/ragu_pcd/src/fuse/_09_eval.rs
+++ b/crates/ragu_pcd/src/fuse/_09_eval.rs
@@ -30,10 +30,22 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
     {
         let u = *u.value().take();
 
-        let eval_witness = native::stages::eval::Witness {
-            left: native::stages::eval::ChildEvaluationsWitness::from_proof(left, u),
-            right: native::stages::eval::ChildEvaluationsWitness::from_proof(right, u),
-            current: native::stages::eval::CurrentStepWitness {
+        // ProofBuilder is not Sync, so re-borrow the read-only polynomials
+        // before the rayon closure captures them.
+        let native_a_poly = builder.native_a_poly();
+        let native_b_poly = builder.native_b_poly();
+        let native_registry_xy_poly = builder.native_registry_xy_poly();
+
+        // Evaluate left/right child witnesses concurrently with the
+        // current-step polynomial evaluations at u.
+        let ((left_witness, right_witness), current) = maybe_rayon::join(
+            || {
+                maybe_rayon::join(
+                    || native::stages::eval::ChildEvaluationsWitness::from_proof(left, u),
+                    || native::stages::eval::ChildEvaluationsWitness::from_proof(right, u),
+                )
+            },
+            || native::stages::eval::CurrentStepWitness {
                 // TODO: the registry evaluations here could _theoretically_ be more
                 // efficient if they're computed simultaneously with assistance
                 // from the registry itself, rather than individually evaluated for
@@ -41,10 +53,15 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                 registry_wx0: s_prime.registry_wx0_poly.eval(u),
                 registry_wx1: s_prime.registry_wx1_poly.eval(u),
                 registry_wy: registry_wy.poly.eval(u),
-                a_poly: builder.native_a_poly().eval(u),
-                b_poly: builder.native_b_poly().eval(u),
-                registry_xy: builder.native_registry_xy_poly().eval(u),
+                a_poly: native_a_poly.eval(u),
+                b_poly: native_b_poly.eval(u),
+                registry_xy: native_registry_xy_poly.eval(u),
             },
+        );
+        let eval_witness = native::stages::eval::Witness {
+            left: left_witness,
+            right: right_witness,
+            current,
         };
         let rx = native::stages::eval::Stage::<C, R, HEADER_SIZE>::rx(
             C::CircuitField::random(&mut *rng),

--- a/crates/ragu_pcd/src/fuse/_09_eval.rs
+++ b/crates/ragu_pcd/src/fuse/_09_eval.rs
@@ -46,10 +46,6 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, B: crate::SelectableBackend>
             || native::stages::eval::ChildEvaluationsWitness::from_proof::<C, R, B>(left, u),
             || native::stages::eval::ChildEvaluationsWitness::from_proof::<C, R, B>(right, u),
             || native::stages::eval::CurrentStepWitness {
-                // TODO: registry_wx0_poly, registry_wx1_poly, and
-                // registry_wy.poly are each evaluated independently here. A
-                // batched evaluation path (analogous to wxy_over_domain) could
-                // amortize the per-circuit cost across all three.
                 registry_wx0: B::sparse_eval(&s_prime.registry_wx0_poly, u),
                 registry_wx1: B::sparse_eval(&s_prime.registry_wx1_poly, u),
                 registry_wy: B::sparse_eval(&registry_wy.poly, u),

--- a/crates/ragu_pcd/src/fuse/_09_eval.rs
+++ b/crates/ragu_pcd/src/fuse/_09_eval.rs
@@ -32,10 +32,30 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, B: crate::SelectableBackend>
     {
         let u = *u.value().take();
 
-        native::stages::eval::Witness {
-            left: native::stages::eval::ChildEvaluationsWitness::from_proof::<C, R, B>(left, u),
-            right: native::stages::eval::ChildEvaluationsWitness::from_proof::<C, R, B>(right, u),
-            current: native::stages::eval::CurrentStepWitness {
+        // ProofBuilder is not Sync, so re-borrow the read-only polynomials
+        // before the rayon closure captures them.
+        let native_a_poly = builder.native_a_poly();
+        let native_b_poly = builder.native_b_poly();
+        let native_registry_xy_poly = builder.native_registry_xy_poly();
+
+        // Evaluate left/right child witnesses concurrently with the
+        // current-step polynomial evaluations at u.
+        let ((left_witness, right_witness), current) = maybe_rayon::join(
+            || {
+                maybe_rayon::join(
+                    || {
+                        native::stages::eval::ChildEvaluationsWitness::from_proof::<C, R, B>(
+                            left, u,
+                        )
+                    },
+                    || {
+                        native::stages::eval::ChildEvaluationsWitness::from_proof::<C, R, B>(
+                            right, u,
+                        )
+                    },
+                )
+            },
+            || native::stages::eval::CurrentStepWitness {
                 // TODO: the registry evaluations here could _theoretically_ be more
                 // efficient if they're computed simultaneously with assistance
                 // from the registry itself, rather than individually evaluated for
@@ -43,10 +63,16 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, B: crate::SelectableBackend>
                 registry_wx0: B::sparse_eval(&s_prime.registry_wx0_poly, u),
                 registry_wx1: B::sparse_eval(&s_prime.registry_wx1_poly, u),
                 registry_wy: B::sparse_eval(&registry_wy.poly, u),
-                a_poly: B::sparse_eval(builder.native_a_poly(), u),
-                b_poly: B::sparse_eval(builder.native_b_poly(), u),
-                registry_xy: B::sparse_eval(builder.native_registry_xy_poly(), u),
+                a_poly: B::sparse_eval(native_a_poly, u),
+                b_poly: B::sparse_eval(native_b_poly, u),
+                registry_xy: B::sparse_eval(native_registry_xy_poly, u),
             },
+        );
+
+        native::stages::eval::Witness {
+            left: left_witness,
+            right: right_witness,
+            current,
         }
     }
 

--- a/crates/ragu_pcd/src/fuse/_09_eval.rs
+++ b/crates/ragu_pcd/src/fuse/_09_eval.rs
@@ -4,7 +4,7 @@
 //! of every element that was also queried in the `query` stage. The evaluation
 //! $f(u)$ is derived from the aforementioned evaluations.
 
-use ragu_arithmetic::{Cycle, ff::Field, rand::CryptoRng};
+use ragu_arithmetic::{Cycle, ff::Field, par_join, rand::CryptoRng};
 use ragu_circuits::{
     polynomials::{Rank, sparse},
     staging::StageExt,
@@ -32,34 +32,24 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, B: crate::SelectableBackend>
     {
         let u = *u.value().take();
 
-        // ProofBuilder is not Sync, so re-borrow the read-only polynomials
-        // before the rayon closure captures them.
+        // ProofBuilder contains OnceCell fields and is therefore !Sync.
+        // Extract shared references to the already-set polynomials so the
+        // closures below capture &Polynomial (which is Sync) rather than
+        // &ProofBuilder.
         let native_a_poly = builder.native_a_poly();
         let native_b_poly = builder.native_b_poly();
         let native_registry_xy_poly = builder.native_registry_xy_poly();
 
         // Evaluate left/right child witnesses concurrently with the
         // current-step polynomial evaluations at u.
-        let ((left_witness, right_witness), current) = maybe_rayon::join(
-            || {
-                maybe_rayon::join(
-                    || {
-                        native::stages::eval::ChildEvaluationsWitness::from_proof::<C, R, B>(
-                            left, u,
-                        )
-                    },
-                    || {
-                        native::stages::eval::ChildEvaluationsWitness::from_proof::<C, R, B>(
-                            right, u,
-                        )
-                    },
-                )
-            },
+        let (left_witness, right_witness, current) = par_join!(
+            || native::stages::eval::ChildEvaluationsWitness::from_proof::<C, R, B>(left, u),
+            || native::stages::eval::ChildEvaluationsWitness::from_proof::<C, R, B>(right, u),
             || native::stages::eval::CurrentStepWitness {
-                // TODO: the registry evaluations here could _theoretically_ be more
-                // efficient if they're computed simultaneously with assistance
-                // from the registry itself, rather than individually evaluated for
-                // each of these restrictions.
+                // TODO: registry_wx0_poly, registry_wx1_poly, and
+                // registry_wy.poly are each evaluated independently here. A
+                // batched evaluation path (analogous to wxy_over_domain) could
+                // amortize the per-circuit cost across all three.
                 registry_wx0: B::sparse_eval(&s_prime.registry_wx0_poly, u),
                 registry_wx1: B::sparse_eval(&s_prime.registry_wx1_poly, u),
                 registry_wy: B::sparse_eval(&registry_wy.poly, u),


### PR DESCRIPTION
Inspired by https://github.com/tachyon-zcash/ragu/issues/573, closes TODOs in our fuse pipeline by evaluating fuse polynomial evaluations in query and eval stages using _coarse_-grained parallelism. Unlike MSMs which use `maybe::into_par_iter` (which is for data-parallelism when you need to split a collection across threads), this implements `maybe::join` (which is for task parallelism since we're working with independent closures). It doesn't use `scope` which needs channels or shared state. This parallelizes:

- 13 independent poly evals at omega
- 6 independent poly evals at u
- Left/right child witness construction

------------

Benches against main suggest **~5%** improvement in fuse. 

```
git stash && cargo bench --bench fuse_criterion -p ragu_pcd --features multicore
git stash pop && cargo bench --bench fuse_criterion -p ragu_pcd --features multicore 
```

<img width="830" height="72" alt="Screenshot 2026-03-19 at 4 51 20 PM" src="https://github.com/user-attachments/assets/3ea98d32-9d89-496d-ae2c-f134a1163e8f" />