### PR TITLE
chore: structurally couple compute_f and poly_queries query count

### DIFF
--- a/crates/ragu_pcd/src/fuse/_08_f.rs
+++ b/crates/ragu_pcd/src/fuse/_08_f.rs
@@ -104,7 +104,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         };
 
         // This must exactly match the ordering of the `poly_queries` function
-        // in the `compute_v` circuit.
+        // in the `compute_v` circuit. See `NUM_POLY_QUERIES` for the count.
         let mut iters: Vec<_> = vec![
             // Child proof p(u)=v checks
             factor_iter(left.p.native.poly.iter_coeffs(), left.challenges.u),
@@ -165,6 +165,12 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                 omega_j(id),
             ));
         }
+
+        assert_eq!(
+            iters.len(),
+            native::NUM_POLY_QUERIES,
+            "compute_f query count diverged from poly_queries"
+        );
 
         let mut coeffs = Vec::with_capacity(R::num_coeffs());
         let (first, rest) = iters.split_first_mut().unwrap();

--- a/crates/ragu_pcd/src/internal/native/circuits/compute_v.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/compute_v.rs
@@ -552,10 +552,13 @@ fn compute_axbx<'dr, D: Driver<'dr>, P: Parameters>(
 ///
 /// The queries must be ordered exactly as in the prover's computation of $f(X)$
 /// in [`compute_f`], since the ordering affects the weight (with respect to
-/// [$\alpha$]) of each quotient polynomial.
+/// [$\alpha$]) of each quotient polynomial. See [`NUM_POLY_QUERIES`] for the
+/// shared count.
 ///
 /// [`compute_f`]: crate::Application::compute_f
 /// [$\alpha$]: unified::Output::alpha
+/// [`NUM_POLY_QUERIES`]: super::super::NUM_POLY_QUERIES
+///
 #[rustfmt::skip]
 fn poly_queries<'a, 'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usize>(
     eval: &'a native_eval::Output<'dr, D>,
@@ -565,7 +568,7 @@ fn poly_queries<'a, 'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HE
     computed_ax: &'a Element<'dr, D>,
     computed_bx: &'a Element<'dr, D>,
 ) -> impl Iterator<Item = (&'a Element<'dr, D>, &'a Element<'dr, D>, &'a Element<'dr, D>)> {
-    [
+    let static_queries = [
         // Check p(u) = v for each child proof.
         (&eval.left.p_poly,        &preamble.left.unified.v,                     &d.left.u),
         (&eval.right.p_poly,       &preamble.right.unified.v,                    &d.right.u),
@@ -595,7 +598,13 @@ fn poly_queries<'a, 'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HE
         // prover.
         (&eval.a_poly,             computed_ax,                                      &d.challenges.xz),
         (&eval.b_poly,             computed_bx,                                      &d.challenges.x),
-    ].into_iter()
+    ];
+    assert_eq!(
+        static_queries.len() + 2 * RxIndex::ALL.len() + InternalCircuitIndex::ALL.len(),
+        super::super::NUM_POLY_QUERIES,
+        "poly_queries count diverged from compute_f"
+    );
+    static_queries.into_iter()
     // Stage and circuit rx evaluations at xz for each child proof.
     // The same r_i(xz) values feed into both A(xz) (undilated) and
     // B(x) (Z-dilated) recomputations.

--- a/crates/ragu_pcd/src/internal/native/mod.rs
+++ b/crates/ragu_pcd/src/internal/native/mod.rs
@@ -195,6 +195,17 @@ pub enum RxIndex {
 /// The number of rx polynomial components.
 const NUM_RX_COMPONENTS: usize = 11;
 
+/// Total number of polynomial queries in the multi-quotient polynomial $f(X)$.
+///
+/// Both `compute_f` (prover, `fuse/_08_f.rs`) and `poly_queries` (verifier
+/// circuit, `compute_v.rs`) must enumerate exactly this many queries in
+/// identical order. The breakdown is:
+///
+/// - 20 static queries (p evals, registry transitions, a/b polynomials)
+/// - `2 * NUM_RX_COMPONENTS` rx evaluations (one per component per child)
+/// - `NUM_INTERNAL_CIRCUITS` internal circuit registry evaluations
+pub(crate) const NUM_POLY_QUERIES: usize = 20 + 2 * NUM_RX_COMPONENTS + NUM_INTERNAL_CIRCUITS;
+
 impl RxIndex {
     /// All variants in canonical order.
     ///


### PR DESCRIPTION
'`compute_f` (`fuse/_08_f.rs`) and
   `poly_queries` (`compute_v.rs`) independently enumerate 20+
  polynomial queries whose α-weighting must agree. Adds a shared
  `NUM_POLY_QUERIES` constant and runtime assertions on both sides so
   that additions or removals to either query list are caught
  immediately.