### PR TITLE
fix(book): typo

### DIFF
--- a/book/src/guide/getting_started.md
+++ b/book/src/guide/getting_started.md
@@ -122,10 +122,10 @@ impl<'params, C: Cycle> Step<C> for CreateLeaf<'params, C> {
     const INDEX: Index = Index::new(0);  // Step ID
 
     type Witness<'source> = C::CircuitField;  // Input: field element
-    type Aux<'source> = C::CircuitField;      // Output: hash result
-    type Left = ();                            // No left input
-    type Right = ();                           // No right input
-    type Output = LeafNode;                    // Produces LeafNode
+    type Aux<'source> = ();                   // Output: hash result
+    type Left = ();                           // No left input
+    type Right = ();                          // No right input
+    type Output = LeafNode;                   // Produces LeafNode
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
         &self,
@@ -164,9 +164,10 @@ impl<'params, C: Cycle> Step<C> for CreateLeaf<'params, C> {
             (
                 Encoded::from_gadget(()),  // No left
                 Encoded::from_gadget(()),  // No right
-                leaf_encoded,               // Our output
+                leaf_encoded,              // Our output
             ),
             leaf_value,  // Hash result
+            D::unit(),
         ))
     }
 }
@@ -191,11 +192,11 @@ struct CombineNodes<'params, C: Cycle> {
 impl<'params, C: Cycle> Step<C> for CombineNodes<'params, C> {
     const INDEX: Index = Index::new(1);  // Different step ID
 
-    type Witness<'source> = ();           // No extra witness
-    type Aux<'source> = C::CircuitField;  // Return combined hash
-    type Left = LeafNode;                 // Takes LeafNode
-    type Right = LeafNode;                // Takes LeafNode
-    type Output = InternalNode;           // Produces InternalNode
+    type Witness<'source> = ();  // No extra witness
+    type Aux<'source> = ();      // Return combined hash
+    type Left = LeafNode;        // Takes LeafNode
+    type Right = LeafNode;       // Takes LeafNode
+    type Output = InternalNode;  // Produces InternalNode
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
         &self,
@@ -230,7 +231,7 @@ impl<'params, C: Cycle> Step<C> for CombineNodes<'params, C> {
         let output = Encoded::from_gadget(output);
 
         // 4. Return verified proofs + output data + aux
-        Ok(((left, right, output), output_value, output_value))
+        Ok(((left, right, output), output_value, D::unit()))
     }
 }
 ```


### PR DESCRIPTION
- `arithmetic` -> `ragu_arithmetic`
- In the getting-started example, aux data is updated to `()` and return values from `fn witness` are fixed