### PR TITLE
Simplify polynomial arithemtic

### DIFF
--- a/crates/ragu_circuits/src/polynomials/sparse/mod.rs
+++ b/crates/ragu_circuits/src/polynomials/sparse/mod.rs
@@ -192,28 +192,17 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     /// Returns an iterator over the coefficients of this polynomial in
     /// ascending degree order, yielding `F::ZERO` for gaps between blocks.
     pub fn iter_coeffs(&self) -> impl DoubleEndedIterator<Item = F> + ExactSizeIterator + '_ {
-        let (packed, num_blocks) = self.non_empty_blocks();
         CoeffIter {
-            blocks: packed,
-            num_blocks,
+            blocks: [
+                (self.blocks[0].0, self.blocks[0].1.as_slice()),
+                (self.blocks[1].0, self.blocks[1].1.as_slice()),
+                (self.blocks[2].0, self.blocks[2].1.as_slice()),
+            ],
             front: 0,
             back: R::num_coeffs(),
             front_blk: 0,
-            back_blk: num_blocks,
+            back_blk: 3,
         }
-    }
-
-    /// Returns non-empty blocks as a packed fixed-size array plus a count.
-    fn non_empty_blocks(&self) -> ([(usize, &[F]); 3], usize) {
-        let mut packed: [(usize, &[F]); 3] = [(0, &[]); 3];
-        let mut n = 0;
-        for (off, data) in &self.blocks {
-            if !data.is_empty() {
-                packed[n] = (*off, data);
-                n += 1;
-            }
-        }
-        (packed, n)
     }
 
     /// Multiplies all coefficients by `by`.
@@ -376,41 +365,49 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     /// Inner product of `self` with the coefficient-reversed `other`.
     ///
     /// Computes $\sum\_{k} \text{self}\[k\] \cdot \text{other}\[4n - 1 - k\]$.
+    ///
+    /// The fixed region boundaries mean only 3 pairs contribute:
+    /// lo `[0,n)` pairs with reversed hi `[3n,4n)`, mid `[n,3n)` with
+    /// reversed mid, and hi with reversed lo.
     pub fn revdot(&self, other: &Self) -> F {
         let n4 = R::num_coeffs();
+        // lo x rev(hi), mid x rev(mid), hi x rev(lo)
+        Self::revdot_pair(&self.blocks[0], &other.blocks[2], n4)
+            + Self::revdot_pair(&self.blocks[1], &other.blocks[1], n4)
+            + Self::revdot_pair(&self.blocks[2], &other.blocks[0], n4)
+    }
+
+    /// Dot product of block `a` with the coefficient-reversed block `b`.
+    fn revdot_pair(a: &(usize, Vec<F>), b: &(usize, Vec<F>), n4: usize) -> F {
+        let (a_off, a_data) = (a.0, a.1.as_slice());
+        let (b_off, b_data) = (b.0, b.1.as_slice());
+        if a_data.is_empty() || b_data.is_empty() {
+            return F::ZERO;
+        }
+
+        // Block b at [b_off, b_off+b_len) reversed maps to
+        // [n4 - b_off - b_len, n4 - b_off).
+        let a_end = a_off + a_data.len();
+        let rev_lo = n4 - b_off - b_data.len();
+        let rev_hi = n4 - b_off;
+
+        let overlap_lo = a_off.max(rev_lo);
+        let overlap_hi = a_end.min(rev_hi);
+        if overlap_lo >= overlap_hi {
+            return F::ZERO;
+        }
+
+        let a_slice = &a_data[overlap_lo - a_off..overlap_hi - a_off];
+        // For index k in [overlap_lo, overlap_hi), b's value is at
+        // b_data[n4 - 1 - k - b_off]. As k increases, the b_data index
+        // decreases, so we zip a forward with b reversed.
+        let b_idx_lo = n4 - 1 - (overlap_hi - 1) - b_off;
+        let b_idx_hi = n4 - 1 - overlap_lo - b_off;
+        let b_slice = &b_data[b_idx_lo..=b_idx_hi];
+
         let mut result = F::ZERO;
-        for &(a_off, ref a_data) in &self.blocks {
-            if a_data.is_empty() {
-                continue;
-            }
-            let a_end = a_off + a_data.len();
-            for &(b_off, ref b_data) in &other.blocks {
-                if b_data.is_empty() {
-                    continue;
-                }
-                // Other's block [b_off, b_off+b_len) reversed maps to
-                // [n4 - b_off - b_len, n4 - b_off).
-                let rev_lo = n4 - b_off - b_data.len();
-                let rev_hi = n4 - b_off;
-
-                let overlap_lo = a_off.max(rev_lo);
-                let overlap_hi = a_end.min(rev_hi);
-                if overlap_lo >= overlap_hi {
-                    continue;
-                }
-
-                let a_slice = &a_data[overlap_lo - a_off..overlap_hi - a_off];
-                // For index k in [overlap_lo, overlap_hi), other's value is at
-                // b_data[n4 - 1 - k - b_off]. As k increases, the b_data
-                // index decreases, so we zip a forward with b reversed.
-                let b_idx_lo = n4 - 1 - (overlap_hi - 1) - b_off;
-                let b_idx_hi = n4 - 1 - overlap_lo - b_off;
-                let b_slice = &b_data[b_idx_lo..=b_idx_hi];
-
-                for (a_val, b_val) in a_slice.iter().zip(b_slice.iter().rev()) {
-                    result += *a_val * *b_val;
-                }
-            }
+        for (a_val, b_val) in a_slice.iter().zip(b_slice.iter().rev()) {
+            result += *a_val * *b_val;
         }
         result
     }
@@ -457,8 +454,9 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
 /// An iterator over all coefficients of a sparse polynomial in ascending
 /// degree order, yielding `F::ZERO` for gaps between blocks.
 struct CoeffIter<'a, F> {
+    /// All 3 blocks (including empty ones — skipped naturally by the
+    /// advance/retreat logic since empty blocks have `start + 0 <= front`).
     blocks: [(usize, &'a [F]); 3],
-    num_blocks: usize,
     front: usize,
     back: usize,
     /// Index of the first block whose end extends past `front`.
@@ -475,14 +473,14 @@ impl<F: Field> Iterator for CoeffIter<'_, F> {
             return None;
         }
         // Advance past blocks fully before `front`.
-        while self.front_blk < self.num_blocks {
+        while self.front_blk < 3 {
             let (start, data) = self.blocks[self.front_blk];
             if start + data.len() > self.front {
                 break;
             }
             self.front_blk += 1;
         }
-        let val = if self.front_blk < self.num_blocks {
+        let val = if self.front_blk < 3 {
             let (start, data) = self.blocks[self.front_blk];
             if self.front >= start {
                 data[self.front - start]

--- a/crates/ragu_circuits/src/polynomials/sparse/mod.rs
+++ b/crates/ragu_circuits/src/polynomials/sparse/mod.rs
@@ -1,29 +1,28 @@
-//! Block-compressed sparse polynomial representation.
+//! Sparse polynomial representation using three fixed-region segments.
 //!
 //! [`Polynomial<T, R>`] stores a polynomial of degree up to
-//! `R::num_coeffs() - 1` as sorted, non-overlapping blocks of contiguous
-//! coefficients. Gaps between blocks are implicitly zero, so memory and
-//! commitment cost scale with the number of stored coefficients rather than the
-//! total degree.
+//! `R::num_coeffs() - 1` using three dense segments separated by two gaps,
+//! with each segment constrained to a fixed degree region:
 //!
-//! Several sources of sparsity arise in practice:
+//! - **lo**: degrees `[0, n)` — the `c`-wire region
+//! - **mid**: degrees `[n, 3n)` — the `b_rev ++ a` region (meeting at `2n`)
+//! - **hi**: degrees `[3n, 4n)` — the `d_rev` region
 //!
-//! - **Alloc-optimized circuits** leave most `b`/`c`-wire coefficients zero for
-//!   allocation gates and the `d`-wire zero for multiplication gates.
-//! - **Stage polynomials** are zero outside a small active region.
-//! - **Tail-sparse vectors** have long trailing zero runs after synthesis.
+//! where `n = R::n()`. Each segment stores an offset and a dense vector
+//! within its region. The fixed region boundaries guarantee that
+//! segment-wise arithmetic is always safe — no variant dispatch or
+//! compatibility checks needed.
 //!
 //! # Construction
 //!
 //! - [`Polynomial::new`]: empty (zero) polynomial.
-//! - [`Polynomial::from_coeffs`]: compress a dense coefficient vector, stripping
-//!   leading and trailing zeros; short interior zero gaps are kept inline
-//!   within blocks.
+//! - [`Polynomial::from_coeffs`]: decompose a dense coefficient vector into the
+//!   three regions, trimming leading and trailing zeros within each.
 //! - [`View`]: a builder that maps four gate-indexed wire buffers to degree
-//!   positions, producing a polynomial via [`View::build`]. Zero elements within
-//!   a wire buffer are **preserved** in the resulting blocks — push only
-//!   non-zero values for maximum compression, or use [`Polynomial::from_coeffs`]
-//!   to compress a pre-built dense vector.
+//!   positions via [`View::build`]. Zero elements within a wire buffer are
+//!   **preserved** in the resulting segments — push only non-zero values for
+//!   maximum compression, or use [`Polynomial::from_coeffs`] to strip a
+//!   pre-built dense vector.
 //!
 //! Once constructed, the polynomial supports algebraic operations ([`scale`],
 //! [`add_assign`], [`sub_assign`], [`negate`], [`eval`], [`revdot`],
@@ -56,95 +55,77 @@ use core::marker::PhantomData;
 
 use super::Rank;
 
-/// A sparse polynomial with coefficients stored as non-overlapping blocks.
+/// A sparse polynomial with coefficients stored in three fixed-region segments.
 ///
 /// See the [module documentation](self) for details.
 #[derive(Clone, Debug)]
 pub struct Polynomial<T, R: Rank> {
-    /// Sorted, non-overlapping, non-empty blocks of `(start_index, values)`.
-    blocks: Vec<(usize, Vec<T>)>,
+    lo_offset: usize,
+    lo: Vec<T>,
+    mid_offset: usize,
+    mid: Vec<T>,
+    hi_offset: usize,
+    hi: Vec<T>,
     _marker: PhantomData<R>,
 }
 
 impl<T, R: Rank> Polynomial<T, R> {
-    /// Panics if the block list violates any structural invariant: blocks must
-    /// be sorted by start index, non-empty, non-overlapping, and each block
-    /// must fit within `[0, R::num_coeffs())`. Adjacent blocks are permitted.
+    /// Panics if the representation violates region-bound invariants.
+    ///
+    /// Each segment must stay within its fixed degree region:
+    /// - `lo` within `[0, n)`
+    /// - `mid` within `[n, 3n)`
+    /// - `hi` within `[3n, 4n)`
     fn assert_invariants(&self) {
-        let mut prev_end: usize = 0;
-        for (i, (start, data)) in self.blocks.iter().enumerate() {
-            assert!(!data.is_empty(), "block {i} is empty");
-            assert!(
-                *start + data.len() <= R::num_coeffs(),
-                "block {i} exceeds capacity"
-            );
-            if i > 0 {
-                assert!(
-                    *start >= prev_end,
-                    "block {i} overlaps previous (start={start}, prev_end={prev_end})"
-                );
-            }
-            prev_end = *start + data.len();
-        }
+        let n = R::n();
+        assert!(
+            self.lo_offset + self.lo.len() <= n,
+            "lo [{}, {}) exceeds region [0, {n})",
+            self.lo_offset,
+            self.lo_offset + self.lo.len(),
+        );
+        assert!(
+            n <= self.mid_offset,
+            "mid_offset {} below region start {n}",
+            self.mid_offset,
+        );
+        assert!(
+            self.mid_offset + self.mid.len() <= 3 * n,
+            "mid [{}, {}) exceeds region [{n}, {})",
+            self.mid_offset,
+            self.mid_offset + self.mid.len(),
+            3 * n,
+        );
+        assert!(
+            3 * n <= self.hi_offset,
+            "hi_offset {} below region start {}",
+            self.hi_offset,
+            3 * n,
+        );
+        assert!(
+            self.hi_offset + self.hi.len() <= R::num_coeffs(),
+            "hi [{}, {}) exceeds capacity {}",
+            self.hi_offset,
+            self.hi_offset + self.hi.len(),
+            R::num_coeffs(),
+        );
     }
 
-    /// Creates a polynomial from pre-built blocks. The caller must ensure
-    /// blocks are sorted, non-overlapping, non-empty, and within capacity.
-    fn from_blocks(blocks: Vec<(usize, Vec<T>)>) -> Self {
+    // Constructs from three `(offset, data)` blocks, asserting region-bound
+    // invariants. The blocks correspond to lo, mid, hi in order.
+    fn from_blocks(blocks: [(usize, Vec<T>); 3]) -> Self {
+        let [(lo_offset, lo), (mid_offset, mid), (hi_offset, hi)] = blocks;
         let poly = Self {
-            blocks,
+            lo_offset,
+            lo,
+            mid_offset,
+            mid,
+            hi_offset,
+            hi,
             _marker: PhantomData,
         };
         poly.assert_invariants();
         poly
-    }
-}
-
-/// Maximum number of consecutive zero coefficients that may be kept inline
-/// within a block rather than triggering a split. Inline zeros waste MSM
-/// slots in [`commit`](Polynomial::commit), so this is kept small. The
-/// tolerance covers only the per-block overhead (allocation, merge
-/// iterations in [`combine_assign`](Polynomial::combine_assign)) — each
-/// extra block requires a `pow_vartime` call to skip the gap.
-///
-/// TODO(#608): benchmark to determine the optimal value.
-const GAP_TOLERANCE: usize = 4;
-
-/// Splits `data` into runs of coefficients and appends each run to `out` as
-/// `(base + run_offset, run_values)`. Zero gaps of up to [`GAP_TOLERANCE`]
-/// consecutive zeros are kept inline within a run; longer gaps cause a split.
-/// Leading and trailing zeros are always trimmed.
-fn extend_runs<F: Field>(out: &mut Vec<(usize, Vec<F>)>, base: usize, data: Vec<F>) {
-    let mut run_start: Option<usize> = None;
-    let mut run = Vec::new();
-    let mut zero_count: usize = 0;
-
-    for (i, coeff) in data.into_iter().enumerate() {
-        let is_zero = bool::from(coeff.is_zero());
-
-        match (run_start, is_zero) {
-            (None, true) => {}
-            (None, false) => {
-                run_start = Some(base + i);
-                run.push(coeff);
-            }
-            (Some(_), false) => {
-                run.extend(core::iter::repeat_n(F::ZERO, zero_count));
-                zero_count = 0;
-                run.push(coeff);
-            }
-            (Some(_), true) => {
-                zero_count += 1;
-                if zero_count > GAP_TOLERANCE {
-                    out.push((run_start.take().unwrap(), core::mem::take(&mut run)));
-                    zero_count = 0;
-                }
-            }
-        }
-    }
-
-    if let Some(s) = run_start {
-        out.push((s, run));
     }
 }
 
@@ -158,19 +139,23 @@ impl<T, R: Rank> Polynomial<T, R> {
     /// Creates a new empty (zero) polynomial.
     pub fn new() -> Self {
         Self {
-            blocks: Vec::new(),
+            lo_offset: 0,
+            lo: Vec::new(),
+            mid_offset: R::n(),
+            mid: Vec::new(),
+            hi_offset: 3 * R::n(),
+            hi: Vec::new(),
             _marker: PhantomData,
         }
     }
 }
 
 impl<F: Field, R: Rank> Polynomial<F, R> {
-    /// Compresses a dense coefficient vector into sparse block form. Short
-    /// interior zero gaps are kept inline within blocks; longer gaps cause a
-    /// block split. Leading and trailing zeros are always stripped.
+    /// Decomposes a dense coefficient vector into three fixed-region segments,
+    /// trimming leading and trailing zeros within each region.
     ///
     /// Panics if `coeffs.len()` exceeds `R::num_coeffs()`.
-    pub fn from_coeffs(coeffs: Vec<F>) -> Self {
+    pub fn from_coeffs(mut coeffs: Vec<F>) -> Self {
         assert!(
             coeffs.len() <= R::num_coeffs(),
             "coefficient vector length {} exceeds capacity {}",
@@ -178,167 +163,218 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
             R::num_coeffs()
         );
 
-        let mut blocks = Vec::new();
-        extend_runs(&mut blocks, 0, coeffs);
-        Self::from_blocks(blocks)
+        let n = R::n();
+        coeffs.resize(R::num_coeffs(), F::ZERO);
+
+        let mut hi = coeffs.split_off(3 * n);
+        let mut mid = coeffs.split_off(n);
+        let mut lo = coeffs;
+
+        let mut lo_offset = 0;
+        let mut mid_offset = n;
+        let mut hi_offset = 3 * n;
+
+        Self::trim_segment(&mut lo_offset, &mut lo);
+        Self::trim_segment(&mut mid_offset, &mut mid);
+        Self::trim_segment(&mut hi_offset, &mut hi);
+
+        Self::from_blocks([(lo_offset, lo), (mid_offset, mid), (hi_offset, hi)])
     }
 
     /// Creates a polynomial with random coefficients filling all `4n` slots.
     pub fn random<RNG: CryptoRng>(rng: &mut RNG) -> Self {
         assert!(R::num_coeffs() > 0, "num_coeffs must be positive");
-        let coeffs: Vec<F> = (0..R::num_coeffs()).map(|_| F::random(&mut *rng)).collect();
-        Self::from_blocks(alloc::vec![(0, coeffs)])
+        let n = R::n();
+        let mut coeffs: Vec<F> = (0..R::num_coeffs()).map(|_| F::random(&mut *rng)).collect();
+        let hi = coeffs.split_off(3 * n);
+        let mid = coeffs.split_off(n);
+        let lo = coeffs;
+        Self::from_blocks([(0, lo), (n, mid), (3 * n, hi)])
     }
 }
 
 impl<T, R: Rank> Polynomial<T, R> {
     /// Applies a closure to every stored element.
     fn apply_all(&mut self, mut op: impl FnMut(&mut T)) {
-        for (_, data) in &mut self.blocks {
-            for elem in data.iter_mut() {
-                op(elem);
-            }
+        for elem in &mut self.lo {
+            op(elem);
+        }
+        for elem in &mut self.mid {
+            op(elem);
+        }
+        for elem in &mut self.hi {
+            op(elem);
         }
     }
 }
 
 impl<F: Field, R: Rank> Polynomial<F, R> {
     /// Returns an iterator over the coefficients of this polynomial in
-    /// ascending degree order, yielding `F::ZERO` for gaps between blocks.
+    /// ascending degree order, yielding `F::ZERO` for gaps between segments.
     pub fn iter_coeffs(&self) -> impl DoubleEndedIterator<Item = F> + ExactSizeIterator + '_ {
+        let (segments, num_segments) = self.as_segments();
         CoeffIter {
-            blocks: &self.blocks,
+            segments,
+            num_segments,
             front: 0,
             back: R::num_coeffs(),
-            front_block: 0,
-            back_block: self.blocks.len(),
+            front_seg: 0,
+            back_seg: num_segments,
         }
     }
 
-    /// Merges another polynomial into this one using the given binary
-    /// operation, pruning all-zero blocks from the result.
-    fn combine_assign(&mut self, other: &Self, mut op: impl FnMut(&mut F, &F)) {
-        if other.blocks.is_empty() {
-            return;
+    /// Returns the stored segments as a fixed-size array of `(offset, slice)`
+    /// pairs plus a count of how many are populated (skipping empty segments).
+    fn as_segments(&self) -> ([(usize, &[F]); 3], usize) {
+        let mut segs: [(usize, &[F]); 3] = [(0, &[]), (0, &[]), (0, &[])];
+        let mut n = 0;
+        if !self.lo.is_empty() {
+            segs[n] = (self.lo_offset, &self.lo);
+            n += 1;
         }
-        if self.blocks.is_empty() {
-            let mut out = Vec::new();
-            for (s, d) in &other.blocks {
-                let mut v = alloc::vec![F::ZERO; d.len()];
-                for (o, r) in v.iter_mut().zip(d) {
-                    op(o, r);
-                }
-                extend_runs(&mut out, *s, v);
-            }
-            self.blocks = out;
-            self.assert_invariants();
-            return;
+        if !self.mid.is_empty() {
+            segs[n] = (self.mid_offset, &self.mid);
+            n += 1;
         }
-
-        let mut lhs = core::mem::take(&mut self.blocks);
-        let rhs = &other.blocks;
-        let mut out = Vec::with_capacity(lhs.len() + rhs.len());
-        let mut li = 0usize;
-        let mut ri = 0usize;
-
-        while li < lhs.len() || ri < rhs.len() {
-            // Start of the next cluster of overlapping/adjacent blocks.
-            let cluster_start = match (lhs.get(li), rhs.get(ri)) {
-                (Some(l), Some(r)) => l.0.min(r.0),
-                (Some(l), None) => l.0,
-                (None, Some(r)) => r.0,
-                (None, None) => break,
-            };
-
-            // Extend the cluster to cover all overlapping or adjacent blocks.
-            let mut cluster_end = cluster_start;
-            let li_start = li;
-            let ri_start = ri;
-            loop {
-                let mut extended = false;
-                while li < lhs.len() && lhs[li].0 <= cluster_end {
-                    cluster_end = cluster_end.max(lhs[li].0 + lhs[li].1.len());
-                    li += 1;
-                    extended = true;
-                }
-                while ri < rhs.len() && rhs[ri].0 <= cluster_end {
-                    cluster_end = cluster_end.max(rhs[ri].0 + rhs[ri].1.len());
-                    ri += 1;
-                    extended = true;
-                }
-                if !extended {
-                    break;
-                }
-            }
-
-            // No RHS blocks in this cluster — LHS blocks pass through
-            // unchanged, avoiding the dense intermediate buffer.
-            if ri == ri_start {
-                for block in &mut lhs[li_start..li] {
-                    out.push((block.0, core::mem::take(&mut block.1)));
-                }
-                continue;
-            }
-
-            let cluster_len = cluster_end - cluster_start;
-
-            // If one LHS block covers the entire cluster, reuse its
-            // allocation instead of copying into a fresh buffer.
-            let mut data = if li == li_start + 1
-                && lhs[li_start].0 == cluster_start
-                && lhs[li_start].1.len() == cluster_len
-            {
-                core::mem::take(&mut lhs[li_start].1)
-            } else {
-                let mut data = alloc::vec![F::ZERO; cluster_len];
-                for (ls, ld) in &lhs[li_start..li] {
-                    let off = ls - cluster_start;
-                    data[off..off + ld.len()].copy_from_slice(ld);
-                }
-                data
-            };
-
-            // Apply RHS contributions with tight slice loops.
-            for (rs, rd) in &rhs[ri_start..ri] {
-                let off = rs - cluster_start;
-                for (d, r) in data[off..off + rd.len()].iter_mut().zip(rd) {
-                    op(d, r);
-                }
-            }
-
-            if cluster_start == 0 && cluster_len == R::num_coeffs() {
-                out.push((cluster_start, data));
-            } else {
-                extend_runs(&mut out, cluster_start, data);
-            }
+        if !self.hi.is_empty() {
+            segs[n] = (self.hi_offset, &self.hi);
+            n += 1;
         }
+        (segs, n)
+    }
 
-        self.blocks = out;
-        self.assert_invariants();
+    /// Returns mutable segment references as a fixed-size array.
+    fn as_segments_mut(&mut self) -> ([(usize, &mut [F]); 3], usize) {
+        let mut segs: [(usize, &mut [F]); 3] = [(0, &mut []), (0, &mut []), (0, &mut [])];
+        let mut n = 0;
+        if !self.lo.is_empty() {
+            segs[n] = (self.lo_offset, self.lo.as_mut_slice());
+            n += 1;
+        }
+        if !self.mid.is_empty() {
+            segs[n] = (self.mid_offset, self.mid.as_mut_slice());
+            n += 1;
+        }
+        if !self.hi.is_empty() {
+            segs[n] = (self.hi_offset, self.hi.as_mut_slice());
+            n += 1;
+        }
+        (segs, n)
     }
 
     /// Multiplies all coefficients by `by`.
     pub fn scale(&mut self, by: F) {
         if bool::from(by.is_zero()) {
-            self.blocks.clear();
+            self.lo.clear();
+            self.lo_offset = 0;
+            self.mid.clear();
+            self.mid_offset = R::n();
+            self.hi.clear();
+            self.hi_offset = 3 * R::n();
         } else {
             self.apply_all(|x| *x *= by);
         }
     }
 
+    /// Negates all coefficients.
+    pub fn negate(&mut self) {
+        self.apply_all(|x| *x = -*x);
+    }
+
     /// Adds the coefficients of `other` to `self`.
     pub fn add_assign(&mut self, other: &Self) {
-        self.combine_assign(other, |a, b| *a += *b);
+        self.op_assign(other, |a, b| *a += *b);
     }
 
     /// Subtracts the coefficients of `other` from `self`.
     pub fn sub_assign(&mut self, other: &Self) {
-        self.combine_assign(other, |a, b| *a -= *b);
+        self.op_assign(other, |a, b| *a -= *b);
     }
 
-    /// Negates all coefficients.
-    pub fn negate(&mut self) {
-        self.apply_all(|x| *x = -*x);
+    /// Applies a binary operation segment-wise. Always safe because both
+    /// polynomials have segments within the same fixed region bounds.
+    fn op_assign(&mut self, other: &Self, op: impl Fn(&mut F, &F)) {
+        Self::merge(
+            &mut self.lo_offset,
+            &mut self.lo,
+            other.lo_offset,
+            &other.lo,
+            &op,
+        );
+        Self::merge(
+            &mut self.mid_offset,
+            &mut self.mid,
+            other.mid_offset,
+            &other.mid,
+            &op,
+        );
+        Self::merge(
+            &mut self.hi_offset,
+            &mut self.hi,
+            other.hi_offset,
+            &other.hi,
+            &op,
+        );
+        Self::trim_segment(&mut self.lo_offset, &mut self.lo);
+        Self::trim_segment(&mut self.mid_offset, &mut self.mid);
+        Self::trim_segment(&mut self.hi_offset, &mut self.hi);
+    }
+
+    /// Strips leading and trailing zeros from a segment in place, adjusting
+    /// the offset. Clears the segment entirely if all elements are zero.
+    fn trim_segment(offset: &mut usize, data: &mut Vec<F>) {
+        // Trim trailing zeros.
+        while data.last().is_some_and(|v| bool::from(v.is_zero())) {
+            data.pop();
+        }
+        // Trim leading zeros.
+        let leading = data
+            .iter()
+            .position(|v| !bool::from(v.is_zero()))
+            .unwrap_or(0);
+        if leading > 0 {
+            data.drain(..leading);
+            *offset += leading;
+        }
+    }
+
+    /// Merges `other` segment into `self` segment, expanding `self` to cover
+    /// the union range if needed, then applying `op` element-wise.
+    fn merge(
+        s_off: &mut usize,
+        s_data: &mut Vec<F>,
+        o_off: usize,
+        o_data: &[F],
+        op: &impl Fn(&mut F, &F),
+    ) {
+        if o_data.is_empty() {
+            return;
+        }
+        if s_data.is_empty() {
+            *s_off = o_off;
+            *s_data = alloc::vec![F::ZERO; o_data.len()];
+            for (dst, src) in s_data.iter_mut().zip(o_data) {
+                op(dst, src);
+            }
+            return;
+        }
+        let s_end = *s_off + s_data.len();
+        let o_end = o_off + o_data.len();
+        let new_off = (*s_off).min(o_off);
+        let new_end = s_end.max(o_end);
+
+        if new_off < *s_off || new_end > s_end {
+            let mut new_buf = alloc::vec![F::ZERO; new_end - new_off];
+            let rel = *s_off - new_off;
+            new_buf[rel..rel + s_data.len()].copy_from_slice(s_data);
+            *s_data = new_buf;
+            *s_off = new_off;
+        }
+
+        let rel = o_off - *s_off;
+        for (dst, src) in s_data[rel..rel + o_data.len()].iter_mut().zip(o_data) {
+            op(dst, src);
+        }
     }
 
     /// Horner-style weighted sum of polynomials by powers of `scale_factor`.
@@ -355,11 +391,15 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
         })
     }
 
-    /// Evaluates this polynomial at `z` using reverse Horner's method by block.
+    /// Evaluates this polynomial at `z` using reverse Horner's method by
+    /// segment.
     pub fn eval(&self, z: F) -> F {
+        let (segments, num_segments) = self.as_segments();
         let mut result = F::ZERO;
         let mut prev_start = R::num_coeffs();
-        for (start, data) in self.blocks.iter().rev() {
+
+        for i in (0..num_segments).rev() {
+            let (start, data) = segments[i];
             let gap = prev_start - (start + data.len());
             if gap > 0 {
                 result *= z.pow_vartime([gap as u64]);
@@ -367,7 +407,7 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
             for coeff in data.iter().rev() {
                 result = result * z + *coeff;
             }
-            prev_start = *start;
+            prev_start = start;
         }
         if prev_start > 0 {
             result *= z.pow_vartime([prev_start as u64]);
@@ -378,10 +418,12 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     /// Transforms `p(X)` into `p(zX)` by multiplying each coefficient at
     /// degree `k` by `z^k`.
     pub fn dilate(&mut self, z: F) {
+        let (mut segments, num_segments) = self.as_segments_mut();
         let mut power = F::ONE;
         let mut prev_end: usize = 0;
-        for (start, data) in &mut self.blocks {
-            let gap = *start - prev_end;
+
+        for &mut (start, ref mut data) in &mut segments[..num_segments] {
+            let gap = start - prev_end;
             if gap > 0 {
                 power *= z.pow_vartime([gap as u64]);
             }
@@ -389,62 +431,60 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
                 *coeff *= power;
                 power *= z;
             }
-            prev_end = *start + data.len();
+            prev_end = start + data.len();
         }
     }
 
     /// Inner product of `self` with the coefficient-reversed `other`.
     ///
     /// Computes $\sum\_{k} \text{self}\[k\] \cdot \text{other}\[4n - 1 - k\]$.
-    ///
-    /// Uses a two-pointer merge over both block lists for $O(\text{nnz})$
-    /// time.
     pub fn revdot(&self, other: &Self) -> F {
-        let max_deg = R::num_coeffs() - 1;
+        let n4 = R::num_coeffs();
+        let (s_segs, s_n) = self.as_segments();
+        let (o_segs, o_n) = other.as_segments();
         let mut result = F::ZERO;
-
-        let mut a_iter = self.blocks.iter().peekable();
-        // Iterating other's blocks in reverse yields ascending reversed-index
-        // ranges, suitable for a merge with self's ascending blocks.
-        let mut b_iter = other.blocks.iter().rev().peekable();
-
-        while let (Some(a_blk), Some(b_blk)) = (a_iter.peek(), b_iter.peek()) {
-            let (a_start, a_data) = (a_blk.0, &a_blk.1);
-            let (b_start, b_data) = (b_blk.0, &b_blk.1);
-
-            let a_end = a_start + a_data.len();
-            let b_len = b_data.len();
-            // Other block (b_start, b_data) covers original indices
-            // [b_start, b_start + b_len). In the reversed view these map to
-            // [max_deg - b_start - b_len + 1, max_deg - b_start + 1).
-            let rev_lo = max_deg + 1 - b_start - b_len;
-            let rev_hi = max_deg + 1 - b_start;
-
-            let overlap_lo = a_start.max(rev_lo);
-            let overlap_hi = a_end.min(rev_hi);
-
-            if overlap_lo < overlap_hi {
-                let a_slice = &a_data[overlap_lo - a_start..overlap_hi - a_start];
-                // For index k in [overlap_lo, overlap_hi), the other value is
-                // at b_data[max_deg - k - b_start]. As k increases, the
-                // b_data index decreases, so we zip a forward with b reversed.
-                let b_idx_lo = max_deg - (overlap_hi - 1) - b_start;
-                let b_idx_hi = max_deg - overlap_lo - b_start;
-                let b_slice = &b_data[b_idx_lo..=b_idx_hi];
-
-                for (a_val, b_val) in a_slice.iter().zip(b_slice.iter().rev()) {
-                    result += *a_val * *b_val;
-                }
-            }
-
-            if a_end <= rev_hi {
-                a_iter.next();
-            }
-            if rev_hi <= a_end {
-                b_iter.next();
+        for &(s_off, s_data) in &s_segs[..s_n] {
+            for &(o_off, o_data) in &o_segs[..o_n] {
+                result += Self::revdot_segment_pair(s_off, s_data, o_off, o_data, n4);
             }
         }
+        result
+    }
 
+    /// Computes the revdot contribution between one segment from self at
+    /// `[a_off, a_off + a_data.len())` and one segment from other at
+    /// `[b_off, b_off + b_data.len())`, where other is coefficient-reversed.
+    ///
+    /// The reversed segment maps to `[n4 - b_off - b_data.len(), n4 - b_off)`.
+    fn revdot_segment_pair(a_off: usize, a_data: &[F], b_off: usize, b_data: &[F], n4: usize) -> F {
+        if a_data.is_empty() || b_data.is_empty() {
+            return F::ZERO;
+        }
+
+        let a_end = a_off + a_data.len();
+        // Reversed range of other's segment.
+        let rev_lo = n4 - b_off - b_data.len();
+        let rev_hi = n4 - b_off;
+
+        let overlap_lo = a_off.max(rev_lo);
+        let overlap_hi = a_end.min(rev_hi);
+
+        if overlap_lo >= overlap_hi {
+            return F::ZERO;
+        }
+
+        let a_slice = &a_data[overlap_lo - a_off..overlap_hi - a_off];
+        // For index k in [overlap_lo, overlap_hi), other's value is at
+        // b_data[n4 - 1 - k - b_off]. As k increases, the b_data index
+        // decreases, so we zip a forward with b reversed.
+        let b_idx_lo = n4 - 1 - (overlap_hi - 1) - b_off;
+        let b_idx_hi = n4 - 1 - overlap_lo - b_off;
+        let b_slice = &b_data[b_idx_lo..=b_idx_hi];
+
+        let mut result = F::ZERO;
+        for (a_val, b_val) in a_slice.iter().zip(b_slice.iter().rev()) {
+            result += *a_val * *b_val;
+        }
         result
     }
 
@@ -459,13 +499,14 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     ) -> C::Curve {
         assert!(generators.g().len() >= R::num_coeffs());
 
+        let (segments, num_segments) = self.as_segments();
         let g = generators.g();
         ragu_arithmetic::mul(
-            self.blocks
+            segments[..num_segments]
                 .iter()
                 .flat_map(|(_, data)| data.iter())
                 .chain(core::iter::once(&blind)),
-            self.blocks
+            segments[..num_segments]
                 .iter()
                 .flat_map(|(start, data)| &g[*start..*start + data.len()])
                 .chain(core::iter::once(generators.h())),
@@ -486,15 +527,16 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
 }
 
 /// An iterator over all coefficients of a sparse polynomial in ascending
-/// degree order, yielding `F::ZERO` for gaps between blocks.
+/// degree order, yielding `F::ZERO` for gaps between segments.
 struct CoeffIter<'a, F> {
-    blocks: &'a [(usize, Vec<F>)],
+    segments: [(usize, &'a [F]); 3],
+    num_segments: usize,
     front: usize,
     back: usize,
-    /// Index of the first block whose end extends past `front`.
-    front_block: usize,
-    /// One past the last block whose start is at or before `back - 1`.
-    back_block: usize,
+    /// Index of the first segment whose end extends past `front`.
+    front_seg: usize,
+    /// One past the last segment whose start is at or before `back - 1`.
+    back_seg: usize,
 }
 
 impl<F: Field> Iterator for CoeffIter<'_, F> {
@@ -504,18 +546,18 @@ impl<F: Field> Iterator for CoeffIter<'_, F> {
         if self.front >= self.back {
             return None;
         }
-        // Advance past blocks fully before `front`.
-        while self.front_block < self.blocks.len() {
-            let (start, data) = &self.blocks[self.front_block];
-            if *start + data.len() > self.front {
+        // Advance past segments fully before `front`.
+        while self.front_seg < self.num_segments {
+            let (start, data) = self.segments[self.front_seg];
+            if start + data.len() > self.front {
                 break;
             }
-            self.front_block += 1;
+            self.front_seg += 1;
         }
-        let val = if self.front_block < self.blocks.len() {
-            let (start, data) = &self.blocks[self.front_block];
-            if self.front >= *start {
-                data[self.front - *start]
+        let val = if self.front_seg < self.num_segments {
+            let (start, data) = self.segments[self.front_seg];
+            if self.front >= start {
+                data[self.front - start]
             } else {
                 F::ZERO
             }
@@ -538,18 +580,18 @@ impl<F: Field> DoubleEndedIterator for CoeffIter<'_, F> {
             return None;
         }
         self.back -= 1;
-        // Retreat past blocks that start after `back`.
-        while self.back_block > 0 {
-            let (start, _) = &self.blocks[self.back_block - 1];
-            if *start <= self.back {
+        // Retreat past segments that start after `back`.
+        while self.back_seg > 0 {
+            let (start, _) = self.segments[self.back_seg - 1];
+            if start <= self.back {
                 break;
             }
-            self.back_block -= 1;
+            self.back_seg -= 1;
         }
-        let val = if self.back_block > 0 {
-            let (start, data) = &self.blocks[self.back_block - 1];
-            if self.back < *start + data.len() {
-                data[self.back - *start]
+        let val = if self.back_seg > 0 {
+            let (start, data) = self.segments[self.back_seg - 1];
+            if self.back < start + data.len() {
+                data[self.back - start]
             } else {
                 F::ZERO
             }

--- a/crates/ragu_circuits/src/polynomials/sparse/mod.rs
+++ b/crates/ragu_circuits/src/polynomials/sparse/mod.rs
@@ -55,21 +55,33 @@ use core::marker::PhantomData;
 
 use super::Rank;
 
+/// Region names for assertion messages.
+const REGION_NAMES: [&str; 3] = ["lo", "mid", "hi"];
+
 /// A sparse polynomial with coefficients stored in three fixed-region segments.
 ///
 /// See the [module documentation](self) for details.
 #[derive(Clone, Debug)]
 pub struct Polynomial<T, R: Rank> {
-    lo_offset: usize,
-    lo: Vec<T>,
-    mid_offset: usize,
-    mid: Vec<T>,
-    hi_offset: usize,
-    hi: Vec<T>,
+    /// Three `(offset, data)` segments for lo `[0, n)`, mid `[n, 3n)`, hi
+    /// `[3n, 4n)`.
+    segments: [(usize, Vec<T>); 3],
     _marker: PhantomData<R>,
 }
 
 impl<T, R: Rank> Polynomial<T, R> {
+    /// Default offsets for the three regions: `[0, n, 3n]`.
+    fn default_offsets() -> [usize; 3] {
+        let n = R::n();
+        [0, n, 3 * n]
+    }
+
+    /// Region bounds: `[(0, n), (n, 3n), (3n, 4n)]`.
+    fn region_bounds() -> [(usize, usize); 3] {
+        let n = R::n();
+        [(0, n), (n, 3 * n), (3 * n, 4 * n)]
+    }
+
     /// Panics if the representation violates region-bound invariants.
     ///
     /// Each segment must stay within its fixed degree region:
@@ -77,51 +89,23 @@ impl<T, R: Rank> Polynomial<T, R> {
     /// - `mid` within `[n, 3n)`
     /// - `hi` within `[3n, 4n)`
     fn assert_invariants(&self) {
-        let n = R::n();
-        assert!(
-            self.lo_offset + self.lo.len() <= n,
-            "lo [{}, {}) exceeds region [0, {n})",
-            self.lo_offset,
-            self.lo_offset + self.lo.len(),
-        );
-        assert!(
-            n <= self.mid_offset,
-            "mid_offset {} below region start {n}",
-            self.mid_offset,
-        );
-        assert!(
-            self.mid_offset + self.mid.len() <= 3 * n,
-            "mid [{}, {}) exceeds region [{n}, {})",
-            self.mid_offset,
-            self.mid_offset + self.mid.len(),
-            3 * n,
-        );
-        assert!(
-            3 * n <= self.hi_offset,
-            "hi_offset {} below region start {}",
-            self.hi_offset,
-            3 * n,
-        );
-        assert!(
-            self.hi_offset + self.hi.len() <= R::num_coeffs(),
-            "hi [{}, {}) exceeds capacity {}",
-            self.hi_offset,
-            self.hi_offset + self.hi.len(),
-            R::num_coeffs(),
-        );
+        let bounds = Self::region_bounds();
+        for (i, ((off, data), (lo, hi))) in self.segments.iter().zip(bounds).enumerate() {
+            assert!(
+                *off >= lo && off + data.len() <= hi,
+                "{} segment [{}, {}) exceeds region [{lo}, {hi})",
+                REGION_NAMES[i],
+                off,
+                off + data.len(),
+            );
+        }
     }
 
     // Constructs from three `(offset, data)` blocks, asserting region-bound
     // invariants. The blocks correspond to lo, mid, hi in order.
-    fn from_blocks(blocks: [(usize, Vec<T>); 3]) -> Self {
-        let [(lo_offset, lo), (mid_offset, mid), (hi_offset, hi)] = blocks;
+    fn from_blocks(segments: [(usize, Vec<T>); 3]) -> Self {
         let poly = Self {
-            lo_offset,
-            lo,
-            mid_offset,
-            mid,
-            hi_offset,
-            hi,
+            segments,
             _marker: PhantomData,
         };
         poly.assert_invariants();
@@ -138,13 +122,13 @@ impl<T, R: Rank> Default for Polynomial<T, R> {
 impl<T, R: Rank> Polynomial<T, R> {
     /// Creates a new empty (zero) polynomial.
     pub fn new() -> Self {
+        let offsets = Self::default_offsets();
         Self {
-            lo_offset: 0,
-            lo: Vec::new(),
-            mid_offset: R::n(),
-            mid: Vec::new(),
-            hi_offset: 3 * R::n(),
-            hi: Vec::new(),
+            segments: [
+                (offsets[0], Vec::new()),
+                (offsets[1], Vec::new()),
+                (offsets[2], Vec::new()),
+            ],
             _marker: PhantomData,
         }
     }
@@ -170,15 +154,12 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
         let mut mid = coeffs.split_off(n);
         let mut lo = coeffs;
 
-        let mut lo_offset = 0;
-        let mut mid_offset = n;
-        let mut hi_offset = 3 * n;
+        let mut offsets = Self::default_offsets();
+        Self::trim_segment(&mut offsets[0], &mut lo);
+        Self::trim_segment(&mut offsets[1], &mut mid);
+        Self::trim_segment(&mut offsets[2], &mut hi);
 
-        Self::trim_segment(&mut lo_offset, &mut lo);
-        Self::trim_segment(&mut mid_offset, &mut mid);
-        Self::trim_segment(&mut hi_offset, &mut hi);
-
-        Self::from_blocks([(lo_offset, lo), (mid_offset, mid), (hi_offset, hi)])
+        Self::from_blocks([(offsets[0], lo), (offsets[1], mid), (offsets[2], hi)])
     }
 
     /// Creates a polynomial with random coefficients filling all `4n` slots.
@@ -196,14 +177,10 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
 impl<T, R: Rank> Polynomial<T, R> {
     /// Applies a closure to every stored element.
     fn apply_all(&mut self, mut op: impl FnMut(&mut T)) {
-        for elem in &mut self.lo {
-            op(elem);
-        }
-        for elem in &mut self.mid {
-            op(elem);
-        }
-        for elem in &mut self.hi {
-            op(elem);
+        for (_, data) in &mut self.segments {
+            for elem in data {
+                op(elem);
+            }
         }
     }
 }
@@ -212,7 +189,7 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     /// Returns an iterator over the coefficients of this polynomial in
     /// ascending degree order, yielding `F::ZERO` for gaps between segments.
     pub fn iter_coeffs(&self) -> impl DoubleEndedIterator<Item = F> + ExactSizeIterator + '_ {
-        let (segments, num_segments) = self.as_segments();
+        let (segments, num_segments) = self.non_empty_segments();
         CoeffIter {
             segments,
             num_segments,
@@ -223,41 +200,15 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
         }
     }
 
-    /// Returns the stored segments as a fixed-size array of `(offset, slice)`
-    /// pairs plus a count of how many are populated (skipping empty segments).
-    fn as_segments(&self) -> ([(usize, &[F]); 3], usize) {
-        let mut segs: [(usize, &[F]); 3] = [(0, &[]), (0, &[]), (0, &[])];
+    /// Returns non-empty segments as a packed fixed-size array plus a count.
+    fn non_empty_segments(&self) -> ([(usize, &[F]); 3], usize) {
+        let mut segs: [(usize, &[F]); 3] = [(0, &[]); 3];
         let mut n = 0;
-        if !self.lo.is_empty() {
-            segs[n] = (self.lo_offset, &self.lo);
-            n += 1;
-        }
-        if !self.mid.is_empty() {
-            segs[n] = (self.mid_offset, &self.mid);
-            n += 1;
-        }
-        if !self.hi.is_empty() {
-            segs[n] = (self.hi_offset, &self.hi);
-            n += 1;
-        }
-        (segs, n)
-    }
-
-    /// Returns mutable segment references as a fixed-size array.
-    fn as_segments_mut(&mut self) -> ([(usize, &mut [F]); 3], usize) {
-        let mut segs: [(usize, &mut [F]); 3] = [(0, &mut []), (0, &mut []), (0, &mut [])];
-        let mut n = 0;
-        if !self.lo.is_empty() {
-            segs[n] = (self.lo_offset, self.lo.as_mut_slice());
-            n += 1;
-        }
-        if !self.mid.is_empty() {
-            segs[n] = (self.mid_offset, self.mid.as_mut_slice());
-            n += 1;
-        }
-        if !self.hi.is_empty() {
-            segs[n] = (self.hi_offset, self.hi.as_mut_slice());
-            n += 1;
+        for (off, data) in &self.segments {
+            if !data.is_empty() {
+                segs[n] = (*off, data);
+                n += 1;
+            }
         }
         (segs, n)
     }
@@ -265,12 +216,7 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     /// Multiplies all coefficients by `by`.
     pub fn scale(&mut self, by: F) {
         if bool::from(by.is_zero()) {
-            self.lo.clear();
-            self.lo_offset = 0;
-            self.mid.clear();
-            self.mid_offset = R::n();
-            self.hi.clear();
-            self.hi_offset = 3 * R::n();
+            *self = Self::new();
         } else {
             self.apply_all(|x| *x *= by);
         }
@@ -294,30 +240,16 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     /// Applies a binary operation segment-wise. Always safe because both
     /// polynomials have segments within the same fixed region bounds.
     fn op_assign(&mut self, other: &Self, op: impl Fn(&mut F, &F)) {
-        Self::merge(
-            &mut self.lo_offset,
-            &mut self.lo,
-            other.lo_offset,
-            &other.lo,
-            &op,
-        );
-        Self::merge(
-            &mut self.mid_offset,
-            &mut self.mid,
-            other.mid_offset,
-            &other.mid,
-            &op,
-        );
-        Self::merge(
-            &mut self.hi_offset,
-            &mut self.hi,
-            other.hi_offset,
-            &other.hi,
-            &op,
-        );
-        Self::trim_segment(&mut self.lo_offset, &mut self.lo);
-        Self::trim_segment(&mut self.mid_offset, &mut self.mid);
-        Self::trim_segment(&mut self.hi_offset, &mut self.hi);
+        for i in 0..3 {
+            Self::merge(
+                &mut self.segments[i].0,
+                &mut self.segments[i].1,
+                other.segments[i].0,
+                &other.segments[i].1,
+                &op,
+            );
+            Self::trim_segment(&mut self.segments[i].0, &mut self.segments[i].1);
+        }
     }
 
     /// Strips leading and trailing zeros from a segment in place, adjusting
@@ -394,12 +326,13 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     /// Evaluates this polynomial at `z` using reverse Horner's method by
     /// segment.
     pub fn eval(&self, z: F) -> F {
-        let (segments, num_segments) = self.as_segments();
         let mut result = F::ZERO;
         let mut prev_start = R::num_coeffs();
 
-        for i in (0..num_segments).rev() {
-            let (start, data) = segments[i];
+        for &(start, ref data) in self.segments.iter().rev() {
+            if data.is_empty() {
+                continue;
+            }
             let gap = prev_start - (start + data.len());
             if gap > 0 {
                 result *= z.pow_vartime([gap as u64]);
@@ -418,11 +351,13 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     /// Transforms `p(X)` into `p(zX)` by multiplying each coefficient at
     /// degree `k` by `z^k`.
     pub fn dilate(&mut self, z: F) {
-        let (mut segments, num_segments) = self.as_segments_mut();
         let mut power = F::ONE;
         let mut prev_end: usize = 0;
 
-        for &mut (start, ref mut data) in &mut segments[..num_segments] {
+        for &mut (start, ref mut data) in &mut self.segments {
+            if data.is_empty() {
+                continue;
+            }
             let gap = start - prev_end;
             if gap > 0 {
                 power *= z.pow_vartime([gap as u64]);
@@ -440,11 +375,15 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     /// Computes $\sum\_{k} \text{self}\[k\] \cdot \text{other}\[4n - 1 - k\]$.
     pub fn revdot(&self, other: &Self) -> F {
         let n4 = R::num_coeffs();
-        let (s_segs, s_n) = self.as_segments();
-        let (o_segs, o_n) = other.as_segments();
         let mut result = F::ZERO;
-        for &(s_off, s_data) in &s_segs[..s_n] {
-            for &(o_off, o_data) in &o_segs[..o_n] {
+        for &(s_off, ref s_data) in &self.segments {
+            if s_data.is_empty() {
+                continue;
+            }
+            for &(o_off, ref o_data) in &other.segments {
+                if o_data.is_empty() {
+                    continue;
+                }
                 result += Self::revdot_segment_pair(s_off, s_data, o_off, o_data, n4);
             }
         }
@@ -499,15 +438,16 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     ) -> C::Curve {
         assert!(generators.g().len() >= R::num_coeffs());
 
-        let (segments, num_segments) = self.as_segments();
         let g = generators.g();
         ragu_arithmetic::mul(
-            segments[..num_segments]
+            self.segments
                 .iter()
+                .filter(|(_, data)| !data.is_empty())
                 .flat_map(|(_, data)| data.iter())
                 .chain(core::iter::once(&blind)),
-            segments[..num_segments]
+            self.segments
                 .iter()
+                .filter(|(_, data)| !data.is_empty())
                 .flat_map(|(start, data)| &g[*start..*start + data.len()])
                 .chain(core::iter::once(generators.h())),
         )

--- a/crates/ragu_circuits/src/polynomials/sparse/mod.rs
+++ b/crates/ragu_circuits/src/polynomials/sparse/mod.rs
@@ -63,14 +63,13 @@ const BLOCK_NAMES: [&str; 3] = ["lo", "mid", "hi"];
 /// See the [module documentation](self) for details.
 #[derive(Clone, Debug)]
 pub struct Polynomial<T, R: Rank> {
-    /// Three `(offset, data)` blocks for lo `[0, n)`, mid `[n, 3n)`, hi
-    /// `[3n, 4n)`.
+    /// Three `(offset, data)` blocks for:
+    /// lo in `[0, n)`; mid in `[n, 3n)`; hi in `[3n, 4n)`.
     blocks: [(usize, Vec<T>); 3],
     _marker: PhantomData<R>,
 }
 
 impl<T, R: Rank> Polynomial<T, R> {
-    /// Default offsets for the three regions: `[0, n, 3n]`.
     fn default_offsets() -> [usize; 3] {
         let n = R::n();
         [0, n, 3 * n]
@@ -169,11 +168,13 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     pub fn random<RNG: CryptoRng>(rng: &mut RNG) -> Self {
         assert!(R::num_coeffs() > 0, "num_coeffs must be positive");
         let n = R::n();
-        let mut coeffs: Vec<F> = (0..R::num_coeffs()).map(|_| F::random(&mut *rng)).collect();
-        let hi = coeffs.split_off(3 * n);
-        let mid = coeffs.split_off(n);
-        let lo = coeffs;
-        Self::from_blocks([(0, lo), (n, mid), (3 * n, hi)])
+        let rand_vec = |prng: &mut RNG, l: usize| (0..l).map(|_| F::random(prng)).collect();
+
+        Self::from_blocks([
+            (0, rand_vec(rng, n)),
+            (n, rand_vec(rng, 2 * n)),
+            (3 * n, rand_vec(rng, n)),
+        ])
     }
 }
 
@@ -200,33 +201,9 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
             ],
             front: 0,
             back: R::num_coeffs(),
-            front_blk: 0,
-            back_blk: 3,
+            front_block: 0,
+            back_block: 3,
         }
-    }
-
-    /// Multiplies all coefficients by `by`.
-    pub fn scale(&mut self, by: F) {
-        if bool::from(by.is_zero()) {
-            *self = Self::new();
-        } else {
-            self.apply_all(|x| *x *= by);
-        }
-    }
-
-    /// Negates all coefficients.
-    pub fn negate(&mut self) {
-        self.apply_all(|x| *x = -*x);
-    }
-
-    /// Adds the coefficients of `other` to `self`.
-    pub fn add_assign(&mut self, other: &Self) {
-        self.combine_assign(other, |a, b| *a += *b);
-    }
-
-    /// Subtracts the coefficients of `other` from `self`.
-    pub fn sub_assign(&mut self, other: &Self) {
-        self.combine_assign(other, |a, b| *a -= *b);
     }
 
     /// Applies a binary operation block-wise. Always safe because both
@@ -240,8 +217,31 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
                 &other.blocks[i].1,
                 &op,
             );
-            Self::trim_block(&mut self.blocks[i].0, &mut self.blocks[i].1);
         }
+    }
+
+    /// Multiplies all coefficients by `by`.
+    pub fn scale(&mut self, by: F) {
+        if bool::from(by.is_zero()) {
+            *self = Self::new();
+        } else {
+            self.apply_all(|x| *x *= by);
+        }
+    }
+
+    /// Adds the coefficients of `other` to `self`.
+    pub fn add_assign(&mut self, other: &Self) {
+        self.combine_assign(other, |a, b| *a += *b);
+    }
+
+    /// Negates all coefficients.
+    pub fn negate(&mut self) {
+        self.apply_all(|x| *x = -*x);
+    }
+
+    /// Subtracts the coefficients of `other` from `self`.
+    pub fn sub_assign(&mut self, other: &Self) {
+        self.combine_assign(other, |a, b| *a -= *b);
     }
 
     /// Strips leading and trailing zeros from a block in place, adjusting
@@ -275,33 +275,37 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
             return;
         }
 
-        // When self is empty, adopt other's range; otherwise compute the union.
-        let s_end = *s_off + s_data.len();
-        let new_off = if s_data.is_empty() {
-            o_off
+        // find range union, extends self's data with zeros if necessary
+        if s_data.is_empty() {
+            *s_off = o_off;
+            *s_data = alloc::vec![F::ZERO; o_data.len()];
         } else {
-            (*s_off).min(o_off)
-        };
-        let new_end = if s_data.is_empty() {
-            o_off + o_data.len()
-        } else {
-            s_end.max(o_off + o_data.len())
-        };
+            let new_off = (*s_off).min(o_off);
+            let new_end = {
+                let s_end = *s_off + s_data.len();
+                let o_end = o_off + o_data.len();
+                s_end.max(o_end)
+            };
 
-        // Expand self to cover [new_off, new_end) if needed.
-        if new_off != *s_off || new_end != s_end {
-            let mut buf = alloc::vec![F::ZERO; new_end - new_off];
-            if !s_data.is_empty() {
-                buf[*s_off - new_off..*s_off - new_off + s_data.len()].copy_from_slice(s_data);
+            let mut buf = alloc::vec![];
+            if new_off < *s_off {
+                buf.resize(*s_off - new_off, F::ZERO); // zero prefix
             }
-            *s_data = buf;
+            buf.extend_from_slice(s_data);
+            buf.resize(new_end - new_off, F::ZERO); // zero suffix
+
             *s_off = new_off;
+            *s_data = buf;
         }
 
+        // Operate on the range-aligned data
         let rel = o_off - *s_off;
         for (dst, src) in s_data[rel..rel + o_data.len()].iter_mut().zip(o_data) {
             op(dst, src);
         }
+
+        // Trim off leading and trailing zero post-operation
+        Self::trim_block(s_off, s_data);
     }
 
     /// Horner-style weighted sum of polynomials by powers of `scale_factor`.
@@ -318,13 +322,12 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
         })
     }
 
-    /// Evaluates this polynomial at `z` using reverse Horner's method by
-    /// block.
+    /// Evaluates this polynomial at `z` using reverse Horner's method by block.
     pub fn eval(&self, z: F) -> F {
         let mut result = F::ZERO;
         let mut prev_start = R::num_coeffs();
 
-        for &(start, ref data) in self.blocks.iter().rev() {
+        for (start, data) in self.blocks.iter().rev() {
             if data.is_empty() {
                 continue;
             }
@@ -335,7 +338,7 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
             for coeff in data.iter().rev() {
                 result = result * z + *coeff;
             }
-            prev_start = start;
+            prev_start = *start;
         }
         if prev_start > 0 {
             result *= z.pow_vartime([prev_start as u64]);
@@ -349,11 +352,11 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
         let mut power = F::ONE;
         let mut prev_end: usize = 0;
 
-        for &mut (start, ref mut data) in &mut self.blocks {
+        for (start, data) in &mut self.blocks {
             if data.is_empty() {
                 continue;
             }
-            let gap = start - prev_end;
+            let gap = *start - prev_end;
             if gap > 0 {
                 power *= z.pow_vartime([gap as u64]);
             }
@@ -361,7 +364,7 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
                 *coeff *= power;
                 power *= z;
             }
-            prev_end = start + data.len();
+            prev_end = *start + data.len();
         }
     }
 
@@ -373,28 +376,21 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     /// lo `[0,n)` pairs with reversed hi `[3n,4n)`, mid `[n,3n)` with
     /// reversed mid, and hi with reversed lo.
     pub fn revdot(&self, other: &Self) -> F {
-        // self[a_off+i] pairs with other[b_off+j] where i+j = mirror.
-        // Fixed regions pair: lo(0) x hi(2), mid(1) x mid(1), hi(2) x lo(0).
-        let mirror_base = R::num_coeffs() - 1;
         let mut result = F::ZERO;
         for i in 0..3 {
-            result += Self::revdot_pair(&self.blocks[i], &other.blocks[2 - i], mirror_base);
+            result += Self::revdot_block(&self.blocks[i], &other.blocks[2 - i]);
         }
         result
     }
 
-    /// Dot product of block `a` with the coefficient-reversed block `b`.
-    ///
-    /// `a_data[i]` pairs with `b_data[j]` where `i + j = mirror`, and
-    /// `mirror = mirror_base - a_off - b_off`.
-    fn revdot_pair(a: &(usize, Vec<F>), b: &(usize, Vec<F>), mirror_base: usize) -> F {
-        let (a_off, a_data) = (a.0, a.1.as_slice());
-        let (b_off, b_data) = (b.0, b.1.as_slice());
+    /// Revdot product of block `a` and `b`.
+    fn revdot_block((a_off, a_data): &(usize, Vec<F>), (b_off, b_data): &(usize, Vec<F>)) -> F {
         if a_data.is_empty() || b_data.is_empty() {
             return F::ZERO;
         }
 
-        // i + j = mirror, with i ∈ [0, a_len) and j ∈ [0, b_len).
+        // i + j = mirror, with i \in [0, a_len) and j \in [0, b_len).
+        let mirror_base = R::num_coeffs() - 1;
         let Some(mirror) = mirror_base.checked_sub(a_off + b_off) else {
             return F::ZERO;
         };
@@ -463,9 +459,9 @@ struct CoeffIter<'a, F> {
     front: usize,
     back: usize,
     /// Index of the first block whose end extends past `front`.
-    front_blk: usize,
+    front_block: usize,
     /// One past the last block whose start is at or before `back - 1`.
-    back_blk: usize,
+    back_block: usize,
 }
 
 impl<F: Field> Iterator for CoeffIter<'_, F> {
@@ -476,17 +472,17 @@ impl<F: Field> Iterator for CoeffIter<'_, F> {
             return None;
         }
         // Advance past blocks fully before `front`.
-        while self.front_blk < 3 {
-            let (start, data) = self.blocks[self.front_blk];
-            if start + data.len() > self.front {
+        while self.front_block < 3 {
+            let (start, data) = &self.blocks[self.front_block];
+            if *start + data.len() > self.front {
                 break;
             }
-            self.front_blk += 1;
+            self.front_block += 1;
         }
-        let val = if self.front_blk < 3 {
-            let (start, data) = self.blocks[self.front_blk];
-            if self.front >= start {
-                data[self.front - start]
+        let val = if self.front_block < 3 {
+            let (start, data) = &self.blocks[self.front_block];
+            if self.front >= *start {
+                data[self.front - *start]
             } else {
                 F::ZERO
             }
@@ -510,17 +506,17 @@ impl<F: Field> DoubleEndedIterator for CoeffIter<'_, F> {
         }
         self.back -= 1;
         // Retreat past blocks that start after `back`.
-        while self.back_blk > 0 {
-            let (start, _) = self.blocks[self.back_blk - 1];
-            if start <= self.back {
+        while self.back_block > 0 {
+            let (start, _) = &self.blocks[self.back_block - 1];
+            if *start <= self.back {
                 break;
             }
-            self.back_blk -= 1;
+            self.back_block -= 1;
         }
-        let val = if self.back_blk > 0 {
-            let (start, data) = self.blocks[self.back_blk - 1];
-            if self.back < start + data.len() {
-                data[self.back - start]
+        let val = if self.back_block > 0 {
+            let (start, data) = &self.blocks[self.back_block - 1];
+            if self.back < *start + data.len() {
+                data[self.back - *start]
             } else {
                 F::ZERO
             }

--- a/crates/ragu_circuits/src/polynomials/sparse/mod.rs
+++ b/crates/ragu_circuits/src/polynomials/sparse/mod.rs
@@ -370,40 +370,39 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     /// lo `[0,n)` pairs with reversed hi `[3n,4n)`, mid `[n,3n)` with
     /// reversed mid, and hi with reversed lo.
     pub fn revdot(&self, other: &Self) -> F {
-        let n4 = R::num_coeffs();
+        // For global indices: self[a_off + i] pairs with other[b_off + j]
+        // where (a_off + i) + (b_off + j) = 4n - 1, i.e. i + j = mirror.
+        let mirror_base = R::num_coeffs() - 1;
         // lo x rev(hi), mid x rev(mid), hi x rev(lo)
-        Self::revdot_pair(&self.blocks[0], &other.blocks[2], n4)
-            + Self::revdot_pair(&self.blocks[1], &other.blocks[1], n4)
-            + Self::revdot_pair(&self.blocks[2], &other.blocks[0], n4)
+        Self::revdot_pair(&self.blocks[0], &other.blocks[2], mirror_base)
+            + Self::revdot_pair(&self.blocks[1], &other.blocks[1], mirror_base)
+            + Self::revdot_pair(&self.blocks[2], &other.blocks[0], mirror_base)
     }
 
     /// Dot product of block `a` with the coefficient-reversed block `b`.
-    fn revdot_pair(a: &(usize, Vec<F>), b: &(usize, Vec<F>), n4: usize) -> F {
+    ///
+    /// `a_data[i]` pairs with `b_data[j]` where `i + j = mirror`, and
+    /// `mirror = mirror_base - a_off - b_off`.
+    fn revdot_pair(a: &(usize, Vec<F>), b: &(usize, Vec<F>), mirror_base: usize) -> F {
         let (a_off, a_data) = (a.0, a.1.as_slice());
         let (b_off, b_data) = (b.0, b.1.as_slice());
         if a_data.is_empty() || b_data.is_empty() {
             return F::ZERO;
         }
 
-        // Block b at [b_off, b_off+b_len) reversed maps to
-        // [n4 - b_off - b_len, n4 - b_off).
-        let a_end = a_off + a_data.len();
-        let rev_lo = n4 - b_off - b_data.len();
-        let rev_hi = n4 - b_off;
+        // i + j = mirror, with i ∈ [0, a_len) and j ∈ [0, b_len).
+        let Some(mirror) = mirror_base.checked_sub(a_off + b_off) else {
+            return F::ZERO;
+        };
 
-        let overlap_lo = a_off.max(rev_lo);
-        let overlap_hi = a_end.min(rev_hi);
-        if overlap_lo >= overlap_hi {
+        let i_lo = mirror.saturating_sub(b_data.len() - 1);
+        let i_hi = (mirror + 1).min(a_data.len()); // exclusive
+        if i_lo >= i_hi {
             return F::ZERO;
         }
 
-        let a_slice = &a_data[overlap_lo - a_off..overlap_hi - a_off];
-        // For index k in [overlap_lo, overlap_hi), b's value is at
-        // b_data[n4 - 1 - k - b_off]. As k increases, the b_data index
-        // decreases, so we zip a forward with b reversed.
-        let b_idx_lo = n4 - 1 - (overlap_hi - 1) - b_off;
-        let b_idx_hi = n4 - 1 - overlap_lo - b_off;
-        let b_slice = &b_data[b_idx_lo..=b_idx_hi];
+        let a_slice = &a_data[i_lo..i_hi];
+        let b_slice = &b_data[mirror - (i_hi - 1)..=mirror - i_lo];
 
         let mut result = F::ZERO;
         for (a_val, b_val) in a_slice.iter().zip(b_slice.iter().rev()) {

--- a/crates/ragu_circuits/src/polynomials/sparse/mod.rs
+++ b/crates/ragu_circuits/src/polynomials/sparse/mod.rs
@@ -274,24 +274,27 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
         if o_data.is_empty() {
             return;
         }
-        if s_data.is_empty() {
-            *s_off = o_off;
-            *s_data = alloc::vec![F::ZERO; o_data.len()];
-            for (dst, src) in s_data.iter_mut().zip(o_data) {
-                op(dst, src);
-            }
-            return;
-        }
-        let s_end = *s_off + s_data.len();
-        let o_end = o_off + o_data.len();
-        let new_off = (*s_off).min(o_off);
-        let new_end = s_end.max(o_end);
 
-        if new_off < *s_off || new_end > s_end {
-            let mut new_buf = alloc::vec![F::ZERO; new_end - new_off];
-            let rel = *s_off - new_off;
-            new_buf[rel..rel + s_data.len()].copy_from_slice(s_data);
-            *s_data = new_buf;
+        // When self is empty, adopt other's range; otherwise compute the union.
+        let s_end = *s_off + s_data.len();
+        let new_off = if s_data.is_empty() {
+            o_off
+        } else {
+            (*s_off).min(o_off)
+        };
+        let new_end = if s_data.is_empty() {
+            o_off + o_data.len()
+        } else {
+            s_end.max(o_off + o_data.len())
+        };
+
+        // Expand self to cover [new_off, new_end) if needed.
+        if new_off != *s_off || new_end != s_end {
+            let mut buf = alloc::vec![F::ZERO; new_end - new_off];
+            if !s_data.is_empty() {
+                buf[*s_off - new_off..*s_off - new_off + s_data.len()].copy_from_slice(s_data);
+            }
+            *s_data = buf;
             *s_off = new_off;
         }
 
@@ -370,13 +373,14 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     /// lo `[0,n)` pairs with reversed hi `[3n,4n)`, mid `[n,3n)` with
     /// reversed mid, and hi with reversed lo.
     pub fn revdot(&self, other: &Self) -> F {
-        // For global indices: self[a_off + i] pairs with other[b_off + j]
-        // where (a_off + i) + (b_off + j) = 4n - 1, i.e. i + j = mirror.
+        // self[a_off+i] pairs with other[b_off+j] where i+j = mirror.
+        // Fixed regions pair: lo(0) x hi(2), mid(1) x mid(1), hi(2) x lo(0).
         let mirror_base = R::num_coeffs() - 1;
-        // lo x rev(hi), mid x rev(mid), hi x rev(lo)
-        Self::revdot_pair(&self.blocks[0], &other.blocks[2], mirror_base)
-            + Self::revdot_pair(&self.blocks[1], &other.blocks[1], mirror_base)
-            + Self::revdot_pair(&self.blocks[2], &other.blocks[0], mirror_base)
+        let mut result = F::ZERO;
+        for i in 0..3 {
+            result += Self::revdot_pair(&self.blocks[i], &other.blocks[2 - i], mirror_base);
+        }
+        result
     }
 
     /// Dot product of block `a` with the coefficient-reversed block `b`.

--- a/crates/ragu_circuits/src/polynomials/sparse/mod.rs
+++ b/crates/ragu_circuits/src/polynomials/sparse/mod.rs
@@ -1,16 +1,16 @@
-//! Sparse polynomial representation using three fixed-region segments.
+//! Sparse polynomial representation using three fixed-region blocks.
 //!
 //! [`Polynomial<T, R>`] stores a polynomial of degree up to
-//! `R::num_coeffs() - 1` using three dense segments separated by two gaps,
-//! with each segment constrained to a fixed degree region:
+//! `R::num_coeffs() - 1` using three dense blocks separated by two gaps,
+//! with each block constrained to a fixed degree region:
 //!
 //! - **lo**: degrees `[0, n)` — the `c`-wire region
 //! - **mid**: degrees `[n, 3n)` — the `b_rev ++ a` region (meeting at `2n`)
 //! - **hi**: degrees `[3n, 4n)` — the `d_rev` region
 //!
-//! where `n = R::n()`. Each segment stores an offset and a dense vector
+//! where `n = R::n()`. Each block stores an offset and a dense vector
 //! within its region. The fixed region boundaries guarantee that
-//! segment-wise arithmetic is always safe — no variant dispatch or
+//! block-wise arithmetic is always safe — no variant dispatch or
 //! compatibility checks needed.
 //!
 //! # Construction
@@ -20,7 +20,7 @@
 //!   three regions, trimming leading and trailing zeros within each.
 //! - [`View`]: a builder that maps four gate-indexed wire buffers to degree
 //!   positions via [`View::build`]. Zero elements within a wire buffer are
-//!   **preserved** in the resulting segments — push only non-zero values for
+//!   **preserved** in the resulting blocks — push only non-zero values for
 //!   maximum compression, or use [`Polynomial::from_coeffs`] to strip a
 //!   pre-built dense vector.
 //!
@@ -55,17 +55,17 @@ use core::marker::PhantomData;
 
 use super::Rank;
 
-/// Region names for assertion messages.
-const REGION_NAMES: [&str; 3] = ["lo", "mid", "hi"];
+/// Block names for assertion messages.
+const BLOCK_NAMES: [&str; 3] = ["lo", "mid", "hi"];
 
-/// A sparse polynomial with coefficients stored in three fixed-region segments.
+/// A sparse polynomial with coefficients stored in three fixed-region blocks.
 ///
 /// See the [module documentation](self) for details.
 #[derive(Clone, Debug)]
 pub struct Polynomial<T, R: Rank> {
-    /// Three `(offset, data)` segments for lo `[0, n)`, mid `[n, 3n)`, hi
+    /// Three `(offset, data)` blocks for lo `[0, n)`, mid `[n, 3n)`, hi
     /// `[3n, 4n)`.
-    segments: [(usize, Vec<T>); 3],
+    blocks: [(usize, Vec<T>); 3],
     _marker: PhantomData<R>,
 }
 
@@ -76,25 +76,20 @@ impl<T, R: Rank> Polynomial<T, R> {
         [0, n, 3 * n]
     }
 
-    /// Region bounds: `[(0, n), (n, 3n), (3n, 4n)]`.
-    fn region_bounds() -> [(usize, usize); 3] {
-        let n = R::n();
-        [(0, n), (n, 3 * n), (3 * n, 4 * n)]
-    }
-
     /// Panics if the representation violates region-bound invariants.
     ///
-    /// Each segment must stay within its fixed degree region:
+    /// Each block must stay within its fixed degree region:
     /// - `lo` within `[0, n)`
     /// - `mid` within `[n, 3n)`
     /// - `hi` within `[3n, 4n)`
     fn assert_invariants(&self) {
-        let bounds = Self::region_bounds();
-        for (i, ((off, data), (lo, hi))) in self.segments.iter().zip(bounds).enumerate() {
+        let n = R::n();
+        let bounds = [(0, n), (n, 3 * n), (3 * n, 4 * n)];
+        for (i, ((off, data), (lo, hi))) in self.blocks.iter().zip(bounds).enumerate() {
             assert!(
                 *off >= lo && off + data.len() <= hi,
-                "{} segment [{}, {}) exceeds region [{lo}, {hi})",
-                REGION_NAMES[i],
+                "{} block [{}, {}) exceeds region [{lo}, {hi})",
+                BLOCK_NAMES[i],
                 off,
                 off + data.len(),
             );
@@ -103,9 +98,9 @@ impl<T, R: Rank> Polynomial<T, R> {
 
     // Constructs from three `(offset, data)` blocks, asserting region-bound
     // invariants. The blocks correspond to lo, mid, hi in order.
-    fn from_blocks(segments: [(usize, Vec<T>); 3]) -> Self {
+    fn from_blocks(blocks: [(usize, Vec<T>); 3]) -> Self {
         let poly = Self {
-            segments,
+            blocks,
             _marker: PhantomData,
         };
         poly.assert_invariants();
@@ -124,7 +119,7 @@ impl<T, R: Rank> Polynomial<T, R> {
     pub fn new() -> Self {
         let offsets = Self::default_offsets();
         Self {
-            segments: [
+            blocks: [
                 (offsets[0], Vec::new()),
                 (offsets[1], Vec::new()),
                 (offsets[2], Vec::new()),
@@ -135,29 +130,37 @@ impl<T, R: Rank> Polynomial<T, R> {
 }
 
 impl<F: Field, R: Rank> Polynomial<F, R> {
-    /// Decomposes a dense coefficient vector into three fixed-region segments,
+    /// Decomposes a dense coefficient vector into three fixed-region blocks,
     /// trimming leading and trailing zeros within each region.
     ///
     /// Panics if `coeffs.len()` exceeds `R::num_coeffs()`.
     pub fn from_coeffs(mut coeffs: Vec<F>) -> Self {
+        let len = coeffs.len();
         assert!(
-            coeffs.len() <= R::num_coeffs(),
-            "coefficient vector length {} exceeds capacity {}",
-            coeffs.len(),
+            len <= R::num_coeffs(),
+            "coefficient vector length {len} exceeds capacity {}",
             R::num_coeffs()
         );
 
         let n = R::n();
-        coeffs.resize(R::num_coeffs(), F::ZERO);
+        let mut offsets = Self::default_offsets();
 
-        let mut hi = coeffs.split_off(3 * n);
-        let mut mid = coeffs.split_off(n);
+        // Split at region boundaries without padding — only split what exists.
+        let mut hi = if len > 3 * n {
+            coeffs.split_off(3 * n)
+        } else {
+            Vec::new()
+        };
+        let mut mid = if len > n {
+            coeffs.split_off(n)
+        } else {
+            Vec::new()
+        };
         let mut lo = coeffs;
 
-        let mut offsets = Self::default_offsets();
-        Self::trim_segment(&mut offsets[0], &mut lo);
-        Self::trim_segment(&mut offsets[1], &mut mid);
-        Self::trim_segment(&mut offsets[2], &mut hi);
+        Self::trim_block(&mut offsets[0], &mut lo);
+        Self::trim_block(&mut offsets[1], &mut mid);
+        Self::trim_block(&mut offsets[2], &mut hi);
 
         Self::from_blocks([(offsets[0], lo), (offsets[1], mid), (offsets[2], hi)])
     }
@@ -177,7 +180,7 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
 impl<T, R: Rank> Polynomial<T, R> {
     /// Applies a closure to every stored element.
     fn apply_all(&mut self, mut op: impl FnMut(&mut T)) {
-        for (_, data) in &mut self.segments {
+        for (_, data) in &mut self.blocks {
             for elem in data {
                 op(elem);
             }
@@ -187,30 +190,30 @@ impl<T, R: Rank> Polynomial<T, R> {
 
 impl<F: Field, R: Rank> Polynomial<F, R> {
     /// Returns an iterator over the coefficients of this polynomial in
-    /// ascending degree order, yielding `F::ZERO` for gaps between segments.
+    /// ascending degree order, yielding `F::ZERO` for gaps between blocks.
     pub fn iter_coeffs(&self) -> impl DoubleEndedIterator<Item = F> + ExactSizeIterator + '_ {
-        let (segments, num_segments) = self.non_empty_segments();
+        let (packed, num_blocks) = self.non_empty_blocks();
         CoeffIter {
-            segments,
-            num_segments,
+            blocks: packed,
+            num_blocks,
             front: 0,
             back: R::num_coeffs(),
-            front_seg: 0,
-            back_seg: num_segments,
+            front_blk: 0,
+            back_blk: num_blocks,
         }
     }
 
-    /// Returns non-empty segments as a packed fixed-size array plus a count.
-    fn non_empty_segments(&self) -> ([(usize, &[F]); 3], usize) {
-        let mut segs: [(usize, &[F]); 3] = [(0, &[]); 3];
+    /// Returns non-empty blocks as a packed fixed-size array plus a count.
+    fn non_empty_blocks(&self) -> ([(usize, &[F]); 3], usize) {
+        let mut packed: [(usize, &[F]); 3] = [(0, &[]); 3];
         let mut n = 0;
-        for (off, data) in &self.segments {
+        for (off, data) in &self.blocks {
             if !data.is_empty() {
-                segs[n] = (*off, data);
+                packed[n] = (*off, data);
                 n += 1;
             }
         }
-        (segs, n)
+        (packed, n)
     }
 
     /// Multiplies all coefficients by `by`.
@@ -229,32 +232,32 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
 
     /// Adds the coefficients of `other` to `self`.
     pub fn add_assign(&mut self, other: &Self) {
-        self.op_assign(other, |a, b| *a += *b);
+        self.combine_assign(other, |a, b| *a += *b);
     }
 
     /// Subtracts the coefficients of `other` from `self`.
     pub fn sub_assign(&mut self, other: &Self) {
-        self.op_assign(other, |a, b| *a -= *b);
+        self.combine_assign(other, |a, b| *a -= *b);
     }
 
-    /// Applies a binary operation segment-wise. Always safe because both
-    /// polynomials have segments within the same fixed region bounds.
-    fn op_assign(&mut self, other: &Self, op: impl Fn(&mut F, &F)) {
+    /// Applies a binary operation block-wise. Always safe because both
+    /// polynomials have blocks within the same fixed region bounds.
+    fn combine_assign(&mut self, other: &Self, op: impl Fn(&mut F, &F)) {
         for i in 0..3 {
             Self::merge(
-                &mut self.segments[i].0,
-                &mut self.segments[i].1,
-                other.segments[i].0,
-                &other.segments[i].1,
+                &mut self.blocks[i].0,
+                &mut self.blocks[i].1,
+                other.blocks[i].0,
+                &other.blocks[i].1,
                 &op,
             );
-            Self::trim_segment(&mut self.segments[i].0, &mut self.segments[i].1);
+            Self::trim_block(&mut self.blocks[i].0, &mut self.blocks[i].1);
         }
     }
 
-    /// Strips leading and trailing zeros from a segment in place, adjusting
-    /// the offset. Clears the segment entirely if all elements are zero.
-    fn trim_segment(offset: &mut usize, data: &mut Vec<F>) {
+    /// Strips leading and trailing zeros from a block in place, adjusting
+    /// the offset. Clears the block entirely if all elements are zero.
+    fn trim_block(offset: &mut usize, data: &mut Vec<F>) {
         // Trim trailing zeros.
         while data.last().is_some_and(|v| bool::from(v.is_zero())) {
             data.pop();
@@ -270,7 +273,7 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
         }
     }
 
-    /// Merges `other` segment into `self` segment, expanding `self` to cover
+    /// Merges `other` block into `self` block, expanding `self` to cover
     /// the union range if needed, then applying `op` element-wise.
     fn merge(
         s_off: &mut usize,
@@ -324,12 +327,12 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     }
 
     /// Evaluates this polynomial at `z` using reverse Horner's method by
-    /// segment.
+    /// block.
     pub fn eval(&self, z: F) -> F {
         let mut result = F::ZERO;
         let mut prev_start = R::num_coeffs();
 
-        for &(start, ref data) in self.segments.iter().rev() {
+        for &(start, ref data) in self.blocks.iter().rev() {
             if data.is_empty() {
                 continue;
             }
@@ -354,7 +357,7 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
         let mut power = F::ONE;
         let mut prev_end: usize = 0;
 
-        for &mut (start, ref mut data) in &mut self.segments {
+        for &mut (start, ref mut data) in &mut self.blocks {
             if data.is_empty() {
                 continue;
             }
@@ -376,53 +379,38 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
     pub fn revdot(&self, other: &Self) -> F {
         let n4 = R::num_coeffs();
         let mut result = F::ZERO;
-        for &(s_off, ref s_data) in &self.segments {
-            if s_data.is_empty() {
+        for &(a_off, ref a_data) in &self.blocks {
+            if a_data.is_empty() {
                 continue;
             }
-            for &(o_off, ref o_data) in &other.segments {
-                if o_data.is_empty() {
+            let a_end = a_off + a_data.len();
+            for &(b_off, ref b_data) in &other.blocks {
+                if b_data.is_empty() {
                     continue;
                 }
-                result += Self::revdot_segment_pair(s_off, s_data, o_off, o_data, n4);
+                // Other's block [b_off, b_off+b_len) reversed maps to
+                // [n4 - b_off - b_len, n4 - b_off).
+                let rev_lo = n4 - b_off - b_data.len();
+                let rev_hi = n4 - b_off;
+
+                let overlap_lo = a_off.max(rev_lo);
+                let overlap_hi = a_end.min(rev_hi);
+                if overlap_lo >= overlap_hi {
+                    continue;
+                }
+
+                let a_slice = &a_data[overlap_lo - a_off..overlap_hi - a_off];
+                // For index k in [overlap_lo, overlap_hi), other's value is at
+                // b_data[n4 - 1 - k - b_off]. As k increases, the b_data
+                // index decreases, so we zip a forward with b reversed.
+                let b_idx_lo = n4 - 1 - (overlap_hi - 1) - b_off;
+                let b_idx_hi = n4 - 1 - overlap_lo - b_off;
+                let b_slice = &b_data[b_idx_lo..=b_idx_hi];
+
+                for (a_val, b_val) in a_slice.iter().zip(b_slice.iter().rev()) {
+                    result += *a_val * *b_val;
+                }
             }
-        }
-        result
-    }
-
-    /// Computes the revdot contribution between one segment from self at
-    /// `[a_off, a_off + a_data.len())` and one segment from other at
-    /// `[b_off, b_off + b_data.len())`, where other is coefficient-reversed.
-    ///
-    /// The reversed segment maps to `[n4 - b_off - b_data.len(), n4 - b_off)`.
-    fn revdot_segment_pair(a_off: usize, a_data: &[F], b_off: usize, b_data: &[F], n4: usize) -> F {
-        if a_data.is_empty() || b_data.is_empty() {
-            return F::ZERO;
-        }
-
-        let a_end = a_off + a_data.len();
-        // Reversed range of other's segment.
-        let rev_lo = n4 - b_off - b_data.len();
-        let rev_hi = n4 - b_off;
-
-        let overlap_lo = a_off.max(rev_lo);
-        let overlap_hi = a_end.min(rev_hi);
-
-        if overlap_lo >= overlap_hi {
-            return F::ZERO;
-        }
-
-        let a_slice = &a_data[overlap_lo - a_off..overlap_hi - a_off];
-        // For index k in [overlap_lo, overlap_hi), other's value is at
-        // b_data[n4 - 1 - k - b_off]. As k increases, the b_data index
-        // decreases, so we zip a forward with b reversed.
-        let b_idx_lo = n4 - 1 - (overlap_hi - 1) - b_off;
-        let b_idx_hi = n4 - 1 - overlap_lo - b_off;
-        let b_slice = &b_data[b_idx_lo..=b_idx_hi];
-
-        let mut result = F::ZERO;
-        for (a_val, b_val) in a_slice.iter().zip(b_slice.iter().rev()) {
-            result += *a_val * *b_val;
         }
         result
     }
@@ -440,12 +428,12 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
 
         let g = generators.g();
         ragu_arithmetic::mul(
-            self.segments
+            self.blocks
                 .iter()
                 .filter(|(_, data)| !data.is_empty())
                 .flat_map(|(_, data)| data.iter())
                 .chain(core::iter::once(&blind)),
-            self.segments
+            self.blocks
                 .iter()
                 .filter(|(_, data)| !data.is_empty())
                 .flat_map(|(start, data)| &g[*start..*start + data.len()])
@@ -467,16 +455,16 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
 }
 
 /// An iterator over all coefficients of a sparse polynomial in ascending
-/// degree order, yielding `F::ZERO` for gaps between segments.
+/// degree order, yielding `F::ZERO` for gaps between blocks.
 struct CoeffIter<'a, F> {
-    segments: [(usize, &'a [F]); 3],
-    num_segments: usize,
+    blocks: [(usize, &'a [F]); 3],
+    num_blocks: usize,
     front: usize,
     back: usize,
-    /// Index of the first segment whose end extends past `front`.
-    front_seg: usize,
-    /// One past the last segment whose start is at or before `back - 1`.
-    back_seg: usize,
+    /// Index of the first block whose end extends past `front`.
+    front_blk: usize,
+    /// One past the last block whose start is at or before `back - 1`.
+    back_blk: usize,
 }
 
 impl<F: Field> Iterator for CoeffIter<'_, F> {
@@ -486,16 +474,16 @@ impl<F: Field> Iterator for CoeffIter<'_, F> {
         if self.front >= self.back {
             return None;
         }
-        // Advance past segments fully before `front`.
-        while self.front_seg < self.num_segments {
-            let (start, data) = self.segments[self.front_seg];
+        // Advance past blocks fully before `front`.
+        while self.front_blk < self.num_blocks {
+            let (start, data) = self.blocks[self.front_blk];
             if start + data.len() > self.front {
                 break;
             }
-            self.front_seg += 1;
+            self.front_blk += 1;
         }
-        let val = if self.front_seg < self.num_segments {
-            let (start, data) = self.segments[self.front_seg];
+        let val = if self.front_blk < self.num_blocks {
+            let (start, data) = self.blocks[self.front_blk];
             if self.front >= start {
                 data[self.front - start]
             } else {
@@ -520,16 +508,16 @@ impl<F: Field> DoubleEndedIterator for CoeffIter<'_, F> {
             return None;
         }
         self.back -= 1;
-        // Retreat past segments that start after `back`.
-        while self.back_seg > 0 {
-            let (start, _) = self.segments[self.back_seg - 1];
+        // Retreat past blocks that start after `back`.
+        while self.back_blk > 0 {
+            let (start, _) = self.blocks[self.back_blk - 1];
             if start <= self.back {
                 break;
             }
-            self.back_seg -= 1;
+            self.back_blk -= 1;
         }
-        let val = if self.back_seg > 0 {
-            let (start, data) = self.segments[self.back_seg - 1];
+        let val = if self.back_blk > 0 {
+            let (start, data) = self.blocks[self.back_blk - 1];
             if self.back < start + data.len() {
                 data[self.back - start]
             } else {

--- a/crates/ragu_circuits/src/polynomials/sparse/tests.rs
+++ b/crates/ragu_circuits/src/polynomials/sparse/tests.rs
@@ -750,3 +750,50 @@ fn ring_convolution() {
 
     assert_eq!(a.revdot(&b), cx);
 }
+
+/// Verifies that `from_coeffs` followed by `iter_coeffs` yields the same
+/// order as the input coefficients.
+#[test]
+fn from_coeffs_iter_matches_input() {
+    let coeffs: Vec<Fp> = (0..R::num_coeffs()).map(|i| Fp::from(i as u64)).collect();
+    let poly = Polynomial::<Fp, R>::from_coeffs(coeffs.clone());
+    let recovered: Vec<Fp> = poly.iter_coeffs().collect();
+    assert_eq!(recovered, coeffs);
+}
+
+/// Verifies `from_coeffs` with leading zeros does not allocate unnecessary storage.
+#[test]
+fn from_coeffs_leading_zeros_trimmed() {
+    // A polynomial with a single non-zero at degree 5 (within [0, n)).
+    let mut coeffs = alloc::vec![Fp::ZERO; R::num_coeffs()];
+    coeffs[5] = Fp::from(42u64);
+    let poly = Polynomial::<Fp, R>::from_coeffs(coeffs.clone());
+
+    // Verify correctness.
+    let recovered: Vec<Fp> = poly.iter_coeffs().collect();
+    assert_eq!(recovered, coeffs);
+
+    // Verify the lo segment is trimmed (not storing 5 leading zeros).
+    assert_eq!(poly.lo_offset, 5);
+    assert_eq!(poly.lo.len(), 1);
+}
+
+/// Verifies `from_coeffs` decomposes across all three regions correctly.
+#[test]
+fn from_coeffs_spans_all_regions() {
+    let n = R::n();
+    // Non-zero at degree 0 (lo), degree 2n (mid), degree 4n-1 (hi).
+    let mut coeffs = alloc::vec![Fp::ZERO; R::num_coeffs()];
+    coeffs[0] = Fp::from(1u64);
+    coeffs[2 * n] = Fp::from(2u64);
+    coeffs[4 * n - 1] = Fp::from(3u64);
+    let poly = Polynomial::<Fp, R>::from_coeffs(coeffs.clone());
+
+    let recovered: Vec<Fp> = poly.iter_coeffs().collect();
+    assert_eq!(recovered, coeffs);
+
+    // Each region should have exactly 1 element.
+    assert_eq!(poly.lo.len(), 1);
+    assert_eq!(poly.mid.len(), 1);
+    assert_eq!(poly.hi.len(), 1);
+}

--- a/crates/ragu_circuits/src/polynomials/sparse/tests.rs
+++ b/crates/ragu_circuits/src/polynomials/sparse/tests.rs
@@ -774,8 +774,8 @@ fn from_coeffs_leading_zeros_trimmed() {
     assert_eq!(recovered, coeffs);
 
     // Verify the lo segment is trimmed (not storing 5 leading zeros).
-    assert_eq!(poly.lo_offset, 5);
-    assert_eq!(poly.lo.len(), 1);
+    assert_eq!(poly.segments[0].0, 5);
+    assert_eq!(poly.segments[0].1.len(), 1);
 }
 
 /// Verifies `from_coeffs` decomposes across all three regions correctly.
@@ -793,7 +793,7 @@ fn from_coeffs_spans_all_regions() {
     assert_eq!(recovered, coeffs);
 
     // Each region should have exactly 1 element.
-    assert_eq!(poly.lo.len(), 1);
-    assert_eq!(poly.mid.len(), 1);
-    assert_eq!(poly.hi.len(), 1);
+    assert_eq!(poly.segments[0].1.len(), 1);
+    assert_eq!(poly.segments[1].1.len(), 1);
+    assert_eq!(poly.segments[2].1.len(), 1);
 }

--- a/crates/ragu_circuits/src/polynomials/sparse/tests.rs
+++ b/crates/ragu_circuits/src/polynomials/sparse/tests.rs
@@ -774,8 +774,8 @@ fn from_coeffs_leading_zeros_trimmed() {
     assert_eq!(recovered, coeffs);
 
     // Verify the lo segment is trimmed (not storing 5 leading zeros).
-    assert_eq!(poly.segments[0].0, 5);
-    assert_eq!(poly.segments[0].1.len(), 1);
+    assert_eq!(poly.blocks[0].0, 5);
+    assert_eq!(poly.blocks[0].1.len(), 1);
 }
 
 /// Verifies `from_coeffs` decomposes across all three regions correctly.
@@ -793,7 +793,7 @@ fn from_coeffs_spans_all_regions() {
     assert_eq!(recovered, coeffs);
 
     // Each region should have exactly 1 element.
-    assert_eq!(poly.segments[0].1.len(), 1);
-    assert_eq!(poly.segments[1].1.len(), 1);
-    assert_eq!(poly.segments[2].1.len(), 1);
+    assert_eq!(poly.blocks[0].1.len(), 1);
+    assert_eq!(poly.blocks[1].1.len(), 1);
+    assert_eq!(poly.blocks[2].1.len(), 1);
 }

--- a/crates/ragu_circuits/src/polynomials/sparse/view.rs
+++ b/crates/ragu_circuits/src/polynomials/sparse/view.rs
@@ -2,7 +2,7 @@
 //!
 //! A [`View`] provides four dense wire buffers (`a`, `b`, `c`, `d`) that the
 //! caller fills in at gate indices. Calling [`View::build`] maps each buffer
-//! to the appropriate degree positions and produces a sparse [`Polynomial`].
+//! to the appropriate degree positions and produces a [`Polynomial`].
 //!
 //! # Perspectives
 //!
@@ -34,9 +34,7 @@
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
-use ff::Field;
-
-use super::{Polynomial, Rank, extend_runs};
+use super::{Polynomial, Rank};
 
 mod private {
     pub trait Sealed {}
@@ -45,14 +43,16 @@ mod private {
 }
 
 /// Marker trait for the perspective of a [`View`].
+///
+/// Maps four wire buffers (`a`, `b`, `c`, `d`) to the three degree-region
+/// segments of a [`Polynomial`]: lo, mid, and hi.
+#[allow(private_interfaces)]
 pub trait Perspective: private::Sealed {
-    /// Maps the four wire buffers (a, b, c, d) to degree-ordered blocks.
+    /// Maps the four wire buffers to three `(offset, data)` blocks
+    /// corresponding to the lo, mid, and hi degree regions.
     ///
-    /// Returns up to 4 blocks sorted by start degree. Adjacent blocks can
-    /// occur when wire regions share a boundary (for example, when both `b`
-    /// and `a` are full); this is permitted by the sparse polynomial
-    /// representation. The `n` parameter is `R::n()` (the maximum number of
-    /// multiplication gates).
+    /// The `n` parameter is `R::n()` (the maximum number of multiplication
+    /// gates).
     ///
     /// # Preconditions
     ///
@@ -64,7 +64,7 @@ pub trait Perspective: private::Sealed {
         c: Vec<T>,
         d: Vec<T>,
         n: usize,
-    ) -> Vec<(usize, Vec<T>)>;
+    ) -> [(usize, Vec<T>); 3];
 }
 
 /// Standard perspective: `a[i]` maps to degree $2n + i$, `b[i]` to
@@ -76,6 +76,7 @@ pub struct Forward;
 /// mapping.
 pub struct Backward;
 
+#[allow(private_interfaces)]
 impl Perspective for Forward {
     fn map_to_blocks<T>(
         a: Vec<T>,
@@ -83,31 +84,26 @@ impl Perspective for Forward {
         c: Vec<T>,
         mut d: Vec<T>,
         n: usize,
-    ) -> Vec<(usize, Vec<T>)> {
-        // c[i] -> degree i             (range [0, c.len()))
-        // b[i] -> degree 2*n-1-i       (reversed, range [2*n-b.len(), 2*n))
-        // a[i] -> degree 2*n+i         (range [2*n, 2*n+a.len()))
-        // d[i] -> degree 4*n-1-i       (reversed, range [4*n-d.len(), 4*n))
+    ) -> [(usize, Vec<T>); 3] {
+        // c[i] -> degree i              (range [0, c.len()))
+        // b[i] -> degree 2*n-1-i        (reversed, range [2*n-b.len(), 2*n))
+        // a[i] -> degree 2*n+i          (range [2*n, 2*n+a.len()))
+        // b̂ and a are always adjacent at the 2n boundary, forming one mid segment.
+        // d[i] -> degree 4*n-1-i        (reversed, range [4*n-d.len(), 4*n))
         b.reverse();
         d.reverse();
 
-        let mut blocks = Vec::new();
-        if !c.is_empty() {
-            blocks.push((0, c));
-        }
-        if !b.is_empty() {
-            blocks.push((2 * n - b.len(), b));
-        }
-        if !a.is_empty() {
-            blocks.push((2 * n, a));
-        }
-        if !d.is_empty() {
-            blocks.push((4 * n - d.len(), d));
-        }
-        blocks
+        let mid_offset = 2 * n - b.len();
+        let mut mid = b;
+        mid.extend(a);
+
+        let hi_offset = 4 * n - d.len();
+
+        [(0, c), (mid_offset, mid), (hi_offset, d)]
     }
 }
 
+#[allow(private_interfaces)]
 impl Perspective for Backward {
     fn map_to_blocks<T>(
         a: Vec<T>,
@@ -115,7 +111,7 @@ impl Perspective for Backward {
         c: Vec<T>,
         d: Vec<T>,
         n: usize,
-    ) -> Vec<(usize, Vec<T>)> {
+    ) -> [(usize, Vec<T>); 3] {
         // Backward swaps a<->b and c<->d relative to Forward:
         //   a[i] -> degree 2*n-1-i   (b's forward mapping)
         //   b[i] -> degree 2*n+i     (a's forward mapping)
@@ -177,19 +173,15 @@ impl<T, R: Rank> View<T, R, Backward> {
     }
 }
 
-impl<F: Field, R: Rank, P: Perspective> View<F, R, P> {
+impl<T, R: Rank, P: Perspective> View<T, R, P> {
     /// Consumes this view, mapping wire buffers to degree positions and
     /// producing a [`Polynomial`].
-    ///
-    /// Raw blocks are compressed via `extend_runs` (stripping leading/trailing
-    /// zeros and splitting interior zero gaps exceeding `GAP_TOLERANCE`) before
-    /// final validation.
     ///
     /// # Panics
     ///
     /// Panics if any wire buffer exceeds `R::n()` entries (one entry per
     /// multiplication gate).
-    pub fn build(self) -> Polynomial<F, R> {
+    pub fn build(self) -> Polynomial<T, R> {
         let n = R::n();
         assert!(
             self.a.len() <= n,
@@ -212,11 +204,6 @@ impl<F: Field, R: Rank, P: Perspective> View<F, R, P> {
             self.d.len()
         );
 
-        let raw_blocks = P::map_to_blocks(self.a, self.b, self.c, self.d, n);
-        let mut blocks = Vec::with_capacity(raw_blocks.len());
-        for (start, data) in raw_blocks {
-            extend_runs(&mut blocks, start, data);
-        }
-        Polynomial::from_blocks(blocks)
+        Polynomial::from_blocks(P::map_to_blocks(self.a, self.b, self.c, self.d, n))
     }
 }

--- a/crates/ragu_circuits/src/polynomials/sparse/view.rs
+++ b/crates/ragu_circuits/src/polynomials/sparse/view.rs
@@ -43,10 +43,6 @@ mod private {
 }
 
 /// Marker trait for the perspective of a [`View`].
-///
-/// Maps four wire buffers (`a`, `b`, `c`, `d`) to the three degree-region
-/// segments of a [`Polynomial`]: lo, mid, and hi.
-#[allow(private_interfaces)]
 pub trait Perspective: private::Sealed {
     /// Maps the four wire buffers to three `(offset, data)` blocks
     /// corresponding to the lo, mid, and hi degree regions.
@@ -76,7 +72,6 @@ pub struct Forward;
 /// mapping.
 pub struct Backward;
 
-#[allow(private_interfaces)]
 impl Perspective for Forward {
     fn map_to_blocks<T>(
         a: Vec<T>,
@@ -85,14 +80,14 @@ impl Perspective for Forward {
         mut d: Vec<T>,
         n: usize,
     ) -> [(usize, Vec<T>); 3] {
-        // c[i] -> degree i              (range [0, c.len()))
-        // b[i] -> degree 2*n-1-i        (reversed, range [2*n-b.len(), 2*n))
-        // a[i] -> degree 2*n+i          (range [2*n, 2*n+a.len()))
-        // b̂ and a are always adjacent at the 2n boundary, forming one mid segment.
-        // d[i] -> degree 4*n-1-i        (reversed, range [4*n-d.len(), 4*n))
+        // c[i] -> degree i             (range [0, c.len()))
+        // b[i] -> degree 2*n-1-i       (reversed, range [2*n-b.len(), 2*n))
+        // a[i] -> degree 2*n+i         (range [2*n, 2*n+a.len()))
+        // d[i] -> degree 4*n-1-i       (reversed, range [4*n-d.len(), 4*n))
         b.reverse();
         d.reverse();
 
+        // b_rev and a are adjacent at the 2n boundary, forming the mid segment
         let mid_offset = 2 * n - b.len();
         let mut mid = b;
         mid.extend(a);
@@ -103,7 +98,6 @@ impl Perspective for Forward {
     }
 }
 
-#[allow(private_interfaces)]
 impl Perspective for Backward {
     fn map_to_blocks<T>(
         a: Vec<T>,


### PR DESCRIPTION
As commented https://github.com/tachyon-zcash/ragu/pull/605#issuecomment-4127097537, 

I think a `TwoGap/ThreeBlock` model is general enough for our need for sparse polynomials. 
We strictly enforce that even unstructured polys are built like a structured one, respecting the `lo: [0, n); mid: [n, 3n); hi: [3n, 4n)` region boundaries. This invariant help simplify the logic of a super general "intermittent block"-based sparse poly. 

IMO, the arithmetic logic after refactoring is much more readable with its correctness more verifiable. 
LOC reduction =~50 lines. 
This simplification doesn't restrict the generality, it's just as expressive, and can represent all masking, staging polynomial in sparse form, also any dense & unstructured polynomial. (the expressiveness is reflected in the fact all diff is limited to `ragu_circuits` crate, not any downstream user.