### PR TITLE
Make constant() and add() fallible

### DIFF
--- a/crates/ragu_circuits/src/horner.rs
+++ b/crates/ragu_circuits/src/horner.rs
@@ -39,22 +39,25 @@ impl<'a, 'dr, D: Driver<'dr>> Horner<'a, 'dr, D> {
     /// Finishes the evaluation, returning the accumulated result.
     ///
     /// Returns zero if no elements were written.
-    pub fn finish(self, dr: &mut D) -> Element<'dr, D> {
-        self.result.unwrap_or_else(|| Element::zero(dr))
+    pub fn finish(self, dr: &mut D) -> Result<Element<'dr, D>> {
+        match self.result {
+            Some(el) => Ok(el),
+            None => Element::zero(dr),
+        }
     }
 
     /// Finishes the evaluation with a trailing constant $1$ term appended,
     /// following the $k(Y)$ polynomial convention.
     pub fn finish_ky(mut self, dr: &mut D) -> Result<Element<'dr, D>> {
         Element::one().write(dr, &mut self)?;
-        Ok(self.finish(dr))
+        self.finish(dr)
     }
 }
 
 impl<'a, 'dr, D: Driver<'dr>> Buffer<'dr, D> for Horner<'a, 'dr, D> {
     fn write(&mut self, dr: &mut D, value: &Element<'dr, D>) -> Result<()> {
         self.result = Some(match self.result.take() {
-            Some(acc) => acc.mul(dr, self.point)?.add(dr, value),
+            Some(acc) => acc.mul(dr, self.point)?.add(dr, value)?,
             None => value.clone(),
         });
         Ok(())

--- a/crates/ragu_circuits/src/metrics.rs
+++ b/crates/ragu_circuits/src/metrics.rs
@@ -411,8 +411,8 @@ impl<'dr, F: FromUniformBytes<64>> Driver<'dr> for Counter<F> {
     }
 
     /// Computes a linear combination of wire evaluations.
-    fn add(&mut self, lc: impl Fn(Self::LCadd) -> Self::LCadd) -> Self::Wire {
-        WireEval::Value(lc(WireEvalSum::new(self.one)).value)
+    fn add(&mut self, lc: impl Fn(Self::LCadd) -> Self::LCadd) -> Result<Self::Wire> {
+        Ok(WireEval::Value(lc(WireEvalSum::new(self.one)).value))
     }
 
     /// Increments linear constraint count and applies one Horner step:

--- a/crates/ragu_circuits/src/polynomials/txz.rs
+++ b/crates/ragu_circuits/src/polynomials/txz.rs
@@ -77,15 +77,15 @@ impl<F: Field, R: Rank> Routine<F> for Evaluate<R> {
         let mut xzinv_step = x_inv.mul(dr, &z_inv)?;
         for _ in 0..R::log2_n() {
             let l_mul = l.mul(dr, &xz_step)?;
-            l = l.add(dr, &l_mul);
+            l = l.add(dr, &l_mul)?;
             let r_mul = r.mul(dr, &xzinv_step)?;
-            r = r.add(dr, &r_mul);
+            r = r.add(dr, &r_mul)?;
             xz_step = xz_step.square(dr)?;
             xzinv_step = xzinv_step.square(dr)?;
         }
         let r_zinv = r.mul(dr, &z_inv)?;
-        let sum = l.add(dr, &r_zinv);
-        Ok(sum.negate(dr))
+        let sum = l.add(dr, &r_zinv)?;
+        sum.negate(dr)
     }
 
     fn predict<'dr, D: Driver<'dr, F = F>>(

--- a/crates/ragu_circuits/src/s/sx.rs
+++ b/crates/ragu_circuits/src/s/sx.rs
@@ -286,8 +286,8 @@ impl<'dr, F: Field, R: Rank> Driver<'dr> for Evaluator<'_, F, R> {
     /// Evaluates the linear combination immediately using [`WireEvalSum`] and
     /// returns the sum as a [`WireEval::Value`]. No deferred computation is
     /// needed because all wire values are concrete field elements.
-    fn add(&mut self, lc: impl Fn(Self::LCadd) -> Self::LCadd) -> Self::Wire {
-        WireEval::Value(lc(WireEvalSum::new(self.one)).value)
+    fn add(&mut self, lc: impl Fn(Self::LCadd) -> Self::LCadd) -> Result<Self::Wire> {
+        Ok(WireEval::Value(lc(WireEvalSum::new(self.one)).value))
     }
 
     /// Records a linear constraint as a polynomial coefficient.

--- a/crates/ragu_circuits/src/s/sxy.rs
+++ b/crates/ragu_circuits/src/s/sxy.rs
@@ -262,8 +262,8 @@ impl<'dr, F: Field, R: Rank> Driver<'dr> for Evaluator<'_, F, R> {
     ///
     /// Evaluates the linear combination immediately using [`WireEvalSum`] and
     /// returns the sum as a [`WireEval::Value`].
-    fn add(&mut self, lc: impl Fn(Self::LCadd) -> Self::LCadd) -> Self::Wire {
-        WireEval::Value(lc(WireEvalSum::new(self.one)).value)
+    fn add(&mut self, lc: impl Fn(Self::LCadd) -> Self::LCadd) -> Result<Self::Wire> {
+        Ok(WireEval::Value(lc(WireEvalSum::new(self.one)).value))
     }
 
     /// Applies one Horner step: `result = result * y + coefficient`.

--- a/crates/ragu_circuits/src/s/sy.rs
+++ b/crates/ragu_circuits/src/s/sy.rs
@@ -561,15 +561,15 @@ impl<'table, 'sy, F: Field, R: Rank> Driver<'table> for Evaluator<'table, 'sy, '
     /// Allocates a new virtual wire from [`VirtualTable`], collects terms via
     /// [`TermCollector`], and stores them in the virtual wire. The returned
     /// [`Wire`] handle owns one reference to the virtual wire.
-    fn add(&mut self, lc: impl Fn(Self::LCadd) -> Self::LCadd) -> Self::Wire {
+    fn add(&mut self, lc: impl Fn(Self::LCadd) -> Self::LCadd) -> Result<Self::Wire> {
         let wire = self.virtual_table.borrow_mut().alloc();
         let terms = lc(TermCollector::new()).terms;
         self.virtual_table.borrow_mut().update(wire, terms);
 
-        Wire {
+        Ok(Wire {
             index: wire,
             table: Some(self.virtual_table),
-        }
+        })
     }
 
     /// Applies a linear constraint weighted by the current $y$ power.

--- a/crates/ragu_circuits/src/staging/bonding.rs
+++ b/crates/ragu_circuits/src/staging/bonding.rs
@@ -66,9 +66,6 @@ where
         // Validate: run synthesis with a driver that rejects mul/gate and ONE usage.
         let mut validator = BondingValidator::<F>::new();
         self.witness(&mut validator, Empty)?;
-        if let Some(msg) = validator.error {
-            return Err(ragu_core::Error::InvalidWitness(msg.into()));
-        }
 
         // Build the CircuitObject via the standard pipeline.
         let inner = into_circuit_object::<_, _, R>(self)?;
@@ -107,25 +104,12 @@ impl<F: Field> LinearExpression<BondingWire, F> for RejectOne {
 /// [`add`](Driver::add), and [`enforce_zero`](Driver::enforce_zero) with
 /// normal wires. Calling [`mul`](Driver::mul)/[`gate`](DriverTypes::gate),
 /// [`constant`](Driver::constant), or referencing the [`ONE`](Driver::ONE)
-/// wire in any linear constraint records a violation.
-///
-/// All methods succeed; violations are accumulated in the `error` field and
-/// checked by the caller after the witness completes.
-struct BondingValidator<F> {
-    error: Option<&'static str>,
-    _marker: core::marker::PhantomData<F>,
-}
+/// wire in any linear constraint returns an error immediately.
+struct BondingValidator<F>(core::marker::PhantomData<F>);
 
 impl<F> BondingValidator<F> {
     fn new() -> Self {
-        BondingValidator {
-            error: None,
-            _marker: core::marker::PhantomData,
-        }
-    }
-
-    fn record(&mut self, msg: &'static str) {
-        self.error.get_or_insert(msg);
+        BondingValidator(core::marker::PhantomData)
     }
 }
 
@@ -140,12 +124,8 @@ impl<F: Field> DriverTypes for BondingValidator<F> {
         &mut self,
         _: impl Fn() -> Result<(Coeff<F>, Coeff<F>, Coeff<F>, Coeff<F>)>,
     ) -> Result<(BondingWire, BondingWire, BondingWire, BondingWire)> {
-        self.record("bonding circuits must not call mul/gate");
-        Ok((
-            BondingWire::Normal,
-            BondingWire::Normal,
-            BondingWire::Normal,
-            BondingWire::Normal,
+        Err(ragu_core::Error::InvalidWitness(
+            "bonding circuits must not call mul/gate".into(),
         ))
     }
 }
@@ -159,21 +139,26 @@ impl<'dr, F: Field> Driver<'dr> for BondingValidator<F> {
         Ok(BondingWire::Normal)
     }
 
-    fn constant(&mut self, _: Coeff<F>) -> BondingWire {
-        self.record("bonding circuits must not create constants");
-        BondingWire::Normal
+    fn constant(&mut self, _: Coeff<F>) -> Result<BondingWire> {
+        Err(ragu_core::Error::InvalidWitness(
+            "bonding circuits must not create constants".into(),
+        ))
     }
 
-    fn add(&mut self, lc: impl Fn(RejectOne) -> RejectOne) -> BondingWire {
+    fn add(&mut self, lc: impl Fn(RejectOne) -> RejectOne) -> Result<BondingWire> {
         if lc(RejectOne(false)).0 {
-            self.record("bonding circuits must not reference the ONE wire");
+            return Err(ragu_core::Error::InvalidWitness(
+                "bonding circuits must not reference the ONE wire".into(),
+            ));
         }
-        BondingWire::Normal
+        Ok(BondingWire::Normal)
     }
 
     fn enforce_zero(&mut self, lc: impl Fn(RejectOne) -> RejectOne) -> Result<()> {
         if lc(RejectOne(false)).0 {
-            self.record("bonding circuits must not reference the ONE wire");
+            return Err(ragu_core::Error::InvalidWitness(
+                "bonding circuits must not reference the ONE wire".into(),
+            ));
         }
         Ok(())
     }
@@ -328,7 +313,7 @@ mod tests {
             _: DriverValue<D, ()>,
         ) -> Result<WithAux<Bound<'dr, D, ()>, DriverValue<D, ()>>> {
             let dr = builder.finish();
-            let _ = dr.constant(Coeff::One);
+            dr.constant(Coeff::One)?;
             Ok(WithAux::new((), D::unit()))
         }
     }
@@ -387,7 +372,7 @@ mod tests {
             _: DriverValue<D, ()>,
         ) -> Result<WithAux<Bound<'dr, D, ()>, DriverValue<D, ()>>> {
             let dr = builder.finish();
-            let _ = dr.add(|lc| lc.add(&D::ONE));
+            dr.add(|lc| lc.add(&D::ONE))?;
             Ok(WithAux::new((), D::unit()))
         }
     }

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -822,11 +822,11 @@ mod tests {
             // Allocate each challenge value followed by zero, which
             // ensures challenges land in b-positions, zeros in d-positions.
             let a0 = Element::alloc(dr, witness.as_ref().map(|w| w[0]))?;
-            let b0 = Element::zero(dr);
+            let b0 = Element::zero(dr)?;
             let a1 = Element::alloc(dr, witness.as_ref().map(|w| w[1]))?;
-            let b1 = Element::zero(dr);
+            let b1 = Element::zero(dr)?;
             let a2 = Element::alloc(dr, witness.as_ref().map(|w| w[2]))?;
-            let b2 = Element::zero(dr);
+            let b2 = Element::zero(dr)?;
 
             Ok(ThreeAOnlyElements {
                 a0,
@@ -863,11 +863,11 @@ mod tests {
             Self: 'dr,
         {
             let a0 = Element::alloc(dr, witness.as_ref().map(|w| w[0]))?;
-            let b0 = Element::zero(dr);
+            let b0 = Element::zero(dr)?;
             let a1 = Element::alloc(dr, witness.as_ref().map(|w| w[1]))?;
-            let b1 = Element::zero(dr);
+            let b1 = Element::zero(dr)?;
             let a2 = Element::alloc(dr, witness.as_ref().map(|w| w[2]))?;
-            let b2 = Element::zero(dr);
+            let b2 = Element::zero(dr)?;
 
             Ok(ThreeAOnlyElements {
                 a0,

--- a/crates/ragu_circuits/src/tests/identity.rs
+++ b/crates/ragu_circuits/src/tests/identity.rs
@@ -143,7 +143,7 @@ impl Routine<Fp> for AddTwo {
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         let (a, b) = input;
-        Ok(a.add(dr, &b))
+        a.add(dr, &b)
     }
 
     fn predict<'dr, D: Driver<'dr, F = Fp>>(
@@ -460,7 +460,7 @@ impl Routine<Fp> for NestThenAdd {
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         let nested = dr.routine(SquareOnce, input)?;
-        Ok(nested.add(dr, &nested))
+        nested.add(dr, &nested)
     }
 
     fn predict<'dr, D: Driver<'dr, F = Fp>>(
@@ -578,7 +578,7 @@ impl Routine<Fp> for DelegateThenAddEnforce {
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         let output = dr.routine(SquareOnce, input.clone())?;
-        let sum = output.add(dr, &input);
+        let sum = output.add(dr, &input)?;
         sum.enforce_zero(dr)?;
         Ok(output)
     }
@@ -609,7 +609,7 @@ impl Routine<Fp> for AllocThenAddEnforce {
     ) -> Result<Bound<'dr, D, Self::Output>> {
         let _consume_paired_b = Element::alloc(dr, D::just(|| Fp::ZERO))?;
         let fresh = Element::alloc(dr, D::just(|| Fp::ZERO))?;
-        let sum = fresh.add(dr, &input);
+        let sum = fresh.add(dr, &input)?;
         sum.enforce_zero(dr)?;
         Ok(fresh)
     }

--- a/crates/ragu_circuits/src/tests/mod.rs
+++ b/crates/ragu_circuits/src/tests/mod.rs
@@ -121,8 +121,8 @@ fn test_simple_circuit() {
 
             dr.enforce_zero(|lc| lc.add(a5.wire()).sub(b2.wire()))?;
 
-            let c = a.add(dr, &b);
-            let d = a.sub(dr, &b);
+            let c = a.add(dr, &b)?;
+            let d = a.sub(dr, &b)?;
 
             Ok(WithAux::new((c, d), D::unit()))
         }
@@ -203,7 +203,7 @@ impl Routine<Fp> for TestRoutine {
         let precomputed_value = aux.take();
         let element_from_aux = Element::alloc(dr, D::just(|| precomputed_value))?;
         let other = Element::alloc(dr, D::just(|| Fp::from(5u64)))?;
-        let result = element_from_aux.add(dr, &other);
+        let result = element_from_aux.add(dr, &other)?;
         Ok(result)
     }
 

--- a/crates/ragu_circuits/src/trace.rs
+++ b/crates/ragu_circuits/src/trace.rs
@@ -264,7 +264,9 @@ impl<'scope, 'env, F: Field> Driver<'env> for Evaluator<'scope, 'env, F> {
         }
     }
 
-    fn add(&mut self, _: impl Fn(Self::LCadd) -> Self::LCadd) -> Self::Wire {}
+    fn add(&mut self, _: impl Fn(Self::LCadd) -> Self::LCadd) -> Result<Self::Wire> {
+        Ok(())
+    }
 
     fn enforce_zero(&mut self, _: impl Fn(Self::LCenforce) -> Self::LCenforce) -> Result<()> {
         Ok(())

--- a/crates/ragu_core/src/drivers.rs
+++ b/crates/ragu_core/src/drivers.rs
@@ -247,7 +247,7 @@ pub trait Driver<'dr>: DriverTypes<ImplWire = Self::Wire, ImplField = Self::F> +
     }
 
     /// Returns a virtual wire that has a fixed constant value.
-    fn constant(&mut self, value: Coeff<Self::F>) -> Self::Wire {
+    fn constant(&mut self, value: Coeff<Self::F>) -> Result<Self::Wire> {
         self.add(|lc| lc.add_term(&Self::ONE, value))
     }
 
@@ -298,7 +298,7 @@ pub trait Driver<'dr>: DriverTypes<ImplWire = Self::Wire, ImplField = Self::F> +
     /// drivers with `MaybeKind = Empty` still call expression-building closures
     /// when they need constraint structure, so `Fn` is the sole type-level
     /// purity signal here.
-    fn add(&mut self, lc: impl Fn(Self::LCadd) -> Self::LCadd) -> Self::Wire;
+    fn add(&mut self, lc: impl Fn(Self::LCadd) -> Self::LCadd) -> Result<Self::Wire>;
 
     /// Asks the driver to create a constraint that a linear combination of
     /// wires equals zero.

--- a/crates/ragu_core/src/drivers/emulator.rs
+++ b/crates/ragu_core/src/drivers/emulator.rs
@@ -295,9 +295,13 @@ impl<'dr, M: MaybeKind, F: Field> Driver<'dr> for Emulator<Wireless<M, F>> {
     type Wire = ();
     const ONE: Self::Wire = ();
 
-    fn constant(&mut self, _: Coeff<Self::F>) -> Self::Wire {}
+    fn constant(&mut self, _: Coeff<Self::F>) -> Result<Self::Wire> {
+        Ok(())
+    }
 
-    fn add(&mut self, _: impl Fn(Self::LCadd) -> Self::LCadd) -> Self::Wire {}
+    fn add(&mut self, _: impl Fn(Self::LCadd) -> Self::LCadd) -> Result<Self::Wire> {
+        Ok(())
+    }
 
     fn enforce_zero(&mut self, _: impl Fn(Self::LCenforce) -> Self::LCenforce) -> Result<()> {
         Ok(())
@@ -317,13 +321,13 @@ impl<'dr, F: Field> Driver<'dr> for Emulator<Wired<F>> {
     type Wire = F;
     const ONE: Self::Wire = F::ONE;
 
-    fn constant(&mut self, coeff: Coeff<Self::F>) -> Self::Wire {
-        coeff.value()
+    fn constant(&mut self, coeff: Coeff<Self::F>) -> Result<Self::Wire> {
+        Ok(coeff.value())
     }
 
-    fn add(&mut self, lc: impl Fn(Self::LCadd) -> Self::LCadd) -> Self::Wire {
+    fn add(&mut self, lc: impl Fn(Self::LCadd) -> Self::LCadd) -> Result<Self::Wire> {
         let lc = lc(DirectSum::default());
-        lc.value()
+        Ok(lc.value())
     }
 
     fn enforce_zero(&mut self, _: impl Fn(Self::LCenforce) -> Self::LCenforce) -> Result<()> {
@@ -443,12 +447,12 @@ mod tests {
     fn wired_constant_returns_correct_wire() -> Result<()> {
         let mut dr = Emulator::<Wired<F>>::extractor();
 
-        let c_one = dr.constant(Coeff::One);
-        let c_zero = dr.constant(Coeff::Zero);
-        let c_neg = dr.constant(Coeff::NegativeOne);
-        let c_arb = dr.constant(Coeff::Arbitrary(F::from(7)));
-        let c_two = dr.constant(Coeff::Two);
-        let c_neg_arb = dr.constant(Coeff::NegativeArbitrary(F::from(13)));
+        let c_one = dr.constant(Coeff::One)?;
+        let c_zero = dr.constant(Coeff::Zero)?;
+        let c_neg = dr.constant(Coeff::NegativeOne)?;
+        let c_arb = dr.constant(Coeff::Arbitrary(F::from(7)))?;
+        let c_two = dr.constant(Coeff::Two)?;
+        let c_neg_arb = dr.constant(Coeff::NegativeArbitrary(F::from(13)))?;
 
         assert_eq!(c_one, F::ONE);
         assert_eq!(c_zero, F::ZERO);
@@ -487,7 +491,7 @@ mod tests {
         let w2 = dr.alloc(|| Ok(Coeff::Arbitrary(F::from(20))))?;
 
         // 1*w1 + 3*w2 = 10 + 60 = 70
-        let sum = dr.add(|lc| lc.add(&w1).add_term(&w2, Coeff::Arbitrary(F::from(3))));
+        let sum = dr.add(|lc| lc.add(&w1).add_term(&w2, Coeff::Arbitrary(F::from(3))))?;
 
         assert_eq!(sum, F::from(70));
         Ok(())
@@ -524,7 +528,7 @@ mod tests {
         let wires = Emulator::<Wired<F>>::emulate_wired((), |dr, _witness| {
             let a = dr.alloc(|| Ok(Coeff::Arbitrary(F::from(5))))?;
             let b = dr.alloc(|| Ok(Coeff::Arbitrary(F::from(10))))?;
-            let sum = dr.add(|lc| lc.add(&a).add(&b));
+            let sum = dr.add(|lc| lc.add(&a).add(&b))?;
 
             let gadget = TwoWires {
                 a,
@@ -554,7 +558,7 @@ mod tests {
             Ok(Coeff::Arbitrary(F::from(42)))
         })?;
 
-        let () = dr.constant(Coeff::One);
+        let () = dr.constant(Coeff::One)?;
 
         let ((), (), ()) = dr.mul(|| {
             called.set(called.get() + 1);
@@ -568,7 +572,7 @@ mod tests {
         let () = dr.add(|lc| {
             called.set(called.get() + 1);
             lc
-        });
+        })?;
 
         let r = dr.enforce_zero(|lc| {
             called.set(called.get() + 1);
@@ -588,7 +592,7 @@ mod tests {
 
         let ((), (), ()) = dr.mul(|| Ok((Coeff::One, Coeff::One, Coeff::One)))?;
 
-        let () = dr.add(|lc| lc);
+        let () = dr.add(|lc| lc)?;
         Ok(())
     }
 

--- a/crates/ragu_core/src/drivers/phantom.rs
+++ b/crates/ragu_core/src/drivers/phantom.rs
@@ -50,7 +50,9 @@ impl<F: Field> Driver<'_> for core::marker::PhantomData<F> {
     type Wire = ();
     const ONE: Self::Wire = ();
 
-    fn add(&mut self, _: impl Fn(Self::LCadd) -> Self::LCadd) -> Self::Wire {}
+    fn add(&mut self, _: impl Fn(Self::LCadd) -> Self::LCadd) -> Result<Self::Wire> {
+        Ok(())
+    }
 
     fn enforce_zero(&mut self, _: impl Fn(Self::LCenforce) -> Self::LCenforce) -> Result<()> {
         Ok(())
@@ -82,7 +84,7 @@ mod tests {
         dr.add(|lc| {
             called.set(called.get() + 1);
             lc
-        });
+        })?;
 
         dr.enforce_zero(|lc| {
             called.set(called.get() + 1);
@@ -94,7 +96,7 @@ mod tests {
             Ok(Coeff::One)
         })?;
 
-        dr.constant(Coeff::One);
+        dr.constant(Coeff::One)?;
 
         assert_eq!(called.get(), 0);
         Ok(())
@@ -108,9 +110,10 @@ mod tests {
     }
 
     #[test]
-    fn phantom_add_returns_unit() {
+    fn phantom_add_returns_unit() -> Result<()> {
         let mut dr = PhantomData::<F>;
-        let _: () = dr.add(|_lc| panic!("must not be called"));
+        let _: () = dr.add(|_lc| panic!("must not be called"))?;
+        Ok(())
     }
 
     #[test]
@@ -128,9 +131,10 @@ mod tests {
     }
 
     #[test]
-    fn phantom_constant_returns_unit() {
+    fn phantom_constant_returns_unit() -> Result<()> {
         let mut dr = PhantomData::<F>;
-        let _: () = dr.constant(Coeff::Arbitrary(F::from(42)));
+        let _: () = dr.constant(Coeff::Arbitrary(F::from(42)))?;
+        Ok(())
     }
 
     #[test]

--- a/crates/ragu_pcd/src/fuse/_05_outer_error.rs
+++ b/crates/ragu_pcd/src/fuse/_05_outer_error.rs
@@ -107,7 +107,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                     preamble.right.unified.c.clone(),
                     &left_ky,
                     &right_ky,
-                );
+                )?;
                 let mut ky = native::claims::ky_values(&ky_source);
 
                 let fold_products = fold_revdot::ClaimFolder::new(dr, &mu, &nu)?;

--- a/crates/ragu_pcd/src/fuse/claims.rs
+++ b/crates/ragu_pcd/src/fuse/claims.rs
@@ -223,18 +223,19 @@ impl<'m, 'rx, F: PrimeField, R: Rank> Processor<Atom<'rx, FoldKey, F, R>, Circui
         self.b.push(Cow::Borrowed(b.poly));
     }
 
-    fn circuit(&mut self, circuit_id: CircuitIndex, rx: Atom<'rx, FoldKey, F, R>) {
+    fn circuit(&mut self, circuit_id: CircuitIndex, rx: Atom<'rx, FoldKey, F, R>) -> Result<()> {
         self.circuit_impl(
             circuit_id,
             TrackedPoly::single(Cow::Borrowed(rx.poly), rx.key),
         );
+        Ok(())
     }
 
     fn internal_circuit(
         &mut self,
         id: InternalCircuitIndex,
         rxs: impl Iterator<Item = Atom<'rx, FoldKey, F, R>>,
-    ) {
+    ) -> Result<()> {
         let atoms: Vec<_> = rxs.collect();
         // Plain sum: poly = sum_i rx_i, so each constituent has coefficient 1.
         let decomp = CommitmentDecomposition {
@@ -243,6 +244,7 @@ impl<'m, 'rx, F: PrimeField, R: Rank> Processor<Atom<'rx, FoldKey, F, R>, Circui
         let circuit_id = id.circuit_index();
         let poly = sum_polynomials(atoms.iter().map(|a| a.poly));
         self.circuit_impl(circuit_id, TrackedPoly::new(poly, decomp));
+        Ok(())
     }
 
     fn bonding(

--- a/crates/ragu_pcd/src/internal/fold_revdot.rs
+++ b/crates/ragu_pcd/src/internal/fold_revdot.rs
@@ -251,11 +251,11 @@ fn fold_products_impl<'dr, D: Driver<'dr>, S: Len>(
             };
             inner_horner.write(dr, term)?;
         }
-        let row_result = inner_horner.finish(dr);
+        let row_result = inner_horner.finish(dr)?;
         outer_horner.write(dr, &row_result)?;
     }
 
-    Ok(outer_horner.finish(dr))
+    outer_horner.finish(dr)
 }
 
 pub fn fold_two_layer<'dr, D: Driver<'dr>, P: Parameters>(
@@ -267,7 +267,7 @@ pub fn fold_two_layer<'dr, D: Driver<'dr>, P: Parameters>(
     let m = P::GroupSize::len();
     let mut results = alloc::vec::Vec::with_capacity(P::NumGroups::len());
 
-    let zero = Element::zero(dr);
+    let zero = Element::zero(dr)?;
     for chunk in sources.chunks(m) {
         results.push(Element::fold(
             dr,
@@ -337,20 +337,18 @@ mod tests {
 
         // Run routine with Emulator
         let dr = &mut Emulator::execute();
-        let mu_elem = Element::constant(dr, mu);
-        let nu_elem = Element::constant(dr, nu);
+        let mu_elem = Element::constant(dr, mu)?;
+        let nu_elem = Element::constant(dr, nu)?;
 
         let error_terms = error
             .iter()
             .map(|&v| Element::constant(dr, v))
-            .collect_fixed()
-            .unwrap();
+            .try_collect_fixed()?;
 
         let ky_values = ky
             .iter()
             .map(|&v| Element::constant(dr, v))
-            .collect_fixed()
-            .unwrap();
+            .try_collect_fixed()?;
 
         let fold_products = ClaimFolder::new(dr, &mu_elem, &nu_elem)?;
         let result = fold_products.fold_outer::<P>(dr, &error_terms, &ky_values)?;
@@ -402,8 +400,8 @@ mod tests {
 
             // Verify layer 1 invariant for each group
             let dr = &mut Emulator::execute();
-            let mu_elem = Element::constant(dr, mu);
-            let nu_elem = Element::constant(dr, nu);
+            let mu_elem = Element::constant(dr, mu)?;
+            let nu_elem = Element::constant(dr, nu)?;
             let fold_products = ClaimFolder::new(dr, &mu_elem, &nu_elem)?;
 
             for g in 0..n {
@@ -413,16 +411,16 @@ mod tests {
                 // Compute claim via ClaimFolder
                 let ky_start = g * m;
                 let ky_end = (ky_start + m).min(count);
-                let ky_group: FixedVec<Element<'_, _>, _> = FixedVec::from_fn(|i| {
+                let ky_group: FixedVec<Element<'_, _>, _> = FixedVec::try_from_fn(|i| {
                     let val = if ky_start + i < ky_end {
                         ky_values[ky_start + i]
                     } else {
                         Fp::ZERO
                     };
                     Element::constant(dr, val)
-                });
+                })?;
                 let error_group: FixedVec<Element<'_, _>, _> =
-                    FixedVec::from_fn(|i| Element::constant(dr, inner_error[g][i]));
+                    FixedVec::try_from_fn(|i| Element::constant(dr, inner_error[g][i]))?;
 
                 let computed = fold_products.fold_inner::<P>(dr, &error_group, &ky_group)?;
                 let computed_val = *computed.value().take();
@@ -449,12 +447,12 @@ mod tests {
     fn test_fold_products_constraints() -> Result<()> {
         fn measure<P: Parameters>() -> Result<usize> {
             let sim = Simulator::simulate((), |dr, _| {
-                let mu = Element::constant(dr, Fp::random(&mut rand::rng()));
-                let nu = Element::constant(dr, Fp::random(&mut rand::rng()));
+                let mu = Element::constant(dr, Fp::random(&mut rand::rng()))?;
+                let nu = Element::constant(dr, Fp::random(&mut rand::rng()))?;
                 let error_terms =
-                    FixedVec::from_fn(|_| Element::constant(dr, Fp::random(&mut rand::rng())));
+                    FixedVec::try_from_fn(|_| Element::constant(dr, Fp::random(&mut rand::rng())))?;
                 let ky_values =
-                    FixedVec::from_fn(|_| Element::constant(dr, Fp::random(&mut rand::rng())));
+                    FixedVec::try_from_fn(|_| Element::constant(dr, Fp::random(&mut rand::rng())))?;
 
                 let fold_products = ClaimFolder::new(dr, &mu, &nu)?;
                 fold_products.fold_outer::<P>(dr, &error_terms, &ky_values)?;
@@ -647,16 +645,16 @@ mod tests {
             let lhs_elems: Vec<Element<'_, _>> = lhs_evals
                 .iter()
                 .map(|&v| Element::constant(dr, v))
-                .collect();
+                .collect::<Result<_>>()?;
             let rhs_elems: Vec<Element<'_, _>> = rhs_evals
                 .iter()
                 .map(|&v| Element::constant(dr, v))
-                .collect();
+                .collect::<Result<_>>()?;
 
-            let mu_inv_elem = Element::constant(dr, mu_inv);
-            let mu_prime_inv_elem = Element::constant(dr, mu_prime_inv);
-            let munu_elem = Element::constant(dr, munu);
-            let mu_prime_nu_prime_elem = Element::constant(dr, mu_prime_nu_prime);
+            let mu_inv_elem = Element::constant(dr, mu_inv)?;
+            let mu_prime_inv_elem = Element::constant(dr, mu_prime_inv)?;
+            let munu_elem = Element::constant(dr, munu)?;
+            let mu_prime_nu_prime_elem = Element::constant(dr, mu_prime_nu_prime)?;
 
             let lhs_result =
                 fold_two_layer::<_, P>(dr, &lhs_elems, &mu_inv_elem, &mu_prime_inv_elem)?;
@@ -854,12 +852,12 @@ mod tests {
         // Verify layer 1 constraint count formula: 2M^2 + 1 per group
         fn measure_m<const M: usize>() -> Result<usize> {
             let sim = Simulator::simulate((), |dr, _| {
-                let mu = Element::constant(dr, Fp::random(&mut rand::rng()));
-                let nu = Element::constant(dr, Fp::random(&mut rand::rng()));
+                let mu = Element::constant(dr, Fp::random(&mut rand::rng()))?;
+                let nu = Element::constant(dr, Fp::random(&mut rand::rng()))?;
                 let error_terms: FixedVec<_, NumErrorTerms<ConstLen<M>>> =
-                    FixedVec::from_fn(|_| Element::constant(dr, Fp::random(&mut rand::rng())));
+                    FixedVec::try_from_fn(|_| Element::constant(dr, Fp::random(&mut rand::rng())))?;
                 let ky_values: FixedVec<_, ConstLen<M>> =
-                    FixedVec::from_fn(|_| Element::constant(dr, Fp::random(&mut rand::rng())));
+                    FixedVec::try_from_fn(|_| Element::constant(dr, Fp::random(&mut rand::rng())))?;
 
                 let fold_products = ClaimFolder::new(dr, &mu, &nu)?;
                 fold_products.fold_inner::<TestParams<1, M>>(dr, &error_terms, &ky_values)?;
@@ -906,8 +904,8 @@ mod tests {
 
         // Verify at least the first few groups
         let dr = &mut Emulator::execute();
-        let mu_elem = Element::constant(dr, mu);
-        let nu_elem = Element::constant(dr, nu);
+        let mu_elem = Element::constant(dr, mu)?;
+        let nu_elem = Element::constant(dr, nu)?;
         let fold_products = ClaimFolder::new(dr, &mu_elem, &nu_elem)?;
 
         let ky_values: Vec<Fp> = lhs.iter().zip(&rhs).map(|(l, r)| l.revdot(r)).collect();
@@ -920,16 +918,16 @@ mod tests {
 
             let ky_start = g * m;
             let ky_end = (ky_start + m).min(count);
-            let ky_group: FixedVec<Element<'_, _>, _> = FixedVec::from_fn(|i| {
+            let ky_group: FixedVec<Element<'_, _>, _> = FixedVec::try_from_fn(|i| {
                 let val = if ky_start + i < ky_end {
                     ky_values[ky_start + i]
                 } else {
                     Fp::ZERO
                 };
                 Element::constant(dr, val)
-            });
+            })?;
             let error_group: FixedVec<Element<'_, _>, _> =
-                FixedVec::from_fn(|i| Element::constant(dr, inner_error[g][i]));
+                FixedVec::try_from_fn(|i| Element::constant(dr, inner_error[g][i]))?;
 
             let computed =
                 fold_products.fold_inner::<RevdotParameters>(dr, &error_group, &ky_group)?;

--- a/crates/ragu_pcd/src/internal/native/circuits/compute_v.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/compute_v.rs
@@ -215,9 +215,11 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> MultiStageCircuit<C::CircuitFi
                     &computed_ax,
                     &computed_bx,
                 ) {
-                    pu.sub(dr, v).mul(dr, denominator)?.write(dr, &mut horner)?;
+                    pu.sub(dr, v)?
+                        .mul(dr, denominator)?
+                        .write(dr, &mut horner)?;
                 }
-                horner.finish(dr)
+                horner.finish(dr)?
             };
 
             // Step 3: Compute v = f(u) + beta * eval via Horner accumulation.
@@ -230,7 +232,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> MultiStageCircuit<C::CircuitFi
                 let mut horner = Horner::new(&effective_beta);
                 fu.write(dr, &mut horner)?;
                 eval.write(dr, &mut horner)?;
-                horner.finish(dr)
+                horner.finish(dr)?
             };
 
             // Constrain v: the computed value must equal the claimed v in the
@@ -425,32 +427,34 @@ impl<'a, 'dr, D: Driver<'dr>> Processor<&'a Element<'dr, D>, &'a Element<'dr, D>
         self.bx.push(b.clone());
     }
 
-    fn circuit(&mut self, sy: &'a Element<'dr, D>, rx: &'a Element<'dr, D>) {
+    fn circuit(&mut self, sy: &'a Element<'dr, D>, rx: &'a Element<'dr, D>) -> Result<()> {
         // a(xz) = rx(xz)
         self.ax.push(rx.clone());
 
         // b(x) = rx(xz) + s_y + t(xz)
-        self.bx.push(rx.add(self.dr, sy).add(self.dr, self.txz));
+        self.bx.push(rx.add(self.dr, sy)?.add(self.dr, self.txz)?);
+        Ok(())
     }
 
     fn internal_circuit(
         &mut self,
         id: InternalCircuitIndex,
         rxs: impl Iterator<Item = &'a Element<'dr, D>>,
-    ) {
+    ) -> Result<()> {
         let sy = self.fixed_registry.get(id);
 
-        let mut sum = Element::zero(self.dr);
+        let mut sum = Element::zero(self.dr)?;
 
         for rx in rxs {
-            sum = sum.add(self.dr, rx);
+            sum = sum.add(self.dr, rx)?;
         }
 
         // a(xz) = rx(xz)
         self.ax.push(sum.clone());
 
         // b(x) = rx(xz) + s_y + t(xz)
-        self.bx.push(sum.add(self.dr, sy).add(self.dr, self.txz));
+        self.bx.push(sum.add(self.dr, sy)?.add(self.dr, self.txz)?);
+        Ok(())
     }
 
     fn bonding(
@@ -650,7 +654,7 @@ impl<'dr, D: Driver<'dr, F: ff::PrimeField>> Inverter<'dr, D> {
     /// after calling [`invert`](Self::invert).
     fn add(&mut self, dr: &mut D, value: &Element<'dr, D>) -> Result<usize> {
         let index = self.differences.len();
-        let diff = self.base.sub(dr, value);
+        let diff = self.base.sub(dr, value)?;
         self.differences.push(diff);
         Ok(index)
     }
@@ -666,7 +670,7 @@ impl<'dr, D: Driver<'dr, F: ff::PrimeField>> Inverter<'dr, D> {
     /// Returns an index that can be used to retrieve the inverted difference
     /// after calling [`invert`](Self::invert).
     fn add_constant(&mut self, dr: &mut D, value: D::F) -> Result<usize> {
-        let constant = Element::constant(dr, value);
+        let constant = Element::constant(dr, value)?;
         self.add(dr, &constant)
     }
 

--- a/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
@@ -297,7 +297,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
             unified,
         };
 
-        let zero = Element::zero(dr);
+        let zero = Element::zero(dr)?;
         Ok(WithAux::new(WithSuffix::new(output, zero), updated))
     }
 }

--- a/crates/ragu_pcd/src/internal/native/circuits/inner_collapse.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/inner_collapse.rs
@@ -172,7 +172,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
             preamble.right.unified.c.clone(),
             &outer_error.left,
             &outer_error.right,
-        );
+        )?;
         let mut ky = ky_values(&ky);
 
         // Verify each group's layer 1 reduction. For each group, fold the

--- a/crates/ragu_pcd/src/internal/native/circuits/outer_collapse.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/outer_collapse.rs
@@ -176,7 +176,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
             // witness any c value to seed the recursion.
             preamble
                 .is_base_case(dr)?
-                .not(dr)
+                .not(dr)?
                 .conditional_enforce_equal(dr, &witnessed_c, &computed_c)?;
         }
 

--- a/crates/ragu_pcd/src/internal/native/claims.rs
+++ b/crates/ragu_pcd/src/internal/native/claims.rs
@@ -62,12 +62,16 @@ pub trait Processor<Rx, AppCircuitId> {
     fn raw_claim(&mut self, a: Rx, b: Rx);
 
     /// Process an application circuit claim ($k(y) = \text{application\_ky}$).
-    fn circuit(&mut self, app_id: AppCircuitId, rx: Rx);
+    fn circuit(&mut self, app_id: AppCircuitId, rx: Rx) -> Result<()>;
 
     /// Process an internal circuit claim (sum of rxs, $k(y) = \text{internal\_ky}$).
     ///
     /// The processor looks up registry via [`InternalCircuitIndex`] from its stored context.
-    fn internal_circuit(&mut self, id: InternalCircuitIndex, rxs: impl Iterator<Item = Rx>);
+    fn internal_circuit(
+        &mut self,
+        id: InternalCircuitIndex,
+        rxs: impl Iterator<Item = Rx>,
+    ) -> Result<()>;
 
     /// Process a bonding claim (fold of rxs, $k(y) = 0$).
     ///
@@ -83,18 +87,24 @@ impl<'m, 'rx, F: PrimeField, R: Rank> Processor<&'rx sparse::Polynomial<F, R>, C
         self.b.push(Cow::Borrowed(b));
     }
 
-    fn circuit(&mut self, circuit_id: CircuitIndex, rx: &'rx sparse::Polynomial<F, R>) {
+    fn circuit(
+        &mut self,
+        circuit_id: CircuitIndex,
+        rx: &'rx sparse::Polynomial<F, R>,
+    ) -> Result<()> {
         self.circuit_impl(circuit_id, Cow::Borrowed(rx));
+        Ok(())
     }
 
     fn internal_circuit(
         &mut self,
         id: InternalCircuitIndex,
         rxs: impl Iterator<Item = &'rx sparse::Polynomial<F, R>>,
-    ) {
+    ) -> Result<()> {
         let circuit_id = id.circuit_index();
         let rx = sum_polynomials(rxs);
         self.circuit_impl(circuit_id, rx);
+        Ok(())
     }
 
     fn bonding(
@@ -133,7 +143,7 @@ where
 
     // App circuits (interleaved per proof)
     for (app_id, rx) in source.app_circuits().zip(source.rx(Rx(Application))) {
-        processor.circuit(app_id, rx);
+        processor.circuit(app_id, rx)?;
     }
 
     // Internal circuits and stages in canonical order.
@@ -147,14 +157,14 @@ where
                     .zip(source.rx(Rx(Preamble)))
                     .zip(source.rx(Rx(OuterError)))
                 {
-                    processor.internal_circuit(id, [h1, pre, en].into_iter());
+                    processor.internal_circuit(id, [h1, pre, en].into_iter())?;
                 }
             }
 
             // hashes_2: Hashes2 + OuterError
             Hashes2Circuit => {
                 for (h2, en) in source.rx(Rx(Hashes2)).zip(source.rx(Rx(OuterError))) {
-                    processor.internal_circuit(id, [h2, en].into_iter());
+                    processor.internal_circuit(id, [h2, en].into_iter())?;
                 }
             }
 
@@ -166,7 +176,7 @@ where
                     .zip(source.rx(Rx(InnerError)))
                     .zip(source.rx(Rx(OuterError)))
                 {
-                    processor.internal_circuit(id, [pc, pre, em, en].into_iter());
+                    processor.internal_circuit(id, [pc, pre, em, en].into_iter())?;
                 }
             }
 
@@ -177,7 +187,7 @@ where
                     .zip(source.rx(Rx(Preamble)))
                     .zip(source.rx(Rx(OuterError)))
                 {
-                    processor.internal_circuit(id, [fc, pre, en].into_iter());
+                    processor.internal_circuit(id, [fc, pre, en].into_iter())?;
                 }
             }
 
@@ -189,7 +199,7 @@ where
                     .zip(source.rx(Rx(Query)))
                     .zip(source.rx(Rx(Eval)))
                 {
-                    processor.internal_circuit(id, [cv, pre, q, e].into_iter());
+                    processor.internal_circuit(id, [cv, pre, q, e].into_iter())?;
                 }
             }
 
@@ -294,8 +304,8 @@ impl<'dr, D: Driver<'dr>> TwoProofKySource<'dr, D> {
         right_raw_c: Element<'dr, D>,
         left_ky: &super::stages::outer_error::ChildKyOutputs<'dr, D>,
         right_ky: &super::stages::outer_error::ChildKyOutputs<'dr, D>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        Ok(Self {
             left_raw_c,
             right_raw_c,
             left_app: left_ky.application.clone(),
@@ -304,8 +314,8 @@ impl<'dr, D: Driver<'dr>> TwoProofKySource<'dr, D> {
             right_bridge: right_ky.unified_bridge.clone(),
             left_unified: left_ky.unified.clone(),
             right_unified: right_ky.unified.clone(),
-            zero: Element::zero(dr),
-        }
+            zero: Element::zero(dr)?,
+        })
     }
 }
 

--- a/crates/ragu_pcd/src/internal/native/stages/preamble.rs
+++ b/crates/ragu_pcd/src/internal/native/stages/preamble.rs
@@ -115,13 +115,13 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usiz
         Ok((
             ({
                 let mut ky = ky.clone();
-                Element::zero(dr).write(dr, &mut ky)?;
+                Element::zero(dr)?.write(dr, &mut ky)?;
                 ky.finish_ky(dr)?
             }),
             ({
                 self.children.left.write(dr, &mut ky)?;
                 self.children.right.write(dr, &mut ky)?;
-                Element::zero(dr).write(dr, &mut ky)?;
+                Element::zero(dr)?.write(dr, &mut ky)?;
                 ky.finish_ky(dr)?
             }),
         ))

--- a/crates/ragu_pcd/src/internal/native/unified.rs
+++ b/crates/ragu_pcd/src/internal/native/unified.rs
@@ -489,7 +489,7 @@ impl<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>> OutputBuilder<'dr, D, C
         Bound<'dr, D, InternalOutputKind<C>>,
         DriverValue<D, Instance<C>>,
     )> {
-        let zero = Element::zero(dr);
+        let zero = Element::zero(dr)?;
         let (output, instance) = self.finish_no_suffix(dr)?;
         Ok((WithSuffix::new(output, zero), instance))
     }

--- a/crates/ragu_pcd/src/internal/transcript.rs
+++ b/crates/ragu_pcd/src/internal/transcript.rs
@@ -85,16 +85,16 @@ impl<'dr, D: Driver<'dr>, P: PoseidonPermutation<D::F>> Transcript<'dr, D, P> {
     where
         D::F: PrimeField,
     {
-        let mut sponge = Sponge::new(dr, params);
+        let mut sponge = Sponge::new(dr, params)?;
 
         // prefix with the tag length
-        let len_elem = Element::constant(dr, D::F::from(tag.len() as u64));
+        let len_elem = Element::constant(dr, D::F::from(tag.len() as u64))?;
         sponge.absorb(dr, &len_elem)?;
 
         // Then absorb the tag content in 16-byte chunks as u128
         for chunk in tag.chunks(16) {
             let bytes: [u8; 16] = core::array::from_fn(|i| chunk.get(i).copied().unwrap_or(0));
-            let elem = Element::constant(dr, D::F::from_u128(u128::from_le_bytes(bytes)));
+            let elem = Element::constant(dr, D::F::from_u128(u128::from_le_bytes(bytes)))?;
             sponge.absorb(dr, &elem)?;
         }
 
@@ -224,7 +224,7 @@ mod tests {
         ops.iter()
             .filter_map(|op| match op {
                 Op::Absorb(v) => {
-                    let e = Element::constant(dr, *v);
+                    let e = Element::constant(dr, *v).unwrap();
                     e.write(dr, t).unwrap();
                     None
                 }
@@ -244,7 +244,7 @@ mod tests {
             let mut tr1 = Transcript::new(&mut dr, poseidon, &t1).unwrap();
             let mut tr2 = Transcript::new(&mut dr, poseidon, &t2).unwrap();
 
-            let elem = Element::constant(&mut dr, v);
+            let elem = Element::constant(&mut dr, v).unwrap();
             elem.write(&mut dr, &mut tr1).unwrap();
             elem.write(&mut dr, &mut tr2).unwrap();
 
@@ -262,7 +262,7 @@ mod tests {
                 let mut dr = Sim::new();
                 let mut t = Transcript::new(&mut dr, poseidon, b"determinism").unwrap();
                 for &v in vs {
-                    let e = Element::constant(&mut dr, v);
+                    let e = Element::constant(&mut dr, v).unwrap();
                     e.write(&mut dr, &mut t).unwrap();
                 }
                 *t.challenge(&mut dr).unwrap().value().take()
@@ -277,7 +277,7 @@ mod tests {
             let mut dr = Sim::new();
 
             let mut t = Transcript::new(&mut dr, Pasta::circuit_poseidon(params), b"distinct").unwrap();
-            let e = Element::constant(&mut dr, v);
+            let e = Element::constant(&mut dr, v).unwrap();
             e.write(&mut dr, &mut t).unwrap();
 
             let c0 = *t.challenge(&mut dr).unwrap().value().take();
@@ -357,7 +357,7 @@ mod tests {
 
         let mut t =
             Transcript::new(&mut dr, Pasta::circuit_poseidon(params), b"skip-squeeze").unwrap();
-        let e = Element::constant(&mut dr, Fp::from(42u64));
+        let e = Element::constant(&mut dr, Fp::from(42u64)).unwrap();
         e.write(&mut dr, &mut t).unwrap();
 
         let state = t.save_state(&mut dr).expect("save_state should succeed");

--- a/crates/ragu_pcd/src/step/internal/adapter.rs
+++ b/crates/ragu_pcd/src/step/internal/adapter.rs
@@ -173,7 +173,7 @@ mod tests {
             let right_elem = Element::alloc(dr, right)?;
 
             // Output is sum of left and right
-            let output_elem = left_elem.add(dr, &right_elem);
+            let output_elem = left_elem.add(dr, &right_elem)?;
             let output_val = output_elem.value().map(|v| *v);
 
             let left_enc = Encoded::from_gadget(left_elem);

--- a/crates/ragu_pcd/src/step/internal/padded.rs
+++ b/crates/ragu_pcd/src/step/internal/padded.rs
@@ -43,7 +43,7 @@ pub(crate) fn for_header<
     gadget: Bound<'dr, D, H::Output>,
 ) -> Result<Padded<'dr, D, H::Output, HEADER_SIZE>> {
     let padded_content = PaddedContent { gadget };
-    let suffix = Element::constant(dr, D::F::from(H::SUFFIX.get()));
+    let suffix = Element::constant(dr, D::F::from(H::SUFFIX.get()))?;
     Ok(Padded {
         inner: WithSuffix::new(padded_content, suffix),
     })
@@ -83,7 +83,7 @@ impl<F: Field, G: GadgetKind<F> + Write<F>, const HEADER_SIZE: usize> Write<F>
         // Add padding to reach HEADER_SIZE - 1 elements (suffix will be added
         // after).
         while counting.written < HEADER_SIZE - 1 {
-            Element::zero(dr).write(dr, &mut counting)?;
+            Element::zero(dr)?.write(dr, &mut counting)?;
         }
 
         Ok(())
@@ -158,7 +158,7 @@ mod tests {
                 gadget: gadget.clone(),
             };
             let padded_gadget = Padded::<'_, _, Kind![F; MySillyGadget<'_, _>], 6> {
-                inner: WithSuffix::new(padded_content, Element::constant(dr, F::from(42u64))),
+                inner: WithSuffix::new(padded_content, Element::constant(dr, F::from(42u64))?),
             };
             let mut buffer = vec![];
             padded_gadget.write(dr, &mut buffer)?;
@@ -193,7 +193,7 @@ mod tests {
                 gadget: gadget.clone(),
             };
             let padded_gadget = Padded::<'_, _, Kind![F; MySillyGadget<'_, _>], 4> {
-                inner: WithSuffix::new(padded_content, Element::constant(dr, F::from(42u64))),
+                inner: WithSuffix::new(padded_content, Element::constant(dr, F::from(42u64))?),
             };
             let mut buffer = vec![];
             assert!(padded_gadget.write(dr, &mut buffer).is_err());

--- a/crates/ragu_primitives/benches/primitives.rs
+++ b/crates/ragu_primitives/benches/primitives.rs
@@ -51,7 +51,7 @@ fn element_is_zero((mut emu, (elem,)): (BenchEmu, (Element<'static, BenchEmu>,))
 fn element_multiadd(
     (mut emu, (elements, coeffs)): (BenchEmu, (Vec<Element<'static, BenchEmu>>, Vec<Fp>)),
 ) {
-    black_box(multiadd(&mut emu, &elements, &coeffs));
+    black_box(multiadd(&mut emu, &elements, &coeffs)).unwrap();
 }
 
 library_benchmark_group!(
@@ -96,7 +96,7 @@ fn point_double_and_add_incomplete(
 #[library_benchmark(setup = setup_emu)]
 #[bench::point_endo((alloc_point,))]
 fn point_endo((mut emu, (point,)): (BenchEmu, (Point<'static, BenchEmu, EpAffine>,))) {
-    black_box(point.endo(&mut emu));
+    black_box(point.endo(&mut emu)).unwrap();
 }
 
 library_benchmark_group!(

--- a/crates/ragu_primitives/benches/setup/mod.rs
+++ b/crates/ragu_primitives/benches/setup/mod.rs
@@ -72,7 +72,7 @@ pub fn alloc_sponge(
     emu: &mut BenchEmu,
     _rng: &mut StdRng,
 ) -> Sponge<'static, BenchEmu, PoseidonFp> {
-    Sponge::new(emu, Pasta::circuit_poseidon(Pasta::baked()))
+    Sponge::new(emu, Pasta::circuit_poseidon(Pasta::baked())).unwrap()
 }
 
 // Parameterized allocators for collections

--- a/crates/ragu_primitives/src/boolean.rs
+++ b/crates/ragu_primitives/src/boolean.rs
@@ -58,11 +58,11 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
     }
 
     /// Computes the NOT of this boolean. This is "free" in the circuit model.
-    pub fn not(&self, dr: &mut D) -> Self {
+    pub fn not(&self, dr: &mut D) -> Result<Self> {
         // The wire w is transformed into 1 - w, its logical NOT.
-        let wire = dr.add(|lc| lc.add(&D::ONE).sub(self.wire()));
+        let wire = dr.add(|lc| lc.add(&D::ONE).sub(self.wire()))?;
         let value = self.value().not();
-        Boolean { wire, value }
+        Ok(Boolean { wire, value })
     }
 
     /// Computes the AND of two booleans. This costs one multiplication
@@ -96,9 +96,9 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
         b: &Element<'dr, D>,
     ) -> Result<Element<'dr, D>> {
         // Result = a + cond * (b - a)
-        let diff = b.sub(dr, a);
+        let diff = b.sub(dr, a)?;
         let cond_times_diff = self.element().mul(dr, &diff)?;
-        Ok(a.add(dr, &cond_times_diff))
+        a.add(dr, &cond_times_diff)
     }
 
     /// Conditionally enforces that two elements are equal.
@@ -115,7 +115,7 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
         // Equivalent to: condition * (a - b) == 0
         // - When condition = 1: a - b = 0
         // - When condition = 0: 0 = 0 (trivially satisfied)
-        let diff = a.sub(dr, b);
+        let diff = a.sub(dr, b)?;
         let product = self.element().mul(dr, &diff)?;
         product.enforce_zero(dr)
     }
@@ -240,7 +240,7 @@ pub fn multipack<'dr, D: Driver<'dr, F: ff::PrimeField>>(
                 lc = lc.gain(Coeff::Two);
             }
             lc
-        });
+        })?;
 
         v.push(Element::promote(wire, value));
     }
@@ -456,7 +456,7 @@ mod proptests {
             let mut actual = None;
             Simulator::simulate(a_val, |dr, witness| {
                 let a = Boolean::alloc(dr, witness)?;
-                let not_a = a.not(dr);
+                let not_a = a.not(dr)?;
                 let result = a.and(dr, &not_a)?;
                 actual = Some(result.value().take());
                 Ok(())

--- a/crates/ragu_primitives/src/element.rs
+++ b/crates/ragu_primitives/src/element.rs
@@ -110,19 +110,19 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
     }
 
     /// Creates an element for the zero constant value.
-    pub fn zero(dr: &mut D) -> Self {
-        let wire = dr.constant(Coeff::Zero);
+    pub fn zero(dr: &mut D) -> Result<Self> {
+        let wire = dr.constant(Coeff::Zero)?;
         let value = D::just(|| D::F::ZERO);
 
-        Element { value, wire }
+        Ok(Element { value, wire })
     }
 
     /// Creates an element for the provided constant value.
-    pub fn constant(dr: &mut D, value: D::F) -> Self {
-        let wire = dr.constant(Coeff::Arbitrary(value));
+    pub fn constant(dr: &mut D, value: D::F) -> Result<Self> {
+        let wire = dr.constant(Coeff::Arbitrary(value))?;
         let value = D::just(|| value);
 
-        Element { value, wire }
+        Ok(Element { value, wire })
     }
 
     /// Constructs a new element from a wire and a witness value. **It is the
@@ -179,54 +179,54 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
     }
 
     /// Negates this element.
-    pub fn negate(&self, dr: &mut D) -> Self {
+    pub fn negate(&self, dr: &mut D) -> Result<Self> {
         self.scale(dr, Coeff::NegativeOne)
     }
 
     /// Add two elements together.
-    pub fn add(&self, dr: &mut D, other: &Self) -> Self {
+    pub fn add(&self, dr: &mut D, other: &Self) -> Result<Self> {
         let value = D::just(|| {
             let a = *self.value.snag();
             let b = *other.value.snag();
             a + b
         });
 
-        let wire = dr.add(|lc| lc.add(&self.wire).add(&other.wire));
+        let wire = dr.add(|lc| lc.add(&self.wire).add(&other.wire))?;
 
-        Element { value, wire }
+        Ok(Element { value, wire })
     }
 
     /// Subtracts another element from this one.
-    pub fn sub(&self, dr: &mut D, other: &Self) -> Self {
+    pub fn sub(&self, dr: &mut D, other: &Self) -> Result<Self> {
         let value = D::just(|| {
             let a = *self.value.snag();
             let b = *other.value.snag();
             a - b
         });
 
-        let wire = dr.add(|lc| lc.add(&self.wire).sub(&other.wire));
+        let wire = dr.add(|lc| lc.add(&self.wire).sub(&other.wire))?;
 
-        Element { value, wire }
+        Ok(Element { value, wire })
     }
 
     /// Add another element scaled by a constant: `self` + `other` * `coeff`.
-    pub fn add_coeff(&self, dr: &mut D, other: &Self, coeff: Coeff<D::F>) -> Self {
+    pub fn add_coeff(&self, dr: &mut D, other: &Self, coeff: Coeff<D::F>) -> Result<Self> {
         let value = D::just(|| {
             *self.value.snag() + (Coeff::Arbitrary(*other.value.snag()) * coeff).value()
         });
-        let wire = dr.add(|lc| lc.add(&self.wire).add_term(&other.wire, coeff));
-        Element { value, wire }
+        let wire = dr.add(|lc| lc.add(&self.wire).add_term(&other.wire, coeff))?;
+        Ok(Element { value, wire })
     }
 
     /// Scale this element by a constant.
-    pub fn scale(&self, dr: &mut D, coeff: Coeff<D::F>) -> Self {
+    pub fn scale(&self, dr: &mut D, coeff: Coeff<D::F>) -> Result<Self> {
         let value = D::just(|| (Coeff::Arbitrary(*self.value.snag()) * coeff).value());
-        let wire = dr.add(|lc| lc.add_term(&self.wire, coeff));
-        Element { value, wire }
+        let wire = dr.add(|lc| lc.add_term(&self.wire, coeff))?;
+        Ok(Element { value, wire })
     }
 
     /// Double this element.
-    pub fn double(&self, dr: &mut D) -> Self {
+    pub fn double(&self, dr: &mut D) -> Result<Self> {
         self.add(dr, self)
     }
 
@@ -310,7 +310,7 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
 
     /// Returns a boolean indicating whether this element equals another.
     pub fn is_equal(&self, dr: &mut D, other: &Self) -> Result<Boolean<'dr, D>> {
-        let diff = self.sub(dr, other);
+        let diff = self.sub(dr, other)?;
         diff.is_zero(dr)
     }
 
@@ -327,11 +327,11 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
     ) -> Result<Self> {
         let mut iter = elements.into_iter();
         let Some(first) = iter.next() else {
-            return Ok(Element::zero(dr));
+            return Element::zero(dr);
         };
         iter.try_fold(first.borrow().clone(), |acc, elem| {
             acc.mul(dr, scale_factor)
-                .map(|scaled| scaled.add(dr, elem.borrow()))
+                .and_then(|scaled| scaled.add(dr, elem.borrow()))
         })
     }
 
@@ -342,7 +342,7 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
             value = value.square(dr)?;
         }
         let one = Element::one();
-        let diff = value.sub(dr, &one);
+        let diff = value.sub(dr, &one)?;
         diff.enforce_zero(dr)?;
         Ok(())
     }
@@ -354,10 +354,10 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
     pub fn sum<E: Borrow<Element<'dr, D>>>(
         dr: &mut D,
         elements: impl IntoIterator<Item = E>,
-    ) -> Self {
+    ) -> Result<Self> {
         elements
             .into_iter()
-            .fold(Element::zero(dr), |acc, elem| acc.add(dr, elem.borrow()))
+            .try_fold(Element::zero(dr)?, |acc, elem| acc.add(dr, elem.borrow()))
     }
 }
 
@@ -409,7 +409,7 @@ pub fn multiadd<'dr, D: Driver<'dr>>(
     dr: &mut D,
     values: &[Element<'dr, D>],
     coeffs: &[D::F],
-) -> Element<'dr, D> {
+) -> Result<Element<'dr, D>> {
     assert_eq!(values.len(), coeffs.len());
     let value = D::just(|| {
         let mut sum = D::F::ZERO;
@@ -423,9 +423,9 @@ pub fn multiadd<'dr, D: Driver<'dr>>(
             lc = lc.add_term(value.wire(), Coeff::Arbitrary(*coeff));
         }
         lc
-    });
+    })?;
 
-    Element::promote(wire, value)
+    Ok(Element::promote(wire, value))
 }
 
 #[cfg(test)]
@@ -532,8 +532,8 @@ mod proptests {
                 let (a, b) = witness.cast();
                 let a = Element::alloc(dr, a)?;
                 let b = Element::alloc(dr, b)?;
-                let sum = a.add(dr, &b);
-                let result = sum.sub(dr, &b);
+                let sum = a.add(dr, &b)?;
+                let result = sum.sub(dr, &b)?;
                 actual = Some(*result.value().take());
                 Ok(())
             }).map_err(|e| TestCaseError::fail(format!("{e:?}")))?;

--- a/crates/ragu_primitives/src/endoscalar.rs
+++ b/crates/ragu_primitives/src/endoscalar.rs
@@ -152,7 +152,7 @@ impl<'dr, D: Driver<'dr>> Endoscalar<'dr, D> {
         dr: &mut D,
         p: &Point<'dr, D, C>,
     ) -> Result<Point<'dr, D, C>> {
-        let mut acc = p.endo(dr).add_incomplete(dr, p, None)?.double(dr)?;
+        let mut acc = p.endo(dr)?.add_incomplete(dr, p, None)?.double(dr)?;
         let mut bits = self.bits();
 
         // Uendo::BITS is guaranteed to be even (enforced in ragu_arithmetic).
@@ -181,7 +181,7 @@ impl<'dr, D: Driver<'dr>> Endoscalar<'dr, D> {
             (D::F::ONE - D::F::ZETA).double(),
         ];
 
-        let mut acc = Element::zero(dr);
+        let mut acc = Element::zero(dr)?;
         let mut bits = self.bits();
 
         // Uendo::BITS is guaranteed to be even (enforced in ragu_arithmetic).
@@ -190,21 +190,21 @@ impl<'dr, D: Driver<'dr>> Endoscalar<'dr, D> {
             let e = bits.next().unwrap();
             let ne = n.and(dr, &e)?;
 
-            acc = acc.double(dr);
+            acc = acc.double(dr)?;
             constant_term = constant_term.double();
             constant_term += D::F::ONE;
 
-            let n = n.element().scale(dr, Coeff::Arbitrary(coeffs[0]));
-            let e = e.element().scale(dr, Coeff::Arbitrary(coeffs[1]));
-            let ne = ne.element().scale(dr, Coeff::Arbitrary(coeffs[2]));
+            let n = n.element().scale(dr, Coeff::Arbitrary(coeffs[0]))?;
+            let e = e.element().scale(dr, Coeff::Arbitrary(coeffs[1]))?;
+            let ne = ne.element().scale(dr, Coeff::Arbitrary(coeffs[2]))?;
 
-            acc = acc.add(dr, &n);
-            acc = acc.add(dr, &e);
-            acc = acc.add(dr, &ne);
+            acc = acc.add(dr, &n)?;
+            acc = acc.add(dr, &e)?;
+            acc = acc.add(dr, &ne)?;
         }
 
-        let tmp = Element::constant(dr, constant_term);
-        acc = acc.add(dr, &tmp);
+        let tmp = Element::constant(dr, constant_term)?;
+        acc = acc.add(dr, &tmp)?;
 
         Ok(acc)
     }

--- a/crates/ragu_primitives/src/point.rs
+++ b/crates/ragu_primitives/src/point.rs
@@ -74,8 +74,8 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
     /// identity.
     pub fn constant(dr: &mut D, p: C) -> Result<Self> {
         if let Some(coordinates) = p.coordinates().into_option() {
-            let x = Element::constant(dr, *coordinates.x());
-            let y = Element::constant(dr, *coordinates.y());
+            let x = Element::constant(dr, *coordinates.x())?;
+            let y = Element::constant(dr, *coordinates.y())?;
 
             Ok(Point::new_unchecked(x, y))
         } else {
@@ -95,30 +95,30 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
     }
 
     /// Applies the endomorphism to this point.
-    pub fn endo(&self, dr: &mut D) -> Self {
-        let x = self.x.scale(dr, Coeff::Arbitrary(C::Base::ZETA));
-        Point::new_unchecked(x, self.y.clone())
+    pub fn endo(&self, dr: &mut D) -> Result<Self> {
+        let x = self.x.scale(dr, Coeff::Arbitrary(C::Base::ZETA))?;
+        Ok(Point::new_unchecked(x, self.y.clone()))
     }
 
     /// Negates this point.
-    pub fn negate(&self, dr: &mut D) -> Self {
-        Point {
+    pub fn negate(&self, dr: &mut D) -> Result<Self> {
+        Ok(Point {
             x: self.x.clone(),
-            y: self.y.negate(dr),
+            y: self.y.negate(dr)?,
             _marker: PhantomData,
-        }
+        })
     }
 
     /// Apply the endomorphism iff the provided condition is true.
     pub fn conditional_endo(&self, dr: &mut D, condition: &Boolean<'dr, D>) -> Result<Self> {
-        let endo_x = self.x.scale(dr, Coeff::Arbitrary(D::F::ZETA));
+        let endo_x = self.x.scale(dr, Coeff::Arbitrary(D::F::ZETA))?;
         let x = condition.conditional_select(dr, &self.x, &endo_x)?;
         Ok(Point::new_unchecked(x, self.y.clone()))
     }
 
     /// Apply the negation map iff the provided condition is true.
     pub fn conditional_negate(&self, dr: &mut D, condition: &Boolean<'dr, D>) -> Result<Self> {
-        let neg_y = self.y.negate(dr);
+        let neg_y = self.y.negate(dr)?;
         let y = condition.conditional_select(dr, &self.y, &neg_y)?;
         Ok(Point::new_unchecked(self.x.clone(), y))
     }
@@ -127,20 +127,20 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
     /// two, and thus all affine points have affine doubles.
     pub fn double(&self, dr: &mut D) -> Result<Self> {
         // delta = 3x^2 / 2y
-        let double_y = self.y.double(dr);
+        let double_y = self.y.double(dr)?;
         let delta = self
             .x
             .square(dr)?
-            .scale(dr, Coeff::Arbitrary(D::F::from(3)))
+            .scale(dr, Coeff::Arbitrary(D::F::from(3)))?
             .div_nonzero(dr, &double_y)?;
 
         // x3 = delta^2 - 2x
-        let double_x = self.x.double(dr);
-        let x3 = delta.square(dr)?.sub(dr, &double_x);
+        let double_x = self.x.double(dr)?;
+        let x3 = delta.square(dr)?.sub(dr, &double_x)?;
 
         // y3 = delta * (x - x3) - y
-        let x_sub_x3 = self.x.sub(dr, &x3);
-        let y3 = delta.mul(dr, &x_sub_x3)?.sub(dr, &self.y);
+        let x_sub_x3 = self.x.sub(dr, &x3)?;
+        let y3 = delta.mul(dr, &x_sub_x3)?.sub(dr, &self.y)?;
 
         Ok(Point::new_unchecked(x3, y3))
     }
@@ -160,18 +160,18 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
         nonzero: Option<&mut Element<'dr, D>>,
     ) -> Result<Self> {
         // delta = (y1 - y0) / (x1 - x0)
-        let tmp = other.x.sub(dr, &self.x);
+        let tmp = other.x.sub(dr, &self.x)?;
         if let Some(nonzero) = nonzero {
             *nonzero = nonzero.mul(dr, &tmp)?;
         }
-        let delta = other.y.sub(dr, &self.y).div_nonzero(dr, &tmp)?;
+        let delta = other.y.sub(dr, &self.y)?.div_nonzero(dr, &tmp)?;
 
         // x3 = delta^2 - x0 - x1
-        let x3 = delta.square(dr)?.sub(dr, &self.x).sub(dr, &other.x);
+        let x3 = delta.square(dr)?.sub(dr, &self.x)?.sub(dr, &other.x)?;
 
         // y3 = delta * (x0 - x3) - y0
-        let tmp = self.x.sub(dr, &x3);
-        let y3 = delta.mul(dr, &tmp)?.sub(dr, &self.y);
+        let tmp = self.x.sub(dr, &x3)?;
+        let y3 = delta.mul(dr, &tmp)?.sub(dr, &self.y)?;
 
         Ok(Point {
             x: x3,
@@ -187,22 +187,26 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
         // See <https://github.com/zcash/zcash/issues/3924> for an explanation.
 
         // lambda_1 = (y_q - y_p)/(x_q - x_p)
-        let tmp = other.x.sub(dr, &self.x);
-        let lambda_1 = other.y.sub(dr, &self.y).div_nonzero(dr, &tmp)?;
+        let tmp = other.x.sub(dr, &self.x)?;
+        let lambda_1 = other.y.sub(dr, &self.y)?.div_nonzero(dr, &tmp)?;
 
         // x_r = lambda_1^2 - x_p - x_q
-        let x_r = lambda_1.square(dr)?.sub(dr, &self.x).sub(dr, &other.x);
+        let x_r = lambda_1.square(dr)?.sub(dr, &self.x)?.sub(dr, &other.x)?;
 
         // lambda_2 = 2 y_p /(x_p - x_r) - lambda_1
-        let tmp = self.x.sub(dr, &x_r);
-        let lambda_2 = self.y.double(dr).div_nonzero(dr, &tmp)?.sub(dr, &lambda_1);
+        let tmp = self.x.sub(dr, &x_r)?;
+        let lambda_2 = self
+            .y
+            .double(dr)?
+            .div_nonzero(dr, &tmp)?
+            .sub(dr, &lambda_1)?;
 
         // x_s = lambda_2^2 - x_r - x_p
-        let x_s = lambda_2.square(dr)?.sub(dr, &x_r).sub(dr, &self.x);
+        let x_s = lambda_2.square(dr)?.sub(dr, &x_r)?.sub(dr, &self.x)?;
 
         // y_s = lambda_2 (x_p - x_s) - y_p
-        let tmp = self.x.sub(dr, &x_s);
-        let y_s = lambda_2.mul(dr, &tmp)?.sub(dr, &self.y);
+        let tmp = self.x.sub(dr, &x_s)?;
+        let y_s = lambda_2.mul(dr, &tmp)?.sub(dr, &self.y)?;
 
         Ok(Point {
             x: x_s,

--- a/crates/ragu_primitives/src/poseidon.rs
+++ b/crates/ragu_primitives/src/poseidon.rs
@@ -104,18 +104,20 @@ impl<'dr, D: Driver<'dr>, P: ragu_arithmetic::PoseidonPermutation<D::F>> Buffer<
 
 impl<'dr, D: Driver<'dr>, P: ragu_arithmetic::PoseidonPermutation<D::F>> Sponge<'dr, D, P> {
     /// Initialize the sponge in absorb mode with a fixed initial state.
-    pub fn new(dr: &mut D, params: &'dr P) -> Self {
-        Sponge {
+    pub fn new(dr: &mut D, params: &'dr P) -> Result<Self> {
+        Ok(Sponge {
             mode: Mode::Absorb {
                 values: vec![],
                 state: SpongeState {
-                    values: vec![Element::zero(dr); P::T]
+                    values: (0..P::T)
+                        .map(|_| Element::zero(dr))
+                        .collect::<Result<Vec<_>>>()?
                         .try_into()
                         .expect("P::T is the state length"),
                 },
             },
             params,
-        }
+        })
     }
 
     fn permute(&mut self, dr: &mut D) -> Result<()> {
@@ -126,7 +128,7 @@ impl<'dr, D: Driver<'dr>, P: ragu_arithmetic::PoseidonPermutation<D::F>> Sponge<
             }
             Mode::Absorb { values, state } => {
                 for (state, v) in state.values.iter_mut().zip(values.iter()) {
-                    *state = state.add(dr, v);
+                    *state = state.add(dr, v)?;
                 }
                 values.clear();
                 *state = dr.routine(Permutation::from(self.params), state.clone())?;
@@ -328,12 +330,9 @@ fn mds<'i, 'dr, D: Driver<'dr>>(
 ) -> Result<()> {
     assert_eq!(state.len(), matrix.len());
     scratch.clear();
-    scratch.extend(
-        state
-            .iter()
-            .zip(matrix)
-            .map(|(_, coeffs)| multiadd(dr, state, coeffs)),
-    );
+    for (_, coeffs) in state.iter().zip(matrix) {
+        scratch.push(multiadd(dr, state, coeffs)?);
+    }
     state.clone_from_slice(&scratch[..]);
 
     Ok(())
@@ -343,11 +342,12 @@ fn add_round_constants<'dr, D: Driver<'dr>>(
     dr: &mut D,
     state: &mut [Element<'dr, D>],
     round_constants: &[D::F],
-) {
+) -> Result<()> {
     assert_eq!(state.len(), round_constants.len());
     for (x, c) in state.iter_mut().zip(round_constants) {
-        *x = x.add_coeff(dr, &Element::one(), Coeff::Arbitrary(*c));
+        *x = x.add_coeff(dr, &Element::one(), Coeff::Arbitrary(*c))?;
     }
+    Ok(())
 }
 
 struct Permutation<'a, F: Field, P: ragu_arithmetic::PoseidonPermutation<F>> {
@@ -394,7 +394,7 @@ impl<F: Field, P: ragu_arithmetic::PoseidonPermutation<F>> Routine<F> for Permut
                 dr,
                 &mut state.values[..],
                 rcs.next().expect("round constants match total round count"),
-            );
+            )?;
             sbox::<_, P>(dr, &mut state.values[0..elems])?;
             mds(
                 dr,
@@ -445,7 +445,7 @@ mod tests {
             let mut sponge = Sponge::<'_, _, <Pasta as Cycle>::CircuitPoseidon>::new(
                 dr,
                 Pasta::circuit_poseidon(params),
-            );
+            )?;
             let value = Element::alloc(dr, value)?;
             sponge.absorb(dr, &value)?;
             sponge.squeeze(dr)?;
@@ -467,7 +467,7 @@ mod tests {
             let sponge = Sponge::<'_, _, <Pasta as Cycle>::CircuitPoseidon>::new(
                 dr,
                 Pasta::circuit_poseidon(params),
-            );
+            )?;
             // Try to save without absorbing anything
             let result = sponge.save_state(dr);
             assert!(matches!(result, Err(SaveError::NothingAbsorbed)));
@@ -485,7 +485,7 @@ mod tests {
         let mut sponge = Sponge::<'_, _, <Pasta as Cycle>::CircuitPoseidon>::new(
             &mut dr,
             Pasta::circuit_poseidon(params),
-        );
+        )?;
 
         // Squeeze without absorbing anything should fail
         assert!(sponge.squeeze(&mut dr).is_err());
@@ -500,7 +500,7 @@ mod tests {
             let mut sponge = Sponge::<'_, _, <Pasta as Cycle>::CircuitPoseidon>::new(
                 dr,
                 Pasta::circuit_poseidon(params),
-            );
+            )?;
             let value = Element::alloc(dr, value)?;
             sponge.absorb(dr, &value)?;
             // Squeeze to enter squeeze mode
@@ -523,7 +523,7 @@ mod tests {
             let mut sponge = Sponge::<'_, _, <Pasta as Cycle>::CircuitPoseidon>::new(
                 dr,
                 Pasta::circuit_poseidon(params),
-            );
+            )?;
             let value = Element::alloc(dr, value)?;
             sponge.absorb(dr, &value)?;
             // Save should succeed
@@ -548,7 +548,7 @@ mod tests {
             let mut sponge = Sponge::<'_, _, <Pasta as Cycle>::CircuitPoseidon>::new(
                 dr,
                 Pasta::circuit_poseidon(params),
-            );
+            )?;
             let value = Element::alloc(dr, value)?;
             sponge.absorb(dr, &value)?;
             let squeezed = sponge.squeeze(dr)?;
@@ -561,7 +561,7 @@ mod tests {
             let mut sponge = Sponge::<'_, _, <Pasta as Cycle>::CircuitPoseidon>::new(
                 dr,
                 Pasta::circuit_poseidon(params),
-            );
+            )?;
             let value = Element::alloc(dr, value)?;
             sponge.absorb(dr, &value)?;
             let state = sponge.save_state(dr).expect("save_state should succeed");
@@ -592,7 +592,7 @@ mod tests {
             let mut sponge = Sponge::<'_, _, <Pasta as Cycle>::CircuitPoseidon>::new(
                 dr,
                 Pasta::circuit_poseidon(params),
-            );
+            )?;
             let (v1, v2) = v.cast();
             let v1 = Element::alloc(dr, v1)?;
             let v2 = Element::alloc(dr, v2)?;
@@ -611,7 +611,7 @@ mod tests {
             let mut sponge = Sponge::<'_, _, <Pasta as Cycle>::CircuitPoseidon>::new(
                 dr,
                 Pasta::circuit_poseidon(params),
-            );
+            )?;
             let (v1, v2) = v.cast();
             let v1 = Element::alloc(dr, v1)?;
             let v2 = Element::alloc(dr, v2)?;

--- a/crates/ragu_primitives/src/promotion.rs
+++ b/crates/ragu_primitives/src/promotion.rs
@@ -72,7 +72,7 @@ impl<'dr, D: Driver<'dr>> Driver<'dr> for DemotedDriver<D> {
         unreachable!("DemotedDriver cannot be constructed")
     }
 
-    fn add(&mut self, _: impl Fn(Self::LCadd) -> Self::LCadd) -> Self::Wire {
+    fn add(&mut self, _: impl Fn(Self::LCadd) -> Self::LCadd) -> Result<Self::Wire> {
         unreachable!("DemotedDriver cannot be constructed")
     }
 

--- a/crates/ragu_primitives/src/simulator.rs
+++ b/crates/ragu_primitives/src/simulator.rs
@@ -130,13 +130,13 @@ impl<'dr, F: Field> Driver<'dr> for Simulator<F> {
         Ok(value.value())
     }
 
-    fn constant(&mut self, value: Coeff<Self::F>) -> Self::Wire {
-        value.value()
+    fn constant(&mut self, value: Coeff<Self::F>) -> Result<Self::Wire> {
+        Ok(value.value())
     }
 
-    fn add(&mut self, lc: impl Fn(Self::LCadd) -> Self::LCadd) -> Self::Wire {
+    fn add(&mut self, lc: impl Fn(Self::LCadd) -> Self::LCadd) -> Result<Self::Wire> {
         let lc = lc(DirectSum::default());
-        lc.value()
+        Ok(lc.value())
     }
 
     fn enforce_zero(&mut self, lc: impl Fn(Self::LCenforce) -> Self::LCenforce) -> Result<()> {

--- a/crates/ragu_testing/src/circuits/mod.rs
+++ b/crates/ragu_testing/src/circuits/mod.rs
@@ -52,8 +52,8 @@ impl<F: Field> Circuit<F> for MySimpleCircuit {
 
         dr.enforce_zero(|lc| lc.add(a5.wire()).sub(b2.wire()))?;
 
-        let c = a.add(dr, &b);
-        let d = a.sub(dr, &b);
+        let c = a.add(dr, &b)?;
+        let d = a.sub(dr, &b)?;
 
         Ok(WithAux::new((c, d), D::unit()))
     }

--- a/crates/ragu_testing/src/pcd/nontrivial.rs
+++ b/crates/ragu_testing/src/pcd/nontrivial.rs
@@ -77,7 +77,7 @@ impl<C: Cycle> Step<C> for Hash2<'_, C> {
         let left = Encoded::new(dr, left)?;
         let right = Encoded::new(dr, right)?;
 
-        let mut sponge = Sponge::new(dr, self.poseidon_params);
+        let mut sponge = Sponge::new(dr, self.poseidon_params)?;
         sponge.absorb(dr, left.as_gadget())?;
         sponge.absorb(dr, right.as_gadget())?;
         let output = sponge.squeeze(dr)?;
@@ -119,7 +119,7 @@ impl<C: Cycle> Step<C> for WitnessLeaf<'_, C> {
         Self: 'dr,
     {
         let leaf = Element::alloc(dr, witness)?;
-        let mut sponge = Sponge::new(dr, self.poseidon_params);
+        let mut sponge = Sponge::new(dr, self.poseidon_params)?;
         sponge.absorb(dr, &leaf)?;
         let leaf = sponge.squeeze(dr)?;
         let leaf_data = leaf.value().map(|v| *v);


### PR DESCRIPTION
Addressing my own comment: https://github.com/tachyon-zcash/ragu/pull/600#discussion_r3004316063

Change `Driver::constant()` and `Driver::add()` to return `Result<Self::Wire>,` aligning them with `mul(),` `alloc(),` `gate(),` and `enforce_zero()` which were already fallible. This lets `BondingValidator` return `Err` immediately on constraint violations instead of accumulating errors in an `Option` field and checking after the witness completes.
