### PR TITLE
chore: remove consequence language from API contract doc

### DIFF
--- a/.claude/book-review/standards.md
+++ b/.claude/book-review/standards.md
@@ -51,6 +51,17 @@ rules:
 - Nested brackets are acceptable when a citation tag appears inside link
   text (e.g., `[Halo [BGH19]](url)`). Do not flag this as a style issue.
 
+## API Contracts
+
+When describing API contracts (preconditions, invariants, required properties),
+state the contract itself — not the consequences of violating it. Adding
+"violations may cause panics or incorrect behavior" is noise, since *any*
+contract violation can produce incorrect behavior. The documentation should be
+aimed at consumers; implementors know they must satisfy the contract.
+
+Exception: `# Safety` sections on `unsafe` items, where the consequences
+are undefined behavior and the caller must be warned explicitly.
+
 ## Code Accuracy
 
 When book prose describes a specific API signature, trait method, default

--- a/crates/ragu_arithmetic/src/util.rs
+++ b/crates/ragu_arithmetic/src/util.rs
@@ -183,8 +183,7 @@ pub fn batch_to_affine<C: CurveAffine, const N: usize>(projectives: [C::Curve; N
 /// # Correctness
 ///
 /// The caller must ensure that `coeffs` and `bases` yield the same number of
-/// elements. If they differ, the shorter iterator silently wins (via `zip`)
-/// and the result will be incorrect.
+/// elements.
 pub fn mul<
     'a,
     C: CurveAffine,

--- a/crates/ragu_core/src/gadgets.rs
+++ b/crates/ragu_core/src/gadgets.rs
@@ -201,8 +201,7 @@ pub trait Gadget<'dr, D: Driver<'dr>>: Clone {
 /// * `D::Wire: Send` implies `Rebind<'dr, D>: Send`.
 ///
 /// This is the **only** safety invariant. Fungibility (documented on
-/// [`Gadget`]) is a separate API contract: violating it may produce incorrect
-/// circuits but does not cause undefined behavior and is not `unsafe`.
+/// [`Gadget`]) is a separate API contract, not a safety invariant.
 ///
 /// It is difficult to express the `Send` bound for all gadgets in Rust's type
 /// system, though it can be done with enormous API complexity. Instead, this

--- a/crates/ragu_primitives/src/element.rs
+++ b/crates/ragu_primitives/src/element.rs
@@ -127,7 +127,8 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
 
     /// Constructs a new element from a wire and a witness value. **It is the
     /// caller's responsibility to ensure that the provided witness value is
-    /// consistent with the provided wire's value.**
+    /// consistent with the provided wire's actual assignment.** If they disagree,
+    /// other witness logic could produce assignments that violate constraints.
     pub fn promote(wire: D::Wire, value: DriverValue<D, D::F>) -> Self {
         Element { wire, value }
     }

--- a/crates/ragu_primitives/src/element.rs
+++ b/crates/ragu_primitives/src/element.rs
@@ -125,10 +125,9 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
         Element { value, wire }
     }
 
-    /// Constructs a new element from a wire and a witness value. **It is the
-    /// caller's responsibility to ensure that the provided witness value is
-    /// consistent with the provided wire's value.** If the values disagree,
-    /// downstream constraints may silently produce incorrect witnesses.
+    /// Constructs a new element from a wire and a witness value. **The
+    /// provided witness value must be consistent with the provided wire's
+    /// value.**
     pub fn promote(wire: D::Wire, value: DriverValue<D, D::F>) -> Self {
         Element { wire, value }
     }

--- a/crates/ragu_primitives/src/element.rs
+++ b/crates/ragu_primitives/src/element.rs
@@ -125,9 +125,9 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
         Element { value, wire }
     }
 
-    /// Constructs a new element from a wire and a witness value. **The
-    /// provided witness value must be consistent with the provided wire's
-    /// value.**
+    /// Constructs a new element from a wire and a witness value. **It is the
+    /// caller's responsibility to ensure that the provided witness value is
+    /// consistent with the provided wire's value.**
     pub fn promote(wire: D::Wire, value: DriverValue<D, D::F>) -> Self {
         Element { wire, value }
     }

--- a/crates/ragu_primitives/src/point.rs
+++ b/crates/ragu_primitives/src/point.rs
@@ -145,8 +145,7 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
         Ok(Point::new_unchecked(x3, y3))
     }
 
-    /// Adds two points with different x-coordinates. If the x-coordinates are
-    /// equal, the division by `x_1 - x_0` is undefined and synthesis will fail.
+    /// Adds two points. The two points must have different x-coordinates.
     ///
     /// If you cannot guarantee `x_0 != x_1` up front, pass `Some(acc)` via
     /// `nonzero`. On each call, `*acc` is multiplied by `x_1 - x_0`. After
@@ -182,7 +181,6 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
 
     /// Computes $\[2\] Q + P$. **The caller must ensure that $P$ and $Q$ do not
     /// have the same x-coordinate and that the result is not the identity.**
-    /// Violating either precondition causes a division by zero during synthesis.
     pub fn double_and_add_incomplete(&self, dr: &mut D, other: &Self) -> Result<Self> {
         // See <https://github.com/zcash/zcash/issues/3924> for an explanation.
 


### PR DESCRIPTION
 - Remove \"violations may cause X\" language
from 5 doc comments across `ragu_core`, `ragu_primitives`, and `ragu_arithmetic` — state the contract, not the consequences (per @ebfull feedback on #532 )
- Add matching API Contracts section to `.claude/book-review/standards.md`

closes #617 