### PR TITLE
Bundle HEADER_SIZE const generic into PcdConfig trait

### DIFF
--- a/crates/ragu_pcd/src/fuse/_01_application.rs
+++ b/crates/ragu_pcd/src/fuse/_01_application.rs
@@ -11,11 +11,11 @@ use ragu_core::Result;
 use rand::CryptoRng;
 
 use crate::{
-    Application, Header, Pcd, Proof, proof,
+    Application, Header, Pcd, PcdConfig, Proof, proof,
     step::{Step, internal::adapter::Adapter},
 };
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, Cfg: PcdConfig> Application<'_, C, R, Cfg> {
     pub(super) fn compute_application_proof<'source, RNG: CryptoRng, S: Step<C>>(
         &self,
         rng: &mut RNG,
@@ -32,7 +32,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
     )> {
         let (left_proof, left_data) = left.into_parts();
         let (right_proof, right_data) = right.into_parts();
-        let (trace, aux) = Adapter::<C, S, R, HEADER_SIZE>::new(step)
+        let (trace, aux) = Adapter::<C, S, R, Cfg>::new(step)
             .trace((left_data, right_data, witness))?
             .into_parts();
         let rx = self.native_registry.assemble(

--- a/crates/ragu_pcd/src/fuse/_02_preamble.rs
+++ b/crates/ragu_pcd/src/fuse/_02_preamble.rs
@@ -10,12 +10,12 @@ use ragu_core::Result;
 use rand::CryptoRng;
 
 use crate::{
-    Application, Proof,
+    Application, PcdConfig, Proof,
     internal::{native, nested},
     proof,
 };
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, Cfg: PcdConfig> Application<'_, C, R, Cfg> {
     pub(super) fn compute_preamble<'a, RNG: CryptoRng>(
         &self,
         rng: &mut RNG,
@@ -24,7 +24,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         application: &proof::Application<C, R>,
     ) -> Result<(
         proof::Preamble<C, R>,
-        native::stages::preamble::Witness<'a, C, R, HEADER_SIZE>,
+        native::stages::preamble::Witness<'a, C, R, Cfg::HeaderSize>,
     )> {
         let (native, preamble_witness) =
             self.compute_native_preamble(rng, left, right, application)?;
@@ -52,7 +52,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         application: &proof::Application<C, R>,
     ) -> Result<(
         proof::RxTriple<C, R>,
-        native::stages::preamble::Witness<'a, C, R, HEADER_SIZE>,
+        native::stages::preamble::Witness<'a, C, R, Cfg::HeaderSize>,
     )> {
         let preamble_witness = native::stages::preamble::Witness::new(
             left,
@@ -61,7 +61,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             &application.right_header,
         )?;
 
-        let rx = native::stages::preamble::Stage::<C, R, HEADER_SIZE>::rx(
+        let rx = native::stages::preamble::Stage::<C, R, Cfg::HeaderSize>::rx(
             C::CircuitField::random(&mut *rng),
             &preamble_witness,
         )?;

--- a/crates/ragu_pcd/src/fuse/_03_s_prime.rs
+++ b/crates/ragu_pcd/src/fuse/_03_s_prime.rs
@@ -9,9 +9,9 @@ use ragu_circuits::{polynomials::Rank, registry::RegistryAt, staging::StageExt};
 use ragu_core::Result;
 use rand::CryptoRng;
 
-use crate::{Application, Proof, internal::nested, proof};
+use crate::{Application, PcdConfig, Proof, internal::nested, proof};
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, Cfg: PcdConfig> Application<'_, C, R, Cfg> {
     pub(super) fn compute_s_prime<RNG: CryptoRng>(
         &self,
         rng: &mut RNG,

--- a/crates/ragu_pcd/src/fuse/_04_inner_error.rs
+++ b/crates/ragu_pcd/src/fuse/_04_inner_error.rs
@@ -15,14 +15,14 @@ use ragu_primitives::Element;
 use rand::CryptoRng;
 
 use crate::{
-    Application,
+    Application, PcdConfig,
     internal::{claims, fold_revdot, native, nested},
     proof,
 };
 
 use super::claims::{FuseBuilder, FuseProofSource};
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, Cfg: PcdConfig> Application<'_, C, R, Cfg> {
     pub(super) fn inner_error_terms<'dr, 'rx, D, RNG: CryptoRng>(
         &self,
         rng: &mut RNG,
@@ -90,7 +90,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                 ),
             };
         let native_rx =
-            native::stages::inner_error::Stage::<C, R, HEADER_SIZE, native::RevdotParameters>::rx(
+            native::stages::inner_error::Stage::<C, R, Cfg::HeaderSize, native::RevdotParameters>::rx(
                 C::CircuitField::random(&mut *rng),
                 &inner_error_witness,
             )?;

--- a/crates/ragu_pcd/src/fuse/_05_outer_error.rs
+++ b/crates/ragu_pcd/src/fuse/_05_outer_error.rs
@@ -21,7 +21,7 @@ use ragu_primitives::{Element, vec::FixedVec};
 use rand::CryptoRng;
 
 use crate::{
-    Application,
+    Application, PcdConfig,
     internal::{
         fold_revdot, native,
         native::stages::outer_error::{ChildKyValues, KyValues},
@@ -34,11 +34,11 @@ use super::claims::{FoldKey, FuseBuilder, TrackedPoly};
 
 type NativeNumGroups = <native::RevdotParameters as fold_revdot::Parameters>::NumGroups;
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, Cfg: PcdConfig> Application<'_, C, R, Cfg> {
     pub(super) fn outer_error_terms<'dr, 'rx, D, RNG: CryptoRng>(
         &self,
         rng: &mut RNG,
-        preamble_witness: &native::stages::preamble::Witness<'_, C, R, HEADER_SIZE>,
+        preamble_witness: &native::stages::preamble::Witness<'_, C, R, Cfg::HeaderSize>,
         inner_error_witness: &native::stages::inner_error::Witness<C, native::RevdotParameters>,
         claims: FuseBuilder<'_, 'rx, C::CircuitField, R>,
         y: &Element<'dr, D>,
@@ -77,7 +77,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             |dr, witness| {
                 let (preamble_witness, inner_error_terms, y, mu, nu) = witness.cast();
 
-                let preamble = native::stages::preamble::Stage::<C, R, HEADER_SIZE>::default()
+                let preamble = native::stages::preamble::Stage::<C, R, Cfg::HeaderSize>::default()
                     .witness(dr, preamble_witness.as_ref().map(|w| *w))?;
 
                 let y = Element::alloc(dr, y)?;
@@ -175,7 +175,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         outer_error_witness: &native::stages::outer_error::Witness<C, native::RevdotParameters>,
     ) -> Result<proof::RxTriple<C, R>> {
         let rx =
-            native::stages::outer_error::Stage::<C, R, HEADER_SIZE, native::RevdotParameters>::rx(
+            native::stages::outer_error::Stage::<C, R, Cfg::HeaderSize, native::RevdotParameters>::rx(
                 C::CircuitField::random(&mut *rng),
                 outer_error_witness,
             )?;

--- a/crates/ragu_pcd/src/fuse/_06_ab.rs
+++ b/crates/ragu_pcd/src/fuse/_06_ab.rs
@@ -40,7 +40,7 @@ use rand::CryptoRng;
 use alloc::vec::Vec;
 
 use crate::{
-    Application,
+    Application, PcdConfig,
     internal::{fold_revdot, native, nested},
     proof,
 };
@@ -49,7 +49,7 @@ use super::claims::{FoldKey, FuseProofSource, TrackedPoly};
 
 type NativeNumGroups = <native::RevdotParameters as fold_revdot::Parameters>::NumGroups;
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, Cfg: PcdConfig> Application<'_, C, R, Cfg> {
     pub(super) fn compute_ab<'dr, D>(
         &self,
         rng: &mut impl CryptoRng,

--- a/crates/ragu_pcd/src/fuse/_07_query.rs
+++ b/crates/ragu_pcd/src/fuse/_07_query.rs
@@ -16,12 +16,12 @@ use ragu_primitives::Element;
 use rand::CryptoRng;
 
 use crate::{
-    Application, Proof,
+    Application, PcdConfig, Proof,
     internal::{native, nested},
     proof,
 };
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, Cfg: PcdConfig> Application<'_, C, R, Cfg> {
     pub(super) fn compute_query<'dr, D, RNG: CryptoRng>(
         &self,
         rng: &mut RNG,
@@ -105,7 +105,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             ),
         };
 
-        let rx = native::stages::query::Stage::<C, R, HEADER_SIZE>::rx(
+        let rx = native::stages::query::Stage::<C, R, Cfg::HeaderSize>::rx(
             C::CircuitField::random(&mut *rng),
             &query_witness,
         )?;

--- a/crates/ragu_pcd/src/fuse/_08_f.rs
+++ b/crates/ragu_pcd/src/fuse/_08_f.rs
@@ -22,12 +22,12 @@ use rand::CryptoRng;
 use alloc::{vec, vec::Vec};
 
 use crate::{
-    Application, Proof,
+    Application, PcdConfig, Proof,
     internal::{native, native::RxIndex, nested},
     proof,
 };
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, Cfg: PcdConfig> Application<'_, C, R, Cfg> {
     pub(super) fn compute_f<'dr, D, RNG: CryptoRng>(
         &self,
         rng: &mut RNG,

--- a/crates/ragu_pcd/src/fuse/_09_eval.rs
+++ b/crates/ragu_pcd/src/fuse/_09_eval.rs
@@ -12,12 +12,12 @@ use ragu_primitives::Element;
 use rand::CryptoRng;
 
 use crate::{
-    Application, Proof,
+    Application, PcdConfig, Proof,
     internal::{native, nested},
     proof,
 };
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, Cfg: PcdConfig> Application<'_, C, R, Cfg> {
     pub(super) fn compute_eval<'dr, D, RNG: CryptoRng>(
         &self,
         rng: &mut RNG,
@@ -92,7 +92,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                 registry_xy: query.native.registry_xy_poly.eval(u),
             },
         };
-        let rx = native::stages::eval::Stage::<C, R, HEADER_SIZE>::rx(
+        let rx = native::stages::eval::Stage::<C, R, Cfg::HeaderSize>::rx(
             C::CircuitField::random(&mut *rng),
             &eval_witness,
         )?;

--- a/crates/ragu_pcd/src/fuse/_10_p.rs
+++ b/crates/ragu_pcd/src/fuse/_10_p.rs
@@ -27,7 +27,7 @@ use crate::internal::endoscalar::{
 };
 use crate::internal::native::RxIndex;
 use crate::internal::nested::NUM_ENDOSCALING_POINTS;
-use crate::{Application, Proof, proof};
+use crate::{Application, PcdConfig, Proof, proof};
 
 /// Accumulates polynomials with their commitments.
 struct Accumulator<'a, C: Cycle, R: Rank> {
@@ -47,7 +47,7 @@ impl<C: Cycle, R: Rank> Accumulator<'_, C, R> {
     }
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, Cfg: PcdConfig> Application<'_, C, R, Cfg> {
     pub(super) fn compute_p<'dr, D, RNG: rand::CryptoRng>(
         &self,
         rng: &mut RNG,

--- a/crates/ragu_pcd/src/fuse/_11_circuits.rs
+++ b/crates/ragu_pcd/src/fuse/_11_circuits.rs
@@ -4,12 +4,12 @@ use ragu_core::Result;
 use rand::CryptoRng;
 
 use crate::{
-    Application,
+    Application, PcdConfig,
     internal::{native, native::total_circuit_counts},
     proof,
 };
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, Cfg: PcdConfig> Application<'_, C, R, Cfg> {
     pub(super) fn compute_internal_circuits<RNG: CryptoRng>(
         &self,
         rng: &mut RNG,
@@ -22,7 +22,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         f: &proof::F<C, R>,
         eval: &proof::Eval<C, R>,
         p: &proof::P<C, R>,
-        preamble_witness: &native::stages::preamble::Witness<'_, C, R, HEADER_SIZE>,
+        preamble_witness: &native::stages::preamble::Witness<'_, C, R, Cfg::HeaderSize>,
         outer_error_witness: &native::stages::outer_error::Witness<C, native::RevdotParameters>,
         inner_error_witness: &native::stages::inner_error::Witness<C, native::RevdotParameters>,
         query_witness: &native::stages::query::Witness<C>,
@@ -57,7 +57,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         let (hashes_1_trace, unified) = native::circuits::hashes_1::Circuit::<
             C,
             R,
-            HEADER_SIZE,
+            Cfg::HeaderSize,
             native::RevdotParameters,
         >::new(
             self.params,
@@ -78,7 +78,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         let (hashes_2_trace, unified) = native::circuits::hashes_2::Circuit::<
             C,
             R,
-            HEADER_SIZE,
+            Cfg::HeaderSize,
             native::RevdotParameters,
         >::new(self.params)
         .trace(native::circuits::hashes_2::Witness {
@@ -95,7 +95,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         let (inner_collapse_trace, unified) = native::circuits::inner_collapse::Circuit::<
             C,
             R,
-            HEADER_SIZE,
+            Cfg::HeaderSize,
             native::RevdotParameters,
         >::new()
         .trace(native::circuits::inner_collapse::Witness {
@@ -114,7 +114,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         let (outer_collapse_trace, unified) = native::circuits::outer_collapse::Circuit::<
             C,
             R,
-            HEADER_SIZE,
+            Cfg::HeaderSize,
             native::RevdotParameters,
         >::new()
         .trace(native::circuits::outer_collapse::Witness {
@@ -130,7 +130,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         )?;
 
         let (compute_v_trace, unified) =
-            native::circuits::compute_v::Circuit::<C, R, HEADER_SIZE>::new()
+            native::circuits::compute_v::Circuit::<C, R, Cfg::HeaderSize>::new()
                 .trace(native::circuits::compute_v::Witness {
                     unified,
                     preamble_witness,

--- a/crates/ragu_pcd/src/fuse/mod.rs
+++ b/crates/ragu_pcd/src/fuse/mod.rs
@@ -23,12 +23,12 @@ use ragu_primitives::{GadgetExt, Point, vec::CollectFixed};
 use rand::CryptoRng;
 
 use crate::{
-    Application, Pcd, Proof, RAGU_TAG, internal::transcript::Transcript, proof, step::Step,
+    Application, Pcd, PcdConfig, Proof, RAGU_TAG, internal::transcript::Transcript, proof, step::Step,
 };
 
 use claims::FuseProofSource;
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, Cfg: PcdConfig> Application<'_, C, R, Cfg> {
     /// Fuse two [`Pcd`] into one using a provided [`Step`].
     ///
     /// The provided `step` must have been previously registered with this

--- a/crates/ragu_pcd/src/internal/native/circuits/compute_v.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/compute_v.rs
@@ -56,7 +56,7 @@ use ragu_core::{
     gadgets::Bound,
     maybe::Maybe,
 };
-use ragu_primitives::{Element, Endoscalar, GadgetExt};
+use ragu_primitives::{Element, Endoscalar, GadgetExt, vec::Len};
 
 use alloc::{vec, vec::Vec};
 use core::marker::PhantomData;
@@ -85,11 +85,11 @@ use ragu_circuits::horner::Horner;
 ///
 /// [module-level documentation]: self
 /// [$v$]: unified::Output::v
-pub struct Circuit<C: Cycle, R, const HEADER_SIZE: usize> {
-    _marker: PhantomData<(C, R)>,
+pub struct Circuit<C: Cycle, R, HS: Len> {
+    _marker: PhantomData<fn() -> (C, R, HS)>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Circuit<C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, HS: Len> Circuit<C, R, HS> {
     pub fn new() -> MultiStage<C::CircuitField, R, Self> {
         MultiStage::new(Circuit {
             _marker: PhantomData,
@@ -105,24 +105,24 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Circuit<C, R, HEADER_SIZE> {
 /// - Evaluation component polynomials from eval stage
 ///
 /// [$v$]: unified::Output::v
-pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize> {
+pub struct Witness<'a, C: Cycle, R: Rank, HS: Len> {
     /// The unified instance containing challenges and accumulated coverage.
     pub unified: unified::Instance<C>,
     /// Witness for the preamble stage (provides child proof data).
-    pub preamble_witness: &'a native_preamble::Witness<'a, C, R, HEADER_SIZE>,
+    pub preamble_witness: &'a native_preamble::Witness<'a, C, R, HS>,
     /// Witness for the query stage (provides registry and polynomial evaluations).
     pub query_witness: &'a native_query::Witness<C>,
     /// Witness for the eval stage (provides evaluation component polynomials).
     pub eval_witness: &'a native_eval::Witness<C::CircuitField>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> MultiStageCircuit<C::CircuitField, R>
-    for Circuit<C, R, HEADER_SIZE>
+impl<C: Cycle, R: Rank, HS: Len> MultiStageCircuit<C::CircuitField, R>
+    for Circuit<C, R, HS>
 {
-    type Last = native_eval::Stage<C, R, HEADER_SIZE>;
+    type Last = native_eval::Stage<C, R, HS>;
 
     type Instance<'source> = &'source unified::Instance<C>;
-    type Witness<'source> = Witness<'source, C, R, HEADER_SIZE>;
+    type Witness<'source> = Witness<'source, C, R, HS>;
     type Output = unified::InternalOutputKind<C>;
     type Aux<'source> = unified::Instance<C>;
 
@@ -148,9 +148,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> MultiStageCircuit<C::CircuitFi
         // Set up multi-stage circuit pipeline: preamble -> query -> eval.
         // Each stage provides data needed for the v computation.
         let (preamble, builder) =
-            builder.add_stage::<native_preamble::Stage<C, R, HEADER_SIZE>>()?;
-        let (query, builder) = builder.add_stage::<native_query::Stage<C, R, HEADER_SIZE>>()?;
-        let (eval, builder) = builder.add_stage::<native_eval::Stage<C, R, HEADER_SIZE>>()?;
+            builder.add_stage::<native_preamble::Stage<C, R, HS>>()?;
+        let (query, builder) = builder.add_stage::<native_query::Stage<C, R, HS>>()?;
+        let (eval, builder) = builder.add_stage::<native_eval::Stage<C, R, HS>>()?;
         let dr = builder.finish();
 
         // Preamble is enforced because it contains child proof data that must
@@ -277,14 +277,14 @@ struct Denominators<'dr, D: Driver<'dr>> {
 }
 
 impl<'dr, D: Driver<'dr>> Denominators<'dr, D> {
-    fn new<C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usize>(
+    fn new<C: Cycle<CircuitField = D::F>, HS: Len>(
         dr: &mut D,
         u: &Element<'dr, D>,
         w: &Element<'dr, D>,
         x: &Element<'dr, D>,
         y: &Element<'dr, D>,
         z: &Element<'dr, D>,
-        preamble: &native_preamble::Output<'dr, D, C, HEADER_SIZE>,
+        preamble: &native_preamble::Output<'dr, D, C, HS>,
     ) -> Result<Self>
     where
         D::F: ff::PrimeField,
@@ -556,10 +556,10 @@ fn compute_axbx<'dr, D: Driver<'dr>, P: Parameters>(
 /// [`compute_f`]: crate::Application::compute_f
 /// [$\alpha$]: unified::Output::alpha
 #[rustfmt::skip]
-fn poly_queries<'a, 'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usize>(
+fn poly_queries<'a, 'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, HS: Len>(
     eval: &'a native_eval::Output<'dr, D>,
     query: &'a native_query::Output<'dr, D>,
-    preamble: &'a native_preamble::Output<'dr, D, C, HEADER_SIZE>,
+    preamble: &'a native_preamble::Output<'dr, D, C, HS>,
     d: &'a Denominators<'dr, D>,
     computed_ax: &'a Element<'dr, D>,
     computed_bx: &'a Element<'dr, D>,

--- a/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
@@ -87,7 +87,7 @@ use ragu_core::{
 use ragu_primitives::{
     Element, GadgetExt,
     io::Write,
-    vec::{ConstLen, FixedVec},
+    vec::{Len, FixedVec},
 };
 
 use core::marker::PhantomData;
@@ -110,16 +110,16 @@ use crate::internal::{suffix::WithSuffix, transcript::Transcript};
 /// Other internal circuits use only the [`unified::Output`] to avoid the
 /// overhead of witnessing headers in circuits that do not require them.
 #[derive(Gadget, Write)]
-pub struct Output<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usize> {
+pub struct Output<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, HS: Len> {
     /// The unified instance shared across internal circuits.
     #[ragu(gadget)]
     pub unified: unified::Output<'dr, D, C>,
     /// The left child proof's output header.
     #[ragu(gadget)]
-    pub left_header: FixedVec<Element<'dr, D>, ConstLen<HEADER_SIZE>>,
+    pub left_header: FixedVec<Element<'dr, D>, HS>,
     /// The right child proof's output header.
     #[ragu(gadget)]
-    pub right_header: FixedVec<Element<'dr, D>, ConstLen<HEADER_SIZE>>,
+    pub right_header: FixedVec<Element<'dr, D>, HS>,
 }
 
 /// First hash circuit for Fiat-Shamir challenge derivation.
@@ -128,14 +128,14 @@ pub struct Output<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEAD
 /// circuit.
 ///
 /// [module-level documentation]: self
-pub struct Circuit<'params, C: Cycle, R, const HEADER_SIZE: usize, FP: fold_revdot::Parameters> {
+pub struct Circuit<'params, C: Cycle, R, HS: Len, FP: fold_revdot::Parameters> {
     params: &'params C::Params,
     log2_circuits: u32,
-    _marker: PhantomData<(R, FP)>,
+    _marker: PhantomData<fn() -> (R, HS, FP)>,
 }
 
-impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    Circuit<'params, C, R, HEADER_SIZE, FP>
+impl<'params, C: Cycle, R: Rank, HS: Len, FP: fold_revdot::Parameters>
+    Circuit<'params, C, R, HS, FP>
 {
     /// Creates a new multi-stage circuit.
     ///
@@ -160,7 +160,7 @@ impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Para
 ///
 /// Combines the unified instance with stage witnesses needed to perform the
 /// Fiat-Shamir derivations and $k(y)$ consistency checks.
-pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters> {
+pub struct Witness<'a, C: Cycle, R: Rank, HS: Len, FP: fold_revdot::Parameters> {
     /// The unified instance containing expected challenge values and
     /// accumulated coverage from prior circuits.
     pub unified: unified::Instance<C>,
@@ -169,7 +169,7 @@ pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_rev
     /// (unenforced).
     ///
     /// Provides output headers and data for computing $k(y)$ evaluations.
-    pub preamble_witness: &'a native_preamble::Witness<'a, C, R, HEADER_SIZE>,
+    pub preamble_witness: &'a native_preamble::Witness<'a, C, R, HS>,
 
     /// Witness for the [`outer_error`](super::super::stages::outer_error) stage
     /// (unenforced).
@@ -179,14 +179,14 @@ pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_rev
     pub outer_error_witness: &'a native_outer_error::Witness<C, FP>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    MultiStageCircuit<C::CircuitField, R> for Circuit<'_, C, R, HEADER_SIZE, FP>
+impl<C: Cycle, R: Rank, HS: Len, FP: fold_revdot::Parameters>
+    MultiStageCircuit<C::CircuitField, R> for Circuit<'_, C, R, HS, FP>
 {
-    type Last = native_outer_error::Stage<C, R, HEADER_SIZE, FP>;
+    type Last = native_outer_error::Stage<C, R, HS, FP>;
 
     type Instance<'source> = &'source unified::Instance<C>;
-    type Witness<'source> = Witness<'source, C, R, HEADER_SIZE, FP>;
-    type Output = Kind![C::CircuitField; WithSuffix<'_, _, Output<'_, _, C, HEADER_SIZE>>];
+    type Witness<'source> = Witness<'source, C, R, HS, FP>;
+    type Output = Kind![C::CircuitField; WithSuffix<'_, _, Output<'_, _, C, HS>>];
     type Aux<'source> = unified::Instance<C>;
 
     fn instance<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>>(
@@ -209,9 +209,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         Self: 'dr,
     {
         let (preamble, builder) =
-            builder.add_stage::<native_preamble::Stage<C, R, HEADER_SIZE>>()?;
+            builder.add_stage::<native_preamble::Stage<C, R, HS>>()?;
         let (outer_error, builder) =
-            builder.add_stage::<native_outer_error::Stage<C, R, HEADER_SIZE, FP>>()?;
+            builder.add_stage::<native_outer_error::Stage<C, R, HS, FP>>()?;
         let dr = builder.finish();
 
         let preamble = preamble.unenforced(dr, witness.as_ref().map(|w| w.preamble_witness))?;

--- a/crates/ragu_pcd/src/internal/native/circuits/hashes_2.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/hashes_2.rs
@@ -70,8 +70,7 @@ use ragu_core::{
     gadgets::Bound,
     maybe::Maybe,
 };
-use ragu_primitives::GadgetExt;
-
+use ragu_primitives::{GadgetExt, vec::Len};
 use core::marker::PhantomData;
 
 use super::super::{
@@ -87,13 +86,13 @@ use crate::internal::transcript::Transcript;
 /// circuit.
 ///
 /// [module-level documentation]: self
-pub struct Circuit<'params, C: Cycle, R, const HEADER_SIZE: usize, FP: fold_revdot::Parameters> {
+pub struct Circuit<'params, C: Cycle, R, HS: Len, FP: fold_revdot::Parameters> {
     params: &'params C::Params,
-    _marker: PhantomData<(R, FP)>,
+    _marker: PhantomData<fn() -> (R, HS, FP)>,
 }
 
-impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    Circuit<'params, C, R, HEADER_SIZE, FP>
+impl<'params, C: Cycle, R: Rank, HS: Len, FP: fold_revdot::Parameters>
+    Circuit<'params, C, R, HS, FP>
 {
     /// Creates a new multi-stage circuit.
     ///
@@ -125,10 +124,10 @@ pub struct Witness<'a, C: Cycle, FP: fold_revdot::Parameters> {
     pub outer_error_witness: &'a native_outer_error::Witness<C, FP>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    MultiStageCircuit<C::CircuitField, R> for Circuit<'_, C, R, HEADER_SIZE, FP>
+impl<C: Cycle, R: Rank, HS: Len, FP: fold_revdot::Parameters>
+    MultiStageCircuit<C::CircuitField, R> for Circuit<'_, C, R, HS, FP>
 {
-    type Last = native_outer_error::Stage<C, R, HEADER_SIZE, FP>;
+    type Last = native_outer_error::Stage<C, R, HS, FP>;
 
     type Instance<'source> = &'source unified::Instance<C>;
     type Witness<'source> = Witness<'source, C, FP>;
@@ -154,9 +153,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
     where
         Self: 'dr,
     {
-        let builder = builder.skip_stage::<native_preamble::Stage<C, R, HEADER_SIZE>>()?;
+        let builder = builder.skip_stage::<native_preamble::Stage<C, R, HS>>()?;
         let (outer_error, builder) =
-            builder.add_stage::<native_outer_error::Stage<C, R, HEADER_SIZE, FP>>()?;
+            builder.add_stage::<native_outer_error::Stage<C, R, HS, FP>>()?;
         let dr = builder.finish();
 
         let outer_error =

--- a/crates/ragu_pcd/src/internal/native/circuits/inner_collapse.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/inner_collapse.rs
@@ -65,7 +65,7 @@ use ragu_core::{
     gadgets::{Bound, Gadget},
     maybe::Maybe,
 };
-use ragu_primitives::vec::FixedVec;
+use ragu_primitives::vec::{FixedVec, Len};
 
 use core::marker::PhantomData;
 
@@ -85,12 +85,12 @@ use crate::internal::fold_revdot;
 /// performed by this circuit.
 ///
 /// [module-level documentation]: self
-pub struct Circuit<C: Cycle, R, const HEADER_SIZE: usize, FP: fold_revdot::Parameters> {
-    _marker: PhantomData<(C, R, FP)>,
+pub struct Circuit<C: Cycle, R, HS: Len, FP: fold_revdot::Parameters> {
+    _marker: PhantomData<fn() -> (C, R, HS, FP)>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    Circuit<C, R, HEADER_SIZE, FP>
+impl<C: Cycle, R: Rank, HS: Len, FP: fold_revdot::Parameters>
+    Circuit<C, R, HS, FP>
 {
     /// Creates a new multi-stage circuit for layer 1 revdot verification.
     pub fn new() -> MultiStage<C::CircuitField, R, Self> {
@@ -101,9 +101,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
 }
 
 /// Witness for the inner collapse circuit.
-pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters> {
+pub struct Witness<'a, C: Cycle, R: Rank, HS: Len, FP: fold_revdot::Parameters> {
     /// Witness for the preamble stage (contains child unified instances with c values).
-    pub preamble_witness: &'a native_preamble::Witness<'a, C, R, HEADER_SIZE>,
+    pub preamble_witness: &'a native_preamble::Witness<'a, C, R, HS>,
     /// The unified instance containing challenges and accumulated coverage.
     pub unified: unified::Instance<C>,
     /// Witness for the inner error stage (layer 1 error terms).
@@ -112,13 +112,13 @@ pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_rev
     pub outer_error_witness: &'a native_outer_error::Witness<C, FP>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    MultiStageCircuit<C::CircuitField, R> for Circuit<C, R, HEADER_SIZE, FP>
+impl<C: Cycle, R: Rank, HS: Len, FP: fold_revdot::Parameters>
+    MultiStageCircuit<C::CircuitField, R> for Circuit<C, R, HS, FP>
 {
-    type Last = native_inner_error::Stage<C, R, HEADER_SIZE, FP>;
+    type Last = native_inner_error::Stage<C, R, HS, FP>;
 
     type Instance<'source> = &'source unified::Instance<C>;
-    type Witness<'source> = Witness<'source, C, R, HEADER_SIZE, FP>;
+    type Witness<'source> = Witness<'source, C, R, HS, FP>;
     type Output = unified::InternalOutputKind<C>;
     type Aux<'source> = unified::Instance<C>;
 
@@ -142,11 +142,11 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         Self: 'dr,
     {
         let (preamble, builder) =
-            builder.add_stage::<native_preamble::Stage<C, R, HEADER_SIZE>>()?;
+            builder.add_stage::<native_preamble::Stage<C, R, HS>>()?;
         let (outer_error, builder) =
-            builder.add_stage::<native_outer_error::Stage<C, R, HEADER_SIZE, FP>>()?;
+            builder.add_stage::<native_outer_error::Stage<C, R, HS, FP>>()?;
         let (inner_error, builder) =
-            builder.add_stage::<native_inner_error::Stage<C, R, HEADER_SIZE, FP>>()?;
+            builder.add_stage::<native_inner_error::Stage<C, R, HS, FP>>()?;
         let dr = builder.finish();
         let preamble = preamble.unenforced(dr, witness.as_ref().map(|w| w.preamble_witness))?;
         let outer_error =

--- a/crates/ragu_pcd/src/internal/native/circuits/outer_collapse.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/outer_collapse.rs
@@ -52,7 +52,7 @@ use ragu_circuits::{
     polynomials::Rank,
     staging::{MultiStage, MultiStageCircuit, StageBuilder},
 };
-use ragu_core::{
+use ragu_primitives::vec::Len;use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
     gadgets::Bound,
@@ -73,12 +73,12 @@ use crate::internal::fold_revdot;
 /// performed by this circuit.
 ///
 /// [module-level documentation]: self
-pub struct Circuit<C: Cycle, R, const HEADER_SIZE: usize, FP: fold_revdot::Parameters> {
-    _marker: PhantomData<(C, R, FP)>,
+pub struct Circuit<C: Cycle, R, HS: Len, FP: fold_revdot::Parameters> {
+    _marker: PhantomData<fn() -> (C, R, HS, FP)>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    Circuit<C, R, HEADER_SIZE, FP>
+impl<C: Cycle, R: Rank, HS: Len, FP: fold_revdot::Parameters>
+    Circuit<C, R, HS, FP>
 {
     /// Creates a new multi-stage circuit for layer 2 revdot verification.
     pub fn new() -> MultiStage<C::CircuitField, R, Self> {
@@ -92,7 +92,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
 ///
 /// Combines the unified instance with stage witnesses needed to perform the
 /// layer 2 revdot verification and base case check.
-pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters> {
+pub struct Witness<'a, C: Cycle, R: Rank, HS: Len, FP: fold_revdot::Parameters> {
     /// The unified instance containing expected challenge values, the
     /// witnessed [$c$](unified::Output::c) claim, and accumulated coverage.
     pub unified: unified::Instance<C>,
@@ -102,7 +102,7 @@ pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_rev
     ///
     /// Provides access to [`is_base_case`](super::super::stages::preamble::Output::is_base_case)
     /// for conditional constraint enforcement.
-    pub preamble_witness: &'a preamble::Witness<'a, C, R, HEADER_SIZE>,
+    pub preamble_witness: &'a preamble::Witness<'a, C, R, HS>,
 
     /// Witness for the [`outer_error`] stage
     /// (unenforced).
@@ -111,13 +111,13 @@ pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_rev
     pub outer_error_witness: &'a outer_error::Witness<C, FP>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    MultiStageCircuit<C::CircuitField, R> for Circuit<C, R, HEADER_SIZE, FP>
+impl<C: Cycle, R: Rank, HS: Len, FP: fold_revdot::Parameters>
+    MultiStageCircuit<C::CircuitField, R> for Circuit<C, R, HS, FP>
 {
-    type Last = outer_error::Stage<C, R, HEADER_SIZE, FP>;
+    type Last = outer_error::Stage<C, R, HS, FP>;
 
     type Instance<'source> = &'source unified::Instance<C>;
-    type Witness<'source> = Witness<'source, C, R, HEADER_SIZE, FP>;
+    type Witness<'source> = Witness<'source, C, R, HS, FP>;
     type Output = unified::InternalOutputKind<C>;
     type Aux<'source> = unified::Instance<C>;
 
@@ -140,9 +140,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
     where
         Self: 'dr,
     {
-        let (preamble, builder) = builder.add_stage::<preamble::Stage<C, R, HEADER_SIZE>>()?;
+        let (preamble, builder) = builder.add_stage::<preamble::Stage<C, R, HS>>()?;
         let (outer_error, builder) =
-            builder.add_stage::<outer_error::Stage<C, R, HEADER_SIZE, FP>>()?;
+            builder.add_stage::<outer_error::Stage<C, R, HS, FP>>()?;
         let dr = builder.finish();
 
         let preamble = preamble.unenforced(dr, witness.as_ref().map(|w| w.preamble_witness))?;

--- a/crates/ragu_pcd/src/internal/native/mod.rs
+++ b/crates/ragu_pcd/src/internal/native/mod.rs
@@ -7,7 +7,7 @@ use ragu_circuits::{
     staging::StageExt,
 };
 use ragu_core::Result;
-use ragu_primitives::vec::ConstLen;
+use ragu_primitives::vec::{ConstLen, Len};
 
 use crate::internal::fold_revdot::Parameters;
 use crate::step;
@@ -309,7 +309,7 @@ pub enum RxComponent {
 ///
 /// Does not register internal steps (rerandomize, trivial); those are
 /// registered by the caller after this function returns.
-pub fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>(
+pub fn register_all<'params, C: Cycle, R: Rank, HS: Len>(
     mut registry: RegistryBuilder<'params, C::CircuitField, R>,
     params: &'params C::Params,
     log2_circuits: u32,
@@ -320,60 +320,60 @@ pub fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>(
         use InternalCircuitIndex::*;
         registry = match id {
             PreambleStage => {
-                registry.register_bonding(stages::preamble::Stage::<C, R, HEADER_SIZE>::mask()?)
+                registry.register_bonding(stages::preamble::Stage::<C, R, HS>::mask()?)
             }
             InnerErrorStage => registry.register_bonding(stages::inner_error::Stage::<
                 C,
                 R,
-                HEADER_SIZE,
+                HS,
                 RevdotParameters,
             >::mask()?),
             OuterErrorStage => registry.register_bonding(stages::outer_error::Stage::<
                 C,
                 R,
-                HEADER_SIZE,
+                HS,
                 RevdotParameters,
             >::mask()?),
             QueryStage => {
-                registry.register_bonding(stages::query::Stage::<C, R, HEADER_SIZE>::mask()?)
+                registry.register_bonding(stages::query::Stage::<C, R, HS>::mask()?)
             }
             EvalStage => {
-                registry.register_bonding(stages::eval::Stage::<C, R, HEADER_SIZE>::mask()?)
+                registry.register_bonding(stages::eval::Stage::<C, R, HS>::mask()?)
             }
             InnerErrorFinalStaged => registry.register_bonding(stages::inner_error::Stage::<
                 C,
                 R,
-                HEADER_SIZE,
+                HS,
                 RevdotParameters,
             >::final_mask()?),
             OuterErrorFinalStaged => registry.register_bonding(stages::outer_error::Stage::<
                 C,
                 R,
-                HEADER_SIZE,
+                HS,
                 RevdotParameters,
             >::final_mask()?),
             EvalFinalStaged => {
-                registry.register_bonding(stages::eval::Stage::<C, R, HEADER_SIZE>::final_mask()?)
+                registry.register_bonding(stages::eval::Stage::<C, R, HS>::final_mask()?)
             }
             Hashes1Circuit => {
                 registry.register_internal_circuit(circuits::hashes_1::Circuit::<
                     C,
                     R,
-                    HEADER_SIZE,
+                    HS,
                     RevdotParameters,
                 >::new(params, log2_circuits))?
             }
             Hashes2Circuit => registry.register_internal_circuit(circuits::hashes_2::Circuit::<
                 C,
                 R,
-                HEADER_SIZE,
+                HS,
                 RevdotParameters,
             >::new(params))?,
             InnerCollapseCircuit => {
                 registry.register_internal_circuit(circuits::inner_collapse::Circuit::<
                     C,
                     R,
-                    HEADER_SIZE,
+                    HS,
                     RevdotParameters,
                 >::new())?
             }
@@ -381,7 +381,7 @@ pub fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>(
                 registry.register_internal_circuit(circuits::outer_collapse::Circuit::<
                     C,
                     R,
-                    HEADER_SIZE,
+                    HS,
                     RevdotParameters,
                 >::new())?
             }
@@ -389,7 +389,7 @@ pub fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>(
                 registry.register_internal_circuit(circuits::compute_v::Circuit::<
                     C,
                     R,
-                    HEADER_SIZE,
+                    HS,
                 >::new())?
             }
         };

--- a/crates/ragu_pcd/src/internal/native/stages/eval.rs
+++ b/crates/ragu_pcd/src/internal/native/stages/eval.rs
@@ -9,8 +9,7 @@ use ragu_core::{
     gadgets::{Bound, Gadget, Kind},
     maybe::Maybe,
 };
-use ragu_primitives::{Element, io::Write};
-
+use ragu_primitives::{Element, io::Write, vec::Len};
 use core::marker::PhantomData;
 
 use crate::Proof;
@@ -120,15 +119,20 @@ pub struct Output<'dr, D: Driver<'dr>> {
 }
 
 /// The eval stage of the fuse witness.
-#[derive(Default)]
-pub struct Stage<C: Cycle, R, const HEADER_SIZE: usize> {
-    _marker: PhantomData<(C, R)>,
+pub struct Stage<C: Cycle, R, HS: Len> {
+    _marker: PhantomData<fn() -> (C, R, HS)>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> staging::Stage<C::CircuitField, R>
-    for Stage<C, R, HEADER_SIZE>
+impl<C: Cycle, R, HS: Len> Default for Stage<C, R, HS> {
+    fn default() -> Self {
+        Stage { _marker: PhantomData }
+    }
+}
+
+impl<C: Cycle, R: Rank, HS: Len> staging::Stage<C::CircuitField, R>
+    for Stage<C, R, HS>
 {
-    type Parent = super::query::Stage<C, R, HEADER_SIZE>;
+    type Parent = super::query::Stage<C, R, HS>;
     type Witness<'source> = &'source Witness<C::CircuitField>;
     type OutputKind = Kind![C::CircuitField; Output<'_, _>];
 
@@ -169,11 +173,11 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> staging::Stage<C::CircuitField
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::internal::native::stages::tests::{HEADER_SIZE, R, assert_stage_values};
+    use crate::internal::native::stages::tests::{HS, R, assert_stage_values};
     use ragu_pasta::Pasta;
 
     #[test]
     fn stage_values_matches_wire_count() {
-        assert_stage_values(&Stage::<Pasta, R, { HEADER_SIZE }>::default());
+        assert_stage_values(&Stage::<Pasta, R, HS>::default());
     }
 }

--- a/crates/ragu_pcd/src/internal/native/stages/inner_error.rs
+++ b/crates/ragu_pcd/src/internal/native/stages/inner_error.rs
@@ -43,15 +43,20 @@ pub struct Output<'dr, D: Driver<'dr>, FP: fold_revdot::Parameters> {
 }
 
 /// The inner error stage (layer 1) of the fuse witness.
-#[derive(Default)]
-pub struct Stage<C: Cycle, R, const HEADER_SIZE: usize, FP: fold_revdot::Parameters> {
-    _marker: PhantomData<(C, R, FP)>,
+pub struct Stage<C: Cycle, R, HS: Len, FP: fold_revdot::Parameters> {
+    _marker: PhantomData<fn() -> (C, R, HS, FP)>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    staging::Stage<C::CircuitField, R> for Stage<C, R, HEADER_SIZE, FP>
+impl<C: Cycle, R, HS: Len, FP: fold_revdot::Parameters> Default for Stage<C, R, HS, FP> {
+    fn default() -> Self {
+        Stage { _marker: PhantomData }
+    }
+}
+
+impl<C: Cycle, R: Rank, HS: Len, FP: fold_revdot::Parameters>
+    staging::Stage<C::CircuitField, R> for Stage<C, R, HS, FP>
 {
-    type Parent = super::outer_error::Stage<C, R, HEADER_SIZE, FP>;
+    type Parent = super::outer_error::Stage<C, R, HS, FP>;
     type Witness<'source> = &'source Witness<C, FP>;
     type OutputKind = Kind![C::CircuitField; Output<'_, _, FP>];
 
@@ -84,12 +89,12 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
 mod tests {
     use super::*;
     use crate::internal::native::stages::tests::{
-        HEADER_SIZE, R, RevdotParameters, assert_stage_values,
+        HS, R, RevdotParameters, assert_stage_values,
     };
     use ragu_pasta::Pasta;
 
     #[test]
     fn stage_values_matches_wire_count() {
-        assert_stage_values(&Stage::<Pasta, R, { HEADER_SIZE }, RevdotParameters>::default());
+        assert_stage_values(&Stage::<Pasta, R, HS, RevdotParameters>::default());
     }
 }

--- a/crates/ragu_pcd/src/internal/native/stages/mod.rs
+++ b/crates/ragu_pcd/src/internal/native/stages/mod.rs
@@ -9,5 +9,5 @@ pub mod query;
 #[cfg(test)]
 pub mod tests {
     pub use crate::internal::native::RevdotParameters;
-    pub use crate::internal::tests::{HEADER_SIZE, R, assert_stage_values};
+    pub use crate::internal::tests::{HS, R, assert_stage_values};
 }

--- a/crates/ragu_pcd/src/internal/native/stages/outer_error.rs
+++ b/crates/ragu_pcd/src/internal/native/stages/outer_error.rs
@@ -104,15 +104,20 @@ pub struct Output<
 }
 
 /// The outer error stage (layer 2) of the fuse witness.
-#[derive(Default)]
-pub struct Stage<C: Cycle, R, const HEADER_SIZE: usize, FP: fold_revdot::Parameters> {
-    _marker: PhantomData<(C, R, FP)>,
+pub struct Stage<C: Cycle, R, HS: Len, FP: fold_revdot::Parameters> {
+    _marker: PhantomData<fn() -> (C, R, HS, FP)>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    staging::Stage<C::CircuitField, R> for Stage<C, R, HEADER_SIZE, FP>
+impl<C: Cycle, R, HS: Len, FP: fold_revdot::Parameters> Default for Stage<C, R, HS, FP> {
+    fn default() -> Self {
+        Stage { _marker: PhantomData }
+    }
+}
+
+impl<C: Cycle, R: Rank, HS: Len, FP: fold_revdot::Parameters>
+    staging::Stage<C::CircuitField, R> for Stage<C, R, HS, FP>
 {
-    type Parent = super::preamble::Stage<C, R, HEADER_SIZE>;
+    type Parent = super::preamble::Stage<C, R, HS>;
     type Witness<'source> = &'source Witness<C, FP>;
     type OutputKind = Kind![C::CircuitField; Output<'_, _, FP, C::CircuitPoseidon>];
 
@@ -169,12 +174,12 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
 mod tests {
     use super::*;
     use crate::internal::native::stages::tests::{
-        HEADER_SIZE, R, RevdotParameters, assert_stage_values,
+        HS, R, RevdotParameters, assert_stage_values,
     };
     use ragu_pasta::Pasta;
 
     #[test]
     fn stage_values_matches_wire_count() {
-        assert_stage_values(&Stage::<Pasta, R, { HEADER_SIZE }, RevdotParameters>::default());
+        assert_stage_values(&Stage::<Pasta, R, HS, RevdotParameters>::default());
     }
 }

--- a/crates/ragu_pcd/src/internal/native/stages/preamble.rs
+++ b/crates/ragu_pcd/src/internal/native/stages/preamble.rs
@@ -14,7 +14,7 @@ use ragu_core::{
 use ragu_primitives::{
     Boolean, Element, GadgetExt,
     consistent::Consistent,
-    vec::{CollectFixed, ConstLen, FixedVec},
+    vec::{CollectFixed, FixedVec, Len},
 };
 
 use alloc::vec::Vec;
@@ -22,12 +22,12 @@ use core::marker::PhantomData;
 
 use crate::{Proof, header::Header, internal::native::unified, step::internal::padded};
 
-type HeaderVec<'dr, D, const HEADER_SIZE: usize> = FixedVec<Element<'dr, D>, ConstLen<HEADER_SIZE>>;
+type HeaderVec<'dr, D, HS> = FixedVec<Element<'dr, D>, HS>;
 
 /// Witness data for a single child proof in the preamble stage.
-pub struct ChildWitness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize> {
+pub struct ChildWitness<'a, C: Cycle, R: Rank, HS: Len> {
     /// Output header for this child proof.
-    pub output_header: FixedVec<C::CircuitField, ConstLen<HEADER_SIZE>>,
+    pub output_header: FixedVec<C::CircuitField, HS>,
     /// Reference to the child proof.
     pub proof: &'a Proof<C, R>,
 }
@@ -36,14 +36,14 @@ pub struct ChildWitness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize> {
 ///
 /// Contains references to the left and right proofs, plus output headers
 /// computed outside the circuit.
-pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize> {
+pub struct Witness<'a, C: Cycle, R: Rank, HS: Len> {
     /// Left child proof witness.
-    pub left: ChildWitness<'a, C, R, HEADER_SIZE>,
+    pub left: ChildWitness<'a, C, R, HS>,
     /// Right child proof witness.
-    pub right: ChildWitness<'a, C, R, HEADER_SIZE>,
+    pub right: ChildWitness<'a, C, R, HS>,
 }
 
-impl<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize> Witness<'a, C, R, HEADER_SIZE> {
+impl<'a, C: Cycle, R: Rank, HS: Len> Witness<'a, C, R, HS> {
     /// Create a witness from child proof references and pre-computed output headers.
     pub fn new(
         left: &'a Proof<C, R>,
@@ -66,33 +66,33 @@ impl<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize> Witness<'a, C, R, HEADER_S
 
 /// Headers claimed by a child proof for its own left and right children.
 #[derive(Gadget, Consistent)]
-pub struct ChildHeaders<'dr, D: Driver<'dr>, const HEADER_SIZE: usize> {
+pub struct ChildHeaders<'dr, D: Driver<'dr>, HS: Len> {
     /// Left child header (grandchild from current perspective).
     #[ragu(gadget)]
-    pub left: HeaderVec<'dr, D, HEADER_SIZE>,
+    pub left: HeaderVec<'dr, D, HS>,
     /// Right child header (grandchild from current perspective).
     #[ragu(gadget)]
-    pub right: HeaderVec<'dr, D, HEADER_SIZE>,
+    pub right: HeaderVec<'dr, D, HS>,
 }
 
 /// Processed inputs from a single child proof in the preamble stage.
 #[derive(Gadget, Consistent)]
-pub struct ProofInputs<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usize>
+pub struct ProofInputs<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, HS: Len>
 {
     /// Headers this child proof claimed for its own children.
     #[ragu(gadget)]
-    pub children: ChildHeaders<'dr, D, HEADER_SIZE>,
+    pub children: ChildHeaders<'dr, D, HS>,
     /// Output header of this child proof.
     #[ragu(gadget)]
-    pub output_header: HeaderVec<'dr, D, HEADER_SIZE>,
+    pub output_header: HeaderVec<'dr, D, HS>,
     #[ragu(gadget)]
     pub circuit_id: Element<'dr, D>,
     #[ragu(gadget)]
     pub unified: unified::Output<'dr, D, C>,
 }
 
-impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usize>
-    ProofInputs<'dr, D, C, HEADER_SIZE>
+impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, HS: Len>
+    ProofInputs<'dr, D, C, HS>
 {
     /// Compute unified k(y) and unified+bridged k(y) values simultaneously,
     /// sharing computation.
@@ -140,35 +140,36 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usiz
 
     /// Returns true if this child proof is a trivial proof (output header suffix == 1).
     pub fn is_trivial(&self, dr: &mut D) -> Result<Boolean<'dr, D>> {
-        let suffix = &self.output_header[HEADER_SIZE - 1];
+        let suffix = &self.output_header[HS::len() - 1];
         suffix.is_equal(dr, &Element::one())
     }
 }
 
-impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usize>
-    ProofInputs<'dr, D, C, HEADER_SIZE>
+impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, HS: Len>
+    ProofInputs<'dr, D, C, HS>
 {
     /// Allocate ProofInputs from a proof reference and pre-computed output header.
     pub fn alloc<R: Rank>(
         dr: &mut D,
         proof: DriverValue<D, &Proof<C, R>>,
-        output_header: DriverValue<D, &FixedVec<D::F, ConstLen<HEADER_SIZE>>>,
+        output_header: DriverValue<D, &FixedVec<D::F, HS>>,
     ) -> Result<Self> {
-        fn alloc_header<'dr, D: Driver<'dr>, const N: usize>(
+        fn alloc_header<'dr, D: Driver<'dr>, L: Len>(
             dr: &mut D,
             data: DriverValue<D, &[D::F]>,
-        ) -> Result<FixedVec<Element<'dr, D>, ConstLen<N>>> {
+        ) -> Result<FixedVec<Element<'dr, D>, L>> {
+            let n = L::len();
             D::try_just(|| {
-                if data.as_ref().take().len() != N {
+                if data.as_ref().take().len() != n {
                     return Err(Error::MalformedEncoding(
-                        "Header data length does not match HEADER_SIZE".into(),
+                        "Header data length does not match header size".into(),
                     ));
                 }
 
                 Ok(())
             })?;
 
-            (0..N)
+            (0..n)
                 .map(|i| Element::alloc(dr, data.as_ref().map(|d| d[i])))
                 .try_collect_fixed()
         }
@@ -207,9 +208,9 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usiz
             let emulator = &mut Emulator::<Wireless<D::MaybeKind, D::F>>::wireless();
 
             let output = H::encode(emulator, header_data)?;
-            let output = padded::for_header::<H, HEADER_SIZE, _>(emulator, output)?;
+            let output = padded::for_header::<H, HS, _>(emulator, output)?;
 
-            let mut header_data = Vec::with_capacity(HEADER_SIZE);
+            let mut header_data = Vec::with_capacity(HS::len());
             output.write(emulator, &mut header_data)?;
 
             header_data
@@ -227,15 +228,15 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usiz
 /// This is stage communication data, not part of the circuit's public instance.
 /// The verifier never sees these values directly.
 #[derive(Gadget, Consistent)]
-pub struct Output<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usize> {
+pub struct Output<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, HS: Len> {
     #[ragu(gadget)]
-    pub left: ProofInputs<'dr, D, C, HEADER_SIZE>,
+    pub left: ProofInputs<'dr, D, C, HS>,
     #[ragu(gadget)]
-    pub right: ProofInputs<'dr, D, C, HEADER_SIZE>,
+    pub right: ProofInputs<'dr, D, C, HS>,
 }
 
-impl<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usize>
-    Output<'dr, D, C, HEADER_SIZE>
+impl<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, HS: Len>
+    Output<'dr, D, C, HS>
 {
     /// Returns true if both child proofs are trivial proofs.
     pub fn is_base_case(&self, dr: &mut D) -> Result<Boolean<'dr, D>> {
@@ -245,21 +246,26 @@ impl<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usiz
     }
 }
 
-#[derive(Default)]
-pub struct Stage<C: Cycle, R, const HEADER_SIZE: usize> {
-    _marker: PhantomData<(C, R)>,
+pub struct Stage<C: Cycle, R, HS: Len> {
+    _marker: PhantomData<fn() -> (C, R, HS)>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> staging::Stage<C::CircuitField, R>
-    for Stage<C, R, HEADER_SIZE>
+impl<C: Cycle, R, HS: Len> Default for Stage<C, R, HS> {
+    fn default() -> Self {
+        Stage { _marker: PhantomData }
+    }
+}
+
+impl<C: Cycle, R: Rank, HS: Len> staging::Stage<C::CircuitField, R>
+    for Stage<C, R, HS>
 {
     type Parent = ();
-    type Witness<'source> = &'source Witness<'source, C, R, HEADER_SIZE>;
-    type OutputKind = Kind![C::CircuitField; Output<'_, _, C, HEADER_SIZE>];
+    type Witness<'source> = &'source Witness<'source, C, R, HS>;
+    type OutputKind = Kind![C::CircuitField; Output<'_, _, C, HS>];
 
     fn values() -> usize {
-        // 2 proofs * (3 headers * HEADER_SIZE + 1 circuit_id + unified instance wires)
-        2 * (3 * HEADER_SIZE + 1 + unified::NUM_WIRES)
+        // 2 proofs * (3 headers * HS::len() + 1 circuit_id + unified instance wires)
+        2 * (3 * HS::len() + 1 + unified::NUM_WIRES)
     }
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>>(
@@ -289,11 +295,11 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> staging::Stage<C::CircuitField
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::internal::native::stages::tests::{HEADER_SIZE, R, assert_stage_values};
+    use crate::internal::native::stages::tests::{HS, R, assert_stage_values};
     use ragu_pasta::Pasta;
 
     #[test]
     fn stage_values_matches_wire_count() {
-        assert_stage_values(&Stage::<Pasta, R, { HEADER_SIZE }>::default());
+        assert_stage_values(&Stage::<Pasta, R, HS>::default());
     }
 }

--- a/crates/ragu_pcd/src/internal/native/stages/query.rs
+++ b/crates/ragu_pcd/src/internal/native/stages/query.rs
@@ -26,8 +26,7 @@ use ragu_core::{
     gadgets::{Bound, Gadget, Kind},
     maybe::Maybe,
 };
-use ragu_primitives::Element;
-
+use ragu_primitives::{Element, vec::Len};
 use core::marker::PhantomData;
 
 use crate::Proof;
@@ -270,15 +269,20 @@ pub struct Output<'dr, D: Driver<'dr>> {
 }
 
 /// The query stage of the fuse witness.
-#[derive(Default)]
-pub struct Stage<C: Cycle, R, const HEADER_SIZE: usize> {
-    _marker: PhantomData<(C, R)>,
+pub struct Stage<C: Cycle, R, HS: Len> {
+    _marker: PhantomData<fn() -> (C, R, HS)>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> staging::Stage<C::CircuitField, R>
-    for Stage<C, R, HEADER_SIZE>
+impl<C: Cycle, R, HS: Len> Default for Stage<C, R, HS> {
+    fn default() -> Self {
+        Stage { _marker: PhantomData }
+    }
+}
+
+impl<C: Cycle, R: Rank, HS: Len> staging::Stage<C::CircuitField, R>
+    for Stage<C, R, HS>
 {
-    type Parent = super::preamble::Stage<C, R, HEADER_SIZE>;
+    type Parent = super::preamble::Stage<C, R, HS>;
     type Witness<'source> = &'source Witness<C>;
     type OutputKind = Kind![C::CircuitField; Output<'_, _>];
 
@@ -311,11 +315,11 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> staging::Stage<C::CircuitField
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::internal::native::stages::tests::{HEADER_SIZE, R, assert_stage_values};
+    use crate::internal::native::stages::tests::{HS, R, assert_stage_values};
     use ragu_pasta::Pasta;
 
     #[test]
     fn stage_values_matches_wire_count() {
-        assert_stage_values(&Stage::<Pasta, R, { HEADER_SIZE }>::default());
+        assert_stage_values(&Stage::<Pasta, R, HS>::default());
     }
 }

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -6,6 +6,7 @@ use native::{
 };
 use ragu_circuits::staging::{Stage, StageExt};
 use ragu_pasta::{Pasta, fp, fq};
+use ragu_primitives::vec::ConstLen;
 pub type R = ragu_circuits::polynomials::ProductionRank;
 
 use ff::PrimeField;
@@ -40,24 +41,28 @@ where
 //   cargo test -p ragu_pcd --release print_internal_circuit -- --nocapture
 // Then copy-paste the output into the check_constraints! calls in the test below.
 pub const HEADER_SIZE: usize = 65;
+pub type HS = ConstLen<HEADER_SIZE>;
+
+struct TestCfg;
+impl PcdConfig for TestCfg { type HeaderSize = HS; }
 
 // Number of dummy application circuits to register before testing internal
 // circuits. This ensures the tests work correctly even when application
 // steps are present.
 const NUM_APP_STEPS: usize = 6000;
 
-type Preamble = preamble::Stage<Pasta, R, HEADER_SIZE>;
-type OuterError = outer_error::Stage<Pasta, R, HEADER_SIZE, RevdotParameters>;
-type InnerError = inner_error::Stage<Pasta, R, HEADER_SIZE, RevdotParameters>;
-type Query = query::Stage<Pasta, R, HEADER_SIZE>;
-type Eval = eval::Stage<Pasta, R, HEADER_SIZE>;
+type Preamble = preamble::Stage<Pasta, R, HS>;
+type OuterError = outer_error::Stage<Pasta, R, HS, RevdotParameters>;
+type InnerError = inner_error::Stage<Pasta, R, HS, RevdotParameters>;
+type Query = query::Stage<Pasta, R, HS>;
+type Eval = eval::Stage<Pasta, R, HS>;
 
 #[rustfmt::skip]
 #[test]
 fn test_internal_circuit_constraint_counts() {
     let pasta = Pasta::baked();
 
-    let app = ApplicationBuilder::<Pasta, R, HEADER_SIZE>::new()
+    let app = ApplicationBuilder::<Pasta, R, TestCfg>::new()
         .register_dummy_circuits(NUM_APP_STEPS)
         .unwrap()
         .finalize(pasta)
@@ -121,7 +126,7 @@ fn print_internal_circuit_constraint_counts() {
 
     let pasta = Pasta::baked();
 
-    let app = ApplicationBuilder::<Pasta, R, HEADER_SIZE>::new()
+    let app = ApplicationBuilder::<Pasta, R, TestCfg>::new()
         .register_dummy_circuits(NUM_APP_STEPS)
         .unwrap()
         .finalize(pasta)
@@ -192,7 +197,7 @@ fn print_internal_stage_parameters() {
 fn test_native_registry_digest() {
     let pasta = Pasta::baked();
 
-    let app = ApplicationBuilder::<Pasta, R, HEADER_SIZE>::new()
+    let app = ApplicationBuilder::<Pasta, R, TestCfg>::new()
         .register_dummy_circuits(NUM_APP_STEPS)
         .unwrap()
         .finalize(pasta)
@@ -216,7 +221,7 @@ fn test_native_registry_digest() {
 fn test_nested_registry_digest() {
     let pasta = Pasta::baked();
 
-    let app = ApplicationBuilder::<Pasta, R, HEADER_SIZE>::new()
+    let app = ApplicationBuilder::<Pasta, R, TestCfg>::new()
         .register_dummy_circuits(NUM_APP_STEPS)
         .unwrap()
         .finalize(pasta)
@@ -242,7 +247,7 @@ fn print_registry_digests() {
 
     let pasta = Pasta::baked();
 
-    let app = ApplicationBuilder::<Pasta, R, HEADER_SIZE>::new()
+    let app = ApplicationBuilder::<Pasta, R, TestCfg>::new()
         .register_dummy_circuits(NUM_APP_STEPS)
         .unwrap()
         .finalize(pasta)

--- a/crates/ragu_pcd/src/lib.rs
+++ b/crates/ragu_pcd/src/lib.rs
@@ -37,6 +37,7 @@ use ragu_circuits::{
     registry::{Registry, RegistryBuilder},
 };
 use ragu_core::{Error, Result};
+use ragu_primitives::vec::Len;
 use rand::CryptoRng;
 
 use alloc::collections::BTreeMap;
@@ -46,29 +47,48 @@ use header::Header;
 pub use proof::{Pcd, Proof};
 use step::{Step, internal::adapter::Adapter};
 
+/// Configuration trait for PCD parameters.
+///
+/// Bundles compile-time parameters that would otherwise cascade as const
+/// generics through the crate. Use [`ConstLen`](ragu_primitives::vec::ConstLen)
+/// to supply a concrete header size:
+///
+/// ```ignore
+/// use ragu_primitives::vec::ConstLen;
+///
+/// struct MyConfig;
+/// impl PcdConfig for MyConfig {
+///     type HeaderSize = ConstLen<4>;
+/// }
+/// ```
+pub trait PcdConfig: 'static + Send + Sync {
+    /// The fixed number of field elements in an encoded header.
+    type HeaderSize: Len;
+}
+
 /// Domain separation tag for Ragu PCD protocol.
 // FIXME: choose a permanent domain separation tag before release.
 pub(crate) const RAGU_TAG: &[u8] = b"FIXME";
 
 /// Builder for an [`Application`] for proof-carrying data.
-pub struct ApplicationBuilder<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize> {
+pub struct ApplicationBuilder<'params, C: Cycle, R: Rank, Cfg: PcdConfig> {
     native_registry: RegistryBuilder<'params, C::CircuitField, R>,
     nested_registry: RegistryBuilder<'params, C::ScalarField, R>,
     num_application_steps: usize,
     header_map: BTreeMap<header::Suffix, TypeId>,
-    _marker: PhantomData<[(); HEADER_SIZE]>,
+    _marker: PhantomData<Cfg>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Default
-    for ApplicationBuilder<'_, C, R, HEADER_SIZE>
+impl<C: Cycle, R: Rank, Cfg: PcdConfig> Default
+    for ApplicationBuilder<'_, C, R, Cfg>
 {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
-    ApplicationBuilder<'params, C, R, HEADER_SIZE>
+impl<'params, C: Cycle, R: Rank, Cfg: PcdConfig>
+    ApplicationBuilder<'params, C, R, Cfg>
 {
     /// Create an empty [`ApplicationBuilder`] for proof-carrying data.
     pub fn new() -> Self {
@@ -99,7 +119,7 @@ impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
 
         self.native_registry =
             self.native_registry
-                .register_circuit(Adapter::<C, S, R, HEADER_SIZE>::new(step))?;
+                .register_circuit(Adapter::<C, S, R, Cfg>::new(step))?;
         self.num_application_steps += 1;
 
         Ok(self)
@@ -130,7 +150,7 @@ impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
     pub fn finalize(
         mut self,
         params: &'params C::Params,
-    ) -> Result<Application<'params, C, R, HEADER_SIZE>> {
+    ) -> Result<Application<'params, C, R, Cfg>> {
         // Build the native registry:
         // 1. Application circuits (already registered)
         // 2. Internal circuits and masks
@@ -139,7 +159,7 @@ impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
             internal::native::total_circuit_counts(self.num_application_steps);
 
         // First, register internal circuits and masks
-        self.native_registry = internal::native::register_all::<C, R, HEADER_SIZE>(
+        self.native_registry = internal::native::register_all::<C, R, Cfg::HeaderSize>(
             self.native_registry,
             params,
             log2_circuits,
@@ -148,12 +168,12 @@ impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
         // Then, register internal steps
         self.native_registry =
             self.native_registry
-                .register_internal_step(Adapter::<C, _, R, HEADER_SIZE>::new(
+                .register_internal_step(Adapter::<C, _, R, Cfg>::new(
                     step::internal::rerandomize::Rerandomize::<()>::new(),
                 ))?;
         self.native_registry =
             self.native_registry
-                .register_internal_step(Adapter::<C, _, R, HEADER_SIZE>::new(
+                .register_internal_step(Adapter::<C, _, R, Cfg>::new(
                     step::internal::trivial::Trivial::new(),
                 ))?;
 
@@ -200,17 +220,17 @@ impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
 }
 
 /// The recursion context that is used to create and verify proof-carrying data.
-pub struct Application<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize> {
+pub struct Application<'params, C: Cycle, R: Rank, Cfg: PcdConfig> {
     native_registry: Registry<'params, C::CircuitField, R>,
     nested_registry: Registry<'params, C::ScalarField, R>,
     params: &'params C::Params,
     num_application_steps: usize,
     /// Cached seeded trivial proof for rerandomization.
     seeded_trivial: OnceCell<Proof<C, R>>,
-    _marker: PhantomData<[(); HEADER_SIZE]>,
+    _marker: PhantomData<Cfg>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, Cfg: PcdConfig> Application<'_, C, R, Cfg> {
     /// Seed a new computation by running a step with trivial inputs.
     ///
     /// This is the entry point for creating leaf nodes in a PCD tree.

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -148,7 +148,7 @@ impl<C: Cycle, R: Rank> Proof<C, R> {
     }
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, Cfg: crate::PcdConfig> crate::Application<'_, C, R, Cfg> {
     pub(crate) fn trivial_pcd(&self) -> Pcd<C, R, ()> {
         self.trivial_proof().carry(())
     }
@@ -199,8 +199,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
         Proof {
             application: Application {
                 circuit_id: CircuitIndex::new(0),
-                left_header: vec![C::CircuitField::ZERO; HEADER_SIZE],
-                right_header: vec![C::CircuitField::ZERO; HEADER_SIZE],
+                left_header: vec![C::CircuitField::ZERO; Cfg::HeaderSize::len()],
+                right_header: vec![C::CircuitField::ZERO; Cfg::HeaderSize::len()],
                 rx_triple: trivial_rx_triple(),
             },
             preamble: Preamble {

--- a/crates/ragu_pcd/src/step/encoder.rs
+++ b/crates/ragu_pcd/src/step/encoder.rs
@@ -10,7 +10,7 @@ use ragu_core::{
 use ragu_primitives::{
     Element, GadgetExt,
     io::Pipe,
-    vec::{ConstLen, FixedVec},
+    vec::{FixedVec, Len},
 };
 
 use alloc::vec::Vec;
@@ -43,20 +43,20 @@ use super::{Header, internal::padded};
 /// circuit structure matches the computation. However, rerandomization requires that
 /// the same circuit handles any header type, necessitating the uniform encoding
 /// (`Uniform`) that erases type-level differences through serialization.
-enum EncodedInner<'dr, D: Driver<'dr>, H: Header<D::F>, const HEADER_SIZE: usize> {
+enum EncodedInner<'dr, D: Driver<'dr>, H: Header<D::F>, HS: Len> {
     /// Standard gadget encoding preserving structure (efficient, type-dependent circuit)
     Gadget(Bound<'dr, D, H::Output>),
     /// Uniform encoding as field elements (less efficient, type-independent circuit)
-    Uniform(FixedVec<Element<'dr, D>, ConstLen<HEADER_SIZE>>),
+    Uniform(FixedVec<Element<'dr, D>, HS>),
 }
 
 /// The result of encoding a header within a step.
-pub struct Encoded<'dr, D: Driver<'dr>, H: Header<D::F>, const HEADER_SIZE: usize>(
-    EncodedInner<'dr, D, H, HEADER_SIZE>,
+pub struct Encoded<'dr, D: Driver<'dr>, H: Header<D::F>, HS: Len>(
+    EncodedInner<'dr, D, H, HS>,
 );
 
-impl<'dr, D: Driver<'dr>, H: Header<D::F>, const HEADER_SIZE: usize> Clone
-    for EncodedInner<'dr, D, H, HEADER_SIZE>
+impl<'dr, D: Driver<'dr>, H: Header<D::F>, HS: Len> Clone
+    for EncodedInner<'dr, D, H, HS>
 {
     fn clone(&self) -> Self {
         match self {
@@ -66,16 +66,16 @@ impl<'dr, D: Driver<'dr>, H: Header<D::F>, const HEADER_SIZE: usize> Clone
     }
 }
 
-impl<'dr, D: Driver<'dr>, H: Header<D::F>, const HEADER_SIZE: usize> Clone
-    for Encoded<'dr, D, H, HEADER_SIZE>
+impl<'dr, D: Driver<'dr>, H: Header<D::F>, HS: Len> Clone
+    for Encoded<'dr, D, H, HS>
 {
     fn clone(&self) -> Self {
         Encoded(self.0.clone())
     }
 }
 
-impl<'dr, D: Driver<'dr, F: PrimeField>, H: Header<D::F>, const HEADER_SIZE: usize>
-    Encoded<'dr, D, H, HEADER_SIZE>
+impl<'dr, D: Driver<'dr, F: PrimeField>, H: Header<D::F>, HS: Len>
+    Encoded<'dr, D, H, HS>
 {
     /// Create an encoded header from a gadget value.
     pub fn from_gadget(gadget: Bound<'dr, D, H::Output>) -> Self {
@@ -95,7 +95,7 @@ impl<'dr, D: Driver<'dr, F: PrimeField>, H: Header<D::F>, const HEADER_SIZE: usi
     pub(crate) fn write(self, dr: &mut D, buf: &mut Vec<Element<'dr, D>>) -> Result<()> {
         match self.0 {
             EncodedInner::Gadget(gadget) => {
-                padded::for_header::<H, HEADER_SIZE, _>(dr, gadget)?.write(dr, buf)?
+                padded::for_header::<H, HS, _>(dr, gadget)?.write(dr, buf)?
             }
             EncodedInner::Uniform(elements) => {
                 buf.extend(elements.into_inner());
@@ -124,9 +124,9 @@ impl<'dr, D: Driver<'dr, F: PrimeField>, H: Header<D::F>, const HEADER_SIZE: usi
     pub(crate) fn new_uniform(dr: &mut D, witness: DriverValue<D, H::Data>) -> Result<Self> {
         let mut emulator: Emulator<Wireless<D::MaybeKind, _>> = Emulator::wireless();
         let gadget = H::encode(&mut emulator, witness)?;
-        let gadget = padded::for_header::<H, HEADER_SIZE, _>(&mut emulator, gadget)?;
+        let gadget = padded::for_header::<H, HS, _>(&mut emulator, gadget)?;
 
-        let mut raw = Vec::with_capacity(HEADER_SIZE);
+        let mut raw = Vec::with_capacity(HS::len());
         gadget.write(&mut emulator, &mut Pipe::new(dr, &mut raw))?;
 
         Ok(Encoded(EncodedInner::Uniform(FixedVec::try_from(raw)?)))
@@ -144,7 +144,9 @@ mod tests {
         maybe::{Always, Maybe, MaybeKind},
     };
     use ragu_pasta::Fp;
+    use ragu_primitives::vec::ConstLen;
 
+    type HS = ConstLen<4>;
     const HEADER_SIZE: usize = 4;
 
     struct SingleHeader;
@@ -184,7 +186,7 @@ mod tests {
         let dr = &mut dr;
 
         let witness = Always::maybe_just(|| Fp::from(42u64));
-        let encoded = Encoded::<_, SingleHeader, HEADER_SIZE>::new(dr, witness)
+        let encoded = Encoded::<_, SingleHeader, HS>::new(dr, witness)
             .expect("encoding should succeed");
 
         let mut buf = vec![];
@@ -199,7 +201,7 @@ mod tests {
         let dr = &mut dr;
 
         let witness = Always::maybe_just(|| Fp::from(42u64));
-        let encoded = Encoded::<_, SingleHeader, HEADER_SIZE>::new_uniform(dr, witness)
+        let encoded = Encoded::<_, SingleHeader, HS>::new_uniform(dr, witness)
             .expect("encoding should succeed");
 
         let mut buf = vec![];
@@ -214,7 +216,7 @@ mod tests {
         let dr = &mut dr;
 
         let witness = Always::maybe_just(|| Fp::from(99u64));
-        let encoded = Encoded::<_, SingleHeader, HEADER_SIZE>::new(dr, witness)
+        let encoded = Encoded::<_, SingleHeader, HS>::new(dr, witness)
             .expect("encoding should succeed");
 
         let gadget = encoded.as_gadget();
@@ -227,7 +229,7 @@ mod tests {
         let dr = &mut dr;
 
         let witness = Always::maybe_just(|| Fp::from(1u64));
-        let encoded = Encoded::<_, SingleHeader, HEADER_SIZE>::new(dr, witness)
+        let encoded = Encoded::<_, SingleHeader, HS>::new(dr, witness)
             .expect("encoding should succeed");
 
         let mut buf = vec![];
@@ -242,19 +244,19 @@ mod tests {
         let mut dr = Emulator::execute();
         let dr = &mut dr;
 
-        let single = Encoded::<_, SingleHeader, HEADER_SIZE>::new_uniform(
+        let single = Encoded::<_, SingleHeader, HS>::new_uniform(
             dr,
             Always::maybe_just(|| Fp::from(1u64)),
         )
         .expect("single encoding should succeed");
 
-        let pair = Encoded::<_, PairHeader, HEADER_SIZE>::new_uniform(
+        let pair = Encoded::<_, PairHeader, HS>::new_uniform(
             dr,
             Always::maybe_just(|| (Fp::from(2u64), Fp::from(3u64))),
         )
         .expect("pair encoding should succeed");
 
-        let trivial = Encoded::<_, (), HEADER_SIZE>::new_uniform(dr, Always::maybe_just(|| ()))
+        let trivial = Encoded::<_, (), HS>::new_uniform(dr, Always::maybe_just(|| ()))
             .expect("trivial encoding should succeed");
 
         let mut buf_single = vec![];
@@ -277,7 +279,7 @@ mod tests {
         let dr = &mut dr;
 
         let witness = Always::maybe_just(|| Fp::from(77u64));
-        let original = Encoded::<_, SingleHeader, HEADER_SIZE>::new(dr, witness)
+        let original = Encoded::<_, SingleHeader, HS>::new(dr, witness)
             .expect("encoding should succeed");
         let cloned = original.clone();
 

--- a/crates/ragu_pcd/src/step/internal/adapter.rs
+++ b/crates/ragu_pcd/src/step/internal/adapter.rs
@@ -8,30 +8,30 @@ use ragu_core::{
 };
 use ragu_primitives::{
     Element,
-    vec::{CollectFixed, ConstLen, FixedVec, Len},
+    vec::{CollectFixed, FixedVec, Len},
 };
 
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use super::super::Step;
-use crate::Header;
+use crate::{Header, PcdConfig};
 
-/// Represents triple a length determined at compile time.
-pub struct TripleConstLen<const N: usize>;
+/// Represents triple a [`Len`] type.
+pub struct TripleLen<L: Len>(PhantomData<L>);
 
-impl<const N: usize> Len for TripleConstLen<N> {
+impl<L: Len> Len for TripleLen<L> {
     fn len() -> usize {
-        N * 3
+        L::len() * 3
     }
 }
 
-pub(crate) struct Adapter<C, S, R, const HEADER_SIZE: usize> {
+pub(crate) struct Adapter<C, S, R, Cfg: PcdConfig> {
     step: S,
-    _marker: PhantomData<(C, R)>,
+    _marker: PhantomData<(C, R, Cfg)>,
 }
 
-impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Adapter<C, S, R, HEADER_SIZE> {
+impl<C: Cycle, S: Step<C>, R: Rank, Cfg: PcdConfig> Adapter<C, S, R, Cfg> {
     pub fn new(step: S) -> Self {
         Adapter {
             step,
@@ -40,12 +40,12 @@ impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Adapter<C, S, R, H
     }
 }
 
-impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Circuit<C::CircuitField>
-    for Adapter<C, S, R, HEADER_SIZE>
+impl<C: Cycle, S: Step<C>, R: Rank, Cfg: PcdConfig> Circuit<C::CircuitField>
+    for Adapter<C, S, R, Cfg>
 {
     type Instance<'source> = (
-        FixedVec<C::CircuitField, ConstLen<HEADER_SIZE>>,
-        FixedVec<C::CircuitField, ConstLen<HEADER_SIZE>>,
+        FixedVec<C::CircuitField, Cfg::HeaderSize>,
+        FixedVec<C::CircuitField, Cfg::HeaderSize>,
         <S::Output as Header<C::CircuitField>>::Data,
     );
     type Witness<'source> = (
@@ -53,11 +53,11 @@ impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Circuit<C::Circuit
         <S::Right as Header<C::CircuitField>>::Data,
         S::Witness<'source>,
     );
-    type Output = Kind![C::CircuitField; FixedVec<Element<'_, _>, TripleConstLen<HEADER_SIZE>>];
+    type Output = Kind![C::CircuitField; FixedVec<Element<'_, _>, TripleLen<Cfg::HeaderSize>>];
     type Aux<'source> = (
         (
-            FixedVec<C::CircuitField, ConstLen<HEADER_SIZE>>,
-            FixedVec<C::CircuitField, ConstLen<HEADER_SIZE>>,
+            FixedVec<C::CircuitField, Cfg::HeaderSize>,
+            FixedVec<C::CircuitField, Cfg::HeaderSize>,
         ),
         <S::Output as Header<C::CircuitField>>::Data,
         S::Aux<'source>,
@@ -79,24 +79,25 @@ impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Circuit<C::Circuit
     where
         Self: 'dr,
     {
+        let header_size = Cfg::HeaderSize::len();
         let (left, right, witness) = witness.cast();
 
         let ((left, right, output), output_data, step_aux) = self
             .step
-            .witness::<_, HEADER_SIZE>(dr, witness, left, right)?;
+            .witness::<_, Cfg::HeaderSize>(dr, witness, left, right)?;
 
-        let mut elements = Vec::with_capacity(HEADER_SIZE * 3);
+        let mut elements = Vec::with_capacity(header_size * 3);
         left.write(dr, &mut elements)?;
         right.write(dr, &mut elements)?;
         output.write(dr, &mut elements)?;
 
         let adapter_aux = D::try_just(|| {
-            let left_header = elements[0..HEADER_SIZE]
+            let left_header = elements[0..header_size]
                 .iter()
                 .map(|e| *e.value().take())
                 .collect_fixed()?;
 
-            let right_header = elements[HEADER_SIZE..HEADER_SIZE * 2]
+            let right_header = elements[header_size..header_size * 2]
                 .iter()
                 .map(|e| *e.value().take())
                 .collect_fixed()?;
@@ -124,9 +125,14 @@ mod tests {
         maybe::{Always, Maybe, MaybeKind},
     };
     use ragu_pasta::{Fp, Pasta};
+    use ragu_primitives::vec::ConstLen;
 
     type TestR = TestRank;
+    type HS = ConstLen<4>;
     const HEADER_SIZE: usize = 4;
+
+    struct TestCfg;
+    impl PcdConfig for TestCfg { type HeaderSize = HS; }
 
     struct TestHeader;
 
@@ -153,7 +159,7 @@ mod tests {
         type Right = TestHeader;
         type Output = TestHeader;
 
-        fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, HeaderSize: Len>(
             &self,
             dr: &mut D,
             _: DriverValue<D, ()>,
@@ -161,9 +167,9 @@ mod tests {
             right: DriverValue<D, Fp>,
         ) -> Result<(
             (
-                Encoded<'dr, D, Self::Left, HS>,
-                Encoded<'dr, D, Self::Right, HS>,
-                Encoded<'dr, D, Self::Output, HS>,
+                Encoded<'dr, D, Self::Left, HeaderSize>,
+                Encoded<'dr, D, Self::Right, HeaderSize>,
+                Encoded<'dr, D, Self::Output, HeaderSize>,
             ),
             DriverValue<D, Fp>,
             DriverValue<D, ()>,
@@ -185,10 +191,10 @@ mod tests {
     }
 
     #[test]
-    fn triple_const_len_returns_3n() {
-        assert_eq!(TripleConstLen::<1>::len(), 3);
-        assert_eq!(TripleConstLen::<4>::len(), 12);
-        assert_eq!(TripleConstLen::<10>::len(), 30);
+    fn triple_len_returns_3n() {
+        assert_eq!(TripleLen::<ConstLen<1>>::len(), 3);
+        assert_eq!(TripleLen::<ConstLen<4>>::len(), 12);
+        assert_eq!(TripleLen::<ConstLen<10>>::len(), 30);
     }
 
     #[test]
@@ -196,7 +202,7 @@ mod tests {
         let mut dr = Emulator::execute();
         let dr = &mut dr;
 
-        let adapter = Adapter::<Pasta, TestStep, TestR, HEADER_SIZE>::new(TestStep);
+        let adapter = Adapter::<Pasta, TestStep, TestR, TestCfg>::new(TestStep);
         let witness = Always::maybe_just(|| (Fp::from(10u64), Fp::from(20u64), ()));
 
         let output = adapter
@@ -213,7 +219,7 @@ mod tests {
         let mut dr = Emulator::execute();
         let dr = &mut dr;
 
-        let adapter = Adapter::<Pasta, TestStep, TestR, HEADER_SIZE>::new(TestStep);
+        let adapter = Adapter::<Pasta, TestStep, TestR, TestCfg>::new(TestStep);
         let witness = Always::maybe_just(|| (Fp::from(10u64), Fp::from(20u64), ()));
 
         let aux = adapter

--- a/crates/ragu_pcd/src/step/internal/padded.rs
+++ b/crates/ragu_pcd/src/step/internal/padded.rs
@@ -7,6 +7,7 @@ use ragu_core::{
 use ragu_primitives::{
     Element, GadgetExt,
     io::{Buffer, Write},
+    vec::Len,
 };
 
 use core::marker::PhantomData;
@@ -18,31 +19,31 @@ use crate::internal::suffix::WithSuffix;
 ///
 /// The serialization order is `[gadget_data | zeros | suffix]`:
 /// - First, the header gadget data
-/// - Then, zero padding to fill up to `HEADER_SIZE - 1` elements
-/// - Finally, the suffix element at position `HEADER_SIZE - 1`
+/// - Then, zero padding to fill up to `HS::len() - 1` elements
+/// - Finally, the suffix element at position `HS::len() - 1`
 #[derive(Gadget, Write)]
 pub(crate) struct Padded<
     'dr,
     D: Driver<'dr>,
     G: GadgetKind<D::F> + Write<D::F>,
-    const HEADER_SIZE: usize,
+    HS: Len,
 > {
     #[ragu(gadget)]
-    inner: WithSuffix<'dr, D, Kind![D::F; PaddedContent<'_, _, G, HEADER_SIZE>]>,
+    inner: WithSuffix<'dr, D, Kind![D::F; PaddedContent<'_, _, G, HS>]>,
 }
 
 /// Constructs a [`Padded`] gadget representing a gadget for a [`Header`] padded
-/// to some fixed size `HEADER_SIZE` encoding, including the header suffix.
+/// to some fixed header size encoding, including the header suffix.
 pub(crate) fn for_header<
     'dr,
     H: Header<D::F>,
-    const HEADER_SIZE: usize,
+    HS: Len,
     D: Driver<'dr, F: PrimeField>,
 >(
     dr: &mut D,
     gadget: Bound<'dr, D, H::Output>,
-) -> Result<Padded<'dr, D, H::Output, HEADER_SIZE>> {
-    let padded_content = PaddedContent { gadget };
+) -> Result<Padded<'dr, D, H::Output, HS>> {
+    let padded_content = PaddedContent { gadget, _hs: PhantomData };
     let suffix = Element::constant(dr, D::F::from(H::SUFFIX.get()));
     Ok(Padded {
         inner: WithSuffix::new(padded_content, suffix),
@@ -50,39 +51,43 @@ pub(crate) fn for_header<
 }
 
 /// Inner gadget that writes the header gadget followed by zero padding up to
-/// `HEADER_SIZE - 1` elements (reserving space for the suffix).
+/// `HS::len() - 1` elements (reserving space for the suffix).
 #[derive(Gadget)]
 pub(crate) struct PaddedContent<
     'dr,
     D: Driver<'dr>,
     G: GadgetKind<D::F> + Write<D::F>,
-    const HEADER_SIZE: usize,
+    HS: Len,
 > {
     #[ragu(gadget)]
     gadget: Bound<'dr, D, G>,
+    #[ragu(phantom)]
+    _hs: PhantomData<HS>,
 }
 
-impl<F: Field, G: GadgetKind<F> + Write<F>, const HEADER_SIZE: usize> Write<F>
-    for PaddedContent<'static, PhantomData<F>, G, HEADER_SIZE>
+impl<F: Field, G: GadgetKind<F> + Write<F>, HS: Len> Write<F>
+    for PaddedContent<'static, PhantomData<F>, G, HS>
 {
     fn write_gadget<'dr, D: Driver<'dr, F = F>, B: Buffer<'dr, D>>(
         this: &Bound<'dr, D, Self>,
         dr: &mut D,
         buf: &mut B,
     ) -> Result<()> {
+        let header_size = HS::len();
         // Create a buffer that intercepts the data being written and counts it,
-        // prohibiting more than HEADER_SIZE - 1 writes (reserving space for
+        // prohibiting more than HS::len() - 1 writes (reserving space for
         // suffix).
-        let mut counting = CountingBuffer::<B, HEADER_SIZE> {
+        let mut counting = CountingBuffer::<B, HS> {
             written: 0,
             inner: buf,
+            _hs: PhantomData,
         };
 
         this.gadget.write(dr, &mut counting)?;
 
-        // Add padding to reach HEADER_SIZE - 1 elements (suffix will be added
+        // Add padding to reach HS::len() - 1 elements (suffix will be added
         // after).
-        while counting.written < HEADER_SIZE - 1 {
+        while counting.written < header_size - 1 {
             Element::zero(dr).write(dr, &mut counting)?;
         }
 
@@ -90,23 +95,25 @@ impl<F: Field, G: GadgetKind<F> + Write<F>, const HEADER_SIZE: usize> Write<F>
     }
 }
 
-struct CountingBuffer<'a, B, const HEADER_SIZE: usize> {
+struct CountingBuffer<'a, B, HS: Len> {
     written: usize,
     inner: &'a mut B,
+    _hs: PhantomData<HS>,
 }
 
-impl<'dr, D, B, const HEADER_SIZE: usize> Buffer<'dr, D> for CountingBuffer<'_, B, HEADER_SIZE>
+impl<'dr, D, B, HS: Len> Buffer<'dr, D> for CountingBuffer<'_, B, HS>
 where
     D: Driver<'dr>,
     B: Buffer<'dr, D>,
 {
     fn write(&mut self, dr: &mut D, value: &Element<'dr, D>) -> Result<()> {
+        let header_size = HS::len();
         // Limit is N - 1 to reserve space for the suffix element
-        if self.written >= HEADER_SIZE - 1 {
+        if self.written >= header_size - 1 {
             return Err(ragu_core::Error::MalformedEncoding(
                 alloc::format!(
-                    "Header encoding size exceeded HEADER_SIZE - 1 ({})",
-                    HEADER_SIZE - 1,
+                    "Header encoding size exceeded HS::len() - 1 ({})",
+                    header_size - 1,
                 )
                 .into(),
             ));
@@ -154,10 +161,11 @@ mod tests {
 
         {
             // Create Padded gadget with suffix value 42
-            let padded_content = super::PaddedContent::<'_, _, Kind![F; MySillyGadget<'_, _>], 6> {
+            let padded_content = super::PaddedContent::<'_, _, Kind![F; MySillyGadget<'_, _>], ConstLen<6>> {
                 gadget: gadget.clone(),
+                _hs: core::marker::PhantomData,
             };
-            let padded_gadget = Padded::<'_, _, Kind![F; MySillyGadget<'_, _>], 6> {
+            let padded_gadget = Padded::<'_, _, Kind![F; MySillyGadget<'_, _>], ConstLen<6>> {
                 inner: WithSuffix::new(padded_content, Element::constant(dr, F::from(42u64))),
             };
             let mut buffer = vec![];
@@ -189,10 +197,11 @@ mod tests {
         {
             // HEADER_SIZE=4 means only 3 elements for content (4 - 1 for suffix)
             // But gadget has 4 elements, so it should fail
-            let padded_content = super::PaddedContent::<'_, _, Kind![F; MySillyGadget<'_, _>], 4> {
+            let padded_content = super::PaddedContent::<'_, _, Kind![F; MySillyGadget<'_, _>], ConstLen<4>> {
                 gadget: gadget.clone(),
+                _hs: core::marker::PhantomData,
             };
-            let padded_gadget = Padded::<'_, _, Kind![F; MySillyGadget<'_, _>], 4> {
+            let padded_gadget = Padded::<'_, _, Kind![F; MySillyGadget<'_, _>], ConstLen<4>> {
                 inner: WithSuffix::new(padded_content, Element::constant(dr, F::from(42u64))),
             };
             let mut buffer = vec![];

--- a/crates/ragu_pcd/src/step/internal/rerandomize.rs
+++ b/crates/ragu_pcd/src/step/internal/rerandomize.rs
@@ -11,6 +11,7 @@ use ragu_core::{
     drivers::{Driver, DriverValue},
     maybe::Maybe,
 };
+use ragu_primitives::vec::Len;
 
 use core::marker::PhantomData;
 
@@ -41,7 +42,7 @@ impl<C: Cycle, H: Header<C::CircuitField>> Step<C> for Rerandomize<H> {
     type Right = ();
     type Output = H;
 
-    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, HS: Len>(
         &self,
         dr: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
@@ -49,9 +50,9 @@ impl<C: Cycle, H: Header<C::CircuitField>> Step<C> for Rerandomize<H> {
         right: DriverValue<D, ()>,
     ) -> Result<(
         (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
         ),
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
@@ -67,7 +68,7 @@ impl<C: Cycle, H: Header<C::CircuitField>> Step<C> for Rerandomize<H> {
         // development. It's possible some other component(s) of the proof being
         // randomized is sufficient, which would be nice since it would avoid
         // extra work here. It would also be complicated to add random wires
-        // here if the amount of wires needed depended on HEADER_SIZE and R:
+        // here if the amount of wires needed depended on HS and R:
         // Rank, both of which are not in scope here.
 
         // Return left's data as the output data - this preserves it!
@@ -89,7 +90,9 @@ fn test_rerandomize_consistency() {
     use ragu_primitives::Element;
     use ragu_testing::registry::TestRegistryBuilder;
 
-    const HEADER_SIZE: usize = 4;
+    use ragu_primitives::vec::ConstLen;
+
+    type HS = ConstLen<4>;
     type R = polynomials::TestRank;
 
     struct Single;
@@ -122,10 +125,15 @@ fn test_rerandomize_consistency() {
         }
     }
 
-    let circuit_single = super::adapter::Adapter::<Pasta, Rerandomize<Single>, R, HEADER_SIZE>::new(
+    use crate::PcdConfig;
+
+    struct TestCfg;
+    impl PcdConfig for TestCfg { type HeaderSize = HS; }
+
+    let circuit_single = super::adapter::Adapter::<Pasta, Rerandomize<Single>, R, TestCfg>::new(
         Rerandomize::new(),
     );
-    let circuit_pair = super::adapter::Adapter::<Pasta, Rerandomize<Pair>, R, HEADER_SIZE>::new(
+    let circuit_pair = super::adapter::Adapter::<Pasta, Rerandomize<Pair>, R, TestCfg>::new(
         Rerandomize::new(),
     );
 

--- a/crates/ragu_pcd/src/step/internal/trivial.rs
+++ b/crates/ragu_pcd/src/step/internal/trivial.rs
@@ -8,6 +8,7 @@ use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
 };
+use ragu_primitives::vec::Len;
 
 use super::super::{Encoded, Index, Step};
 use crate::Header;
@@ -32,7 +33,7 @@ impl<C: Cycle> Step<C> for Trivial {
     type Right = ();
     type Output = ();
 
-    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, HS: Len>(
         &self,
         dr: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
@@ -40,9 +41,9 @@ impl<C: Cycle> Step<C> for Trivial {
         right: DriverValue<D, ()>,
     ) -> Result<(
         (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
         ),
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,

--- a/crates/ragu_pcd/src/step/mod.rs
+++ b/crates/ragu_pcd/src/step/mod.rs
@@ -9,6 +9,7 @@ use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
 };
+use ragu_primitives::vec::Len;
 
 use super::header::Header;
 use crate::internal::native::NUM_INTERNAL_CIRCUITS;
@@ -174,7 +175,7 @@ pub trait Step<C: Cycle>: Sized + Send + Sync {
     ///
     /// Returns the encoded headers (left, right, output), the data to be
     /// carried in the resulting PCD, and any auxiliary witness data.
-    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, HS: Len>(
         &self,
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'source>>,
@@ -182,9 +183,9 @@ pub trait Step<C: Cycle>: Sized + Send + Sync {
         right: DriverValue<D, <Self::Right as Header<C::CircuitField>>::Data>,
     ) -> Result<(
         (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
         ),
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,

--- a/crates/ragu_pcd/src/verify.rs
+++ b/crates/ragu_pcd/src/verify.rs
@@ -7,20 +7,20 @@ use ragu_circuits::{
     registry::CircuitIndex,
 };
 use ragu_core::{Result, drivers::emulator::Emulator, maybe::Maybe};
-use ragu_primitives::Element;
+use ragu_primitives::{Element, vec::Len};
 use rand::CryptoRng;
 
 use core::iter::once;
 
 use crate::{
-    Application, Pcd, Proof,
+    Application, Pcd, PcdConfig, Proof,
     header::Header,
     internal::claims,
     internal::native::stages::preamble::ProofInputs,
     internal::{native::claims as native_claims, nested::claims as nested_claims},
 };
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, Cfg: PcdConfig> Application<'_, C, R, Cfg> {
     /// Verifies some [`Pcd`] for the provided [`Header`].
     ///
     /// Returns `Ok(true)` if all verification checks pass, `Ok(false)` if
@@ -49,8 +49,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         // Validate that the `left_header` and `right_header` lengths match
         // `HEADER_SIZE`. Alternatively, the `Proof` structure could be
         // parameterized on the `HEADER_SIZE`, but this appeared to be simpler.
-        if pcd.proof().application.left_header.len() != HEADER_SIZE
-            || pcd.proof().application.right_header.len() != HEADER_SIZE
+        let header_size = Cfg::HeaderSize::len();
+        if pcd.proof().application.left_header.len() != header_size
+            || pcd.proof().application.right_header.len() != header_size
         {
             return Ok(false);
         }
@@ -61,7 +62,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                 let (proof, data, y) = witness.cast();
                 let y = Element::alloc(dr, y)?;
                 let proof_inputs =
-                    ProofInputs::<_, C, HEADER_SIZE>::alloc_for_verify::<R, H>(dr, proof, data)?;
+                    ProofInputs::<_, C, Cfg::HeaderSize>::alloc_for_verify::<R, H>(dr, proof, data)?;
 
                 let (unified_ky, unified_bridge_ky) = proof_inputs.unified_ky_values(dr, &y)?;
                 let unified_ky = *unified_ky.value().take();
@@ -253,14 +254,18 @@ mod tests {
     use ff::Field;
     use ragu_circuits::{polynomials::ProductionRank, registry::CircuitIndex};
     use ragu_pasta::Pasta;
+    use ragu_primitives::vec::ConstLen;
     use rand::{SeedableRng, rngs::StdRng};
 
     type TestR = ProductionRank;
     const HEADER_SIZE: usize = 4;
 
-    fn create_test_app() -> crate::Application<'static, Pasta, TestR, HEADER_SIZE> {
+    struct TestCfg;
+    impl PcdConfig for TestCfg { type HeaderSize = ConstLen<HEADER_SIZE>; }
+
+    fn create_test_app() -> crate::Application<'static, Pasta, TestR, TestCfg> {
         let pasta = Pasta::baked();
-        ApplicationBuilder::<Pasta, TestR, HEADER_SIZE>::new()
+        ApplicationBuilder::<Pasta, TestR, TestCfg>::new()
             .finalize(pasta)
             .expect("failed to create test application")
     }

--- a/crates/ragu_pcd/tests/nontrivial.rs
+++ b/crates/ragu_pcd/tests/nontrivial.rs
@@ -2,7 +2,11 @@ use ragu_arithmetic::Cycle;
 use ragu_circuits::polynomials::ProductionRank;
 use ragu_core::Result;
 use ragu_pasta::{Fp, Pasta};
-use ragu_pcd::ApplicationBuilder;
+use ragu_pcd::{ApplicationBuilder, PcdConfig};
+use ragu_primitives::vec::ConstLen;
+
+struct TestCfg;
+impl PcdConfig for TestCfg { type HeaderSize = ConstLen<4>; }
 use ragu_testing::pcd::nontrivial::{Hash2, WitnessLeaf};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
@@ -10,7 +14,7 @@ use rand::rngs::StdRng;
 #[test]
 fn various_merging_operations() -> Result<()> {
     let pasta = Pasta::baked();
-    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+    let app = ApplicationBuilder::<Pasta, ProductionRank, TestCfg>::new()
         .register(WitnessLeaf {
             poseidon_params: Pasta::circuit_poseidon(pasta),
         })?

--- a/crates/ragu_pcd/tests/registration_errors.rs
+++ b/crates/ragu_pcd/tests/registration_errors.rs
@@ -6,11 +6,15 @@ use ragu_core::{
     gadgets::Bound,
 };
 use ragu_pasta::Pasta;
-use ragu_pcd::step::{Encoded, Index, Step};
 use ragu_pcd::{
-    ApplicationBuilder,
+    ApplicationBuilder, PcdConfig,
     header::{Header, Suffix},
+    step::{Encoded, Index, Step},
 };
+use ragu_primitives::vec::{ConstLen, Len};
+
+struct TestCfg;
+impl PcdConfig for TestCfg { type HeaderSize = ConstLen<4>; }
 
 // Header A with suffix 0
 struct HSuffixA;
@@ -64,7 +68,7 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step0 {
     type Left = ();
     type Right = ();
     type Output = HSuffixA;
-    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, HS: Len>(
         &self,
         dr: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
@@ -72,9 +76,9 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step0 {
         right: DriverValue<D, ()>,
     ) -> Result<(
         (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
         ),
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
@@ -96,7 +100,7 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step1 {
     type Left = HSuffixA;
     type Right = HSuffixA;
     type Output = HSuffixB;
-    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, HS: Len>(
         &self,
         dr: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
@@ -104,9 +108,9 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step1 {
         right: DriverValue<D, ()>,
     ) -> Result<(
         (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
         ),
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
@@ -128,7 +132,7 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step1Dup {
     type Left = HSuffixA;
     type Right = HSuffixA;
     type Output = HSuffixAOther;
-    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, HS: Len>(
         &self,
         dr: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
@@ -136,9 +140,9 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step1Dup {
         right: DriverValue<D, ()>,
     ) -> Result<(
         (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
         ),
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
@@ -154,7 +158,7 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step1Dup {
 #[test]
 fn register_steps_success_and_finalize() {
     let pasta = Pasta::baked();
-    let builder = ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+    let builder = ApplicationBuilder::<Pasta, ProductionRank, TestCfg>::new()
         .register(Step0)
         .unwrap()
         .register(Step1)
@@ -165,7 +169,7 @@ fn register_steps_success_and_finalize() {
 #[test]
 #[should_panic]
 fn register_steps_out_of_order_should_fail() {
-    ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+    ApplicationBuilder::<Pasta, ProductionRank, TestCfg>::new()
         .register(Step1)
         .unwrap();
 }
@@ -173,7 +177,7 @@ fn register_steps_out_of_order_should_fail() {
 #[test]
 #[should_panic]
 fn register_steps_duplicate_suffix_should_fail() {
-    ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+    ApplicationBuilder::<Pasta, ProductionRank, TestCfg>::new()
         .register(Step0)
         .unwrap()
         .register(Step1Dup)

--- a/crates/ragu_pcd/tests/rerandomization.rs
+++ b/crates/ragu_pcd/tests/rerandomization.rs
@@ -9,13 +9,16 @@ use ragu_core::{
 };
 use ragu_pasta::{Fp, Pasta};
 use ragu_pcd::{
-    ApplicationBuilder,
+    ApplicationBuilder, PcdConfig,
     header::{Header, Suffix},
     step::{Encoded, Index, Step},
 };
-use ragu_primitives::Element;
+use ragu_primitives::{Element, vec::{ConstLen, Len}};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
+
+struct TestCfg;
+impl PcdConfig for TestCfg { type HeaderSize = ConstLen<4>; }
 
 // Header A (suffix 0) - unit data
 struct HeaderA;
@@ -56,7 +59,7 @@ impl Step<Pasta> for StepWithData {
     type Left = ();
     type Right = ();
     type Output = HeaderWithData;
-    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HEADER_SIZE: usize>(
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, HS: Len>(
         &self,
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'source>>,
@@ -64,9 +67,9 @@ impl Step<Pasta> for StepWithData {
         right: DriverValue<D, ()>,
     ) -> Result<(
         (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
         ),
         DriverValue<D, <Self::Output as Header<Fp>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
@@ -87,7 +90,7 @@ impl<C: Cycle> Step<C> for Step0 {
     type Left = ();
     type Right = ();
     type Output = HeaderA;
-    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, HS: Len>(
         &self,
         dr: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
@@ -95,9 +98,9 @@ impl<C: Cycle> Step<C> for Step0 {
         right: DriverValue<D, ()>,
     ) -> Result<(
         (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
         ),
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
@@ -117,7 +120,7 @@ impl<C: Cycle> Step<C> for Step1 {
     type Left = HeaderA;
     type Right = HeaderA;
     type Output = HeaderA;
-    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, HS: Len>(
         &self,
         dr: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
@@ -125,9 +128,9 @@ impl<C: Cycle> Step<C> for Step1 {
         right: DriverValue<D, ()>,
     ) -> Result<(
         (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
         ),
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
@@ -142,7 +145,7 @@ impl<C: Cycle> Step<C> for Step1 {
 #[test]
 fn rerandomization_flow() {
     let pasta = Pasta::baked();
-    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+    let app = ApplicationBuilder::<Pasta, ProductionRank, TestCfg>::new()
         .register(Step0)
         .unwrap()
         .register(Step1)
@@ -171,7 +174,7 @@ fn rerandomization_flow() {
 #[test]
 fn multiple_rerandomizations_all_verify() {
     let pasta = Pasta::baked();
-    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+    let app = ApplicationBuilder::<Pasta, ProductionRank, TestCfg>::new()
         .register(Step0)
         .unwrap()
         .finalize(pasta)
@@ -197,7 +200,7 @@ fn multiple_rerandomizations_all_verify() {
 #[test]
 fn rerandomization_preserves_header_data() {
     let pasta = Pasta::baked();
-    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+    let app = ApplicationBuilder::<Pasta, ProductionRank, TestCfg>::new()
         .register(StepWithData)
         .unwrap()
         .finalize(pasta)
@@ -230,7 +233,7 @@ fn rerandomization_preserves_header_data() {
 #[test]
 fn rerandomized_fused_proof_verifies() {
     let pasta = Pasta::baked();
-    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+    let app = ApplicationBuilder::<Pasta, ProductionRank, TestCfg>::new()
         .register(Step0)
         .unwrap()
         .register(Step1)

--- a/crates/ragu_testing/src/pcd/nontrivial.rs
+++ b/crates/ragu_testing/src/pcd/nontrivial.rs
@@ -12,8 +12,7 @@ use ragu_pcd::{
     header::{Header, Suffix},
     step::{Encoded, Index, Step},
 };
-use ragu_primitives::{Element, poseidon::Sponge};
-
+use ragu_primitives::{Element, poseidon::Sponge, vec::Len};
 pub struct LeafNode;
 
 impl<F: Field> Header<F> for LeafNode {
@@ -56,7 +55,7 @@ impl<C: Cycle> Step<C> for Hash2<'_, C> {
     type Right = LeafNode;
     type Output = InternalNode;
 
-    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, HS: Len>(
         &self,
         dr: &mut D,
         _: DriverValue<D, Self::Witness<'source>>,
@@ -64,9 +63,9 @@ impl<C: Cycle> Step<C> for Hash2<'_, C> {
         right: DriverValue<D, C::CircuitField>,
     ) -> Result<(
         (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
         ),
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
@@ -100,7 +99,7 @@ impl<C: Cycle> Step<C> for WitnessLeaf<'_, C> {
     type Right = ();
     type Output = LeafNode;
 
-    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, HS: Len>(
         &self,
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'source>>,
@@ -108,9 +107,9 @@ impl<C: Cycle> Step<C> for WitnessLeaf<'_, C> {
         _right: DriverValue<D, ()>,
     ) -> Result<(
         (
-            Encoded<'dr, D, Self::Left, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Right, HEADER_SIZE>,
-            Encoded<'dr, D, Self::Output, HEADER_SIZE>,
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
         ),
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,


### PR DESCRIPTION
Replace the cascading `const HEADER_SIZE: usize` parameter with a `PcdConfig` trait whose `HeaderSize` associated type implements `Len`, following the precedent set by `fold_revdot::Parameters`. Internally, stages and circuits take `HS: Len`; the `Application` and fuse pipeline use `Cfg: PcdConfig` and extract `Cfg::HeaderSize`.

Closes #243