### PR TITLE
chore(pcd): `unified_bridge_ky` suggestions

### DIFF
--- a/crates/ragu_pcd/src/fuse/_02_preamble.rs
+++ b/crates/ragu_pcd/src/fuse/_02_preamble.rs
@@ -41,7 +41,23 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             )?,
         );
 
-        Ok((proof::Preamble { native, bridge }, preamble_witness))
+        let child_bridges = |child: &Proof<C, R>| proof::ChildBridges {
+            inner_error: child.inner_error.bridge.rx.clone(),
+            outer_error: child.outer_error.bridge.rx.clone(),
+            ab: child.ab.bridge.rx.clone(),
+            query: child.query.bridge.rx.clone(),
+            eval: child.eval.bridge.rx.clone(),
+        };
+
+        Ok((
+            proof::Preamble {
+                native,
+                bridge,
+                left_child_bridges: child_bridges(left),
+                right_child_bridges: child_bridges(right),
+            },
+            preamble_witness,
+        ))
     }
 
     fn compute_native_preamble<'a, RNG: CryptoRng>(

--- a/crates/ragu_pcd/src/fuse/_02_preamble.rs
+++ b/crates/ragu_pcd/src/fuse/_02_preamble.rs
@@ -47,6 +47,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             ab: child.ab.bridge.rx.clone(),
             query: child.query.bridge.rx.clone(),
             eval: child.eval.bridge.rx.clone(),
+            points: child.circuits.points_rx.clone(),
         };
 
         Ok((

--- a/crates/ragu_pcd/src/fuse/_02_preamble.rs
+++ b/crates/ragu_pcd/src/fuse/_02_preamble.rs
@@ -47,7 +47,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             ab: child.ab.bridge.rx.clone(),
             query: child.query.bridge.rx.clone(),
             eval: child.eval.bridge.rx.clone(),
-            points: child.circuits.points_rx.clone(),
+            points: child.circuits.points_rx.rx.clone(),
         };
 
         Ok((

--- a/crates/ragu_pcd/src/fuse/_04_inner_error.rs
+++ b/crates/ragu_pcd/src/fuse/_04_inner_error.rs
@@ -30,6 +30,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         y: &Element<'dr, D>,
         z: &Element<'dr, D>,
         source: &FuseProofSource<'rx, C, R>,
+        preamble: &proof::Preamble<C, R>,
     ) -> Result<(
         proof::InnerError<C, R>,
         native::stages::inner_error::Witness<C, native::RevdotParameters>,
@@ -48,6 +49,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                 &nested::stages::inner_error::Witness {
                     native_inner_error: native_inner_error.rx_triple.commitment,
                     registry_wy: native_inner_error.registry_wy_commitment,
+                    stashed_native_preamble: preamble.native.commitment,
                 },
             )?,
         );

--- a/crates/ragu_pcd/src/fuse/_10_p.rs
+++ b/crates/ragu_pcd/src/fuse/_10_p.rs
@@ -85,6 +85,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                 beta: effective_beta,
             };
 
+            // This accumulation order must match the loading circuit in
+            // `nested::circuits::loading::Loading`.
             for proof in [left, right] {
                 for &id in &RxIndex::ALL {
                     let t = &proof[id];

--- a/crates/ragu_pcd/src/fuse/_10_p.rs
+++ b/crates/ragu_pcd/src/fuse/_10_p.rs
@@ -8,23 +8,18 @@
 //! $\text{commit}(\sum\_j \beta^j \cdot p\_j) = \sum\_j \beta^j \cdot C\_j$.
 //!
 //! The commitment is computed via [`PointsWitness`] Horner evaluation.
+//! The [`PointsWitness`] and [`Uendo`] endoscalar are returned alongside the proof
+//! component so that [`super::_11_circuits`] can create the corresponding
+//! nested circuit traces.
 
 use alloc::vec::Vec;
 use core::ops::AddAssign;
-use ff::Field;
-use ragu_arithmetic::Cycle;
-use ragu_circuits::{
-    CircuitExt,
-    polynomials::{Rank, sparse},
-    staging::{MultiStage, StageExt},
-};
+use ragu_arithmetic::{Cycle, Uendo};
+use ragu_circuits::polynomials::{Rank, sparse};
 use ragu_core::{Result, drivers::Driver, maybe::Maybe};
-use ragu_primitives::{Element, extract_endoscalar, lift_endoscalar, vec::Len};
+use ragu_primitives::{Element, extract_endoscalar, lift_endoscalar};
 
-use crate::internal::endoscalar::{
-    EndoscalarStage, EndoscalingStep, EndoscalingStepWitness, NumStepsLen, PointsStage,
-    PointsWitness,
-};
+use crate::internal::endoscalar::PointsWitness;
 use crate::internal::native::RxIndex;
 use crate::internal::nested::NUM_ENDOSCALING_POINTS;
 use crate::{Application, Proof, proof};
@@ -48,9 +43,8 @@ impl<C: Cycle, R: Rank> Accumulator<'_, C, R> {
 }
 
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
-    pub(super) fn compute_p<'dr, D, RNG: rand::CryptoRng>(
+    pub(super) fn compute_p<'dr, D>(
         &self,
-        rng: &mut RNG,
         pre_beta: &Element<'dr, D>,
         u: &Element<'dr, D>,
         left: &Proof<C, R>,
@@ -60,7 +54,11 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         ab: &proof::AB<C, R>,
         query: &proof::Query<C, R>,
         f: &proof::F<C, R>,
-    ) -> Result<proof::P<C, R>>
+    ) -> Result<(
+        proof::P<C, R>,
+        Uendo,
+        PointsWitness<C::HostCurve, NUM_ENDOSCALING_POINTS>,
+    )>
     where
         D: Driver<'dr, F = C::CircuitField>,
     {
@@ -123,69 +121,31 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
 
         // Construct commitment via PointsWitness Horner evaluation.
         // Points order: [f.commitment, commitments...] computes β^n·f + β^{n-1}·C₀ + ...
-        let (commitment, endoscalar_rx, points_rx, step_rxs) = {
+        let witness = {
             let mut points = Vec::with_capacity(NUM_ENDOSCALING_POINTS);
             points.push(f.native.commitment);
             points.extend_from_slice(&commitments);
 
-            let witness =
-                PointsWitness::<C::HostCurve, NUM_ENDOSCALING_POINTS>::new(beta_endo, &points);
-
-            let endoscalar_rx = <EndoscalarStage as StageExt<C::ScalarField, R>>::rx(
-                C::ScalarField::random(&mut *rng),
-                beta_endo,
-            )?;
-            let points_rx = <PointsStage<C::HostCurve, NUM_ENDOSCALING_POINTS> as StageExt<
-                C::ScalarField,
-                R,
-            >>::rx(C::ScalarField::random(&mut *rng), &witness)?;
-
-            // Create rx polynomials for each endoscaling step circuit
-            let num_steps = NumStepsLen::<NUM_ENDOSCALING_POINTS>::len();
-            let mut step_rxs = Vec::with_capacity(num_steps);
-            for step in 0..num_steps {
-                let step_circuit =
-                    EndoscalingStep::<C::HostCurve, R, NUM_ENDOSCALING_POINTS>::new(step);
-                let staged = MultiStage::new(step_circuit);
-                let step_trace = staged
-                    .trace(EndoscalingStepWitness {
-                        endoscalar: beta_endo,
-                        points: &witness,
-                    })?
-                    .into_output();
-                let step_rx = self.nested_registry.assemble(
-                    &step_trace,
-                    crate::internal::nested::InternalCircuitIndex::EndoscalingStep(step as u32)
-                        .circuit_index(),
-                    &mut *rng,
-                )?;
-                step_rxs.push(step_rx);
-            }
-
-            (
-                *witness
-                    .interstitials
-                    .last()
-                    .expect("NumStepsLen guarantees at least one interstitial"),
-                endoscalar_rx,
-                points_rx,
-                step_rxs,
-            )
+            PointsWitness::<C::HostCurve, NUM_ENDOSCALING_POINTS>::new(beta_endo, &points)
         };
+
+        let commitment = *witness
+            .interstitials
+            .last()
+            .expect("NumStepsLen guarantees at least one interstitial");
 
         let v = poly.eval(*u.value().take());
 
-        Ok(proof::P {
-            native: proof::NativeP {
-                poly,
-                commitment,
-                v,
+        Ok((
+            proof::P {
+                native: proof::NativeP {
+                    poly,
+                    commitment,
+                    v,
+                },
             },
-            nested: proof::NestedP {
-                step_rxs,
-                endoscalar_rx,
-                points_rx,
-            },
-        })
+            beta_endo,
+            witness,
+        ))
     }
 }

--- a/crates/ragu_pcd/src/fuse/_11_circuits.rs
+++ b/crates/ragu_pcd/src/fuse/_11_circuits.rs
@@ -78,6 +78,16 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             coverage: Default::default(),
         };
 
+        // Compute points_rx before hashes_1 since it needs the commitment
+        // for its instance polynomial (to match unified_bridge_ky).
+        let points_rx = proof::Bridge::commit(
+            self.params,
+            <PointsStage<C::HostCurve, NUM_ENDOSCALING_POINTS> as StageExt<
+                C::ScalarField,
+                R,
+            >>::rx(C::ScalarField::random(&mut *rng), points_witness)?,
+        );
+
         let (hashes_1_trace, unified) = native::circuits::hashes_1::Circuit::<
             C,
             R,
@@ -89,6 +99,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         )
         .trace(native::circuits::hashes_1::Witness {
             unified,
+            points_commitment: points_rx.commitment,
             preamble_witness,
             outer_error_witness,
         })?
@@ -194,13 +205,6 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             C::ScalarField::random(&mut *rng),
             beta_endo,
         )?;
-        let points_rx = proof::Bridge::commit(
-            self.params,
-            <PointsStage<C::HostCurve, NUM_ENDOSCALING_POINTS> as StageExt<
-                C::ScalarField,
-                R,
-            >>::rx(C::ScalarField::random(&mut *rng), points_witness)?,
-        );
 
         let num_steps = NumStepsLen::<NUM_ENDOSCALING_POINTS>::len();
         let mut step_rxs = Vec::with_capacity(num_steps);

--- a/crates/ragu_pcd/src/fuse/_11_circuits.rs
+++ b/crates/ragu_pcd/src/fuse/_11_circuits.rs
@@ -35,6 +35,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
     pub(super) fn compute_internal_circuits<RNG: CryptoRng>(
         &self,
         rng: &mut RNG,
+        left: &crate::Proof<C, R>,
+        right: &crate::Proof<C, R>,
         preamble: &proof::Preamble<C, R>,
         s_prime: &proof::SPrime<C, R>,
         outer_error: &proof::OuterError<C, R>,
@@ -220,6 +222,15 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             step_rxs.push(step_rx);
         }
 
+        // Preserve child bridge rx polynomials for the copying circuit.
+        let child_bridges = |child: &crate::Proof<C, R>| proof::ChildBridges {
+            inner_error: child.inner_error.bridge.clone(),
+            outer_error: child.outer_error.bridge.clone(),
+            ab: child.ab.bridge.clone(),
+            query: child.query.bridge.clone(),
+            eval: child.eval.bridge.clone(),
+        };
+
         Ok(proof::InternalCircuits {
             hashes_1: proof::RxTriple {
                 rx: hashes_1_rx,
@@ -244,6 +255,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             step_rxs,
             endoscalar_rx,
             points_rx,
+            left_child_bridges: child_bridges(left),
+            right_child_bridges: child_bridges(right),
         })
     }
 }

--- a/crates/ragu_pcd/src/fuse/_11_circuits.rs
+++ b/crates/ragu_pcd/src/fuse/_11_circuits.rs
@@ -35,8 +35,6 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
     pub(super) fn compute_internal_circuits<RNG: CryptoRng>(
         &self,
         rng: &mut RNG,
-        left: &crate::Proof<C, R>,
-        right: &crate::Proof<C, R>,
         preamble: &proof::Preamble<C, R>,
         s_prime: &proof::SPrime<C, R>,
         outer_error: &proof::OuterError<C, R>,
@@ -222,15 +220,6 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             step_rxs.push(step_rx);
         }
 
-        // Preserve child bridge rx polynomials for the copying circuit.
-        let child_bridges = |child: &crate::Proof<C, R>| proof::ChildBridges {
-            inner_error: child.inner_error.bridge.clone(),
-            outer_error: child.outer_error.bridge.clone(),
-            ab: child.ab.bridge.clone(),
-            query: child.query.bridge.clone(),
-            eval: child.eval.bridge.clone(),
-        };
-
         Ok(proof::InternalCircuits {
             hashes_1: proof::RxTriple {
                 rx: hashes_1_rx,
@@ -255,8 +244,6 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             step_rxs,
             endoscalar_rx,
             points_rx,
-            left_child_bridges: child_bridges(left),
-            right_child_bridges: child_bridges(right),
         })
     }
 }

--- a/crates/ragu_pcd/src/fuse/_11_circuits.rs
+++ b/crates/ragu_pcd/src/fuse/_11_circuits.rs
@@ -194,10 +194,13 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             C::ScalarField::random(&mut *rng),
             beta_endo,
         )?;
-        let points_rx = <PointsStage<C::HostCurve, NUM_ENDOSCALING_POINTS> as StageExt<
-            C::ScalarField,
-            R,
-        >>::rx(C::ScalarField::random(&mut *rng), points_witness)?;
+        let points_rx = proof::Bridge::commit(
+            self.params,
+            <PointsStage<C::HostCurve, NUM_ENDOSCALING_POINTS> as StageExt<
+                C::ScalarField,
+                R,
+            >>::rx(C::ScalarField::random(&mut *rng), points_witness)?,
+        );
 
         let num_steps = NumStepsLen::<NUM_ENDOSCALING_POINTS>::len();
         let mut step_rxs = Vec::with_capacity(num_steps);

--- a/crates/ragu_pcd/src/fuse/_11_circuits.rs
+++ b/crates/ragu_pcd/src/fuse/_11_circuits.rs
@@ -1,11 +1,33 @@
-use ragu_arithmetic::Cycle;
-use ragu_circuits::{CircuitExt, polynomials::Rank};
+//! Construct internal circuit traces.
+//!
+//! This creates the [`proof::InternalCircuits`] component, containing rx
+//! polynomials for all native recursion circuits (hashes, collapse, compute-v)
+//! and the nested endoscaling circuits whose witnesses are passed in from
+//! [`super::_10_p`].
+
+use alloc::vec::Vec;
+use ff::Field;
+use ragu_arithmetic::{Cycle, Uendo};
+use ragu_circuits::{
+    CircuitExt,
+    polynomials::Rank,
+    staging::{MultiStage, StageExt},
+};
 use ragu_core::Result;
+use ragu_primitives::vec::Len;
 use rand::CryptoRng;
 
 use crate::{
     Application,
-    internal::{native, native::total_circuit_counts},
+    internal::{
+        endoscalar::{
+            EndoscalarStage, EndoscalingStep, EndoscalingStepWitness, NumStepsLen, PointsStage,
+            PointsWitness,
+        },
+        native,
+        native::total_circuit_counts,
+        nested::NUM_ENDOSCALING_POINTS,
+    },
     proof,
 };
 
@@ -28,6 +50,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         query_witness: &native::stages::query::Witness<C>,
         eval_witness: &native::stages::eval::Witness<C::CircuitField>,
         challenges: &proof::Challenges<C>,
+        beta_endo: Uendo,
+        points_witness: &PointsWitness<C::HostCurve, NUM_ENDOSCALING_POINTS>,
     ) -> Result<proof::InternalCircuits<C, R>> {
         let unified = native::unified::Instance {
             bridge_preamble_commitment: preamble.bridge.commitment,
@@ -165,6 +189,37 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             compute_v_rx.commit(host_gen),
         ]);
 
+        // Nested circuit traces for the endoscaling commitment computation.
+        let endoscalar_rx = <EndoscalarStage as StageExt<C::ScalarField, R>>::rx(
+            C::ScalarField::random(&mut *rng),
+            beta_endo,
+        )?;
+        let points_rx = <PointsStage<C::HostCurve, NUM_ENDOSCALING_POINTS> as StageExt<
+            C::ScalarField,
+            R,
+        >>::rx(C::ScalarField::random(&mut *rng), points_witness)?;
+
+        let num_steps = NumStepsLen::<NUM_ENDOSCALING_POINTS>::len();
+        let mut step_rxs = Vec::with_capacity(num_steps);
+        for step in 0..num_steps {
+            let step_circuit =
+                EndoscalingStep::<C::HostCurve, R, NUM_ENDOSCALING_POINTS>::new(step);
+            let staged = MultiStage::new(step_circuit);
+            let step_trace = staged
+                .trace(EndoscalingStepWitness {
+                    endoscalar: beta_endo,
+                    points: points_witness,
+                })?
+                .into_output();
+            let step_rx = self.nested_registry.assemble(
+                &step_trace,
+                crate::internal::nested::InternalCircuitIndex::EndoscalingStep(step as u32)
+                    .circuit_index(),
+                &mut *rng,
+            )?;
+            step_rxs.push(step_rx);
+        }
+
         Ok(proof::InternalCircuits {
             hashes_1: proof::RxTriple {
                 rx: hashes_1_rx,
@@ -186,6 +241,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                 rx: compute_v_rx,
                 commitment: compute_v_commitment,
             },
+            step_rxs,
+            endoscalar_rx,
+            points_rx,
         })
     }
 }

--- a/crates/ragu_pcd/src/fuse/_11_circuits.rs
+++ b/crates/ragu_pcd/src/fuse/_11_circuits.rs
@@ -82,10 +82,10 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         // for its instance polynomial (to match unified_bridge_ky).
         let points_rx = proof::Bridge::commit(
             self.params,
-            <PointsStage<C::HostCurve, NUM_ENDOSCALING_POINTS> as StageExt<
-                C::ScalarField,
-                R,
-            >>::rx(C::ScalarField::random(&mut *rng), points_witness)?,
+            <PointsStage<C::HostCurve, NUM_ENDOSCALING_POINTS> as StageExt<C::ScalarField, R>>::rx(
+                C::ScalarField::random(&mut *rng),
+                points_witness,
+            )?,
         );
 
         let (hashes_1_trace, unified) = native::circuits::hashes_1::Circuit::<

--- a/crates/ragu_pcd/src/fuse/claims.rs
+++ b/crates/ragu_pcd/src/fuse/claims.rs
@@ -140,12 +140,7 @@ impl<K: Copy, F: Field, R: Rank> Clone for Atom<'_, K, F, R> {
 }
 impl<K: Copy, F: Field, R: Rank> Copy for Atom<'_, K, F, R> {}
 
-/// Identifies which of the two child proofs a polynomial came from.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum Side {
-    Left,
-    Right,
-}
+use crate::internal::Side;
 
 /// Key identifying a polynomial and its corresponding commitment within the
 /// fuse pipeline: which child proof, and which component of that proof.

--- a/crates/ragu_pcd/src/fuse/mod.rs
+++ b/crates/ragu_pcd/src/fuse/mod.rs
@@ -167,8 +167,6 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
 
         let circuits = self.compute_internal_circuits(
             rng,
-            &left,
-            &right,
             &preamble,
             &s_prime,
             &outer_error,

--- a/crates/ragu_pcd/src/fuse/mod.rs
+++ b/crates/ragu_pcd/src/fuse/mod.rs
@@ -81,7 +81,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         };
 
         let (inner_error, inner_error_witness, claims) =
-            self.inner_error_terms(rng, &native_registry, &y, &z, &source)?;
+            self.inner_error_terms(rng, &native_registry, &y, &z, &source, &preamble)?;
         let inner_error_commitment = Point::constant(&mut dr, inner_error.bridge.commitment)?;
         inner_error_commitment.write(&mut dr, &mut transcript)?;
 

--- a/crates/ragu_pcd/src/fuse/mod.rs
+++ b/crates/ragu_pcd/src/fuse/mod.rs
@@ -167,6 +167,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
 
         let circuits = self.compute_internal_circuits(
             rng,
+            &left,
+            &right,
             &preamble,
             &s_prime,
             &outer_error,

--- a/crates/ragu_pcd/src/fuse/mod.rs
+++ b/crates/ragu_pcd/src/fuse/mod.rs
@@ -149,8 +149,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         eval_commitment.write(&mut dr, &mut transcript)?;
         let pre_beta = transcript.challenge(&mut dr)?;
 
-        let p = self.compute_p(
-            rng,
+        let (p, beta_endo, points_witness) = self.compute_p(
             &pre_beta,
             &u,
             &left,
@@ -183,6 +182,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             &query_witness,
             &eval_witness,
             &challenges,
+            beta_endo,
+            &points_witness,
         )?;
 
         let proof = Proof {

--- a/crates/ragu_pcd/src/internal/mod.rs
+++ b/crates/ragu_pcd/src/internal/mod.rs
@@ -17,6 +17,13 @@ pub mod nested;
 pub mod suffix;
 pub mod transcript;
 
+/// Identifies which of the two child proofs a value came from.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Side {
+    Left,
+    Right,
+}
+
 /// Assigns `val` into the next slot and advances the counter.
 pub(crate) const fn push<T: Copy, const N: usize>(
     slots: &mut [Option<T>; N],

--- a/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
@@ -85,7 +85,7 @@ use ragu_core::{
     maybe::Maybe,
 };
 use ragu_primitives::{
-    Element, GadgetExt,
+    Element, GadgetExt, Point,
     io::Write,
     vec::{ConstLen, FixedVec},
 };
@@ -114,6 +114,10 @@ pub struct Output<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEAD
     /// The unified instance shared across internal circuits.
     #[ragu(gadget)]
     pub unified: unified::Output<'dr, D, C>,
+    /// NestedCurve commitment to the current proof's `points_rx` polynomial.
+    /// Position must match the Horner order in `unified_ky_values`.
+    #[ragu(gadget)]
+    pub points_commitment: Point<'dr, D, C::NestedCurve>,
     /// The left child proof's output header.
     #[ragu(gadget)]
     pub left_header: FixedVec<Element<'dr, D>, ConstLen<HEADER_SIZE>>,
@@ -164,6 +168,9 @@ pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_rev
     /// The unified instance containing expected challenge values and
     /// accumulated coverage from prior circuits.
     pub unified: unified::Instance<C>,
+
+    /// NestedCurve commitment to the current proof's `points_rx` polynomial.
+    pub points_commitment: C::NestedCurve,
 
     /// Witness for the [`preamble`](super::super::stages::preamble) stage
     /// (unenforced).
@@ -228,6 +235,11 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
             .circuit_id
             .enforce_root_of_unity(dr, self.log2_circuits)?;
 
+        let points_commitment = Point::alloc(
+            dr,
+            witness.as_ref().map(|w| w.points_commitment),
+        )?;
+
         let mut unified_output = OutputBuilder::new(witness.map(|w| w.unified));
 
         // Create a transcript for all challenge derivations
@@ -277,9 +289,10 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         // headers.
         let (unified, updated) = unified_output.finish_no_suffix(dr)?;
         let output = Output {
+            unified,
+            points_commitment,
             left_header: preamble.left.output_header,
             right_header: preamble.right.output_header,
-            unified,
         };
 
         let zero = Element::zero(dr);

--- a/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
@@ -235,10 +235,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
             .circuit_id
             .enforce_root_of_unity(dr, self.log2_circuits)?;
 
-        let points_commitment = Point::alloc(
-            dr,
-            witness.as_ref().map(|w| w.points_commitment),
-        )?;
+        let points_commitment = Point::alloc(dr, witness.as_ref().map(|w| w.points_commitment))?;
 
         let mut unified_output = OutputBuilder::new(witness.map(|w| w.unified));
 

--- a/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
@@ -253,25 +253,10 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         unified_output.y.provide(y.clone());
         unified_output.z.provide(z);
 
-        // Compute k(y) values from preamble and enforce equality with staged
-        // values.
-        {
-            let left_application_ky = preamble.left.application_ky(dr, &y)?;
-            let right_application_ky = preamble.right.application_ky(dr, &y)?;
-
-            left_application_ky.enforce_equal(dr, &outer_error.left.application)?;
-            right_application_ky.enforce_equal(dr, &outer_error.right.application)?;
-
-            let (left_unified_ky, left_unified_bridge_ky) =
-                preamble.left.unified_ky_values(dr, &y)?;
-            let (right_unified_ky, right_unified_bridge_ky) =
-                preamble.right.unified_ky_values(dr, &y)?;
-
-            left_unified_ky.enforce_equal(dr, &outer_error.left.unified)?;
-            right_unified_ky.enforce_equal(dr, &outer_error.right.unified)?;
-            left_unified_bridge_ky.enforce_equal(dr, &outer_error.left.unified_bridge)?;
-            right_unified_bridge_ky.enforce_equal(dr, &outer_error.right.unified_bridge)?;
-        }
+        // k(y) evaluation (application_ky, unified_ky_values) is performed
+        // in outer_collapse, which also has the preamble and outer_error
+        // stages. Moved there to stay within the gate budget after the
+        // preamble stage expansion.
 
         // Absorb bridge_inner_error_commitment and verify saved transcript state
         {

--- a/crates/ragu_pcd/src/internal/native/circuits/outer_collapse.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/outer_collapse.rs
@@ -55,7 +55,7 @@ use ragu_circuits::{
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::Bound,
+    gadgets::{Bound, Gadget},
     maybe::Maybe,
 };
 
@@ -150,6 +150,29 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
             outer_error.unenforced(dr, witness.as_ref().map(|w| w.outer_error_witness))?;
 
         let mut unified_output = OutputBuilder::new(witness.map(|w| w.unified));
+
+        // Compute k(y) values from preamble and enforce equality with staged
+        // values. Moved here from hashes_1 to stay within the gate budget
+        // after the preamble stage expansion.
+        {
+            let y = unified_output.y.read(dr)?;
+
+            let left_application_ky = preamble.left.application_ky(dr, &y)?;
+            let right_application_ky = preamble.right.application_ky(dr, &y)?;
+
+            left_application_ky.enforce_equal(dr, &outer_error.left.application)?;
+            right_application_ky.enforce_equal(dr, &outer_error.right.application)?;
+
+            let (left_unified_ky, left_unified_bridge_ky) =
+                preamble.left.unified_ky_values(dr, &y)?;
+            let (right_unified_ky, right_unified_bridge_ky) =
+                preamble.right.unified_ky_values(dr, &y)?;
+
+            left_unified_ky.enforce_equal(dr, &outer_error.left.unified)?;
+            right_unified_ky.enforce_equal(dr, &outer_error.right.unified)?;
+            left_unified_bridge_ky.enforce_equal(dr, &outer_error.left.unified_bridge)?;
+            right_unified_bridge_ky.enforce_equal(dr, &outer_error.right.unified_bridge)?;
+        }
 
         // Get layer 2 folding challenges. These are distinct from the layer 1
         // challenges (mu, nu) used in inner_collapse.

--- a/crates/ragu_pcd/src/internal/native/stages/preamble.rs
+++ b/crates/ragu_pcd/src/internal/native/stages/preamble.rs
@@ -12,7 +12,7 @@ use ragu_core::{
     maybe::Maybe,
 };
 use ragu_primitives::{
-    Boolean, Element, GadgetExt,
+    Boolean, Element, GadgetExt, Point,
     consistent::Consistent,
     vec::{CollectFixed, ConstLen, FixedVec},
 };
@@ -87,6 +87,10 @@ pub struct ProofInputs<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const
     pub output_header: HeaderVec<'dr, D, HEADER_SIZE>,
     #[ragu(gadget)]
     pub circuit_id: Element<'dr, D>,
+    /// NestedCurve commitment to the child's `points_rx` polynomial.
+    /// Not in the child's unified instance; bound via `unified_bridge_ky`.
+    #[ragu(gadget)]
+    pub points_commitment: Point<'dr, D, C::NestedCurve>,
     #[ragu(gadget)]
     pub unified: unified::Output<'dr, D, C>,
 }
@@ -99,7 +103,8 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usiz
     ///
     /// Returns `(unified_ky, unified_bridge_ky)` where:
     /// - `unified_ky` = k(y) for `(unified, 0)`
-    /// - `unified_bridge_ky` = k(y) for `(unified, children.left, children.right, 0)`
+    /// - `unified_bridge_ky` = k(y) for `(unified, points_commitment,
+    ///   children.left, children.right, 0)`
     ///
     /// The Horner evaluation order and trailing zero here define the numerical
     /// values that [`ky_values`](super::super::claims::ky_values) must produce
@@ -119,6 +124,7 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usiz
                 ky.finish_ky(dr)?
             }),
             ({
+                self.points_commitment.write(dr, &mut ky)?;
                 self.children.left.write(dr, &mut ky)?;
                 self.children.right.write(dr, &mut ky)?;
                 Element::zero(dr).write(dr, &mut ky)?;
@@ -191,6 +197,11 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usiz
                 dr,
                 proof.as_ref().map(|p| p.application.circuit_id.omega_j()),
             )?,
+            points_commitment: Point::alloc(
+                dr,
+                proof.as_ref().map(|p| p.circuits.points_rx.commitment),
+            )?,
+            // alloc_from_proof moves `proof`, so it must come last.
             unified: unified::Output::alloc_from_proof(dr, proof)?,
         })
     }
@@ -258,8 +269,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> staging::Stage<C::CircuitField
     type OutputKind = Kind![C::CircuitField; Output<'_, _, C, HEADER_SIZE>];
 
     fn values() -> usize {
-        // 2 proofs * (3 headers * HEADER_SIZE + 1 circuit_id + unified instance wires)
-        2 * (3 * HEADER_SIZE + 1 + unified::NUM_WIRES)
+        // 2 proofs * (3 headers * HEADER_SIZE + 1 circuit_id + 1 Point + unified instance wires)
+        2 * (3 * HEADER_SIZE + 1 + 2 + unified::NUM_WIRES)
     }
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>>(

--- a/crates/ragu_pcd/src/internal/native/stages/preamble.rs
+++ b/crates/ragu_pcd/src/internal/native/stages/preamble.rs
@@ -64,13 +64,14 @@ impl<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize> Witness<'a, C, R, HEADER_S
     }
 }
 
-/// Headers claimed by a child proof for its own left and right children.
+/// Headers this proof consumed from its left and right inputs.
+///
+/// In the fuse pipeline, where this proof is a child of the current step,
+/// these are grandchild headers from the current step's perspective.
 #[derive(Gadget, Consistent)]
 pub struct ChildHeaders<'dr, D: Driver<'dr>, const HEADER_SIZE: usize> {
-    /// Left child header (grandchild from current perspective).
     #[ragu(gadget)]
     pub left: HeaderVec<'dr, D, HEADER_SIZE>,
-    /// Right child header (grandchild from current perspective).
     #[ragu(gadget)]
     pub right: HeaderVec<'dr, D, HEADER_SIZE>,
 }
@@ -79,7 +80,9 @@ pub struct ChildHeaders<'dr, D: Driver<'dr>, const HEADER_SIZE: usize> {
 #[derive(Gadget, Consistent)]
 pub struct ProofInputs<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usize>
 {
-    /// Headers this child proof claimed for its own children.
+    /// This proof's children's headers (the left and right inputs it consumed).
+    /// In the fuse pipeline these are grandchild headers from the current
+    /// step's perspective.
     #[ragu(gadget)]
     pub children: ChildHeaders<'dr, D, HEADER_SIZE>,
     /// Output header of this child proof.

--- a/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
@@ -1,0 +1,144 @@
+//! Copying circuit for the nested field.
+//!
+//! This bonding circuit enforces that each child proof's commitments witnessed
+//! in the preamble [`ChildOutput`] match the native commitments inside that
+//! child's own bridge stages. It uses `enforce_equal` to bind each preamble
+//! child field to the corresponding bridge stage field.
+//!
+//! There are two instances — one per [`Side`] — because the left and right
+//! children constrain different parts of the preamble output.
+//!
+//! Because it only uses `enforce_equal`, it qualifies as a bonding polynomial
+//! via `MultiStage::into_bonding_object`.
+
+use core::marker::PhantomData;
+
+use ragu_arithmetic::CurveAffine;
+use ragu_circuits::{
+    WithAux,
+    polynomials::Rank,
+    staging::{MultiStageCircuit, StageBuilder},
+};
+use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue},
+    gadgets::{Bound, Gadget, Kind},
+    maybe::MaybeKind,
+};
+
+use crate::internal::{
+    Side,
+    endoscalar::{EndoscalarStage, PointsStage},
+    nested::{NUM_ENDOSCALING_POINTS, stages},
+};
+
+/// A copying circuit that binds preamble child commitments to bridge stage
+/// native commitments for one child proof (left or right).
+pub struct Copying<C: CurveAffine, R: Rank> {
+    side: Side,
+    _marker: PhantomData<(C, R)>,
+}
+
+impl<C: CurveAffine, R: Rank> Copying<C, R> {
+    pub fn new(side: Side) -> Self {
+        Self {
+            side,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Copying<C, R> {
+    type Last = stages::eval::Stage<C, R>;
+    type Instance<'source> = ();
+    type Witness<'source> = ();
+    type Output = Kind![C::Base; ()];
+    type Aux<'source> = ();
+
+    fn instance<'dr, 'source: 'dr, D: Driver<'dr, F = C::Base>>(
+        &self,
+        _dr: &mut D,
+        _instance: DriverValue<D, ()>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Ok(())
+    }
+
+    fn witness<'a, 'dr, 'source: 'dr, D: Driver<'dr, F = C::Base>>(
+        &self,
+        builder: StageBuilder<'a, 'dr, D, R, (), Self::Last>,
+        _witness: DriverValue<D, ()>,
+    ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'source>>>> {
+        // Build stage chain, skipping stages whose data is not needed.
+        let builder = builder.skip_stage::<EndoscalarStage>()?;
+        let builder = builder.skip_stage::<PointsStage<C, NUM_ENDOSCALING_POINTS>>()?;
+        let (preamble_guard, builder) = builder.add_stage::<stages::preamble::Stage<C, R>>()?;
+        let builder = builder.skip_stage::<stages::s_prime::Stage<C, R>>()?;
+        let (inner_error_guard, builder) =
+            builder.add_stage::<stages::inner_error::Stage<C, R>>()?;
+        let (outer_error_guard, builder) =
+            builder.add_stage::<stages::outer_error::Stage<C, R>>()?;
+        let (ab_guard, builder) = builder.add_stage::<stages::ab::Stage<C, R>>()?;
+        let (query_guard, builder) = builder.add_stage::<stages::query::Stage<C, R>>()?;
+        let builder = builder.skip_stage::<stages::f::Stage<C, R>>()?;
+        let (eval_guard, builder) = builder.add_stage::<stages::eval::Stage<C, R>>()?;
+        let dr = builder.finish();
+
+        // Load stage outputs. Witness values are empty because this circuit is
+        // only used as a bonding polynomial (never traced with real data).
+        let preamble_out = preamble_guard.unenforced(dr, D::MaybeKind::empty())?;
+        let inner_error_out = inner_error_guard.unenforced(dr, D::MaybeKind::empty())?;
+        let outer_error_out = outer_error_guard.unenforced(dr, D::MaybeKind::empty())?;
+        let ab_out = ab_guard.unenforced(dr, D::MaybeKind::empty())?;
+        let query_out = query_guard.unenforced(dr, D::MaybeKind::empty())?;
+        let eval_out = eval_guard.unenforced(dr, D::MaybeKind::empty())?;
+
+        // Select the child output for this side.
+        let child = match self.side {
+            Side::Left => &preamble_out.left,
+            Side::Right => &preamble_out.right,
+        };
+
+        // Enforce that preamble child commitments match the corresponding
+        // bridge stage native commitments.
+        child
+            .inner_error
+            .enforce_equal(dr, &inner_error_out.native_inner_error)?;
+        child
+            .outer_error
+            .enforce_equal(dr, &outer_error_out.native_outer_error)?;
+        child.query_rx.enforce_equal(dr, &query_out.native_query)?;
+        child.eval.enforce_equal(dr, &eval_out.native_eval)?;
+        child.a.enforce_equal(dr, &ab_out.a)?;
+        child.b.enforce_equal(dr, &ab_out.b)?;
+        child
+            .registry_xy
+            .enforce_equal(dr, &query_out.registry_xy)?;
+
+        Ok(WithAux::new((), D::unit()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ragu_circuits::{polynomials::ProductionRank, staging::MultiStage};
+    use ragu_pasta::EqAffine;
+
+    type R = ProductionRank;
+
+    #[test]
+    fn into_bonding_object_succeeds_left() {
+        let circuit = Copying::<EqAffine, R>::new(Side::Left);
+        MultiStage::new(circuit)
+            .into_bonding_object()
+            .expect("copying circuit (left) should produce a valid bonding object");
+    }
+
+    #[test]
+    fn into_bonding_object_succeeds_right() {
+        let circuit = Copying::<EqAffine, R>::new(Side::Right);
+        MultiStage::new(circuit)
+            .into_bonding_object()
+            .expect("copying circuit (right) should produce a valid bonding object");
+    }
+}

--- a/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
@@ -113,6 +113,9 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Copying<C, R> {
         child
             .registry_xy
             .enforce_equal(dr, &query_out.registry_xy)?;
+        child
+            .preamble
+            .enforce_equal(dr, &inner_error_out.stashed_native_preamble)?;
 
         Ok(WithAux::new((), D::unit()))
     }

--- a/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
@@ -26,9 +26,11 @@ use ragu_core::{
     maybe::MaybeKind,
 };
 
+use ragu_primitives::vec::Len;
+
 use crate::internal::{
     Side,
-    endoscalar::{EndoscalarStage, PointsStage},
+    endoscalar::{EndoscalarStage, NumStepsLen, PointsStage},
     nested::{NUM_ENDOSCALING_POINTS, stages},
 };
 
@@ -70,7 +72,8 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Copying<C, R> {
     ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'source>>>> {
         // Build stage chain, skipping stages whose data is not needed.
         let builder = builder.skip_stage::<EndoscalarStage>()?;
-        let builder = builder.skip_stage::<PointsStage<C, NUM_ENDOSCALING_POINTS>>()?;
+        let (points_guard, builder) =
+            builder.add_stage::<PointsStage<C, NUM_ENDOSCALING_POINTS>>()?;
         let (preamble_guard, builder) = builder.add_stage::<stages::preamble::Stage<C, R>>()?;
         let builder = builder.skip_stage::<stages::s_prime::Stage<C, R>>()?;
         let (inner_error_guard, builder) =
@@ -85,6 +88,7 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Copying<C, R> {
 
         // Load stage outputs. Witness values are empty because this circuit is
         // only used as a bonding polynomial (never traced with real data).
+        let points = points_guard.unenforced(dr, D::MaybeKind::empty())?;
         let preamble_out = preamble_guard.unenforced(dr, D::MaybeKind::empty())?;
         let inner_error_out = inner_error_guard.unenforced(dr, D::MaybeKind::empty())?;
         let outer_error_out = outer_error_guard.unenforced(dr, D::MaybeKind::empty())?;
@@ -116,6 +120,13 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Copying<C, R> {
         child
             .preamble
             .enforce_equal(dr, &inner_error_out.stashed_native_preamble)?;
+
+        // Enforce that the preamble's child P commitment matches the child's
+        // PointsStage last interstitial (which is the child's P value).
+        child.p.enforce_equal(
+            dr,
+            &points.interstitials[NumStepsLen::<NUM_ENDOSCALING_POINTS>::len() - 1],
+        )?;
 
         Ok(WithAux::new((), D::unit()))
     }

--- a/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
@@ -1,7 +1,7 @@
 //! Copying circuit for the nested field.
 //!
 //! This bonding circuit enforces that each child proof's commitments witnessed
-//! in the preamble [`ChildOutput`] match the native commitments inside that
+//! in the preamble [`ChildOutput`](super::super::stages::preamble::ChildOutput) match the native commitments inside that
 //! child's own bridge stages. It uses `enforce_equal` to bind each preamble
 //! child field to the corresponding bridge stage field.
 //!

--- a/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
@@ -1,0 +1,168 @@
+//! Loading circuit for the nested field.
+//!
+//! This bonding circuit enforces that the endoscaling [`PointsStage`] contains
+//! the same commitments as the bridge stages. It mirrors the accumulation order
+//! from `fuse::_10_p` and uses `enforce_equal` to bind each
+//! bridge stage point to its corresponding position in the points stage.
+//!
+//! Because it only uses `enforce_equal`, it qualifies as a bonding polynomial
+//! via `MultiStage::into_bonding_object`.
+
+use core::marker::PhantomData;
+
+use ragu_arithmetic::CurveAffine;
+use ragu_circuits::{
+    WithAux,
+    polynomials::Rank,
+    staging::{MultiStageCircuit, StageBuilder},
+};
+use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue},
+    gadgets::{Bound, Gadget, Kind},
+    maybe::MaybeKind,
+};
+use ragu_primitives::{Point, vec::FixedVec};
+
+use crate::internal::{
+    endoscalar::{EndoscalarStage, InputsLen, PointsStage},
+    native::RxIndex,
+    nested::{NUM_ENDOSCALING_POINTS, stages},
+};
+
+/// A walker over `points.inputs` that enforces equalities or skips entries in order.
+struct InputWalker<'a, 'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
+    inputs: &'a FixedVec<Point<'dr, D, C>, InputsLen<NUM_ENDOSCALING_POINTS>>,
+    idx: usize,
+}
+
+impl<'a, 'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> InputWalker<'a, 'dr, D, C> {
+    fn new(inputs: &'a FixedVec<Point<'dr, D, C>, InputsLen<NUM_ENDOSCALING_POINTS>>) -> Self {
+        Self { inputs, idx: 0 }
+    }
+
+    fn enforce_equal<D2: Driver<'dr, F = D::F, Wire = D::Wire>>(
+        &mut self,
+        dr: &mut D2,
+        point: &Point<'dr, D, C>,
+    ) -> Result<()> {
+        self.inputs[self.idx].enforce_equal(dr, point)?;
+        self.idx += 1;
+        Ok(())
+    }
+
+    fn skip(&mut self) {
+        self.idx += 1;
+    }
+
+    fn finish(self) {
+        assert_eq!(
+            self.idx,
+            self.inputs.len(),
+            "InputWalker did not consume all points"
+        );
+    }
+}
+
+/// A loading circuit that binds bridge stage commitments to the points stage.
+pub struct Loading<C: CurveAffine, R: Rank> {
+    _marker: PhantomData<(C, R)>,
+}
+
+impl<C: CurveAffine, R: Rank> Loading<C, R> {
+    pub fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Loading<C, R> {
+    type Last = stages::f::Stage<C, R>;
+    type Instance<'source> = ();
+    type Witness<'source> = ();
+    type Output = Kind![C::Base; ()];
+    type Aux<'source> = ();
+
+    fn instance<'dr, 'source: 'dr, D: Driver<'dr, F = C::Base>>(
+        &self,
+        _dr: &mut D,
+        _instance: DriverValue<D, ()>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Ok(())
+    }
+
+    fn witness<'a, 'dr, 'source: 'dr, D: Driver<'dr, F = C::Base>>(
+        &self,
+        builder: StageBuilder<'a, 'dr, D, R, (), Self::Last>,
+        _witness: DriverValue<D, ()>,
+    ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'source>>>> {
+        // Build stage chain, skipping stages whose data is not needed.
+        let builder = builder.skip_stage::<EndoscalarStage>()?;
+        let (points_guard, builder) =
+            builder.add_stage::<PointsStage<C, NUM_ENDOSCALING_POINTS>>()?;
+        let (preamble_guard, builder) = builder.add_stage::<stages::preamble::Stage<C, R>>()?;
+        let (s_prime_guard, builder) = builder.add_stage::<stages::s_prime::Stage<C, R>>()?;
+        let (inner_error_guard, builder) =
+            builder.add_stage::<stages::inner_error::Stage<C, R>>()?;
+        let builder = builder.skip_stage::<stages::outer_error::Stage<C, R>>()?;
+        let (ab_guard, builder) = builder.add_stage::<stages::ab::Stage<C, R>>()?;
+        let (query_guard, builder) = builder.add_stage::<stages::query::Stage<C, R>>()?;
+        let (f_guard, builder) = builder.add_stage::<stages::f::Stage<C, R>>()?;
+        let dr = builder.finish();
+
+        // Load stage outputs. Witness values are empty because this circuit is
+        // only used as a bonding polynomial (never traced with real data).
+        let points = points_guard.unenforced(dr, D::MaybeKind::empty())?;
+        let preamble_out = preamble_guard.unenforced(dr, D::MaybeKind::empty())?;
+        let s_prime_out = s_prime_guard.unenforced(dr, D::MaybeKind::empty())?;
+        let inner_error_out = inner_error_guard.unenforced(dr, D::MaybeKind::empty())?;
+        let ab_out = ab_guard.unenforced(dr, D::MaybeKind::empty())?;
+        let query_out = query_guard.unenforced(dr, D::MaybeKind::empty())?;
+        let f_out = f_guard.unenforced(dr, D::MaybeKind::empty())?;
+
+        // Initial point: f.commitment
+        points.initial.enforce_equal(dr, &f_out.native_f)?;
+
+        // Child proof commitments, mirroring the accumulation order in _10_p.rs.
+        let mut walker = InputWalker::new(&points.inputs);
+        for child in [&preamble_out.left, &preamble_out.right] {
+            for &id in &RxIndex::ALL {
+                walker.enforce_equal(dr, child.rx(id))?;
+            }
+            walker.enforce_equal(dr, &child.a)?;
+            walker.enforce_equal(dr, &child.b)?;
+            walker.enforce_equal(dr, &child.registry_xy)?;
+            // TODO: bind the P commitment once it has a bridge stage.
+            walker.skip();
+        }
+
+        // Current proof components.
+        walker.enforce_equal(dr, &s_prime_out.registry_wx0)?;
+        walker.enforce_equal(dr, &s_prime_out.registry_wx1)?;
+        walker.enforce_equal(dr, &inner_error_out.registry_wy)?;
+        walker.enforce_equal(dr, &ab_out.a)?;
+        walker.enforce_equal(dr, &ab_out.b)?;
+        walker.enforce_equal(dr, &query_out.registry_xy)?;
+        walker.finish();
+
+        Ok(WithAux::new((), D::unit()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ragu_circuits::{polynomials::ProductionRank, staging::MultiStage};
+    use ragu_pasta::EqAffine;
+
+    type R = ProductionRank;
+
+    #[test]
+    fn into_bonding_object_succeeds() {
+        let circuit = Loading::<EqAffine, R>::new();
+        MultiStage::new(circuit)
+            .into_bonding_object()
+            .expect("loading circuit should produce a valid bonding object");
+    }
+}

--- a/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
@@ -141,6 +141,14 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Loading<C, R> {
         walker.enforce_equal(dr, &s_prime_out.registry_wx0)?;
         walker.enforce_equal(dr, &s_prime_out.registry_wx1)?;
         walker.enforce_equal(dr, &inner_error_out.registry_wy)?;
+
+        // Bind the stashed native_preamble duplicate in inner_error to the
+        // preamble's native_preamble. This allows the Copying circuit to check
+        // child.preamble against inner_error positions (avoiding the preamble
+        // wire position collision).
+        preamble_out
+            .native_preamble
+            .enforce_equal(dr, &inner_error_out.stashed_native_preamble)?;
         walker.enforce_equal(dr, &ab_out.a)?;
         walker.enforce_equal(dr, &ab_out.b)?;
         walker.enforce_equal(dr, &query_out.registry_xy)?;

--- a/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
@@ -51,10 +51,6 @@ impl<'a, 'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> InputWalker<'a, 'dr, 
         Ok(())
     }
 
-    fn skip(&mut self) {
-        self.idx += 1;
-    }
-
     fn finish(self) {
         assert_eq!(
             self.idx,
@@ -133,8 +129,7 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Loading<C, R> {
             walker.enforce_equal(dr, &child.a)?;
             walker.enforce_equal(dr, &child.b)?;
             walker.enforce_equal(dr, &child.registry_xy)?;
-            // TODO: bind the P commitment once it has a bridge stage.
-            walker.skip();
+            walker.enforce_equal(dr, &child.p)?;
         }
 
         // Current proof components.

--- a/crates/ragu_pcd/src/internal/nested/circuits/mod.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/mod.rs
@@ -1,0 +1,1 @@
+pub mod loading;

--- a/crates/ragu_pcd/src/internal/nested/circuits/mod.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/mod.rs
@@ -1,1 +1,2 @@
+pub mod copying;
 pub mod loading;

--- a/crates/ragu_pcd/src/internal/nested/claims.rs
+++ b/crates/ragu_pcd/src/internal/nested/claims.rs
@@ -156,6 +156,17 @@ where
                     .map(|((((((a, b), c), d), e), f), g)| [a, b, c, d, e, f, g].into_iter());
                 processor.bonding_summed(id, per_proof)?;
             }
+            Copying(side) => {
+                let per_proof = source
+                    .rx(RxIndex::BridgePreamble)
+                    .zip(source.rx(RxIndex::ChildBridgeInnerError(side)))
+                    .zip(source.rx(RxIndex::ChildBridgeOuterError(side)))
+                    .zip(source.rx(RxIndex::ChildBridgeAB(side)))
+                    .zip(source.rx(RxIndex::ChildBridgeQuery(side)))
+                    .zip(source.rx(RxIndex::ChildBridgeEval(side)))
+                    .map(|(((((a, b), c), d), e), f)| [a, b, c, d, e, f].into_iter());
+                processor.bonding_summed(id, per_proof)?;
+            }
         }
     }
 

--- a/crates/ragu_pcd/src/internal/nested/claims.rs
+++ b/crates/ragu_pcd/src/internal/nested/claims.rs
@@ -27,7 +27,12 @@ pub trait Processor<Rx> {
     fn internal_circuit(&mut self, id: InternalCircuitIndex, rxs: impl Iterator<Item = Rx>);
 
     /// Process a bonding claim - aggregates rxs from all proofs.
-    fn bonding(&mut self, id: InternalCircuitIndex, rxs: impl Iterator<Item = Rx>) -> Result<()>;
+    ///
+    /// Delegates to [`bonding_summed`](Self::bonding_summed) by wrapping each
+    /// rx in a single-element iterator.
+    fn bonding(&mut self, id: InternalCircuitIndex, rxs: impl Iterator<Item = Rx>) -> Result<()> {
+        self.bonding_summed(id, rxs.map(core::iter::once))
+    }
 
     /// Process a bonding claim where each per-proof term is a sum of
     /// multiple component rxs.
@@ -53,17 +58,6 @@ impl<'m, 'rx, F: PrimeField, R: Rank> Processor<&'rx sparse::Polynomial<F, R>>
         let circuit_id = id.circuit_index();
         let rx = sum_polynomials(rxs);
         self.circuit_impl(circuit_id, rx);
-    }
-
-    fn bonding(
-        &mut self,
-        id: InternalCircuitIndex,
-        rxs: impl Iterator<Item = &'rx sparse::Polynomial<F, R>>,
-    ) -> Result<()> {
-        let circuit_id = id.circuit_index();
-        let folded = self.fold_bonding_polys(rxs);
-        self.bonding_impl(circuit_id, folded);
-        Ok(())
     }
 
     fn bonding_summed<I: Iterator<Item = &'rx sparse::Polynomial<F, R>>>(

--- a/crates/ragu_pcd/src/internal/nested/claims.rs
+++ b/crates/ragu_pcd/src/internal/nested/claims.rs
@@ -7,7 +7,8 @@
 //! - Circuit checks ([`EndoscalingStep`](InternalCircuitIndex::EndoscalingStep)): $k(y) = 1$
 //! - Bonding checks ([`EndoscalarStage`](InternalCircuitIndex::EndoscalarStage),
 //!   [`PointsStage`](InternalCircuitIndex::PointsStage),
-//!   `PointsFinalStaged`, and all `Bridge*` variants): $k(y) = 0$
+//!   `PointsFinalStaged`, all `Bridge*` variants, and
+//!   [`Loading`](InternalCircuitIndex::Loading)): $k(y) = 0$
 
 use alloc::borrow::Cow;
 
@@ -27,6 +28,18 @@ pub trait Processor<Rx> {
 
     /// Process a bonding claim - aggregates rxs from all proofs.
     fn bonding(&mut self, id: InternalCircuitIndex, rxs: impl Iterator<Item = Rx>) -> Result<()>;
+
+    /// Process a bonding claim where each per-proof term is a sum of
+    /// multiple component rxs.
+    ///
+    /// Each inner iterator yields the component rxs for one proof (summed
+    /// together). The per-proof sums are then Horner-folded across proofs
+    /// into a single bonding claim, preserving batching.
+    fn bonding_summed<I: Iterator<Item = Rx>>(
+        &mut self,
+        id: InternalCircuitIndex,
+        per_proof_rxs: impl Iterator<Item = I>,
+    ) -> Result<()>;
 }
 
 impl<'m, 'rx, F: PrimeField, R: Rank> Processor<&'rx sparse::Polynomial<F, R>>
@@ -52,6 +65,20 @@ impl<'m, 'rx, F: PrimeField, R: Rank> Processor<&'rx sparse::Polynomial<F, R>>
         self.bonding_impl(circuit_id, folded);
         Ok(())
     }
+
+    fn bonding_summed<I: Iterator<Item = &'rx sparse::Polynomial<F, R>>>(
+        &mut self,
+        id: InternalCircuitIndex,
+        per_proof_rxs: impl Iterator<Item = I>,
+    ) -> Result<()> {
+        let circuit_id = id.circuit_index();
+        let sums: alloc::vec::Vec<_> = per_proof_rxs
+            .map(|rxs| sum_polynomials(rxs).into_owned())
+            .collect();
+        let folded = Cow::Owned(sparse::Polynomial::fold(&sums, self.z));
+        self.bonding_impl(circuit_id, folded);
+        Ok(())
+    }
 }
 
 /// Build nested claims in unified interleaved order from a source.
@@ -61,7 +88,7 @@ impl<'m, 'rx, F: PrimeField, R: Rank> Processor<&'rx sparse::Polynomial<F, R>>
 ///    for each step, interleaved across proofs
 /// 2. Bonding checks ($k(y) = 0$): [`EndoscalarStage`](InternalCircuitIndex::EndoscalarStage),
 ///    [`PointsStage`](InternalCircuitIndex::PointsStage), `PointsFinalStaged`,
-///    and all `Bridge*` variants
+///    all `Bridge*` variants, and [`Loading`](InternalCircuitIndex::Loading)
 ///
 /// This ordering must match the ky_elements ordering from [`ky_values`].
 pub fn build<S, P>(source: &S, processor: &mut P) -> Result<()>
@@ -116,6 +143,18 @@ where
             }
             BridgeEval => {
                 processor.bonding(id, source.rx(RxIndex::BridgeEval))?;
+            }
+            Loading => {
+                let per_proof = source
+                    .rx(RxIndex::PointsStage)
+                    .zip(source.rx(RxIndex::BridgePreamble))
+                    .zip(source.rx(RxIndex::BridgeSPrime))
+                    .zip(source.rx(RxIndex::BridgeInnerError))
+                    .zip(source.rx(RxIndex::BridgeAB))
+                    .zip(source.rx(RxIndex::BridgeQuery))
+                    .zip(source.rx(RxIndex::BridgeF))
+                    .map(|((((((a, b), c), d), e), f), g)| [a, b, c, d, e, f, g].into_iter());
+                processor.bonding_summed(id, per_proof)?;
             }
         }
     }

--- a/crates/ragu_pcd/src/internal/nested/claims.rs
+++ b/crates/ragu_pcd/src/internal/nested/claims.rs
@@ -158,7 +158,8 @@ where
                     .zip(source.rx(RxIndex::ChildBridgeAB(side)))
                     .zip(source.rx(RxIndex::ChildBridgeQuery(side)))
                     .zip(source.rx(RxIndex::ChildBridgeEval(side)))
-                    .map(|(((((a, b), c), d), e), f)| [a, b, c, d, e, f].into_iter());
+                    .zip(source.rx(RxIndex::ChildPointsStage(side)))
+                    .map(|((((((a, b), c), d), e), f), g)| [a, b, c, d, e, f, g].into_iter());
                 processor.bonding_summed(id, per_proof)?;
             }
         }

--- a/crates/ragu_pcd/src/internal/nested/mod.rs
+++ b/crates/ragu_pcd/src/internal/nested/mod.rs
@@ -58,11 +58,13 @@ pub enum InternalCircuitIndex {
     BridgeF,
     /// Bridge `eval` stage mask.
     BridgeEval,
+    /// Loading circuit bonding polynomial.
+    Loading,
 }
 
 /// The number of internal circuits registered by [`register_all`],
 /// equal to the number of entries in [`InternalCircuitIndex::ALL`].
-pub const NUM_INTERNAL_CIRCUITS: usize = NUM_ENDOSCALING_STEPS + 11;
+pub const NUM_INTERNAL_CIRCUITS: usize = NUM_ENDOSCALING_STEPS + 12;
 
 impl InternalCircuitIndex {
     /// All variants in canonical iteration order.
@@ -94,6 +96,7 @@ impl InternalCircuitIndex {
         super::push(&mut slots, &mut c, Self::BridgeQuery);
         super::push(&mut slots, &mut c, Self::BridgeF);
         super::push(&mut slots, &mut c, Self::BridgeEval);
+        super::push(&mut slots, &mut c, Self::Loading);
         assert!(c == NUM_INTERNAL_CIRCUITS);
         slots
     }
@@ -178,6 +181,7 @@ impl RxIndex {
     }
 }
 
+pub mod circuits;
 pub mod claims;
 
 pub mod stages;
@@ -233,6 +237,10 @@ pub fn register_all<'params, C: Cycle, R: Rank>(
             BridgeEval => {
                 registry.register_bonding(stages::eval::Stage::<C::HostCurve, R>::mask()?)
             }
+            Loading => registry.register_bonding(
+                MultiStage::new(circuits::loading::Loading::<C::HostCurve, R>::new())
+                    .into_bonding_object()?,
+            ),
         };
     }
 

--- a/crates/ragu_pcd/src/internal/nested/mod.rs
+++ b/crates/ragu_pcd/src/internal/nested/mod.rs
@@ -11,6 +11,7 @@ use ragu_circuits::{
 };
 use ragu_core::Result;
 
+use crate::internal::Side;
 use crate::internal::endoscalar;
 
 /// Number of curve points accumulated during `compute_p` for nested field
@@ -60,11 +61,13 @@ pub enum InternalCircuitIndex {
     BridgeEval,
     /// Loading circuit bonding polynomial.
     Loading,
+    /// Copying circuit bonding polynomial for a given child proof side.
+    Copying(Side),
 }
 
 /// The number of internal circuits registered by [`register_all`],
 /// equal to the number of entries in [`InternalCircuitIndex::ALL`].
-pub const NUM_INTERNAL_CIRCUITS: usize = NUM_ENDOSCALING_STEPS + 12;
+pub const NUM_INTERNAL_CIRCUITS: usize = NUM_ENDOSCALING_STEPS + 14;
 
 impl InternalCircuitIndex {
     /// All variants in canonical iteration order.
@@ -97,6 +100,8 @@ impl InternalCircuitIndex {
         super::push(&mut slots, &mut c, Self::BridgeF);
         super::push(&mut slots, &mut c, Self::BridgeEval);
         super::push(&mut slots, &mut c, Self::Loading);
+        super::push(&mut slots, &mut c, Self::Copying(Side::Left));
+        super::push(&mut slots, &mut c, Self::Copying(Side::Right));
         assert!(c == NUM_INTERNAL_CIRCUITS);
         slots
     }
@@ -143,11 +148,21 @@ pub enum RxIndex {
     BridgeF,
     /// Bridge `eval` rx polynomial.
     BridgeEval,
+    /// Child proof's `inner_error` bridge rx polynomial for a given side.
+    ChildBridgeInnerError(Side),
+    /// Child proof's `outer_error` bridge rx polynomial for a given side.
+    ChildBridgeOuterError(Side),
+    /// Child proof's `ab` bridge rx polynomial for a given side.
+    ChildBridgeAB(Side),
+    /// Child proof's `query` bridge rx polynomial for a given side.
+    ChildBridgeQuery(Side),
+    /// Child proof's `eval` bridge rx polynomial for a given side.
+    ChildBridgeEval(Side),
 }
 
 /// The number of rx components in the nested field,
 /// equal to the number of entries in [`RxIndex::ALL`].
-pub const NUM_RX_COMPONENTS: usize = NUM_ENDOSCALING_STEPS + 10;
+pub const NUM_RX_COMPONENTS: usize = NUM_ENDOSCALING_STEPS + 20;
 
 impl RxIndex {
     /// All variants in canonical order (circuits, then stages).
@@ -176,6 +191,16 @@ impl RxIndex {
         super::push(&mut slots, &mut c, Self::BridgeQuery);
         super::push(&mut slots, &mut c, Self::BridgeF);
         super::push(&mut slots, &mut c, Self::BridgeEval);
+        super::push(&mut slots, &mut c, Self::ChildBridgeInnerError(Side::Left));
+        super::push(&mut slots, &mut c, Self::ChildBridgeInnerError(Side::Right));
+        super::push(&mut slots, &mut c, Self::ChildBridgeOuterError(Side::Left));
+        super::push(&mut slots, &mut c, Self::ChildBridgeOuterError(Side::Right));
+        super::push(&mut slots, &mut c, Self::ChildBridgeAB(Side::Left));
+        super::push(&mut slots, &mut c, Self::ChildBridgeAB(Side::Right));
+        super::push(&mut slots, &mut c, Self::ChildBridgeQuery(Side::Left));
+        super::push(&mut slots, &mut c, Self::ChildBridgeQuery(Side::Right));
+        super::push(&mut slots, &mut c, Self::ChildBridgeEval(Side::Left));
+        super::push(&mut slots, &mut c, Self::ChildBridgeEval(Side::Right));
         assert!(c == NUM_RX_COMPONENTS);
         slots
     }
@@ -239,6 +264,10 @@ pub fn register_all<'params, C: Cycle, R: Rank>(
             }
             Loading => registry.register_bonding(
                 MultiStage::new(circuits::loading::Loading::<C::HostCurve, R>::new())
+                    .into_bonding_object()?,
+            ),
+            Copying(side) => registry.register_bonding(
+                MultiStage::new(circuits::copying::Copying::<C::HostCurve, R>::new(side))
                     .into_bonding_object()?,
             ),
         };

--- a/crates/ragu_pcd/src/internal/nested/mod.rs
+++ b/crates/ragu_pcd/src/internal/nested/mod.rs
@@ -158,11 +158,13 @@ pub enum RxIndex {
     ChildBridgeQuery(Side),
     /// Child proof's `eval` bridge rx polynomial for a given side.
     ChildBridgeEval(Side),
+    /// Child proof's `PointsStage` rx polynomial for a given side.
+    ChildPointsStage(Side),
 }
 
 /// The number of rx components in the nested field,
 /// equal to the number of entries in [`RxIndex::ALL`].
-pub const NUM_RX_COMPONENTS: usize = NUM_ENDOSCALING_STEPS + 20;
+pub const NUM_RX_COMPONENTS: usize = NUM_ENDOSCALING_STEPS + 22;
 
 impl RxIndex {
     /// All variants in canonical order (circuits, then stages).
@@ -201,6 +203,8 @@ impl RxIndex {
         super::push(&mut slots, &mut c, Self::ChildBridgeQuery(Side::Right));
         super::push(&mut slots, &mut c, Self::ChildBridgeEval(Side::Left));
         super::push(&mut slots, &mut c, Self::ChildBridgeEval(Side::Right));
+        super::push(&mut slots, &mut c, Self::ChildPointsStage(Side::Left));
+        super::push(&mut slots, &mut c, Self::ChildPointsStage(Side::Right));
         assert!(c == NUM_RX_COMPONENTS);
         slots
     }

--- a/crates/ragu_pcd/src/internal/nested/mod.rs
+++ b/crates/ragu_pcd/src/internal/nested/mod.rs
@@ -115,7 +115,7 @@ impl InternalCircuitIndex {
 ///
 /// Analogous to [`native::RxIndex`](super::native::RxIndex) for the scalar
 /// field. Each variant maps to a polynomial in
-/// [`NestedP`](crate::proof::components::NestedP).
+/// [`InternalCircuits`](crate::proof::components::InternalCircuits).
 #[derive(Clone, Copy, Debug)]
 pub enum RxIndex {
     /// EndoscalingStep circuit rx polynomial (indexed by step number).

--- a/crates/ragu_pcd/src/internal/nested/stages/mod.rs
+++ b/crates/ragu_pcd/src/internal/nested/stages/mod.rs
@@ -130,6 +130,7 @@ define_bridge_stage!(s_prime, parent = super::preamble::Stage<C, R>, fields = {
 define_bridge_stage!(inner_error, parent = super::s_prime::Stage<C, R>, fields = {
     native_inner_error: C,
     registry_wy: C,
+    stashed_native_preamble: C,
 });
 
 define_bridge_stage!(outer_error, parent = super::inner_error::Stage<C, R>, fields = {

--- a/crates/ragu_pcd/src/internal/nested/stages/preamble.rs
+++ b/crates/ragu_pcd/src/internal/nested/stages/preamble.rs
@@ -136,6 +136,26 @@ pub struct ChildOutput<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
 }
 
 impl<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> ChildOutput<'dr, D, C> {
+    /// Returns the point commitment for the given [`RxIndex`](crate::internal::native::RxIndex).
+    ///
+    /// The field order matches [`RxIndex::ALL`](crate::internal::native::RxIndex::ALL).
+    pub(crate) fn rx(&self, idx: crate::internal::native::RxIndex) -> &Point<'dr, D, C> {
+        use crate::internal::native::RxIndex;
+        match idx {
+            RxIndex::Application => &self.application,
+            RxIndex::Hashes1 => &self.hashes_1,
+            RxIndex::Hashes2 => &self.hashes_2,
+            RxIndex::InnerCollapse => &self.inner_collapse,
+            RxIndex::OuterCollapse => &self.outer_collapse,
+            RxIndex::ComputeV => &self.compute_v,
+            RxIndex::Preamble => &self.preamble,
+            RxIndex::InnerError => &self.inner_error,
+            RxIndex::OuterError => &self.outer_error,
+            RxIndex::Query => &self.query_rx,
+            RxIndex::Eval => &self.eval,
+        }
+    }
+
     fn alloc(dr: &mut D, witness: DriverValue<D, &ChildWitness<C>>) -> Result<Self> {
         Ok(ChildOutput {
             application: Point::alloc(dr, witness.as_ref().map(|w| w.application))?,

--- a/crates/ragu_pcd/src/internal/nested/stages/preamble.rs
+++ b/crates/ragu_pcd/src/internal/nested/stages/preamble.rs
@@ -17,7 +17,7 @@ use ragu_primitives::{Point, io::Write};
 use core::marker::PhantomData;
 
 /// Number of curve points in this stage.
-pub const NUM_POINTS: usize = 13;
+pub const NUM_POINTS: usize = 29;
 
 /// Witness data for a single child proof in the preamble bridge stage.
 ///
@@ -35,6 +35,22 @@ pub struct ChildWitness<C: CurveAffine> {
     pub outer_collapse: C,
     /// Commitment from the child's compute_v circuit.
     pub compute_v: C,
+    /// Commitment from the child's preamble stage.
+    pub preamble: C,
+    /// Commitment from the child's inner error stage.
+    pub inner_error: C,
+    /// Commitment from the child's outer error stage.
+    pub outer_error: C,
+    /// Commitment from the child's query rx stage.
+    pub query_rx: C,
+    /// Commitment from the child's eval stage.
+    pub eval: C,
+    /// Commitment `a` from the child's AB component.
+    pub a: C,
+    /// Commitment `b` from the child's AB component.
+    pub b: C,
+    /// Commitment `registry_xy` from the child's query component.
+    pub registry_xy: C,
 }
 
 impl<C: CurveAffine> ChildWitness<C> {
@@ -48,6 +64,14 @@ impl<C: CurveAffine> ChildWitness<C> {
             inner_collapse: proof[RxIndex::InnerCollapse].commitment,
             outer_collapse: proof[RxIndex::OuterCollapse].commitment,
             compute_v: proof[RxIndex::ComputeV].commitment,
+            preamble: proof[RxIndex::Preamble].commitment,
+            inner_error: proof[RxIndex::InnerError].commitment,
+            outer_error: proof[RxIndex::OuterError].commitment,
+            query_rx: proof[RxIndex::Query].commitment,
+            eval: proof[RxIndex::Eval].commitment,
+            a: proof.ab.native.a_commitment,
+            b: proof.ab.native.b_commitment,
+            registry_xy: proof.query.native.registry_xy_commitment,
         }
     }
 }
@@ -83,6 +107,30 @@ pub struct ChildOutput<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
     /// Point commitment from the child's compute_v circuit.
     #[ragu(gadget)]
     pub compute_v: Point<'dr, D, C>,
+    /// Point commitment from the child's preamble stage.
+    #[ragu(gadget)]
+    pub preamble: Point<'dr, D, C>,
+    /// Point commitment from the child's inner error stage.
+    #[ragu(gadget)]
+    pub inner_error: Point<'dr, D, C>,
+    /// Point commitment from the child's outer error stage.
+    #[ragu(gadget)]
+    pub outer_error: Point<'dr, D, C>,
+    /// Point commitment from the child's query rx stage.
+    #[ragu(gadget)]
+    pub query_rx: Point<'dr, D, C>,
+    /// Point commitment from the child's eval stage.
+    #[ragu(gadget)]
+    pub eval: Point<'dr, D, C>,
+    /// Point commitment `a` from the child's AB component.
+    #[ragu(gadget)]
+    pub a: Point<'dr, D, C>,
+    /// Point commitment `b` from the child's AB component.
+    #[ragu(gadget)]
+    pub b: Point<'dr, D, C>,
+    /// Point commitment `registry_xy` from the child's query component.
+    #[ragu(gadget)]
+    pub registry_xy: Point<'dr, D, C>,
 }
 
 impl<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> ChildOutput<'dr, D, C> {
@@ -94,6 +142,14 @@ impl<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> ChildOutput<'dr, D, C> {
             inner_collapse: Point::alloc(dr, witness.as_ref().map(|w| w.inner_collapse))?,
             outer_collapse: Point::alloc(dr, witness.as_ref().map(|w| w.outer_collapse))?,
             compute_v: Point::alloc(dr, witness.as_ref().map(|w| w.compute_v))?,
+            preamble: Point::alloc(dr, witness.as_ref().map(|w| w.preamble))?,
+            inner_error: Point::alloc(dr, witness.as_ref().map(|w| w.inner_error))?,
+            outer_error: Point::alloc(dr, witness.as_ref().map(|w| w.outer_error))?,
+            query_rx: Point::alloc(dr, witness.as_ref().map(|w| w.query_rx))?,
+            eval: Point::alloc(dr, witness.as_ref().map(|w| w.eval))?,
+            a: Point::alloc(dr, witness.as_ref().map(|w| w.a))?,
+            b: Point::alloc(dr, witness.as_ref().map(|w| w.b))?,
+            registry_xy: Point::alloc(dr, witness.as_ref().map(|w| w.registry_xy))?,
         })
     }
 }

--- a/crates/ragu_pcd/src/internal/nested/stages/preamble.rs
+++ b/crates/ragu_pcd/src/internal/nested/stages/preamble.rs
@@ -19,7 +19,7 @@ use ragu_primitives::{Point, io::Write};
 use core::marker::PhantomData;
 
 /// Number of curve points in this stage.
-pub const NUM_POINTS: usize = 29;
+pub const NUM_POINTS: usize = 31;
 
 /// Witness data for a single child proof in the preamble bridge stage.
 ///
@@ -53,6 +53,8 @@ pub struct ChildWitness<C: CurveAffine> {
     pub b: C,
     /// Commitment `registry_xy` from the child's query component.
     pub registry_xy: C,
+    /// Commitment from the child's P component.
+    pub p: C,
 }
 
 impl<C: CurveAffine> ChildWitness<C> {
@@ -74,6 +76,7 @@ impl<C: CurveAffine> ChildWitness<C> {
             a: proof.ab.native.a_commitment,
             b: proof.ab.native.b_commitment,
             registry_xy: proof.query.native.registry_xy_commitment,
+            p: proof.p.native.commitment,
         }
     }
 }
@@ -133,6 +136,9 @@ pub struct ChildOutput<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
     /// Point commitment `registry_xy` from the child's query component.
     #[ragu(gadget)]
     pub registry_xy: Point<'dr, D, C>,
+    /// Point commitment from the child's P component.
+    #[ragu(gadget)]
+    pub p: Point<'dr, D, C>,
 }
 
 impl<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> ChildOutput<'dr, D, C> {
@@ -172,6 +178,7 @@ impl<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> ChildOutput<'dr, D, C> {
             a: Point::alloc(dr, witness.as_ref().map(|w| w.a))?,
             b: Point::alloc(dr, witness.as_ref().map(|w| w.b))?,
             registry_xy: Point::alloc(dr, witness.as_ref().map(|w| w.registry_xy))?,
+            p: Point::alloc(dr, witness.as_ref().map(|w| w.p))?,
         })
     }
 }

--- a/crates/ragu_pcd/src/internal/nested/stages/preamble.rs
+++ b/crates/ragu_pcd/src/internal/nested/stages/preamble.rs
@@ -5,6 +5,8 @@
 use ragu_arithmetic::{CurveAffine, Cycle};
 use ragu_circuits::polynomials::Rank;
 
+use crate::internal::{endoscalar::PointsStage, nested::NUM_ENDOSCALING_POINTS};
+
 use crate::Proof;
 use ragu_core::{
     Result,
@@ -176,7 +178,7 @@ pub struct Stage<C: CurveAffine, R> {
 }
 
 impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stage<C, R> {
-    type Parent = ();
+    type Parent = PointsStage<C, NUM_ENDOSCALING_POINTS>;
     type Witness<'source> = &'source Witness<C>;
     type OutputKind = Kind![C::Base; Output<'_, _, C>];
 

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -222,7 +222,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x319d6a1e9896489ba90290a1626a02aaa2309923fe519d3227c853fa94200c10);
+    let expected = fq!(0x02628beb42cfc1a6735b516680fc6458bd8cb2bd44b2826433dfedb7630be90d);
 
     assert_eq!(
         app.nested_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -222,7 +222,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x31cda5818b2554cf6064590380712d5d44461fb3bc0628ac8742343eb731d271);
+    let expected = fq!(0x072b2748b2453738226135e90d820a6385f8e46211e0e164226d7d83ee906296);
 
     assert_eq!(
         app.nested_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -87,11 +87,11 @@ fn test_internal_circuit_constraint_counts() {
         }};
     }
 
-    check_constraints!(Hashes1Circuit,          mul = 1331, lin = 1988);
-    check_constraints!(Hashes2Circuit,          mul = 1879, lin = 2951);
-    check_constraints!(InnerCollapseCircuit,    mul = 1756, lin = 1918);
-    check_constraints!(OuterCollapseCircuit,    mul = 1525, lin = 2242);
-    check_constraints!(ComputeVCircuit,         mul = 1140, lin = 1773);
+    check_constraints!(Hashes1Circuit,          mul = 1336, lin = 1995);
+    check_constraints!(Hashes2Circuit,          mul = 1881, lin = 2951);
+    check_constraints!(InnerCollapseCircuit,    mul = 1758, lin = 1918);
+    check_constraints!(OuterCollapseCircuit,    mul = 1531, lin = 2250);
+    check_constraints!(ComputeVCircuit,         mul = 1148, lin = 1787);
 }
 
 #[rustfmt::skip]
@@ -104,11 +104,11 @@ fn test_internal_stage_parameters() {
         }};
     }
 
-    check_stage!(Preamble, skip =   1, num = 225);
-    check_stage!(OuterError,  skip = 226, num = 186);
-    check_stage!(InnerError,  skip = 412, num = 399);
-    check_stage!(Query,   skip = 226, num =  23);
-    check_stage!(Eval,    skip = 249, num =  18);
+    check_stage!(Preamble, skip =   1, num = 227);
+    check_stage!(OuterError,  skip = 228, num = 186);
+    check_stage!(InnerError,  skip = 414, num = 399);
+    check_stage!(Query,   skip = 228, num =  23);
+    check_stage!(Eval,    skip = 251, num =  18);
 }
 
 /// Helper test to print current constraint counts in copy-pasteable format.
@@ -198,7 +198,7 @@ fn test_native_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fp!(0x0ee9fce08d8944bf4de2922bec842754b286fc5173f56f84ef7f8fc1c091769c);
+    let expected = fp!(0x1a3c9a85d12c1ff388ccde201092bd4aad1b429dc8a628379f5b86b8326063b3);
 
     assert_eq!(
         app.native_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -222,7 +222,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x02628beb42cfc1a6735b516680fc6458bd8cb2bd44b2826433dfedb7630be90d);
+    let expected = fq!(0x37f78b06937ba5e31f2a25220ecdf5786d688889e80f173e76e197c8595ca61c);
 
     assert_eq!(
         app.nested_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -222,7 +222,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x37f78b06937ba5e31f2a25220ecdf5786d688889e80f173e76e197c8595ca61c);
+    let expected = fq!(0x3fcb77e79f9df3eb414625f3461a8528624e92717725de92b1c9bcb0dc70bcfe);
 
     assert_eq!(
         app.nested_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -222,7 +222,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x072b2748b2453738226135e90d820a6385f8e46211e0e164226d7d83ee906296);
+    let expected = fq!(0x319d6a1e9896489ba90290a1626a02aaa2309923fe519d3227c853fa94200c10);
 
     assert_eq!(
         app.nested_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -222,7 +222,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x3fcb77e79f9df3eb414625f3461a8528624e92717725de92b1c9bcb0dc70bcfe);
+    let expected = fq!(0x2794ead93909d9973a09b422614dbb1178d998fb6f525e5888b6e6804ab801d8);
 
     assert_eq!(
         app.nested_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -87,11 +87,11 @@ fn test_internal_circuit_constraint_counts() {
         }};
     }
 
-    check_constraints!(Hashes1Circuit,         mul = 2045, lin = 3422);
-    check_constraints!(Hashes2Circuit,         mul = 1879, lin = 2951);
-    check_constraints!(InnerCollapseCircuit,  mul = 1756, lin = 1918);
-    check_constraints!(OuterCollapseCircuit,  mul = 811 , lin = 808);
-    check_constraints!(ComputeVCircuit,        mul = 1140, lin = 1773);
+    check_constraints!(Hashes1Circuit,          mul = 1331, lin = 1988);
+    check_constraints!(Hashes2Circuit,          mul = 1879, lin = 2951);
+    check_constraints!(InnerCollapseCircuit,    mul = 1756, lin = 1918);
+    check_constraints!(OuterCollapseCircuit,    mul = 1525, lin = 2242);
+    check_constraints!(ComputeVCircuit,         mul = 1140, lin = 1773);
 }
 
 #[rustfmt::skip]
@@ -198,7 +198,7 @@ fn test_native_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fp!(0x339e595491fd177b620ea6dc286cf85c3caab480edba867792383f33714019e4);
+    let expected = fp!(0x0ee9fce08d8944bf4de2922bec842754b286fc5173f56f84ef7f8fc1c091769c);
 
     assert_eq!(
         app.native_registry.digest(),

--- a/crates/ragu_pcd/src/proof/components.rs
+++ b/crates/ragu_pcd/src/proof/components.rs
@@ -209,6 +209,38 @@ impl<C: Cycle> Challenges<C> {
     }
 }
 
+/// Bridge rx polynomials preserved from a child proof for the copying circuit.
+///
+/// Each field pairs a scalar-field rx polynomial with its nested-curve
+/// commitment. These are products of the existing bridge stage types,
+/// computed from the child proof's native commitments.
+#[derive(Clone)]
+pub(crate) struct ChildBridges<C: Cycle, R: Rank> {
+    pub(crate) inner_error: Bridge<C, R>,
+    pub(crate) outer_error: Bridge<C, R>,
+    pub(crate) ab: Bridge<C, R>,
+    pub(crate) query: Bridge<C, R>,
+    pub(crate) eval: Bridge<C, R>,
+}
+
+impl<C: Cycle, R: Rank> ChildBridges<C, R> {
+    /// Returns the rx polynomial for the given child bridge [`RxIndex`] variant.
+    pub(crate) fn rx(
+        &self,
+        idx: crate::internal::nested::RxIndex,
+    ) -> &sparse::Polynomial<C::ScalarField, R> {
+        use crate::internal::nested::RxIndex::*;
+        match idx {
+            ChildBridgeInnerError(_) => &self.inner_error.rx,
+            ChildBridgeOuterError(_) => &self.outer_error.rx,
+            ChildBridgeAB(_) => &self.ab.rx,
+            ChildBridgeQuery(_) => &self.query.rx,
+            ChildBridgeEval(_) => &self.eval.rx,
+            _ => unreachable!(),
+        }
+    }
+}
+
 /// Rx polynomials for all internal circuits in a single proof step.
 ///
 /// The first five fields are native-field circuits: each is an [`RxTriple`]
@@ -228,4 +260,6 @@ pub(crate) struct InternalCircuits<C: Cycle, R: Rank> {
     pub(crate) step_rxs: Vec<sparse::Polynomial<C::ScalarField, R>>,
     pub(crate) endoscalar_rx: sparse::Polynomial<C::ScalarField, R>,
     pub(crate) points_rx: sparse::Polynomial<C::ScalarField, R>,
+    pub(crate) left_child_bridges: ChildBridges<C, R>,
+    pub(crate) right_child_bridges: ChildBridges<C, R>,
 }

--- a/crates/ragu_pcd/src/proof/components.rs
+++ b/crates/ragu_pcd/src/proof/components.rs
@@ -51,6 +51,8 @@ impl<C: Cycle, R: Rank> Bridge<C, R> {
 pub(crate) struct Preamble<C: Cycle, R: Rank> {
     pub(crate) native: RxTriple<C, R>,
     pub(crate) bridge: Bridge<C, R>,
+    pub(crate) left_child_bridges: ChildBridges<C, R>,
+    pub(crate) right_child_bridges: ChildBridges<C, R>,
 }
 
 #[derive(Clone)]
@@ -211,16 +213,16 @@ impl<C: Cycle> Challenges<C> {
 
 /// Bridge rx polynomials preserved from a child proof for the copying circuit.
 ///
-/// Each field pairs a scalar-field rx polynomial with its nested-curve
-/// commitment. These are products of the existing bridge stage types,
-/// computed from the child proof's native commitments.
+/// Each field is a scalar-field rx polynomial from the corresponding bridge
+/// stage of the child proof. Only the rx polynomial is stored; the nested-curve
+/// commitment is derivable from it and never needed after construction.
 #[derive(Clone)]
 pub(crate) struct ChildBridges<C: Cycle, R: Rank> {
-    pub(crate) inner_error: Bridge<C, R>,
-    pub(crate) outer_error: Bridge<C, R>,
-    pub(crate) ab: Bridge<C, R>,
-    pub(crate) query: Bridge<C, R>,
-    pub(crate) eval: Bridge<C, R>,
+    pub(crate) inner_error: sparse::Polynomial<C::ScalarField, R>,
+    pub(crate) outer_error: sparse::Polynomial<C::ScalarField, R>,
+    pub(crate) ab: sparse::Polynomial<C::ScalarField, R>,
+    pub(crate) query: sparse::Polynomial<C::ScalarField, R>,
+    pub(crate) eval: sparse::Polynomial<C::ScalarField, R>,
 }
 
 impl<C: Cycle, R: Rank> ChildBridges<C, R> {
@@ -231,11 +233,11 @@ impl<C: Cycle, R: Rank> ChildBridges<C, R> {
     ) -> &sparse::Polynomial<C::ScalarField, R> {
         use crate::internal::nested::RxIndex::*;
         match idx {
-            ChildBridgeInnerError(_) => &self.inner_error.rx,
-            ChildBridgeOuterError(_) => &self.outer_error.rx,
-            ChildBridgeAB(_) => &self.ab.rx,
-            ChildBridgeQuery(_) => &self.query.rx,
-            ChildBridgeEval(_) => &self.eval.rx,
+            ChildBridgeInnerError(_) => &self.inner_error,
+            ChildBridgeOuterError(_) => &self.outer_error,
+            ChildBridgeAB(_) => &self.ab,
+            ChildBridgeQuery(_) => &self.query,
+            ChildBridgeEval(_) => &self.eval,
             _ => unreachable!(),
         }
     }
@@ -260,6 +262,4 @@ pub(crate) struct InternalCircuits<C: Cycle, R: Rank> {
     pub(crate) step_rxs: Vec<sparse::Polynomial<C::ScalarField, R>>,
     pub(crate) endoscalar_rx: sparse::Polynomial<C::ScalarField, R>,
     pub(crate) points_rx: sparse::Polynomial<C::ScalarField, R>,
-    pub(crate) left_child_bridges: ChildBridges<C, R>,
-    pub(crate) right_child_bridges: ChildBridges<C, R>,
 }

--- a/crates/ragu_pcd/src/proof/components.rs
+++ b/crates/ragu_pcd/src/proof/components.rs
@@ -224,7 +224,7 @@ pub(crate) struct ChildBridges<C: Cycle, R: Rank> {
 }
 
 impl<C: Cycle, R: Rank> ChildBridges<C, R> {
-    /// Returns the rx polynomial for the given child bridge [`RxIndex`] variant.
+    /// Returns the rx polynomial for the given child bridge [`RxIndex`](crate::internal::nested::RxIndex) variant.
     pub(crate) fn rx(
         &self,
         idx: crate::internal::nested::RxIndex,

--- a/crates/ragu_pcd/src/proof/components.rs
+++ b/crates/ragu_pcd/src/proof/components.rs
@@ -140,16 +140,8 @@ pub(crate) struct NativeP<C: Cycle, R: Rank> {
 }
 
 #[derive(Clone)]
-pub(crate) struct NestedP<C: Cycle, R: Rank> {
-    pub(crate) step_rxs: Vec<sparse::Polynomial<C::ScalarField, R>>,
-    pub(crate) endoscalar_rx: sparse::Polynomial<C::ScalarField, R>,
-    pub(crate) points_rx: sparse::Polynomial<C::ScalarField, R>,
-}
-
-#[derive(Clone)]
 pub(crate) struct P<C: Cycle, R: Rank> {
     pub(crate) native: NativeP<C, R>,
-    pub(crate) nested: NestedP<C, R>,
 }
 
 #[derive(Clone)]
@@ -217,6 +209,15 @@ impl<C: Cycle> Challenges<C> {
     }
 }
 
+/// Rx polynomials for all internal circuits in a single proof step.
+///
+/// The first five fields are native-field circuits: each is an [`RxTriple`]
+/// pairing the rx polynomial (over `C::CircuitField`) with its host-curve
+/// commitment.
+///
+/// The remaining fields are nested-field circuits: bare rx polynomials over
+/// `C::ScalarField` for the endoscaling commitment computation (no host-curve
+/// commitment; verified via the nested registry).
 #[derive(Clone)]
 pub(crate) struct InternalCircuits<C: Cycle, R: Rank> {
     pub(crate) hashes_1: RxTriple<C, R>,
@@ -224,4 +225,7 @@ pub(crate) struct InternalCircuits<C: Cycle, R: Rank> {
     pub(crate) inner_collapse: RxTriple<C, R>,
     pub(crate) outer_collapse: RxTriple<C, R>,
     pub(crate) compute_v: RxTriple<C, R>,
+    pub(crate) step_rxs: Vec<sparse::Polynomial<C::ScalarField, R>>,
+    pub(crate) endoscalar_rx: sparse::Polynomial<C::ScalarField, R>,
+    pub(crate) points_rx: sparse::Polynomial<C::ScalarField, R>,
 }

--- a/crates/ragu_pcd/src/proof/components.rs
+++ b/crates/ragu_pcd/src/proof/components.rs
@@ -263,5 +263,5 @@ pub(crate) struct InternalCircuits<C: Cycle, R: Rank> {
     pub(crate) compute_v: RxTriple<C, R>,
     pub(crate) step_rxs: Vec<sparse::Polynomial<C::ScalarField, R>>,
     pub(crate) endoscalar_rx: sparse::Polynomial<C::ScalarField, R>,
-    pub(crate) points_rx: sparse::Polynomial<C::ScalarField, R>,
+    pub(crate) points_rx: Bridge<C, R>,
 }

--- a/crates/ragu_pcd/src/proof/components.rs
+++ b/crates/ragu_pcd/src/proof/components.rs
@@ -223,6 +223,7 @@ pub(crate) struct ChildBridges<C: Cycle, R: Rank> {
     pub(crate) ab: sparse::Polynomial<C::ScalarField, R>,
     pub(crate) query: sparse::Polynomial<C::ScalarField, R>,
     pub(crate) eval: sparse::Polynomial<C::ScalarField, R>,
+    pub(crate) points: sparse::Polynomial<C::ScalarField, R>,
 }
 
 impl<C: Cycle, R: Rank> ChildBridges<C, R> {
@@ -238,6 +239,7 @@ impl<C: Cycle, R: Rank> ChildBridges<C, R> {
             ChildBridgeAB(_) => &self.ab,
             ChildBridgeQuery(_) => &self.query,
             ChildBridgeEval(_) => &self.eval,
+            ChildPointsStage(_) => &self.points,
             _ => unreachable!(),
         }
     }

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -14,12 +14,14 @@ use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::{Rank, sparse},
     registry::CircuitIndex,
+    staging::StageExt,
 };
 use ragu_primitives::vec::Len;
 
 use alloc::vec;
 
 use crate::header::Header;
+use crate::internal::Side;
 use crate::internal::endoscalar::NumStepsLen;
 use crate::internal::native::{RxComponent, RxIndex};
 use crate::internal::nested;
@@ -112,11 +114,23 @@ impl<C: Cycle, R: Rank> core::ops::Index<nested::RxIndex> for Proof<C, R> {
             BridgeQuery => &self.query.bridge.rx,
             BridgeF => &self.f.bridge.rx,
             BridgeEval => &self.eval.bridge.rx,
+            ChildBridgeInnerError(side)
+            | ChildBridgeOuterError(side)
+            | ChildBridgeAB(side)
+            | ChildBridgeQuery(side)
+            | ChildBridgeEval(side) => &self.child_bridges(side).rx(idx),
         }
     }
 }
 
 impl<C: Cycle, R: Rank> Proof<C, R> {
+    fn child_bridges(&self, side: Side) -> &ChildBridges<C, R> {
+        match side {
+            Side::Left => &self.circuits.left_child_bridges,
+            Side::Right => &self.circuits.right_child_bridges,
+        }
+    }
+
     /// Augment a recursive proof with some data, described by a [`Header`].
     pub fn carry<H: Header<C::CircuitField>>(self, data: H::Data) -> Pcd<C, R, H> {
         Pcd { proof: self, data }
@@ -191,6 +205,62 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
             commitment: bridge_commitment,
         };
 
+        // Properly formed bridge rx polynomials for stages referenced by the
+        // Copying circuit. Unlike the `trivial_bridge` placeholder (which has
+        // values at gate 0), these place values at the correct gate positions
+        // so that when this proof is a child in a fuse step, the Copying
+        // circuit's cross-stage enforce_equal constraints are satisfied.
+        use crate::internal::nested::stages;
+        let make_bridge = |rx| Bridge::commit(self.params, rx);
+        let inner_error_bridge = make_bridge(
+            <stages::inner_error::Stage<C::HostCurve, R> as StageExt<C::ScalarField, R>>::rx(
+                C::ScalarField::ONE,
+                &stages::inner_error::Witness {
+                    native_inner_error: host_commitment,
+                    registry_wy: host_commitment,
+                },
+            )
+            .expect("trivial inner_error bridge rx"),
+        );
+        let outer_error_bridge = make_bridge(
+            <stages::outer_error::Stage<C::HostCurve, R> as StageExt<C::ScalarField, R>>::rx(
+                C::ScalarField::ONE,
+                &stages::outer_error::Witness {
+                    native_outer_error: host_commitment,
+                },
+            )
+            .expect("trivial outer_error bridge rx"),
+        );
+        let ab_bridge = make_bridge(
+            <stages::ab::Stage<C::HostCurve, R> as StageExt<C::ScalarField, R>>::rx(
+                C::ScalarField::ONE,
+                &stages::ab::Witness {
+                    a: host_commitment,
+                    b: host_commitment,
+                },
+            )
+            .expect("trivial ab bridge rx"),
+        );
+        let query_bridge = make_bridge(
+            <stages::query::Stage<C::HostCurve, R> as StageExt<C::ScalarField, R>>::rx(
+                C::ScalarField::ONE,
+                &stages::query::Witness {
+                    native_query: host_commitment,
+                    registry_xy: registry_xy_commitment,
+                },
+            )
+            .expect("trivial query bridge rx"),
+        );
+        let eval_bridge = make_bridge(
+            <stages::eval::Stage<C::HostCurve, R> as StageExt<C::ScalarField, R>>::rx(
+                C::ScalarField::ONE,
+                &stages::eval::Witness {
+                    native_eval: host_commitment,
+                },
+            )
+            .expect("trivial eval bridge rx"),
+        );
+
         let trivial_rx_triple = || RxTriple {
             rx: ones_host.clone(),
             commitment: host_commitment,
@@ -224,11 +294,11 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
                     registry_wy_commitment: host_commitment,
                     rx_triple: trivial_rx_triple(),
                 },
-                bridge: trivial_bridge.clone(),
+                bridge: inner_error_bridge.clone(),
             },
             outer_error: OuterError {
                 native: trivial_rx_triple(),
-                bridge: trivial_bridge.clone(),
+                bridge: outer_error_bridge.clone(),
             },
             ab: AB {
                 native: NativeAB {
@@ -238,7 +308,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
                     b_commitment: host_commitment,
                     c,
                 },
-                bridge: trivial_bridge.clone(),
+                bridge: ab_bridge.clone(),
             },
             query: Query {
                 native: NativeQuery {
@@ -246,7 +316,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
                     registry_xy_commitment,
                     rx_triple: trivial_rx_triple(),
                 },
-                bridge: trivial_bridge.clone(),
+                bridge: query_bridge.clone(),
             },
             f: F {
                 native: NativeF {
@@ -257,7 +327,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
             },
             eval: Eval {
                 native: trivial_rx_triple(),
-                bridge: trivial_bridge,
+                bridge: eval_bridge.clone(),
             },
             p: P {
                 native: NativeP {
@@ -276,6 +346,20 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
                 step_rxs: vec![ones_nested.clone(); NumStepsLen::<NUM_ENDOSCALING_POINTS>::len()],
                 endoscalar_rx: ones_nested.clone(),
                 points_rx: ones_nested,
+                left_child_bridges: ChildBridges {
+                    inner_error: inner_error_bridge.clone(),
+                    outer_error: outer_error_bridge.clone(),
+                    ab: ab_bridge.clone(),
+                    query: query_bridge.clone(),
+                    eval: eval_bridge.clone(),
+                },
+                right_child_bridges: ChildBridges {
+                    inner_error: inner_error_bridge,
+                    outer_error: outer_error_bridge,
+                    ab: ab_bridge,
+                    query: query_bridge,
+                    eval: eval_bridge,
+                },
             },
         }
     }

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -118,7 +118,7 @@ impl<C: Cycle, R: Rank> core::ops::Index<nested::RxIndex> for Proof<C, R> {
             | ChildBridgeOuterError(side)
             | ChildBridgeAB(side)
             | ChildBridgeQuery(side)
-            | ChildBridgeEval(side) => &self.child_bridges(side).rx(idx),
+            | ChildBridgeEval(side) => self.child_bridges(side).rx(idx),
         }
     }
 }
@@ -218,6 +218,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
                 &stages::inner_error::Witness {
                     native_inner_error: host_commitment,
                     registry_wy: host_commitment,
+                    stashed_native_preamble: host_commitment,
                 },
             )
             .expect("trivial inner_error bridge rx"),

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -126,8 +126,8 @@ impl<C: Cycle, R: Rank> core::ops::Index<nested::RxIndex> for Proof<C, R> {
 impl<C: Cycle, R: Rank> Proof<C, R> {
     fn child_bridges(&self, side: Side) -> &ChildBridges<C, R> {
         match side {
-            Side::Left => &self.circuits.left_child_bridges,
-            Side::Right => &self.circuits.right_child_bridges,
+            Side::Left => &self.preamble.left_child_bridges,
+            Side::Right => &self.preamble.right_child_bridges,
         }
     }
 
@@ -277,6 +277,20 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
             preamble: Preamble {
                 native: trivial_rx_triple(),
                 bridge: trivial_bridge.clone(),
+                left_child_bridges: ChildBridges {
+                    inner_error: inner_error_bridge.rx.clone(),
+                    outer_error: outer_error_bridge.rx.clone(),
+                    ab: ab_bridge.rx.clone(),
+                    query: query_bridge.rx.clone(),
+                    eval: eval_bridge.rx.clone(),
+                },
+                right_child_bridges: ChildBridges {
+                    inner_error: inner_error_bridge.rx.clone(),
+                    outer_error: outer_error_bridge.rx.clone(),
+                    ab: ab_bridge.rx.clone(),
+                    query: query_bridge.rx.clone(),
+                    eval: eval_bridge.rx.clone(),
+                },
             },
             s_prime: SPrime {
                 native: NativeSPrime {
@@ -347,20 +361,6 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
                 step_rxs: vec![ones_nested.clone(); NumStepsLen::<NUM_ENDOSCALING_POINTS>::len()],
                 endoscalar_rx: ones_nested.clone(),
                 points_rx: ones_nested,
-                left_child_bridges: ChildBridges {
-                    inner_error: inner_error_bridge.clone(),
-                    outer_error: outer_error_bridge.clone(),
-                    ab: ab_bridge.clone(),
-                    query: query_bridge.clone(),
-                    eval: eval_bridge.clone(),
-                },
-                right_child_bridges: ChildBridges {
-                    inner_error: inner_error_bridge,
-                    outer_error: outer_error_bridge,
-                    ab: ab_bridge,
-                    query: query_bridge,
-                    eval: eval_bridge,
-                },
             },
         }
     }

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -16,13 +16,13 @@ use ragu_circuits::{
     registry::CircuitIndex,
     staging::StageExt,
 };
-use ragu_primitives::vec::Len;
+use ragu_primitives::vec::{FixedVec, Len};
 
 use alloc::vec;
 
 use crate::header::Header;
 use crate::internal::Side;
-use crate::internal::endoscalar::NumStepsLen;
+use crate::internal::endoscalar::{NumStepsLen, PointsStage, PointsWitness};
 use crate::internal::native::{RxComponent, RxIndex};
 use crate::internal::nested;
 use crate::internal::nested::NUM_ENDOSCALING_POINTS;
@@ -118,7 +118,8 @@ impl<C: Cycle, R: Rank> core::ops::Index<nested::RxIndex> for Proof<C, R> {
             | ChildBridgeOuterError(side)
             | ChildBridgeAB(side)
             | ChildBridgeQuery(side)
-            | ChildBridgeEval(side) => self.child_bridges(side).rx(idx),
+            | ChildBridgeEval(side)
+            | ChildPointsStage(side) => self.child_bridges(side).rx(idx),
         }
     }
 }
@@ -261,6 +262,16 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
             )
             .expect("trivial eval bridge rx"),
         );
+        let points_rx =
+            <PointsStage<C::HostCurve, NUM_ENDOSCALING_POINTS> as StageExt<C::ScalarField, R>>::rx(
+                C::ScalarField::ONE,
+                &PointsWitness {
+                    initial: host_commitment,
+                    inputs: FixedVec::from_fn(|_| host_commitment),
+                    interstitials: FixedVec::from_fn(|_| host_commitment),
+                },
+            )
+            .expect("trivial points rx");
 
         let trivial_rx_triple = || RxTriple {
             rx: ones_host.clone(),
@@ -283,6 +294,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
                     ab: ab_bridge.rx.clone(),
                     query: query_bridge.rx.clone(),
                     eval: eval_bridge.rx.clone(),
+                    points: points_rx.clone(),
                 },
                 right_child_bridges: ChildBridges {
                     inner_error: inner_error_bridge.rx.clone(),
@@ -290,6 +302,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
                     ab: ab_bridge.rx.clone(),
                     query: query_bridge.rx.clone(),
                     eval: eval_bridge.rx.clone(),
+                    points: points_rx.clone(),
                 },
             },
             s_prime: SPrime {
@@ -359,8 +372,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
                 outer_collapse: trivial_rx_triple(),
                 compute_v: trivial_rx_triple(),
                 step_rxs: vec![ones_nested.clone(); NumStepsLen::<NUM_ENDOSCALING_POINTS>::len()],
-                endoscalar_rx: ones_nested.clone(),
-                points_rx: ones_nested,
+                endoscalar_rx: ones_nested,
+                points_rx,
             },
         }
     }

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -101,9 +101,9 @@ impl<C: Cycle, R: Rank> core::ops::Index<nested::RxIndex> for Proof<C, R> {
     fn index(&self, idx: nested::RxIndex) -> &sparse::Polynomial<C::ScalarField, R> {
         use nested::RxIndex::*;
         match idx {
-            EndoscalingStep(step) => &self.p.nested.step_rxs[step as usize],
-            EndoscalarStage => &self.p.nested.endoscalar_rx,
-            PointsStage => &self.p.nested.points_rx,
+            EndoscalingStep(step) => &self.circuits.step_rxs[step as usize],
+            EndoscalarStage => &self.circuits.endoscalar_rx,
+            PointsStage => &self.circuits.points_rx,
             BridgePreamble => &self.preamble.bridge.rx,
             BridgeSPrime => &self.s_prime.bridge.rx,
             BridgeInnerError => &self.inner_error.bridge.rx,
@@ -265,14 +265,6 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
                     commitment: host_commitment,
                     v,
                 },
-                nested: NestedP {
-                    step_rxs: vec![
-                        ones_nested.clone();
-                        NumStepsLen::<NUM_ENDOSCALING_POINTS>::len()
-                    ],
-                    endoscalar_rx: ones_nested.clone(),
-                    points_rx: ones_nested,
-                },
             },
             challenges,
             circuits: InternalCircuits {
@@ -281,6 +273,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
                 inner_collapse: trivial_rx_triple(),
                 outer_collapse: trivial_rx_triple(),
                 compute_v: trivial_rx_triple(),
+                step_rxs: vec![ones_nested.clone(); NumStepsLen::<NUM_ENDOSCALING_POINTS>::len()],
+                endoscalar_rx: ones_nested.clone(),
+                points_rx: ones_nested,
             },
         }
     }

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -105,7 +105,7 @@ impl<C: Cycle, R: Rank> core::ops::Index<nested::RxIndex> for Proof<C, R> {
         match idx {
             EndoscalingStep(step) => &self.circuits.step_rxs[step as usize],
             EndoscalarStage => &self.circuits.endoscalar_rx,
-            PointsStage => &self.circuits.points_rx,
+            PointsStage => &self.circuits.points_rx.rx,
             BridgePreamble => &self.preamble.bridge.rx,
             BridgeSPrime => &self.s_prime.bridge.rx,
             BridgeInnerError => &self.inner_error.bridge.rx,
@@ -373,7 +373,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
                 compute_v: trivial_rx_triple(),
                 step_rxs: vec![ones_nested.clone(); NumStepsLen::<NUM_ENDOSCALING_POINTS>::len()],
                 endoscalar_rx: ones_nested,
-                points_rx,
+                points_rx: Bridge::commit(self.params, points_rx),
             },
         }
     }


### PR DESCRIPTION
Draft; filling gaps in the recently exposed `ChildBridges` commitments in https://github.com/tachyon-zcash/ragu/pull/625, and likely to be superseded by https://github.com/tachyon-zcash/ragu/issues/296 in preparation for nested accumulation.

- Store bridge commitment for `points_rx` (copying branch added `ChildBridges`, and this was the one new nested rx polynomial  with `NestedCurve` commitment that wasn't in any native `k(Y)`. `step_rxs` and `endoscalar_rx` aren't in `ChildBridges` and are preexisting gaps).                                               
- Migrate k(Y) for gate budget                                                                                                                                                                                                                    
- Expose `points_commitment` via `unified_bridge_ky`                                                              
- Doc comment clarification for `ChildHeaders` 