### PR TITLE
determine GAP_TOLERANCE experimentally

### DIFF
--- a/crates/ragu_circuits/Cargo.toml
+++ b/crates/ragu_circuits/Cargo.toml
@@ -53,3 +53,8 @@ harness = false
 name = "trace_criterion"
 path = "benches/criterion/trace.rs"
 harness = false
+
+[[bench]]
+name = "gap_tolerance"
+path = "benches/criterion/gap_tolerance.rs"
+harness = false

--- a/crates/ragu_circuits/benches/criterion/gap_tolerance.rs
+++ b/crates/ragu_circuits/benches/criterion/gap_tolerance.rs
@@ -93,7 +93,6 @@ fn bench_msm_scaling(c: &mut Criterion) {
     let mut group = c.benchmark_group("gap_tolerance/msm_scaling");
     let generators = Pasta::host_generators(Pasta::baked());
     let mut rng = StdRng::seed_from_u64(42);
-    let blind = Fp::random(&mut rng);
 
     let n = ProductionRank::num_coeffs();
 

--- a/crates/ragu_circuits/benches/criterion/gap_tolerance.rs
+++ b/crates/ragu_circuits/benches/criterion/gap_tolerance.rs
@@ -15,7 +15,7 @@ use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use ff::Field;
-use ragu_pasta::Fp;
+use ragu_pasta::{Fp, Pasta};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 
@@ -78,9 +78,59 @@ fn bench_pow_vs_dilate(c: &mut Criterion) {
     group.finish();
 }
 
+// MSM scaling: commit cost as a function of total stored coefficients
+//
+// Builds polynomials with a single large gap in the middle (always >
+// GAP_TOLERANCE so it splits into two blocks). The gap size determines how
+// many coefficients are excluded from the MSM. Sweeps from 0 excluded
+// (fully dense, 8192 elements in MSM) up to 4096 excluded (half the
+// polynomial is a gap).
+fn bench_msm_scaling(c: &mut Criterion) {
+    use ragu_arithmetic::Cycle;
+    use ragu_circuits::polynomials::{ProductionRank, Rank, sparse};
+    use ragu_pasta::Pasta;
+
+    let mut group = c.benchmark_group("gap_tolerance/msm_scaling");
+    let generators = Pasta::host_generators(Pasta::baked());
+    let mut rng = StdRng::seed_from_u64(42);
+    let blind = Fp::random(&mut rng);
+
+    let n = ProductionRank::num_coeffs();
+
+    // Fully nonzero baseline coefficients.
+    let all_nonzero: Vec<Fp> = (0..n)
+        .map(|_| loop {
+            let v = Fp::random(&mut rng);
+            if !bool::from(v.is_zero()) {
+                break v;
+            }
+        })
+        .collect();
+
+    for excluded in [0, 10, 50, 200, 500, 1000, 2000, 4096] {
+        let half = (n - excluded) / 2;
+        let mut coeffs = Vec::with_capacity(n);
+        coeffs.extend_from_slice(&all_nonzero[..half]);
+        if excluded > 0 {
+            coeffs.extend(core::iter::repeat_n(Fp::ZERO, excluded));
+        }
+        coeffs.extend_from_slice(&all_nonzero[half..half + (n - half - excluded)]);
+        assert_eq!(coeffs.len(), n);
+        let poly = sparse::Polynomial::<Fp, ProductionRank>::from_coeffs(coeffs);
+
+        let msm_size = if excluded > 4 { n - excluded } else { n };
+        group.bench_function(format!("{msm_size}_in_msm"), |b| {
+            b.iter(|| black_box(poly.commit_to_affine(generators, blind)));
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_pow_vs_horner,
     bench_pow_vs_dilate,
+    bench_msm_scaling,
 );
 criterion_main!(benches);

--- a/crates/ragu_circuits/benches/criterion/gap_tolerance.rs
+++ b/crates/ragu_circuits/benches/criterion/gap_tolerance.rs
@@ -1,0 +1,166 @@
+//! Criterion benchmarks to determine the optimal `GAP_TOLERANCE` value for
+//! sparse polynomial block splitting.
+//!
+//! Directly compares the two strategies for skipping a gap of g zeros:
+//!
+//! **eval** — inline does 1 mul per zero (`result = result * z + 0`):
+//!   - "pow":    result *= z.pow_vartime([g])
+//!   - "horner": for _ in 0..g { result *= z }
+//!
+//! **dilate** — inline does 2 muls per zero (`0 *= power; power *= z`):
+//!   - "pow":    power *= z.pow_vartime([g])
+//!   - "dilate": for _ in 0..g { dummy *= power; power *= z }
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use ff::Field;
+use ragu_pasta::Fp;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+const GAP_SIZES: &[usize] = &[1, 2, 3, 4, 5, 6, 8, 12, 16, 24, 32];
+
+fn bench_pow_vs_horner(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gap_tolerance/pow_vs_horner");
+    let mut rng = StdRng::seed_from_u64(42);
+    let z = Fp::random(&mut rng);
+    let result = Fp::random(&mut rng);
+
+    for &gap in GAP_SIZES {
+        group.bench_with_input(BenchmarkId::new("pow", gap), &gap, |b, &gap| {
+            b.iter(|| {
+                let mut r = result;
+                r *= z.pow_vartime([gap as u64]);
+                black_box(r)
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("horner", gap), &gap, |b, &gap| {
+            b.iter(|| {
+                let mut r = result;
+                for _ in 0..gap {
+                    r *= z;
+                }
+                black_box(r)
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_pow_vs_dilate(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gap_tolerance/pow_vs_dilate");
+    let mut rng = StdRng::seed_from_u64(42);
+    let z = Fp::random(&mut rng);
+    let power = Fp::random(&mut rng);
+    let coeff = Fp::ZERO;
+
+    for &gap in GAP_SIZES {
+        group.bench_with_input(BenchmarkId::new("pow", gap), &gap, |b, &gap| {
+            b.iter(|| {
+                let mut p = power;
+                p *= z.pow_vartime([gap as u64]);
+                black_box(p)
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("dilate", gap), &gap, |b, &gap| {
+            b.iter(|| {
+                let mut p = power;
+                let mut c = coeff;
+                for _ in 0..gap {
+                    c *= p;
+                    p *= z;
+                }
+                black_box((c, p))
+            });
+        });
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// combine_assign: many tight clusters vs fewer wide clusters
+//
+// Constructs pairs of polynomials with matching block structure (both have
+// the same number of gaps at the same positions — the realistic case from
+// fold_add_assign in fuse). Sweeps gap size with a fixed number of gaps.
+//
+// With the current GAP_TOLERANCE=4:
+//   - gap <= 4: zeros are inline, both polys are 1 block. combine_assign
+//     gets the single-LHS-block fast path (reuse allocation). The dense
+//     buffer includes the inline zeros: allocated, copied, op'd, and
+//     scanned by extend_runs.
+//   - gap > 4: zeros cause splits, both polys have 11 blocks. Clusters
+//     align perfectly (same positions). Each cluster is tight — no wasted
+//     gap material in the buffer. But there are 11 clusters, each with
+//     its own extend_runs call.
+//
+// The benchmark shows the crossover: at what gap size does the per-cluster
+// overhead of 11 tight clusters exceed the cost of processing inline zeros
+// in one wide cluster?
+// ---------------------------------------------------------------------------
+
+fn bench_combine_assign_matched(c: &mut Criterion) {
+    use ragu_circuits::polynomials::{ProductionRank, Rank, sparse};
+
+    let mut group = c.benchmark_group("gap_tolerance/combine_assign_matched");
+    let mut rng = StdRng::seed_from_u64(42);
+
+    const NUM_GAPS: usize = 10;
+
+    for &gap in GAP_SIZES {
+        let n = ProductionRank::num_coeffs();
+        let total_zeros = gap * NUM_GAPS;
+        if total_zeros >= n {
+            continue;
+        }
+
+        // Build two polynomials with identical gap positions but different
+        // nonzero values — the realistic case for fold_add_assign.
+        let nonzero_total = n - total_zeros;
+        let make_poly = |rng: &mut StdRng| {
+            let mut coeffs = Vec::with_capacity(n);
+            for g in 0..=NUM_GAPS {
+                let run_len = nonzero_total / (NUM_GAPS + 1)
+                    + usize::from(g < nonzero_total % (NUM_GAPS + 1));
+                for _ in 0..run_len {
+                    loop {
+                        let v = Fp::random(&mut *rng);
+                        if !bool::from(v.is_zero()) {
+                            coeffs.push(v);
+                            break;
+                        }
+                    }
+                }
+                if g < NUM_GAPS {
+                    coeffs.extend(core::iter::repeat_n(Fp::ZERO, gap));
+                }
+            }
+            assert_eq!(coeffs.len(), n);
+            sparse::Polynomial::<Fp, ProductionRank>::from_coeffs(coeffs)
+        };
+
+        let poly_a = make_poly(&mut rng);
+        let poly_b = make_poly(&mut rng);
+
+        group.bench_with_input(BenchmarkId::from_parameter(gap), &gap, |b, _| {
+            b.iter_batched(
+                || poly_a.clone(),
+                |mut p| {
+                    p.add_assign(&poly_b);
+                    black_box(p);
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_pow_vs_horner,
+    bench_pow_vs_dilate,
+    bench_combine_assign_matched,
+);
+criterion_main!(benches);

--- a/crates/ragu_circuits/benches/criterion/gap_tolerance.rs
+++ b/crates/ragu_circuits/benches/criterion/gap_tolerance.rs
@@ -99,10 +99,12 @@ fn bench_msm_scaling(c: &mut Criterion) {
 
     // Fully nonzero baseline coefficients.
     let all_nonzero: Vec<Fp> = (0..n)
-        .map(|_| loop {
-            let v = Fp::random(&mut rng);
-            if !bool::from(v.is_zero()) {
-                break v;
+        .map(|_| {
+            loop {
+                let v = Fp::random(&mut rng);
+                if !bool::from(v.is_zero()) {
+                    break v;
+                }
             }
         })
         .collect();

--- a/crates/ragu_circuits/benches/criterion/gap_tolerance.rs
+++ b/crates/ragu_circuits/benches/criterion/gap_tolerance.rs
@@ -122,7 +122,7 @@ fn bench_msm_scaling(c: &mut Criterion) {
 
         let msm_size = if excluded > 4 { n - excluded } else { n };
         group.bench_function(format!("{msm_size}_in_msm"), |b| {
-            b.iter(|| black_box(poly.commit_to_affine(generators, blind)));
+            b.iter(|| black_box(poly.commit_to_affine(generators)));
         });
     }
 

--- a/crates/ragu_circuits/benches/criterion/gap_tolerance.rs
+++ b/crates/ragu_circuits/benches/criterion/gap_tolerance.rs
@@ -3,11 +3,11 @@
 //!
 //! Directly compares the two strategies for skipping a gap of g zeros:
 //!
-//! **eval** — inline does 1 mul per zero (`result = result * z + 0`):
+//! **eval** — inline does 1 field mul per zero (`result = result * z + 0`):
 //!   - "pow":    result *= z.pow_vartime([g])
 //!   - "horner": for _ in 0..g { result *= z }
 //!
-//! **dilate** — inline does 2 muls per zero (`0 *= power; power *= z`):
+//! **dilate** — inline does 2 field muls per zero (`0 *= power; power *= z`):
 //!   - "pow":    power *= z.pow_vartime([g])
 //!   - "dilate": for _ in 0..g { dummy *= power; power *= z }
 
@@ -78,89 +78,9 @@ fn bench_pow_vs_dilate(c: &mut Criterion) {
     group.finish();
 }
 
-// ---------------------------------------------------------------------------
-// combine_assign: many tight clusters vs fewer wide clusters
-//
-// Constructs pairs of polynomials with matching block structure (both have
-// the same number of gaps at the same positions — the realistic case from
-// fold_add_assign in fuse). Sweeps gap size with a fixed number of gaps.
-//
-// With the current GAP_TOLERANCE=4:
-//   - gap <= 4: zeros are inline, both polys are 1 block. combine_assign
-//     gets the single-LHS-block fast path (reuse allocation). The dense
-//     buffer includes the inline zeros: allocated, copied, op'd, and
-//     scanned by extend_runs.
-//   - gap > 4: zeros cause splits, both polys have 11 blocks. Clusters
-//     align perfectly (same positions). Each cluster is tight — no wasted
-//     gap material in the buffer. But there are 11 clusters, each with
-//     its own extend_runs call.
-//
-// The benchmark shows the crossover: at what gap size does the per-cluster
-// overhead of 11 tight clusters exceed the cost of processing inline zeros
-// in one wide cluster?
-// ---------------------------------------------------------------------------
-
-fn bench_combine_assign_matched(c: &mut Criterion) {
-    use ragu_circuits::polynomials::{ProductionRank, Rank, sparse};
-
-    let mut group = c.benchmark_group("gap_tolerance/combine_assign_matched");
-    let mut rng = StdRng::seed_from_u64(42);
-
-    const NUM_GAPS: usize = 10;
-
-    for &gap in GAP_SIZES {
-        let n = ProductionRank::num_coeffs();
-        let total_zeros = gap * NUM_GAPS;
-        if total_zeros >= n {
-            continue;
-        }
-
-        // Build two polynomials with identical gap positions but different
-        // nonzero values — the realistic case for fold_add_assign.
-        let nonzero_total = n - total_zeros;
-        let make_poly = |rng: &mut StdRng| {
-            let mut coeffs = Vec::with_capacity(n);
-            for g in 0..=NUM_GAPS {
-                let run_len = nonzero_total / (NUM_GAPS + 1)
-                    + usize::from(g < nonzero_total % (NUM_GAPS + 1));
-                for _ in 0..run_len {
-                    loop {
-                        let v = Fp::random(&mut *rng);
-                        if !bool::from(v.is_zero()) {
-                            coeffs.push(v);
-                            break;
-                        }
-                    }
-                }
-                if g < NUM_GAPS {
-                    coeffs.extend(core::iter::repeat_n(Fp::ZERO, gap));
-                }
-            }
-            assert_eq!(coeffs.len(), n);
-            sparse::Polynomial::<Fp, ProductionRank>::from_coeffs(coeffs)
-        };
-
-        let poly_a = make_poly(&mut rng);
-        let poly_b = make_poly(&mut rng);
-
-        group.bench_with_input(BenchmarkId::from_parameter(gap), &gap, |b, _| {
-            b.iter_batched(
-                || poly_a.clone(),
-                |mut p| {
-                    p.add_assign(&poly_b);
-                    black_box(p);
-                },
-                criterion::BatchSize::SmallInput,
-            );
-        });
-    }
-    group.finish();
-}
-
 criterion_group!(
     benches,
     bench_pow_vs_horner,
     bench_pow_vs_dilate,
-    bench_combine_assign_matched,
 );
 criterion_main!(benches);

--- a/crates/ragu_circuits/benches/criterion/gap_tolerance.rs
+++ b/crates/ragu_circuits/benches/criterion/gap_tolerance.rs
@@ -15,7 +15,7 @@ use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use ff::Field;
-use ragu_pasta::{Fp, Pasta};
+use ragu_pasta::Fp;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 

--- a/crates/ragu_circuits/src/polynomials/sparse/mod.rs
+++ b/crates/ragu_circuits/src/polynomials/sparse/mod.rs
@@ -101,13 +101,21 @@ impl<T, R: Rank> Polynomial<T, R> {
 }
 
 /// Maximum number of consecutive zero coefficients that may be kept inline
-/// within a block rather than triggering a split. Inline zeros waste MSM
-/// slots in [`commit`](Polynomial::commit), so this is kept small. The
-/// tolerance covers only the per-block overhead (allocation, merge
-/// iterations in [`combine_assign`](Polynomial::combine_assign)) — each
-/// extra block requires a `pow_vartime` call to skip the gap.
+/// within a block rather than triggering a split. More blocks add per-block
+/// overhead in [`combine_assign`](Polynomial::combine_assign) (cluster
+/// iteration, allocation, re-sparsification) and `pow_vartime` gap-jumps in
+/// [`eval`](Polynomial::eval) / [`dilate`](Polynomial::dilate). Inline
+/// zeros waste MSM slots in [`commit`](Polynomial::commit).
 ///
-/// TODO(#608): benchmark to determine the optimal value.
+/// Benchmarked via `cargo bench --bench gap_tolerance` with a fixed number
+/// of gaps (10) to isolate block-split cost from coefficient-count effects.
+/// With nonzero coefficient count held constant, `commit` and `eval` are
+/// unaffected by gap size. The only sensitive operation is
+/// `combine_assign` / `fold`, which incurs a ~47% penalty per block split
+/// (~750 µs → ~1.1 ms for fold of 8 polys with 10 gaps). Since splitting
+/// only adds merge overhead without saving commit or eval cost, the
+/// tolerance should be large enough to absorb common small gaps and
+/// minimize block count.
 const GAP_TOLERANCE: usize = 4;
 
 /// Splits `data` into runs of coefficients and appends each run to `out` as

--- a/crates/ragu_circuits/src/polynomials/sparse/mod.rs
+++ b/crates/ragu_circuits/src/polynomials/sparse/mod.rs
@@ -101,21 +101,13 @@ impl<T, R: Rank> Polynomial<T, R> {
 }
 
 /// Maximum number of consecutive zero coefficients that may be kept inline
-/// within a block rather than triggering a split. More blocks add per-block
-/// overhead in [`combine_assign`](Polynomial::combine_assign) (cluster
-/// iteration, allocation, re-sparsification) and `pow_vartime` gap-jumps in
-/// [`eval`](Polynomial::eval) / [`dilate`](Polynomial::dilate). Inline
-/// zeros waste MSM slots in [`commit`](Polynomial::commit).
+/// within a block rather than triggering a split. Inline zeros waste MSM
+/// slots in [`commit`](Polynomial::commit), so this is kept small. The
+/// tolerance covers only the per-block overhead (allocation, merge
+/// iterations in [`combine_assign`](Polynomial::combine_assign)) — each
+/// extra block requires a `pow_vartime` call to skip the gap.
 ///
-/// Benchmarked via `cargo bench --bench gap_tolerance` with a fixed number
-/// of gaps (10) to isolate block-split cost from coefficient-count effects.
-/// With nonzero coefficient count held constant, `commit` and `eval` are
-/// unaffected by gap size. The only sensitive operation is
-/// `combine_assign` / `fold`, which incurs a ~47% penalty per block split
-/// (~750 µs → ~1.1 ms for fold of 8 polys with 10 gaps). Since splitting
-/// only adds merge overhead without saving commit or eval cost, the
-/// tolerance should be large enough to absorb common small gaps and
-/// minimize block count.
+/// TODO(#608): benchmark to determine the optimal value.
 const GAP_TOLERANCE: usize = 4;
 
 /// Splits `data` into runs of coefficients and appends each run to `out` as


### PR DESCRIPTION
closes https://github.com/tachyon-zcash/ragu/issues/608

tl;dr keep it at 4

Adds benchmarks to determine when the cost of `pow_vartime` calls to deal with jumps in the sparse polynomials is worth it. We learn that `eval` which performs 1 field mul per inline zero, the turnaround is at gaps of length < 6 will result in a few wasted field muls, which equates to 15 nanoseconds. 

  | Gap | pow (ns) | horner (ns) | Winner |
  |-----|----------|-------------|--------|
  | 1 | 54 | 11 | horner (5.0x) |
  | 2 | 68 | 29 | horner (2.3x) |
  | 3 | 83 | 48 | horner (1.7x) |
  | 4 | 81 | 67 | horner (1.2x) |
  | 5 | 97 | 86 | horner (1.1x) |
  | **6** | **96** | **105** | **pow (1.1x)** |
  | 8 | 95 | 142 | pow (1.5x) |
  | 12 | 110 | 217 | pow (2.0x) |
  | 16 | 109 | 298 | pow (2.7x) |
  | 24 | 120 | 460 | pow (3.8x) |
  | 32 | 120 | 602 | pow (5.0x) |

For `dilate` which performs 2 field mul per inline zero, the turnaround is gaps of length 4, the current value.

  | Gap | pow (ns) | dilate (ns) | Winner |
  |-----|----------|-------------|--------|
  | 1 | 53 | 22 | dilate (2.4x) |
  | 2 | 66 | 49 | dilate (1.3x) |
  | 3 | 82 | 79 | dilate (1.04x) |
  | **4** | **80** | **108** | **pow (1.3x)** |
  | 5 | 97 | 137 | pow (1.4x) |
  | 6 | 95 | 164 | pow (1.7x) |
  | 8 | 94 | 226 | pow (2.4x) |
  | 12 | 110 | 340 | pow (3.1x) |
  | 16 | 105 | 450 | pow (4.3x) |
  | 24 | 119 | 685 | pow (5.8x) |
  | 32 | 117 | 938 | pow (8.0x) |

So if we set the constant based on these results, then we have to choose between 4 and 6. Choosing 4 would mean that we occasionally waste two field muls on gaps with length 4-6 during `eval`, and choosing 6 would mean we occasionally waste 2 MSM slots with zeroes.

Are those 2 MSM slots worth it? I benched our current (possibly unoptimized) MSM (single-threaded) to find out at what point the savings appear, and it doesn't look like cutting down slots matters until it starts adding up to big chunks (500+ slots):

| MSM size | Excluded | Time (ms) | Savings vs 8192 |
  |----------|----------|-----------|-----------------|
  | 8192 | 0 | 45.39 | — |
  | 8182 | 10 | 46.00 | noise |
  | 8142 | 50 | 46.11 | noise |
  | 7992 | 200 | 46.96 | noise |
  | 7692 | 500 | 45.49 | noise |
  | 7192 | 1000 | 42.96 | -2.4 ms (5%) |
  | 6192 | 2000 | 37.62 | -7.8 ms (17%) |
  | 4096 | 4096 | 26.17 | -19.2 ms (42%) |
  
If we increase the gap tolerance to 6 to prevent occasionally wasting 15 ns during eval calls, would that add up to ~500+ zeroes needed to start slowing down the MSM?  IMO, every zero counts because _falling off the cliff_ results in _millisecond_ slow downs, and so the occasional 15 wasted _nanoseconds_ doesn't matter.

**Other Consideration**:

There might be other places where this matters, such as `combine_assign` and its consumers, ~~or it might be worth trying to filter zeroes out of the MSM in `commit`~~

How much (per `fuse`) do we call `eval`, `dilate`, and `commit`? Counting those calls would give us a better idea of how to set it, especially if the number (per `fuse`) is fixed.