### PR TITLE
Cache global mask and projection for bonding polynomials

### DIFF
--- a/crates/ragu_arithmetic/src/lib.rs
+++ b/crates/ragu_arithmetic/src/lib.rs
@@ -79,10 +79,9 @@ mod multicore;
 mod uendo;
 mod util;
 
-use ff::{Field, FromUniformBytes, WithSmallOrderMulGroup};
-
 pub use coeff::Coeff;
 pub use domain::Domain;
+use ff::{Field, FromUniformBytes, WithSmallOrderMulGroup};
 pub use fft::{Ring, bitreverse};
 pub use pasta_curves::arithmetic::{Coordinates, CurveAffine, CurveExt};
 /// Converts a 256-bit integer literal into the little endian `[u64; 4]`

--- a/crates/ragu_circuits/src/lib.rs
+++ b/crates/ragu_circuits/src/lib.rs
@@ -207,6 +207,15 @@ pub(crate) trait CircuitObject<F: Field, R: Rank>: Send + Sync {
     /// These records serve as input to [`floor_planner::floor_plan`] for
     /// computing absolute constraint offsets.
     fn segment_records(&self) -> &[SegmentRecord];
+
+    /// Returns `true` if this circuit is a masking polynomial whose
+    /// `sxy`/`sx`/`sy` return only the $-\text{notch}$ term, expecting
+    /// the [`Registry`] to add the shared $S_{\text{global}}$ once.
+    ///
+    /// [`Registry`]: registry::Registry
+    fn is_mask(&self) -> bool {
+        false
+    }
 }
 
 /// Wraps a circuit into a boxed [`CircuitObject`] that can evaluate the

--- a/crates/ragu_circuits/src/lib.rs
+++ b/crates/ragu_circuits/src/lib.rs
@@ -210,7 +210,7 @@ pub(crate) trait CircuitObject<F: Field, R: Rank>: Send + Sync {
 
     /// Returns `true` if this circuit is a masking polynomial whose
     /// `sxy`/`sx`/`sy` return only the $-\text{notch}$ term, expecting
-    /// the [`Registry`] to add the shared $S_{\text{global}}$ once.
+    /// the [`Registry`] to add the shared $S\_{\text{global}}$ once.
     ///
     /// [`Registry`]: registry::Registry
     fn is_mask(&self) -> bool {

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -16,6 +16,7 @@
 //! be efficiently evaluated at different restrictions.
 
 use alloc::{boxed::Box, collections::btree_map::BTreeMap, vec::Vec};
+use core::ops::Range;
 
 use blake2b_simd::Params;
 use ff::{Field, FromUniformBytes, PrimeField};
@@ -177,6 +178,9 @@ impl<'params, F: FromUniformBytes<64>, R: Rank> RegistryBuilder<'params, F, R> {
         let log2_circuits = self.log2_circuits();
         let domain = Domain::<F>::new(log2_circuits);
 
+        let bonding_start = self.internal_circuits.len();
+        let bonding_end = bonding_start + self.bonding.len();
+
         let circuits: Vec<_> = self
             .internal_circuits
             .into_iter()
@@ -214,6 +218,7 @@ impl<'params, F: FromUniformBytes<64>, R: Rank> RegistryBuilder<'params, F, R> {
             circuits,
             floor_plans,
             omega_lookup,
+            bonding_range: bonding_start..bonding_end,
             key: Key::default(),
         };
         registry.key = Key::new(registry.compute_registry_digest());
@@ -306,6 +311,9 @@ pub struct Registry<'params, F: PrimeField, R: Rank> {
     /// Maps from the OmegaKey (which represents some `omega^j`) to the index `i`
     /// of the circuits vector.
     omega_lookup: BTreeMap<OmegaKey, usize>,
+
+    /// Index range of bonding polynomials (stage masks) in `circuits`.
+    bonding_range: Range<usize>,
 
     /// Registry key used to bind circuits to this registry.
     key: Key<F>,
@@ -412,10 +420,22 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     pub fn xy(&self, x: F, y: F) -> sparse::Polynomial<F, R> {
         let key_scalar = self.key_sxy(x, y);
         let mut coeffs = alloc::vec![F::ZERO; R::num_coeffs()];
+
         for (i, circuit) in self.circuits.iter().enumerate() {
             let j = bitreverse(i as u32, self.domain.log2_n()) as usize;
             coeffs[j] = circuit.sxy(x, y, &self.floor_plans[i]);
         }
+
+        // Bonding polynomials return only -notch; add the shared global
+        // term to each bonding slot to reconstruct the full mask value.
+        if !self.bonding_range.is_empty() {
+            let global_xy = crate::staging::mask::global_mask::<F, R>(x, y);
+            for i in self.bonding_range.clone() {
+                let j = bitreverse(i as u32, self.domain.log2_n()) as usize;
+                coeffs[j] += global_xy;
+            }
+        }
+
         // Convert from the Lagrange basis.
         let domain = &self.domain;
         domain.ifft(&mut coeffs[..domain.n()]);
@@ -505,6 +525,34 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
         result
     }
 
+    /// Sums Lagrange coefficients for bonding polynomials at the given $W$ point.
+    fn bonding_coeff_sum(&self, cache: &LagrangeCache<F>) -> F {
+        if self.bonding_range.is_empty() {
+            return F::ZERO;
+        }
+
+        match cache {
+            LagrangeCache::Interpolate(coeffs) => {
+                let mut sum = F::ZERO;
+                for i in self.bonding_range.clone() {
+                    let j = bitreverse(i as u32, self.domain.log2_n()) as usize;
+                    sum += coeffs[j];
+                }
+                sum
+            }
+            LagrangeCache::Direct(i) => {
+                // W is exactly omega^i, so the Lagrange coefficient for
+                // circuit i is ONE and all others are ZERO.
+                if self.bonding_range.contains(i) {
+                    F::ONE
+                } else {
+                    F::ZERO
+                }
+            }
+            LagrangeCache::Empty => F::ZERO,
+        }
+    }
+
     /// Bind the registry to a specific $W$ point, caching Lagrange coefficients.
     ///
     /// Returns a [`RegistryAt`] that can be used to evaluate the registry
@@ -528,7 +576,7 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
 }
 
 impl<F: PrimeField, R: Rank> RegistryAt<'_, F, R> {
-    /// Evaluate the registry polynomial restricted at $W$, unrestricted at $Y$.
+    /// Evaluate the registry polynomial restricted at $W$ and $Y$, unrestricted at $X$.
     pub fn y(&self, y: F) -> sparse::Polynomial<F, R> {
         let mut poly = self.registry.w_cached(
             &self.cache,
@@ -553,7 +601,7 @@ impl<F: PrimeField, R: Rank> RegistryAt<'_, F, R> {
         poly
     }
 
-    /// Evaluate the registry polynomial restricted at $W$, unrestricted at $X$.
+    /// Evaluate the registry polynomial restricted at $W$ and $X$, unrestricted at $Y$.
     pub fn x(&self, x: F) -> sparse::Polynomial<F, R> {
         let mut poly = self.registry.w_cached(
             &self.cache,
@@ -582,13 +630,20 @@ impl<F: PrimeField, R: Rank> RegistryAt<'_, F, R> {
 
     /// Evaluate the registry polynomial at the point ($W$, $X$, $Y$).
     pub fn xy(&self, x: F, y: F) -> F {
-        let result: F = self.registry.w_cached(
+        let mut result: F = self.registry.w_cached(
             &self.cache,
             || F::ZERO,
             |circuit, floor_plan, coeff, result| {
                 *result += circuit.sxy(x, y, floor_plan) * coeff;
             },
         );
+
+        // Bonding polynomials return only -notch(x, y). Apply the shared
+        // global stage mask scalar once.
+        if !self.registry.bonding_range.is_empty() {
+            result += self.registry.bonding_coeff_sum(&self.cache)
+                * crate::staging::mask::global_mask::<F, R>(x, y);
+        }
 
         // Add the registry key contribution.
         result + self.registry.key_sxy(x, y)

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -426,8 +426,8 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
             coeffs[j] = circuit.sxy(x, y, &self.floor_plans[i]);
         }
 
-        // Bonding polynomials return only -notch; add the shared global
-        // term to each bonding slot to reconstruct the full mask value.
+        // The sxy evaluation of bonding polynomials returns only -notch;
+        // add the shared global term to each bonding slot.
         if !self.bonding_range.is_empty() {
             let global_xy = crate::staging::mask::global_mask::<F, R>(x, y);
             for i in self.bonding_range.clone() {
@@ -588,6 +588,14 @@ impl<F: PrimeField, R: Rank> RegistryAt<'_, F, R> {
             },
         );
 
+        // The sy projection of bonding polynomials returns only -notch(X, y).
+        // Add the shared global once, scaled by the sum of Lagrange coefficients.
+        if !self.registry.bonding_range.is_empty() {
+            let mut global = crate::staging::mask::global_project::<F, R>(y);
+            global.scale(self.registry.bonding_coeff_sum(&self.cache));
+            poly.add_assign(&global);
+        }
+
         // Add the registry key contribution k * (XY)^{4n-1}.  Restricted
         // at Y, this is k * y^{4n-1} at X^{4n-1} (c-wire of the SYSTEM gate in
         // the wiring layout).
@@ -612,6 +620,14 @@ impl<F: PrimeField, R: Rank> RegistryAt<'_, F, R> {
                 poly.add_assign(&tmp);
             },
         );
+
+        // The sx projection of bonding polynomials returns only -notch(x, Y).
+        // Add the shared global once, scaled by the sum of Lagrange coefficients.
+        if !self.registry.bonding_range.is_empty() {
+            let mut global = crate::staging::mask::global_project::<F, R>(x);
+            global.scale(self.registry.bonding_coeff_sum(&self.cache));
+            poly.add_assign(&global);
+        }
 
         // Add the registry key contribution k * (XY)^{4n-1}.  Restricted
         // at X, this is k * x^{4n-1} at Y^{4n-1}.
@@ -638,8 +654,8 @@ impl<F: PrimeField, R: Rank> RegistryAt<'_, F, R> {
             },
         );
 
-        // Bonding polynomials return only -notch(x, y). Apply the shared
-        // global stage mask scalar once.
+        // The sxy evaluation of bonding polynomials returns only -notch(x, y).
+        // Apply the shared global stage mask scalar once.
         if !self.registry.bonding_range.is_empty() {
             result += self.registry.bonding_coeff_sum(&self.cache)
                 * crate::staging::mask::global_mask::<F, R>(x, y);

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -337,6 +337,7 @@ enum LagrangeCache<F> {
 pub struct RegistryAt<'a, F: PrimeField, R: Rank> {
     registry: &'a Registry<'a, F, R>,
     cache: LagrangeCache<F>,
+    bonding_coeff_sum: F,
 }
 
 /// Represents a key for identifying a unique $\omega^j$ value where $\omega$ is
@@ -541,8 +542,8 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
                 sum
             }
             LagrangeCache::Direct(i) => {
-                // W is exactly omega^i, so the Lagrange coefficient for
-                // circuit i is ONE and all others are ZERO.
+                // W is exactly omega^bitreverse(i), so the Lagrange
+                // coefficient for circuit i is ONE and all others are ZERO.
                 if self.bonding_range.contains(i) {
                     F::ONE
                 } else {
@@ -568,9 +569,11 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
             // w is in the domain but no circuit registered at that index.
             LagrangeCache::Empty
         };
+        let bonding_coeff_sum = self.bonding_coeff_sum(&cache);
         RegistryAt {
             registry: self,
             cache,
+            bonding_coeff_sum,
         }
     }
 }
@@ -592,7 +595,7 @@ impl<F: PrimeField, R: Rank> RegistryAt<'_, F, R> {
         // Add the shared global once, scaled by the sum of Lagrange coefficients.
         if !self.registry.bonding_range.is_empty() {
             let mut global = crate::staging::mask::global_project::<F, R>(y);
-            global.scale(self.registry.bonding_coeff_sum(&self.cache));
+            global.scale(self.bonding_coeff_sum);
             poly.add_assign(&global);
         }
 
@@ -625,7 +628,7 @@ impl<F: PrimeField, R: Rank> RegistryAt<'_, F, R> {
         // Add the shared global once, scaled by the sum of Lagrange coefficients.
         if !self.registry.bonding_range.is_empty() {
             let mut global = crate::staging::mask::global_project::<F, R>(x);
-            global.scale(self.registry.bonding_coeff_sum(&self.cache));
+            global.scale(self.bonding_coeff_sum);
             poly.add_assign(&global);
         }
 

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -581,8 +581,7 @@ impl<F: PrimeField, R: Rank> RegistryAt<'_, F, R> {
         );
 
         // Masking polynomials return only -notch; add the shared global once,
-        // scaled by the sum of their Lagrange coefficients (non-zero w.h.p.
-        // since the sum is over random-point evaluations of Lagrange bases).
+        // weighted by the sum of Lagrange coefficients for all mask circuits at W.
         let mut global = crate::staging::mask::global_project::<F, R>(y);
         global.scale(self.mask_coeff_sum);
         poly.add_assign(&global);
@@ -613,8 +612,7 @@ impl<F: PrimeField, R: Rank> RegistryAt<'_, F, R> {
         );
 
         // Masking polynomials return only -notch; add the shared global once,
-        // scaled by the sum of their Lagrange coefficients (non-zero w.h.p.
-        // since the sum is over random-point evaluations of Lagrange bases).
+        // weighted by the sum of Lagrange coefficients for all mask circuits at W.
         let mut global = crate::staging::mask::global_project::<F, R>(x);
         global.scale(self.mask_coeff_sum);
         poly.add_assign(&global);

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -16,7 +16,6 @@
 //! be efficiently evaluated at different restrictions.
 
 use alloc::{boxed::Box, collections::btree_map::BTreeMap, vec::Vec};
-use core::ops::Range;
 
 use blake2b_simd::Params;
 use ff::{Field, FromUniformBytes, PrimeField};
@@ -178,9 +177,6 @@ impl<'params, F: FromUniformBytes<64>, R: Rank> RegistryBuilder<'params, F, R> {
         let log2_circuits = self.log2_circuits();
         let domain = Domain::<F>::new(log2_circuits);
 
-        let bonding_start = self.internal_circuits.len();
-        let bonding_end = bonding_start + self.bonding.len();
-
         let circuits: Vec<_> = self
             .internal_circuits
             .into_iter()
@@ -218,7 +214,6 @@ impl<'params, F: FromUniformBytes<64>, R: Rank> RegistryBuilder<'params, F, R> {
             circuits,
             floor_plans,
             omega_lookup,
-            bonding_range: bonding_start..bonding_end,
             key: Key::default(),
         };
         registry.key = Key::new(registry.compute_registry_digest());
@@ -312,9 +307,6 @@ pub struct Registry<'params, F: PrimeField, R: Rank> {
     /// of the circuits vector.
     omega_lookup: BTreeMap<OmegaKey, usize>,
 
-    /// Index range of bonding polynomials (stage masks) in `circuits`.
-    bonding_range: Range<usize>,
-
     /// Registry key used to bind circuits to this registry.
     key: Key<F>,
 }
@@ -337,7 +329,7 @@ enum LagrangeCache<F> {
 pub struct RegistryAt<'a, F: PrimeField, R: Rank> {
     registry: &'a Registry<'a, F, R>,
     cache: LagrangeCache<F>,
-    bonding_coeff_sum: F,
+    mask_coeff_sum: F,
 }
 
 /// Represents a key for identifying a unique $\omega^j$ value where $\omega$ is
@@ -422,19 +414,16 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
         let key_scalar = self.key_sxy(x, y);
         let mut coeffs = alloc::vec![F::ZERO; R::num_coeffs()];
 
+        // Masking polynomials return only -notch from sxy(); add the shared
+        // global term to each mask slot inline.
+        let global_xy = crate::staging::mask::global_mask::<F, R>(x, y);
         for (i, circuit) in self.circuits.iter().enumerate() {
             let j = bitreverse(i as u32, self.domain.log2_n()) as usize;
-            coeffs[j] = circuit.sxy(x, y, &self.floor_plans[i]);
-        }
-
-        // The sxy evaluation of bonding polynomials returns only -notch;
-        // add the shared global term to each bonding slot.
-        if !self.bonding_range.is_empty() {
-            let global_xy = crate::staging::mask::global_mask::<F, R>(x, y);
-            for i in self.bonding_range.clone() {
-                let j = bitreverse(i as u32, self.domain.log2_n()) as usize;
-                coeffs[j] += global_xy;
+            let mut v = circuit.sxy(x, y, &self.floor_plans[i]);
+            if circuit.is_mask() {
+                v += global_xy;
             }
+            coeffs[j] = v;
         }
 
         // Convert from the Lagrange basis.
@@ -526,25 +515,25 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
         result
     }
 
-    /// Sums Lagrange coefficients for bonding polynomials at the given $W$ point.
-    fn bonding_coeff_sum(&self, cache: &LagrangeCache<F>) -> F {
-        if self.bonding_range.is_empty() {
-            return F::ZERO;
-        }
-
+    /// Sums Lagrange coefficients for masking polynomials at the given $W$ point.
+    ///
+    /// Only circuits where [`CircuitObject::is_mask`] returns `true` contribute.
+    fn mask_coeff_sum(&self, cache: &LagrangeCache<F>) -> F {
         match cache {
             LagrangeCache::Interpolate(coeffs) => {
                 let mut sum = F::ZERO;
-                for i in self.bonding_range.clone() {
-                    let j = bitreverse(i as u32, self.domain.log2_n()) as usize;
-                    sum += coeffs[j];
+                for (i, circuit) in self.circuits.iter().enumerate() {
+                    if circuit.is_mask() {
+                        let j = bitreverse(i as u32, self.domain.log2_n()) as usize;
+                        sum += coeffs[j];
+                    }
                 }
                 sum
             }
             LagrangeCache::Direct(i) => {
                 // W is exactly omega^bitreverse(i), so the Lagrange
                 // coefficient for circuit i is ONE and all others are ZERO.
-                if self.bonding_range.contains(i) {
+                if self.circuits[*i].is_mask() {
                     F::ONE
                 } else {
                     F::ZERO
@@ -569,11 +558,11 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
             // w is in the domain but no circuit registered at that index.
             LagrangeCache::Empty
         };
-        let bonding_coeff_sum = self.bonding_coeff_sum(&cache);
+        let mask_coeff_sum = self.mask_coeff_sum(&cache);
         RegistryAt {
             registry: self,
             cache,
-            bonding_coeff_sum,
+            mask_coeff_sum,
         }
     }
 }
@@ -591,13 +580,12 @@ impl<F: PrimeField, R: Rank> RegistryAt<'_, F, R> {
             },
         );
 
-        // The sy projection of bonding polynomials returns only -notch(X, y).
-        // Add the shared global once, scaled by the sum of Lagrange coefficients.
-        if !self.registry.bonding_range.is_empty() {
-            let mut global = crate::staging::mask::global_project::<F, R>(y);
-            global.scale(self.bonding_coeff_sum);
-            poly.add_assign(&global);
-        }
+        // Masking polynomials return only -notch; add the shared global once,
+        // scaled by the sum of their Lagrange coefficients (non-zero w.h.p.
+        // since the sum is over random-point evaluations of Lagrange bases).
+        let mut global = crate::staging::mask::global_project::<F, R>(y);
+        global.scale(self.mask_coeff_sum);
+        poly.add_assign(&global);
 
         // Add the registry key contribution k * (XY)^{4n-1}.  Restricted
         // at Y, this is k * y^{4n-1} at X^{4n-1} (c-wire of the SYSTEM gate in
@@ -624,13 +612,12 @@ impl<F: PrimeField, R: Rank> RegistryAt<'_, F, R> {
             },
         );
 
-        // The sx projection of bonding polynomials returns only -notch(x, Y).
-        // Add the shared global once, scaled by the sum of Lagrange coefficients.
-        if !self.registry.bonding_range.is_empty() {
-            let mut global = crate::staging::mask::global_project::<F, R>(x);
-            global.scale(self.bonding_coeff_sum);
-            poly.add_assign(&global);
-        }
+        // Masking polynomials return only -notch; add the shared global once,
+        // scaled by the sum of their Lagrange coefficients (non-zero w.h.p.
+        // since the sum is over random-point evaluations of Lagrange bases).
+        let mut global = crate::staging::mask::global_project::<F, R>(x);
+        global.scale(self.mask_coeff_sum);
+        poly.add_assign(&global);
 
         // Add the registry key contribution k * (XY)^{4n-1}.  Restricted
         // at X, this is k * x^{4n-1} at Y^{4n-1}.
@@ -657,12 +644,9 @@ impl<F: PrimeField, R: Rank> RegistryAt<'_, F, R> {
             },
         );
 
-        // The sxy evaluation of bonding polynomials returns only -notch(x, y).
-        // Apply the shared global stage mask scalar once.
-        if !self.registry.bonding_range.is_empty() {
-            result += self.registry.bonding_coeff_sum(&self.cache)
-                * crate::staging::mask::global_mask::<F, R>(x, y);
-        }
+        // Masking polynomials return only -notch; apply the shared global
+        // scalar once.
+        result += self.mask_coeff_sum * crate::staging::mask::global_mask::<F, R>(x, y);
 
         // Add the registry key contribution.
         result + self.registry.key_sxy(x, y)

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -47,6 +47,9 @@ pub(crate) fn global_mask<F: Field, R: Rank>(x: F, y: F) -> F {
 /// Used by [`Registry`](crate::registry::Registry) to add the shared global
 /// contribution once, scaled by the sum of bonding Lagrange coefficients.
 pub(crate) fn global_project<F: Field, R: Rank>(p: F) -> sparse::Polynomial<F, R> {
+    if p == F::ZERO {
+        return sparse::Polynomial::default();
+    }
     let n = R::n();
     let mut view = sparse::View::<F, R, _>::wiring();
     view.d.resize(n, F::ZERO);
@@ -188,13 +191,12 @@ impl<F: Field, R: Rank> CircuitObject<F, R> for StageMask<R> {
 
         let xy = x * y;
         let xy_2n = xy.pow_vartime([2 * R::n() as u64]);
-        let xy_inv = xy.invert().expect("xy is not zero");
 
         let gsum = geosum(xy, self.num_gates);
-        let xy_g = xy.pow_vartime([self.skip_gates as u64]);
-        let xy_h = xy_2n * xy_inv.pow_vartime([(self.skip_gates + self.num_gates) as u64]);
+        let skip = xy.pow_vartime([self.skip_gates as u64]);
+        let tail = xy.pow_vartime([(2 * R::n() - self.skip_gates - self.num_gates) as u64]);
 
-        -((F::ONE + xy_2n) * (xy_g + xy_h) * gsum)
+        -((F::ONE + xy_2n) * (skip + tail) * gsum)
     }
 
     fn sx(
@@ -599,6 +601,11 @@ mod tests {
                 prop_assert_eq!(stage_mask.sx(x, &[]).eval(y), notch_sxy);
                 prop_assert_eq!(stage_mask.sy(y, &[]).eval(x), notch_sxy);
 
+                // Polynomial decomposition: global_project + notch_project == full project.
+                let mut reconstructed = super::global_project::<Fp, R>(x);
+                reconstructed += &stage_mask.notch_project(x);
+                prop_assert_eq!(reconstructed.eval(y), sxy);
+
                 Ok(())
             };
 
@@ -609,6 +616,33 @@ mod tests {
             check(x, Fp::ZERO)?;
             check(Fp::ZERO, Fp::ZERO)?;
 
+        }
+
+        /// Two adjacent `StageMask`s that partition gates `1..n` must have
+        /// notch projections that sum to the global projection (negated),
+        /// and notch scalars that sum to the global scalar (negated).
+        #[test]
+        fn test_notch_partition_proptest(split in 1..R::n()) {
+            let mask_a = StageMask::<R>::new(1, split - 1).unwrap();
+            let mask_b = StageMask::<R>::new(split, R::n() - split).unwrap();
+
+            let p = Fp::random(&mut rand::rng());
+            let x = Fp::random(&mut rand::rng());
+            let y = Fp::random(&mut rand::rng());
+
+            // Polynomial-level: (-notch_a(p) + -notch_b(p)).eval(q) == -global_project(p).eval(q)
+            let q = Fp::random(&mut rand::rng());
+            let mut sum_poly = mask_a.notch_project(p);
+            sum_poly += &mask_b.notch_project(p);
+            let mut neg_global = super::global_project::<Fp, R>(p);
+            neg_global.scale(-Fp::ONE);
+            prop_assert_eq!(sum_poly.eval(q), neg_global.eval(q));
+
+            // Scalar-level: -notch_a(x,y) + -notch_b(x,y) == -global_mask(x,y)
+            let sxy_a = mask_a.sxy(x, y, &[]);
+            let sxy_b = mask_b.sxy(x, y, &[]);
+            let global_xy = super::global_mask::<Fp, R>(x, y);
+            prop_assert_eq!(sxy_a + sxy_b, -global_xy);
         }
     }
 

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -40,6 +40,47 @@ pub(crate) fn global_mask<F: Field, R: Rank>(x: F, y: F) -> F {
     geosum(xy, R::n() << 2) - (xy_2n + F::ONE) * (xy_2n * xy_inv + F::ONE)
 }
 
+/// Restricts the global stage mask to a univariate sparse polynomial by
+/// substituting `p` for one variable. Populates `4(n - 1)` wire
+/// positions — all except the four wires of the SYSTEM gate (gate 0).
+///
+/// Used by [`Registry`](crate::registry::Registry) to add the shared global
+/// contribution once, scaled by the sum of bonding Lagrange coefficients.
+pub(crate) fn global_project<F: Field, R: Rank>(p: F) -> sparse::Polynomial<F, R> {
+    let n = R::n();
+    let mut view = sparse::View::<F, R, _>::wiring();
+    view.d.resize(n, F::ZERO);
+    view.a.resize(n, F::ZERO);
+    view.b.resize(n, F::ZERO);
+    view.c.resize(n, F::ZERO);
+
+    let mut cur = F::ONE;
+    for j in 0..n {
+        view.d[j] = cur;
+        cur *= p;
+    }
+    for j in (0..n).rev() {
+        view.a[j] = cur;
+        cur *= p;
+    }
+    for j in 0..n {
+        view.b[j] = cur;
+        cur *= p;
+    }
+    for j in (0..n).rev() {
+        view.c[j] = cur;
+        cur *= p;
+    }
+
+    // The SYSTEM gate wires are always zero in the global mask.
+    view.a[0] = F::ZERO;
+    view.b[0] = F::ZERO;
+    view.c[0] = F::ZERO;
+    view.d[0] = F::ZERO;
+
+    view.build()
+}
+
 #[derive(Clone)]
 pub struct StageMask<R: Rank> {
     skip_gates: usize,
@@ -88,49 +129,40 @@ impl<R: Rank> StageMask<R> {
         })
     }
 
-    /// Projects the bivariate mask polynomial onto a univariate sparse
-    /// polynomial by evaluating one variable at `p`. Used by both
-    /// `sx` ($S(x, Y)$) and `sy` ($S(X, y)$). Unconstrained wires
-    /// (the SYSTEM gate and active-stage gates) are zeroed out.
-    fn project<F: Field>(&self, p: F) -> sparse::Polynomial<F, R> {
+    /// Projects only the negated notch entries: the active-stage gate
+    /// wires at positions `skip_gates..skip_gates + num_gates`, negated.
+    /// The SYSTEM gate is excluded (it is already zero in the global mask).
+    ///
+    /// Returns a sparse polynomial with `4 × num_gates` non-zero entries
+    /// (vs `4(n - 1)` for the full mask projection).
+    fn notch_project<F: Field>(&self, p: F) -> sparse::Polynomial<F, R> {
+        if self.num_gates == 0 || p == F::ZERO {
+            return sparse::Polynomial::default();
+        }
         let n = R::n();
+        let g = self.skip_gates;
+        let m = self.num_gates;
         let mut view = sparse::View::<F, R, _>::wiring();
-        view.d.resize(n, F::ZERO);
-        view.a.resize(n, F::ZERO);
-        view.b.resize(n, F::ZERO);
-        view.c.resize(n, F::ZERO);
+        view.d.resize(g + m, F::ZERO);
+        view.a.resize(g + m, F::ZERO);
+        view.b.resize(g + m, F::ZERO);
+        view.c.resize(g + m, F::ZERO);
 
-        let mut cur = F::ONE;
-        for j in 0..n {
-            view.d[j] = cur;
-            cur *= p;
-        }
-        for j in (0..n).rev() {
-            view.a[j] = cur;
-            cur *= p;
-        }
-        for j in 0..n {
-            view.b[j] = cur;
-            cur *= p;
-        }
-        for j in (0..n).rev() {
-            view.c[j] = cur;
-            cur *= p;
-        }
+        let p_inv = p.invert().expect("p is not zero");
+        let mut d = p.pow_vartime([g as u64]);
+        let mut a = p.pow_vartime([(2 * n - 1 - g) as u64]);
+        let mut b = p.pow_vartime([(2 * n + g) as u64]);
+        let mut c = p.pow_vartime([(4 * n - 1 - g) as u64]);
 
-        // The wires in the SYSTEM gate are unconstrained.
-        view.a[0] = F::ZERO;
-        view.b[0] = F::ZERO;
-        view.c[0] = F::ZERO;
-        view.d[0] = F::ZERO;
-
-        // The wires active in the stage are not constrained.
-        for i in 0..self.num_gates {
-            let j = self.skip_gates + i;
-            view.a[j] = F::ZERO;
-            view.b[j] = F::ZERO;
-            view.c[j] = F::ZERO;
-            view.d[j] = F::ZERO;
+        for j in g..g + m {
+            view.d[j] = -d;
+            view.a[j] = -a;
+            view.b[j] = -b;
+            view.c[j] = -c;
+            d *= p;
+            a *= p_inv;
+            b *= p;
+            c *= p_inv;
         }
 
         view.build()
@@ -170,7 +202,7 @@ impl<F: Field, R: Rank> CircuitObject<F, R> for StageMask<R> {
         x: F,
         _floor_plan: &[crate::floor_planner::ConstraintSegment],
     ) -> sparse::Polynomial<F, R> {
-        self.project(x)
+        self.notch_project(x)
     }
 
     fn sy(
@@ -178,7 +210,7 @@ impl<F: Field, R: Rank> CircuitObject<F, R> for StageMask<R> {
         y: F,
         _floor_plan: &[crate::floor_planner::ConstraintSegment],
     ) -> sparse::Polynomial<F, R> {
-        self.project(y)
+        self.notch_project(y)
     }
 
     fn constraint_counts(&self) -> (usize, usize) {
@@ -408,8 +440,15 @@ mod tests {
         let z = Fp::random(&mut rand::rng());
         let y = Fp::random(&mut rand::rng());
 
+        // sy() now returns -notch; add global_project to recover the full mask.
+        let full_sy = |circ: &dyn CircuitObject<Fp, R>, y| {
+            let mut poly = super::global_project::<Fp, R>(y);
+            poly += &circ.sy(y, &[]);
+            poly
+        };
+
         {
-            let rhs = circ1.sy(y, &[]);
+            let rhs = full_sy(&*circ1, y);
             assert_eq!(rx1_a.revdot(&rhs), Fp::ZERO);
             assert_eq!(rx1_b.revdot(&rhs), Fp::ZERO);
 
@@ -423,10 +462,10 @@ mod tests {
             assert_eq!(combined.revdot(&rhs), Fp::ZERO);
         }
 
-        assert_eq!(rx1_a.revdot(&circ1.sy(y, &[])), Fp::ZERO);
-        assert_eq!(rx2.revdot(&circ2.sy(y, &[])), Fp::ZERO);
-        assert!(rx1_a.revdot(&circ2.sy(y, &[])) != Fp::ZERO);
-        assert!(rx2.revdot(&circ1.sy(y, &[])) != Fp::ZERO);
+        assert_eq!(rx1_a.revdot(&full_sy(&*circ1, y)), Fp::ZERO);
+        assert_eq!(rx2.revdot(&full_sy(&*circ2, y)), Fp::ZERO);
+        assert!(rx1_a.revdot(&full_sy(&*circ2, y)) != Fp::ZERO);
+        assert!(rx2.revdot(&full_sy(&*circ1, y)) != Fp::ZERO);
 
         Ok(())
     }
@@ -438,14 +477,19 @@ mod tests {
         let x = Fp::random(&mut rand::rng());
         let y = Fp::random(&mut rand::rng());
 
-        // sxy returns -notch; sx/sy return the full mask (global - notch).
-        let global_xy = super::global_mask::<Fp, R>(x, y);
-        let sxy = stage_mask.sxy(x, y, &[]) + global_xy;
+        // All three return -notch (the global term is factored out by Registry).
+        let sxy = stage_mask.sxy(x, y, &[]);
         let sx = stage_mask.sx(x, &[]);
         let sy = stage_mask.sy(y, &[]);
 
         assert_eq!(sxy, sx.eval(y));
         assert_eq!(sxy, sy.eval(x));
+
+        // Cross-check: global + notch reconstructs the full mask.
+        let global_xy = super::global_mask::<Fp, R>(x, y);
+        let mut full_sx = super::global_project::<Fp, R>(x);
+        full_sx += &sx;
+        assert_eq!(full_sx.eval(y), sxy + global_xy);
     }
 
     #[test]
@@ -499,9 +543,8 @@ mod tests {
         let x = Fp::random(&mut rand::rng());
         let y = Fp::random(&mut rand::rng());
 
-        // sxy returns -notch; sx/sy return the full mask (global - notch).
-        let global_xy = super::global_mask::<Fp, R>(x, y);
-        let sxy = stage.sxy(x, y, &[]) + global_xy;
+        // All three return -notch (the global term is factored out by Registry).
+        let sxy = stage.sxy(x, y, &[]);
         let sx = stage.sx(x, &[]);
         let sy = stage.sy(y, &[]);
 
@@ -549,11 +592,12 @@ mod tests {
                 // Internal consistency of the RawCircuit impl (with correction)
                 prop_assert_eq!(sy_eval, sxy);
                 prop_assert_eq!(sx_eval, sxy);
-                // StageMask::sxy returns -notch; add global to get the full mask.
+                // StageMask returns -notch from all three methods.
+                let notch_sxy = stage_mask.sxy(x, y, &[]);
                 let global_xy = super::global_mask::<Fp, R>(x, y);
-                prop_assert_eq!(stage_mask.sxy(x, y, &[]) + global_xy, sxy);
-                prop_assert_eq!(stage_mask.sx(x, &[]).eval(y), sxy);
-                prop_assert_eq!(stage_mask.sy(y, &[]).eval(x), sxy);
+                prop_assert_eq!(notch_sxy + global_xy, sxy);
+                prop_assert_eq!(stage_mask.sx(x, &[]).eval(y), notch_sxy);
+                prop_assert_eq!(stage_mask.sy(y, &[]).eval(x), notch_sxy);
 
                 Ok(())
             };
@@ -630,9 +674,10 @@ mod tests {
 
         let stage_mask = ConstrainedStage::mask::<'_>().unwrap().into_inner();
 
-        // rx.revdot(&stage_mask) == 0 for well-formed stages
+        // sy() returns -notch; add global_project to recover the full mask.
         let y = Fp::random(&mut rand::rng());
-        let sy = stage_mask.sy(y, &[]);
+        let mut sy = super::global_project::<Fp, R>(y);
+        sy += &stage_mask.sy(y, &[]);
 
         let check = rx.revdot(&sy);
         assert_eq!(

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -21,7 +21,7 @@ use crate::{
 ///
 /// This term is invariant across all [`StageMask`] instances for a given
 /// `(R, F)` — it depends only on `R::n()`. The [`Registry`] computes it once
-/// and scales by the sum of Lagrange coefficients for all bonding polynomials,
+/// and scales by the sum of Lagrange coefficients for all masking polynomials,
 /// rather than letting each mask evaluate it redundantly.
 ///
 /// Returns [`Field::ZERO`] when `x == 0` or `y == 0` (bonding polynomials
@@ -225,6 +225,10 @@ impl<F: Field, R: Rank> CircuitObject<F, R> for StageMask<R> {
 
     fn segment_records(&self) -> &[crate::SegmentRecord] {
         &[]
+    }
+
+    fn is_mask(&self) -> bool {
+        true
     }
 }
 

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -7,6 +7,39 @@ use crate::{
     polynomials::{Rank, sparse},
 };
 
+/// Evaluates the global stage mask polynomial $S_{\text{global}}(X, Y)$ at
+/// the point $(x, y)$.
+///
+/// The global mask enforces all $4n$ wire slots to zero except the four wires
+/// of the SYSTEM gate (gate 0):
+///
+/// $$S_{\text{global}}(xy) = \sum_{i=0}^{4n-1} (xy)^i
+///     - \bigl((xy)^{2n} + 1\bigr)\bigl((xy)^{2n-1} + 1\bigr)$$
+///
+/// The polynomial depends only on the product $XY$, so both variables
+/// enter only through $xy = x \cdot y$.
+///
+/// This term is invariant across all [`StageMask`] instances for a given
+/// `(R, F)` — it depends only on `R::n()`. The [`Registry`] computes it once
+/// and scales by the sum of Lagrange coefficients for all bonding polynomials,
+/// rather than letting each mask evaluate it redundantly.
+///
+/// Returns [`Field::ZERO`] when `x == 0` or `y == 0` (bonding polynomials
+/// have zero constant term in $Y$).
+///
+/// [`Registry`]: crate::registry::Registry
+pub(crate) fn global_mask<F: Field, R: Rank>(x: F, y: F) -> F {
+    if x == F::ZERO || y == F::ZERO {
+        return F::ZERO;
+    }
+
+    let xy = x * y;
+    let xy_2n = xy.pow_vartime([2 * R::n() as u64]);
+    let xy_inv = xy.invert().expect("xy is not zero");
+
+    geosum(xy, R::n() << 2) - (xy_2n + F::ONE) * (xy_2n * xy_inv + F::ONE)
+}
+
 #[derive(Clone)]
 pub struct StageMask<R: Rank> {
     skip_gates: usize,
@@ -105,36 +138,31 @@ impl<R: Rank> StageMask<R> {
 }
 
 impl<F: Field, R: Rank> CircuitObject<F, R> for StageMask<R> {
+    /// Evaluates the per-instance notch term $-\text{notch}(x, y)$.
+    ///
+    /// The full stage mask is $S_{\text{global}} - \text{notch}$, but
+    /// the invariant $S_{\text{global}}$ term is factored out and applied
+    /// once by the [`Registry`](crate::registry::Registry). This method
+    /// returns only $-\text{notch}$, where
+    ///
+    /// $$\text{notch}(xy) = (1 + (xy)^{2n})\bigl((xy)^g + (xy)^{2n-g-m}\bigr)
+    ///     \cdot \sum_{i=0}^{m-1} (xy)^i$$
+    ///
+    /// with $g = \text{skip\_gates}$ and $m = \text{num\_gates}$.
     fn sxy(&self, x: F, y: F, _floor_plan: &[crate::floor_planner::ConstraintSegment]) -> F {
         if x == F::ZERO || y == F::ZERO {
-            // If either x or y is zero, the polynomial evaluates to zero
-            // (the constant term of a bonding polynomial is always zero).
             return F::ZERO;
         }
 
-        // Precomputed (ideally):
         let xy = x * y;
         let xy_2n = xy.pow_vartime([2 * R::n() as u64]);
         let xy_inv = xy.invert().expect("xy is not zero");
 
-        /// Full wiring polynomial $S(xy)$ over all $4n$ wire slots,
-        /// minus the SYSTEM gate's four unconstrained wires.
-        fn global<F: Field>(xy: F, xy_2n: F, xy_inv: F, n: usize) -> F {
-            geosum(xy, n << 2) - (xy_2n + F::ONE) * (xy_2n * xy_inv + F::ONE)
-        }
+        let gsum = geosum(xy, self.num_gates);
+        let xy_g = xy.pow_vartime([self.skip_gates as u64]);
+        let xy_h = xy_2n * xy_inv.pow_vartime([(self.skip_gates + self.num_gates) as u64]);
 
-        /// Contribution of the `m` active-stage gates starting at gate `g`.
-        /// Subtracted from [`global`] to zero out unconstrained wires.
-        fn notch<F: Field>(xy: F, xy_2n: F, xy_inv: F, g: usize, m: usize) -> F {
-            let gsum = geosum(xy, m);
-            let xy_g = xy.pow_vartime([g as u64]);
-            let xy_h = xy_2n * xy_inv.pow_vartime([(g + m) as u64]);
-
-            (F::ONE + xy_2n) * (xy_g + xy_h) * gsum
-        }
-
-        global(xy, xy_2n, xy_inv, R::n())
-            - notch(xy, xy_2n, xy_inv, self.skip_gates, self.num_gates)
+        -((F::ONE + xy_2n) * (xy_g + xy_h) * gsum)
     }
 
     fn sx(
@@ -410,7 +438,9 @@ mod tests {
         let x = Fp::random(&mut rand::rng());
         let y = Fp::random(&mut rand::rng());
 
-        let sxy = stage_mask.sxy(x, y, &[]);
+        // sxy returns -notch; sx/sy return the full mask (global - notch).
+        let global_xy = super::global_mask::<Fp, R>(x, y);
+        let sxy = stage_mask.sxy(x, y, &[]) + global_xy;
         let sx = stage_mask.sx(x, &[]);
         let sy = stage_mask.sy(y, &[]);
 
@@ -430,7 +460,9 @@ mod tests {
         let stripped = crate::staging::bonding::Stripped::new(generic);
         let corrected_sxy = stripped.sxy(x, y, &plan);
 
-        assert_eq!(stage.sxy(x, y, &[]), corrected_sxy);
+        // StageMask returns -notch; add global to get the full mask.
+        let full_sxy = stage.sxy(x, y, &[]) + super::global_mask::<Fp, R>(x, y);
+        assert_eq!(full_sxy, corrected_sxy);
         assert_eq!(corrected_sxy, stripped.sx(x, &plan).eval(y));
         assert_eq!(corrected_sxy, stripped.sy(y, &plan).eval(x));
     }
@@ -467,7 +499,9 @@ mod tests {
         let x = Fp::random(&mut rand::rng());
         let y = Fp::random(&mut rand::rng());
 
-        let sxy = stage.sxy(x, y, &[]);
+        // sxy returns -notch; sx/sy return the full mask (global - notch).
+        let global_xy = super::global_mask::<Fp, R>(x, y);
+        let sxy = stage.sxy(x, y, &[]) + global_xy;
         let sx = stage.sx(x, &[]);
         let sy = stage.sy(y, &[]);
 
@@ -515,8 +549,9 @@ mod tests {
                 // Internal consistency of the RawCircuit impl (with correction)
                 prop_assert_eq!(sy_eval, sxy);
                 prop_assert_eq!(sx_eval, sxy);
-                // Match against the hand-written CircuitObject
-                prop_assert_eq!(stage_mask.sxy(x, y, &[]), sxy);
+                // StageMask::sxy returns -notch; add global to get the full mask.
+                let global_xy = super::global_mask::<Fp, R>(x, y);
+                prop_assert_eq!(stage_mask.sxy(x, y, &[]) + global_xy, sxy);
                 prop_assert_eq!(stage_mask.sx(x, &[]).eval(y), sxy);
                 prop_assert_eq!(stage_mask.sy(y, &[]).eval(x), sxy);
 

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -7,13 +7,13 @@ use crate::{
     polynomials::{Rank, sparse},
 };
 
-/// Evaluates the global stage mask polynomial $S_{\text{global}}(X, Y)$ at
+/// Evaluates the global stage mask polynomial $S\_{\text{global}}(X, Y)$ at
 /// the point $(x, y)$.
 ///
 /// The global mask enforces all $4n$ wire slots to zero except the four wires
 /// of the SYSTEM gate (gate 0):
 ///
-/// $$S_{\text{global}}(xy) = \sum_{i=0}^{4n-1} (xy)^i
+/// $$S_{\text{global}}(x, y) = \sum_{i=0}^{4n-1} (xy)^i
 ///     - \bigl((xy)^{2n} + 1\bigr)\bigl((xy)^{2n-1} + 1\bigr)$$
 ///
 /// The polynomial depends only on the product $XY$, so both variables
@@ -40,12 +40,13 @@ pub(crate) fn global_mask<F: Field, R: Rank>(x: F, y: F) -> F {
     geosum(xy, R::n() << 2) - (xy_2n + F::ONE) * (xy_2n * xy_inv + F::ONE)
 }
 
-/// Restricts the global stage mask to a univariate sparse polynomial by
-/// substituting `p` for one variable. Populates `4(n - 1)` wire
-/// positions — all except the four wires of the SYSTEM gate (gate 0).
+/// Computes the polynomial restriction $S\_{\text{global}}(p, Y)$ (equivalently
+/// $S\_{\text{global}}(X, p)$ by symmetry) as a sparse univariate polynomial.
+/// Populates `4(n - 1)` wire positions — all except the four wires of the
+/// SYSTEM gate (gate 0).
 ///
 /// Used by [`Registry`](crate::registry::Registry) to add the shared global
-/// contribution once, scaled by the sum of bonding Lagrange coefficients.
+/// contribution once, scaled by the sum of masking circuit Lagrange coefficients.
 pub(crate) fn global_project<F: Field, R: Rank>(p: F) -> sparse::Polynomial<F, R> {
     if p == F::ZERO {
         return sparse::Polynomial::default();
@@ -132,11 +133,11 @@ impl<R: Rank> StageMask<R> {
         })
     }
 
-    /// Projects only the negated notch entries: the active-stage gate
-    /// wires at positions `skip_gates..skip_gates + num_gates`, negated.
+    /// Returns a sparse polynomial containing the negated notch entries for
+    /// the active-stage gate wires at positions `skip_gates..skip_gates + num_gates`.
     /// The SYSTEM gate is excluded (it is already zero in the global mask).
     ///
-    /// Returns a sparse polynomial with `4 × num_gates` non-zero entries
+    /// The result has `4 × num_gates` non-zero entries
     /// (vs `4(n - 1)` for the full mask projection).
     fn notch_project<F: Field>(&self, p: F) -> sparse::Polynomial<F, R> {
         if self.num_gates == 0 || p == F::ZERO {
@@ -152,16 +153,16 @@ impl<R: Rank> StageMask<R> {
         view.c.resize(g + m, F::ZERO);
 
         let p_inv = p.invert().expect("p is not zero");
-        let mut d = p.pow_vartime([g as u64]);
-        let mut a = p.pow_vartime([(2 * n - 1 - g) as u64]);
-        let mut b = p.pow_vartime([(2 * n + g) as u64]);
-        let mut c = p.pow_vartime([(4 * n - 1 - g) as u64]);
+        let mut d = -p.pow_vartime([g as u64]);
+        let mut a = -p.pow_vartime([(2 * n - 1 - g) as u64]);
+        let mut b = -p.pow_vartime([(2 * n + g) as u64]);
+        let mut c = -p.pow_vartime([(4 * n - 1 - g) as u64]);
 
         for j in g..g + m {
-            view.d[j] = -d;
-            view.a[j] = -a;
-            view.b[j] = -b;
-            view.c[j] = -c;
+            view.d[j] = d;
+            view.a[j] = a;
+            view.b[j] = b;
+            view.c[j] = c;
             d *= p;
             a *= p_inv;
             b *= p;
@@ -175,12 +176,12 @@ impl<R: Rank> StageMask<R> {
 impl<F: Field, R: Rank> CircuitObject<F, R> for StageMask<R> {
     /// Evaluates the per-instance notch term $-\text{notch}(x, y)$.
     ///
-    /// The full stage mask is $S_{\text{global}} - \text{notch}$, but
-    /// the invariant $S_{\text{global}}$ term is factored out and applied
+    /// The full stage mask is $S\_{\text{global}} - \text{notch}$, but
+    /// the invariant $S\_{\text{global}}$ term is factored out and applied
     /// once by the [`Registry`](crate::registry::Registry). This method
     /// returns only $-\text{notch}$, where
     ///
-    /// $$\text{notch}(xy) = (1 + (xy)^{2n})\bigl((xy)^g + (xy)^{2n-g-m}\bigr)
+    /// $$\text{notch}(x, y) = (1 + (xy)^{2n})\bigl((xy)^g + (xy)^{2n-g-m}\bigr)
     ///     \cdot \sum_{i=0}^{m-1} (xy)^i$$
     ///
     /// with $g = \text{skip\_gates}$ and $m = \text{num\_gates}$.

--- a/crates/ragu_circuits/src/staging/mod.rs
+++ b/crates/ragu_circuits/src/staging/mod.rs
@@ -121,6 +121,7 @@ pub(crate) mod mask;
 
 use alloc::boxed::Box;
 
+pub use builder::{StageBuilder, StageGuard};
 use ff::Field;
 use ragu_core::{
     Result,
@@ -134,8 +135,6 @@ use crate::{
     BondingObject, Circuit, WithAux,
     polynomials::{Rank, sparse},
 };
-
-pub use builder::{StageBuilder, StageGuard};
 
 /// Represents a partial trace component for a multi-stage circuit.
 pub trait Stage<F: Field, R: Rank> {

--- a/crates/ragu_core/src/drivers.rs
+++ b/crates/ragu_core/src/drivers.rs
@@ -51,6 +51,7 @@ mod linexp;
 mod phantom;
 
 use ff::Field;
+pub use linexp::{DirectSum, LinearExpression};
 use ragu_arithmetic::Coeff;
 
 use crate::{
@@ -59,8 +60,6 @@ use crate::{
     maybe::{Maybe, MaybeKind, Perhaps},
     routines::Routine,
 };
-
-pub use linexp::{DirectSum, LinearExpression};
 
 /// Alias for the concrete [`Maybe<T>`] type for a driver `D`, used to represent input data
 /// that may or may not be available. This provides a uniform interface for both public

--- a/crates/ragu_pasta/src/lib.rs
+++ b/crates/ragu_pasta/src/lib.rs
@@ -42,12 +42,11 @@ mod common {
 mod poseidon_fp;
 mod poseidon_fq;
 
-use ragu_arithmetic::{Cycle, FixedGenerators};
-
 pub use common::{PallasGenerators, PastaParams, VestaGenerators};
 pub use pasta_curves::{Ep, EpAffine, Eq, EqAffine, Fp, Fq};
 pub use poseidon_fp::PoseidonFp;
 pub use poseidon_fq::PoseidonFq;
+use ragu_arithmetic::{Cycle, FixedGenerators};
 
 /// Zero-sized marker type for the [Pasta
 /// curve](https://electriccoin.co/blog/the-pasta-curves-for-halo-2-and-beyond/)

--- a/crates/ragu_pcd/Cargo.toml
+++ b/crates/ragu_pcd/Cargo.toml
@@ -59,3 +59,8 @@ harness = false
 name = "fuse_criterion"
 path = "benches/criterion/fuse.rs"
 harness = false
+
+[[bench]]
+name = "registry_criterion"
+path = "benches/criterion/registry.rs"
+harness = false

--- a/crates/ragu_pcd/benches/criterion/registry.rs
+++ b/crates/ragu_pcd/benches/criterion/registry.rs
@@ -1,0 +1,59 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use ff::Field;
+use ragu_arithmetic::Cycle;
+use ragu_circuits::polynomials::ProductionRank;
+use ragu_pasta::{Fp, Pasta};
+use ragu_pcd::ApplicationBuilder;
+use ragu_testing::pcd::nontrivial;
+use rand::{SeedableRng, rngs::StdRng};
+
+fn registry_bench(c: &mut Criterion) {
+    let pasta = Pasta::baked();
+    let poseidon_params = Pasta::circuit_poseidon(pasta);
+
+    // Time finalize separately: build the ApplicationBuilder, then bench only finalize.
+    let make_builder = || {
+        ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+            .register(nontrivial::WitnessLeaf { poseidon_params })
+            .unwrap()
+            .register(nontrivial::Hash2 { poseidon_params })
+            .unwrap()
+    };
+
+    c.bench_function("registry::finalize", |b| {
+        b.iter_batched(
+            make_builder,
+            |builder| builder.finalize(pasta).unwrap(),
+            criterion::BatchSize::PerIteration,
+        );
+    });
+
+    // Build the finalized app once for evaluation benchmarks.
+    let app = make_builder().finalize(pasta).unwrap();
+    let registry = app.native_registry();
+
+    // Use deterministic "random" field elements.
+    let mut rng = StdRng::seed_from_u64(0xdead);
+    let w = Fp::random(&mut rng);
+    let x = Fp::random(&mut rng);
+    let y = Fp::random(&mut rng);
+
+    c.bench_function("registry::wx", |b| {
+        b.iter(|| registry.wx(w, x));
+    });
+
+    c.bench_function("registry::wy", |b| {
+        b.iter(|| registry.wy(w, y));
+    });
+
+    c.bench_function("registry::wxy", |b| {
+        b.iter(|| registry.wxy(w, x, y));
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = registry_bench
+}
+criterion_main!(benches);

--- a/crates/ragu_pcd/src/lib.rs
+++ b/crates/ragu_pcd/src/lib.rs
@@ -34,6 +34,8 @@ mod verify;
 use alloc::collections::BTreeMap;
 use core::{any::TypeId, cell::OnceCell, marker::PhantomData};
 
+use header::Header;
+pub use proof::{Pcd, Proof};
 use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::Rank,
@@ -41,11 +43,7 @@ use ragu_circuits::{
 };
 use ragu_core::{Error, Result};
 use rand::CryptoRng;
-
-use header::Header;
 use step::{Step, internal::adapter::Adapter};
-
-pub use proof::{Pcd, Proof};
 
 /// Domain separation tag for Ragu PCD protocol.
 // FIXME: choose a permanent domain separation tag before release.

--- a/crates/ragu_pcd/src/lib.rs
+++ b/crates/ragu_pcd/src/lib.rs
@@ -274,4 +274,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         )
         .map(|(pcd, ())| pcd)
     }
+
+    /// Returns a reference to the native [`Registry`].
+    pub fn native_registry(&self) -> &Registry<'_, C::CircuitField, R> {
+        &self.native_registry
+    }
 }

--- a/crates/ragu_pcd/src/step/mod.rs
+++ b/crates/ragu_pcd/src/step/mod.rs
@@ -3,6 +3,7 @@
 mod encoder;
 pub(crate) mod internal;
 
+pub use encoder::Encoded;
 use ragu_arithmetic::Cycle;
 use ragu_circuits::registry::CircuitIndex;
 use ragu_core::{
@@ -12,8 +13,6 @@ use ragu_core::{
 
 use super::header::Header;
 use crate::internal::native::InternalCircuitIndex;
-
-pub use encoder::Encoded;
 
 #[derive(Copy, Clone)]
 #[repr(usize)]

--- a/crates/ragu_primitives/src/io.rs
+++ b/crates/ragu_primitives/src/io.rs
@@ -15,6 +15,7 @@
 mod pipe;
 
 use ff::Field;
+pub use pipe::Pipe;
 use ragu_core::{
     Result,
     drivers::Driver,
@@ -22,8 +23,6 @@ use ragu_core::{
 };
 
 use crate::Element;
-
-pub use pipe::Pipe;
 
 /// Represents a gadget that can be serialized into a sequence of [`Element`]s
 /// that are written to a [`Buffer`].

--- a/crates/ragu_primitives/src/lib.rs
+++ b/crates/ragu_primitives/src/lib.rs
@@ -32,15 +32,13 @@ pub mod suffix;
 mod util;
 pub mod vec;
 
-use ragu_core::{Result, drivers::Driver, gadgets::Gadget};
-
-use io::{Buffer, Write};
-use promotion::Demoted;
-
 pub use boolean::{Boolean, multipack};
 pub use element::{Element, multiadd};
 pub use endoscalar::{Endoscalar, extract_endoscalar, lift_endoscalar};
+use io::{Buffer, Write};
 pub use point::Point;
+use promotion::Demoted;
+use ragu_core::{Result, drivers::Driver, gadgets::Gadget};
 pub use sendable::Sendable;
 pub use simulator::Simulator;
 pub use suffix::WithSuffix;


### PR DESCRIPTION
Closes #623 

Factor the invariant $s_{global}(x,y)$ global stage mask out of `StageMask` to `Registry` so that we only have to compute it once for all the stage mask/bonding polynomials, instead of doing them redundantly per stage mask.

Similarly, the projection for `sx()/sy()` is also split into a global projection and per-stage mask notch projection which is the negation of the active regions (since global projection is roughly the diagonal $p^i$ formatted/partially-reversed like a structured vector. Previously, we zero-out the active region on the `View::wiring()`, but here we defer them to registry for negation/offset. 