### PR TITLE
Pin formatting lints to specific nightly version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,12 +48,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install nightly rustfmt
-        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install pinned nightly rustfmt
+        id: toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2026-04-11
           components: rustfmt
+
       - name: Check formatting
-        run: cargo +nightly fmt --all -- --check
+        run: cargo +${{ steps.toolchain.outputs.name }} fmt --all -- --check
 
   clippy:
     name: clippy

--- a/crates/ragu_arithmetic/src/lib.rs
+++ b/crates/ragu_arithmetic/src/lib.rs
@@ -79,10 +79,9 @@ mod multicore;
 mod uendo;
 mod util;
 
-use ff::{Field, FromUniformBytes, WithSmallOrderMulGroup};
-
 pub use coeff::Coeff;
 pub use domain::Domain;
+use ff::{Field, FromUniformBytes, WithSmallOrderMulGroup};
 pub use fft::{Ring, bitreverse};
 pub use pasta_curves::arithmetic::{Coordinates, CurveAffine, CurveExt};
 /// Converts a 256-bit integer literal into the little endian `[u64; 4]`

--- a/crates/ragu_circuits/src/staging/mod.rs
+++ b/crates/ragu_circuits/src/staging/mod.rs
@@ -121,6 +121,7 @@ pub(crate) mod mask;
 
 use alloc::boxed::Box;
 
+pub use builder::{StageBuilder, StageGuard};
 use ff::Field;
 use ragu_core::{
     Result,
@@ -134,8 +135,6 @@ use crate::{
     BondingObject, Circuit, WithAux,
     polynomials::{Rank, sparse},
 };
-
-pub use builder::{StageBuilder, StageGuard};
 
 /// Represents a partial trace component for a multi-stage circuit.
 pub trait Stage<F: Field, R: Rank> {

--- a/crates/ragu_core/src/drivers.rs
+++ b/crates/ragu_core/src/drivers.rs
@@ -51,6 +51,7 @@ mod linexp;
 mod phantom;
 
 use ff::Field;
+pub use linexp::{DirectSum, LinearExpression};
 use ragu_arithmetic::Coeff;
 
 use crate::{
@@ -59,8 +60,6 @@ use crate::{
     maybe::{Maybe, MaybeKind, Perhaps},
     routines::Routine,
 };
-
-pub use linexp::{DirectSum, LinearExpression};
 
 /// Alias for the concrete [`Maybe<T>`] type for a driver `D`, used to represent input data
 /// that may or may not be available. This provides a uniform interface for both public

--- a/crates/ragu_pasta/src/lib.rs
+++ b/crates/ragu_pasta/src/lib.rs
@@ -42,12 +42,11 @@ mod common {
 mod poseidon_fp;
 mod poseidon_fq;
 
-use ragu_arithmetic::{Cycle, FixedGenerators};
-
 pub use common::{PallasGenerators, PastaParams, VestaGenerators};
 pub use pasta_curves::{Ep, EpAffine, Eq, EqAffine, Fp, Fq};
 pub use poseidon_fp::PoseidonFp;
 pub use poseidon_fq::PoseidonFq;
+use ragu_arithmetic::{Cycle, FixedGenerators};
 
 /// Zero-sized marker type for the [Pasta
 /// curve](https://electriccoin.co/blog/the-pasta-curves-for-halo-2-and-beyond/)

--- a/crates/ragu_pcd/src/lib.rs
+++ b/crates/ragu_pcd/src/lib.rs
@@ -34,6 +34,8 @@ mod verify;
 use alloc::collections::BTreeMap;
 use core::{any::TypeId, cell::OnceCell, marker::PhantomData};
 
+use header::Header;
+pub use proof::{Pcd, Proof};
 use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::Rank,
@@ -41,11 +43,7 @@ use ragu_circuits::{
 };
 use ragu_core::{Error, Result};
 use rand::CryptoRng;
-
-use header::Header;
 use step::{Step, internal::adapter::Adapter};
-
-pub use proof::{Pcd, Proof};
 
 /// Domain separation tag for Ragu PCD protocol.
 // FIXME: choose a permanent domain separation tag before release.

--- a/crates/ragu_pcd/src/step/mod.rs
+++ b/crates/ragu_pcd/src/step/mod.rs
@@ -3,6 +3,7 @@
 mod encoder;
 pub(crate) mod internal;
 
+pub use encoder::Encoded;
 use ragu_arithmetic::Cycle;
 use ragu_circuits::registry::CircuitIndex;
 use ragu_core::{
@@ -12,8 +13,6 @@ use ragu_core::{
 
 use super::header::Header;
 use crate::internal::native::InternalCircuitIndex;
-
-pub use encoder::Encoded;
 
 #[derive(Copy, Clone)]
 #[repr(usize)]

--- a/crates/ragu_primitives/src/io.rs
+++ b/crates/ragu_primitives/src/io.rs
@@ -15,6 +15,7 @@
 mod pipe;
 
 use ff::Field;
+pub use pipe::Pipe;
 use ragu_core::{
     Result,
     drivers::Driver,
@@ -22,8 +23,6 @@ use ragu_core::{
 };
 
 use crate::Element;
-
-pub use pipe::Pipe;
 
 /// Represents a gadget that can be serialized into a sequence of [`Element`]s
 /// that are written to a [`Buffer`].

--- a/crates/ragu_primitives/src/lib.rs
+++ b/crates/ragu_primitives/src/lib.rs
@@ -32,15 +32,13 @@ pub mod suffix;
 mod util;
 pub mod vec;
 
-use ragu_core::{Result, drivers::Driver, gadgets::Gadget};
-
-use io::{Buffer, Write};
-use promotion::Demoted;
-
 pub use boolean::{Boolean, multipack};
 pub use element::{Element, multiadd};
 pub use endoscalar::{Endoscalar, extract_endoscalar, lift_endoscalar};
+use io::{Buffer, Write};
 pub use point::Point;
+use promotion::Demoted;
+use ragu_core::{Result, drivers::Driver, gadgets::Gadget};
 pub use sendable::Sendable;
 pub use simulator::Simulator;
 pub use suffix::WithSuffix;

--- a/justfile
+++ b/justfile
@@ -10,14 +10,16 @@ build *ARGS:
 build_release *ARGS:
   cargo build --release --workspace --all-targets {{ARGS}}
 
+_nightly := "nightly-2026-04-11"
+
 lint: _typos_setup _book_setup
   cargo clippy --workspace --lib --tests --benches --all-features -- -D warnings
-  cargo +nightly fmt --all -- --check
+  cargo +{{_nightly}} fmt --all -- --check
   typos
   mdbook build ./book
 
-fix: _typos_setup 
-  cargo +nightly fmt --all
+fix: _typos_setup
+  cargo +{{_nightly}} fmt --all
   cargo fix --allow-dirty --allow-staged --all-features
   cargo clippy --fix --allow-dirty --allow-staged --all-features
   typos -w
@@ -119,7 +121,7 @@ _flamegraph_linux PACKAGE GROUP TARGET *ARGS: _flamegraph_setup
 # run CI checks locally (formatting, clippy, tests)
 ci_local: _book_setup
   @echo "Running formatting check..."
-  cargo +nightly fmt --all -- --check
+  cargo +{{_nightly}} fmt --all -- --check
   @echo "Running clippy..."
   cargo clippy --workspace --lib --tests --benches --locked --all-features -- -D warnings
   @echo "Running tests..."


### PR DESCRIPTION
I don't like that nightly drifts between local and CI toolchains will cause these lints to start failing randomly or to differ between members of our team.