### PR TITLE
chore(primitives): sparser boolean gate layout

### DIFF
--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -92,7 +92,7 @@ fn test_internal_circuit_constraint_counts() {
     check_constraints!(Hashes2Circuit,         mul = 1879, lin = 2951);
     check_constraints!(InnerCollapseCircuit,  mul = 1756, lin = 1918);
     check_constraints!(OuterCollapseCircuit,  mul = 811 , lin = 808);
-    check_constraints!(ComputeVCircuit,        mul = 1140, lin = 1645);
+    check_constraints!(ComputeVCircuit,        mul = 1140, lin = 1773);
 }
 
 #[rustfmt::skip]
@@ -199,7 +199,7 @@ fn test_native_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fp!(0x2f037c2a251bcfd77ec420686b6373cbeca915419368261a37f114fe3f9da8e7);
+    let expected = fp!(0x1751a6d29d794343a9572ca879168b7b60e8b023e85ffdc056c96d736cd10317);
 
     assert_eq!(
         app.native_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -92,7 +92,7 @@ fn test_internal_circuit_constraint_counts() {
     check_constraints!(Hashes2Circuit,         mul = 1879, lin = 2951);
     check_constraints!(InnerCollapseCircuit,  mul = 1756, lin = 1918);
     check_constraints!(OuterCollapseCircuit,  mul = 811 , lin = 808);
-    check_constraints!(ComputeVCircuit,        mul = 1140, lin = 1773);
+    check_constraints!(ComputeVCircuit,        mul = 1140, lin = 1645);
 }
 
 #[rustfmt::skip]
@@ -199,7 +199,7 @@ fn test_native_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fp!(0x339e595491fd177b620ea6dc286cf85c3caab480edba867792383f33714019e4);
+    let expected = fp!(0x2f037c2a251bcfd77ec420686b6373cbeca915419368261a37f114fe3f9da8e7);
 
     assert_eq!(
         app.native_registry.digest(),

--- a/crates/ragu_primitives/src/boolean.rs
+++ b/crates/ragu_primitives/src/boolean.rs
@@ -38,15 +38,18 @@ pub struct Boolean<'dr, D: Driver<'dr>> {
 impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
     /// Allocates a boolean with the provided witness value.
     ///
-    /// This costs one gate and one constraint. The gate layout is
-    /// $(a, b, 0, d)$ where $a \cdot b = 0$ and the linear constraint
-    /// $1 - a - b = 0$ forces $a$ to be zero or one.
+    /// This costs one gate and two constraints. The gate layout is
+    /// $(a, b, 0, d)$ where $a \cdot b = c$, and the linear constraints
+    /// $c = 0$ and $1 - a - b = 0$ force $a$ to be zero or one.
     pub fn alloc(dr: &mut D, value: DriverValue<D, bool>) -> Result<Self> {
         let complement = value.not();
-        let (a, b, _c) =
+        let (a, b, c) =
             dr.mul(|| Ok((value.coeff().take(), complement.coeff().take(), Coeff::Zero)))?;
 
-        // Enforce a + b = 1. Together with the gate constraint a * b = 0,
+        // Enforce c = 0, so the gate constraint becomes a * b = 0.
+        dr.enforce_zero(|lc| lc.add(&c))?;
+
+        // Enforce a + b = 1. Together with a * b = 0,
         // this gives a(1 - a) = 0, so a is zero or one.
         dr.enforce_zero(|lc| lc.add(&D::ONE).sub(&a).sub(&b))?;
 
@@ -267,7 +270,7 @@ fn test_boolean_alloc() -> Result<()> {
 
         assert_eq!(sim.num_allocations(), 0);
         assert_eq!(sim.num_gates(), 1);
-        assert_eq!(sim.num_constraints(), 1);
+        assert_eq!(sim.num_constraints(), 2);
         Ok(())
     };
 

--- a/crates/ragu_primitives/src/boolean.rs
+++ b/crates/ragu_primitives/src/boolean.rs
@@ -38,22 +38,19 @@ pub struct Boolean<'dr, D: Driver<'dr>> {
 impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
     /// Allocates a boolean with the provided witness value.
     ///
-    /// This costs one gate and two constraints.
+    /// This costs one gate and one constraint. The gate layout is
+    /// $(a, b, 0, d)$ where $a \cdot b = 0$ and the linear constraint
+    /// $1 - a - b = 0$ forces $a$ to be zero or one.
     pub fn alloc(dr: &mut D, value: DriverValue<D, bool>) -> Result<Self> {
-        let (a, b, c) = dr.mul(|| {
-            let value = value.coeff().take();
-            Ok((value, value, value))
-        })?;
+        let complement = value.not();
+        let (a, b, _c) =
+            dr.mul(|| Ok((value.coeff().take(), complement.coeff().take(), Coeff::Zero)))?;
 
-        // Enforce a = b => c = a²
-        dr.enforce_equal(&a, &b)?;
+        // Enforce a + b = 1. Together with the gate constraint a * b = 0,
+        // this gives a(1 - a) = 0, so a is zero or one.
+        dr.enforce_zero(|lc| lc.add(&D::ONE).sub(&a).sub(&b))?;
 
-        // Enforce a = c => a = a²
-        //                => (a - 0)(a - 1) = 0
-        //                => (a = 0) OR (a = 1)
-        dr.enforce_equal(&a, &c)?;
-
-        Ok(Boolean { value, wire: c })
+        Ok(Boolean { value, wire: a })
     }
 
     /// Computes the NOT of this boolean. This is "free" in the circuit model.
@@ -270,7 +267,7 @@ fn test_boolean_alloc() -> Result<()> {
 
         assert_eq!(sim.num_allocations(), 0);
         assert_eq!(sim.num_gates(), 1);
-        assert_eq!(sim.num_constraints(), 2);
+        assert_eq!(sim.num_constraints(), 1);
         Ok(())
     };
 

--- a/crates/ragu_primitives/src/boolean.rs
+++ b/crates/ragu_primitives/src/boolean.rs
@@ -38,9 +38,7 @@ pub struct Boolean<'dr, D: Driver<'dr>> {
 impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
     /// Allocates a boolean with the provided witness value.
     ///
-    /// This costs one gate and two constraints. The gate layout is
-    /// $(a, b, 0, d)$ where $a \cdot b = c$, and the linear constraints
-    /// $c = 0$ and $1 - a - b = 0$ force $a$ to be zero or one.
+    /// This costs one gate and two constraints.
     pub fn alloc(dr: &mut D, value: DriverValue<D, bool>) -> Result<Self> {
         let complement = value.not();
         let (a, b, c) =


### PR DESCRIPTION
https://github.com/tachyon-zcash/ragu/pull/606 modified driver-level allocs (the default `Driver::alloc` still calls `mul`, but synthesis drivers override the gate layout to (0, b, 0, d)). 

This instead modifies the gadget-level alloc for the boolean gadget to (a, b, 0, d), where in practice it's either (0, 1, 0, d) or (1, 0, 0, d) with d currently 0. Specifically, the gate gives us a * b = c with c = 0, and the `enforce_zero` gives us 1 - a - b = 0. This is a sparser gate layout, meaning sparser multiexp. 

This also frees up the d-wire for an extra allocation.