### PR TITLE
doc: add simulator page and fix routing description in concrete drivers

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -12,7 +12,6 @@
     - [Witness Data](guide/drivers/witness.md)
     - [Linear Expressions](guide/drivers/linear.md)
     - [Concrete Drivers](guide/drivers/concrete.md)
-    - [Simulator](guide/drivers/simulator.md)
   - [Gadgets](guide/gadgets/index.md)
     - [Simple Gadgets](guide/gadgets/simple.md)
     - [The GadgetKind Trait](guide/gadgets/gadgetkind.md)
@@ -21,6 +20,7 @@
   - [Routines](guide/routines.md)
   - [Primitives](guide/primitives/index.md) <!-- todo -->
     - [Allocation](guide/primitives/allocation.md) <!-- todo -->
+    - [Simulator](guide/primitives/simulator.md)
   - [Writing Circuits](guide/writing_circuits.md) <!-- todo -->
   - [Configuration](guide/configuration.md) <!-- todo -->
 - [Part II: Protocol Design]()

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -12,6 +12,7 @@
     - [Witness Data](guide/drivers/witness.md)
     - [Linear Expressions](guide/drivers/linear.md)
     - [Concrete Drivers](guide/drivers/concrete.md)
+    - [Simulator](guide/drivers/simulator.md)
   - [Gadgets](guide/gadgets/index.md)
     - [Simple Gadgets](guide/gadgets/simple.md)
     - [The GadgetKind Trait](guide/gadgets/gadgetkind.md)

--- a/book/src/guide/drivers/concrete.md
+++ b/book/src/guide/drivers/concrete.md
@@ -64,8 +64,8 @@ Because emulators are not involved in enforcing constraints, they short-circuit
 [predict](ragu_core::routines::Routine::predict) its output, the emulator skips
 [`execute`](ragu_core::routines::Routine::execute) entirely and returns the
 prediction. This contrasts with the [`Simulator`], which always executes even
-for known predictions so it can verify consistency between the prediction and
-the actual result.
+for known predictions so the full routine body contributes to its metrics
+and all constraints are enforced.
 
 ### Wire Extraction {#wire-extraction}
 

--- a/book/src/guide/drivers/simulator.md
+++ b/book/src/guide/drivers/simulator.md
@@ -1,0 +1,185 @@
+# Simulator
+
+The [Concrete Drivers](concrete.md) page introduced the [`Simulator`] as a
+driver that executes circuit code natively while enforcing constraints and
+tracking metrics. This page covers its public API and shows how to use it
+to measure constraint costs before committing to a [`Rank`].
+
+## Why Measure
+
+Every circuit operates within the budget set by its
+[`Rank`](../configuration.md). If the final circuit is too large, later
+synthesis stages return an error such as:
+
+```text
+Error::GateBoundExceeded { limit: 32 }
+```
+
+The [`Simulator`] helps you catch this early. It runs circuit code exactly
+as the real synthesis drivers do, calling witness closures, enforcing gate
+constraints, and checking linear constraints but reports metrics instead of
+building a proof. You can then compare those counts against the rank limits
+before running the prover.
+
+The simulator itself does **not** raise rank-bound errors. It gives you the
+numbers that let you detect the problem before later synthesis code turns it
+into `GateBoundExceeded` or `ConstraintBoundExceeded`.
+
+## Rank Limits
+
+| Rank | Max gates | Coefficient vector size | Typical use |
+|------|-----------|-------------------------|-------------|
+| `R<7>` | 32 | $2^7 = 128$ | Unit tests |
+| `R<13>` | 2,048 | $2^{13} = 8{,}192$ | Production |
+
+Gates correspond to [`mul()`] calls. Constraints correspond to explicit
+[`enforce_zero()`] calls. The simulator reports both so you can compare
+different circuit designs before committing to a rank.
+
+## API
+
+[`Simulator`] is provided by `ragu_primitives` and re-exported at crate
+root.
+
+### Construction
+
+```rust,ignore
+use ragu_primitives::Simulator;
+
+// Standalone
+let mut dr = Simulator::<F>::new();
+
+// With witness binding (preferred)
+let sim = Simulator::simulate(witness_value, |dr, witness| {
+    // circuit code here
+    Ok(())
+})?;
+```
+
+[`Simulator::simulate`] creates a fresh simulator, wraps the witness in
+`Always<W>`, runs the closure, and returns the simulator with its
+accumulated metrics. This is the standard entry point for measurement.
+
+### Metrics
+
+After synthesis completes, three counters are available:
+
+| Method | Counts | Driver operation |
+|--------|--------|-----------------|
+| [`num_gates()`] | Multiplication gates | [`mul()`] |
+| [`num_allocations()`] | Single-wire allocations | [`alloc()`] |
+| [`num_constraints()`] | Linear constraints enforced | [`enforce_zero()`] |
+
+```rust,ignore
+let sim = Simulator::simulate(my_value, |dr, witness| {
+    let x = Element::alloc(dr, witness)?;
+    let y = x.mul(dr, &x)?;   // 1 gate
+    Ok(())
+})?;
+
+assert_eq!(sim.num_allocations(), 1);
+assert_eq!(sim.num_gates(), 1);
+```
+
+### Resetting
+
+[`reset()`] zeroes all counters without discarding the driver state. This
+isolates the cost of a specific operation from setup overhead:
+
+```rust,ignore
+let sim = Simulator::simulate((x, z), |dr, witness| {
+    let (x, z) = witness.cast();
+    let x = Element::alloc(dr, x)?;
+    let z = Element::alloc(dr, z)?;
+
+    dr.reset();  // ignore allocation cost above
+
+    dr.routine(evaluator.clone(), (x, z))?;
+
+    assert_eq!(dr.num_allocations(), 0);
+    assert_eq!(dr.num_gates(), 76);
+    assert_eq!(dr.num_constraints(), 152);
+
+    Ok(())
+})?;
+```
+
+This pattern is common in Ragu's own test suite: allocate inputs, reset,
+run the operation under test, then assert on the counts.
+
+## Constraint Checking
+
+The [`Simulator`] does not merely count, it verifies. Every gate checks
+$a \cdot b = c$, and every [`enforce_zero()`] checks that the linear
+combination evaluates to zero. A constraint violation returns
+`Error::InvalidWitness` immediately, pinpointing the failing operation.
+
+This makes the simulator useful for catching witness bugs: if a circuit
+produces incorrect assignments, the simulator rejects them before proving
+is attempted.
+
+## Routines
+
+The [`Simulator`] always executes [routines](../routines.md) fully, even
+when a routine can predict its output. This contrasts with the
+[`Emulator`], which skips execution when prediction suffices. The simulator
+uses prediction only to obtain auxiliary data, then still calls
+`execute` so the full routine body contributes to the metrics and all of
+its constraints are enforced.
+
+## Example
+
+Suppose you are writing a step that hashes two field elements with
+Poseidon, and you want to know whether it fits in `R<7>` (32 gates):
+
+```rust,ignore
+use ragu_primitives::Simulator;
+use pasta_curves::Fp;
+
+let sim = Simulator::simulate((Fp::from(1u64), Fp::from(2u64)), |dr, witness| {
+    let (a, b) = witness.cast();
+    let a = Element::alloc(dr, a)?;
+    let b = Element::alloc(dr, b)?;
+
+    dr.reset();
+
+    let mut sponge = Sponge::new(dr, &poseidon_params);
+    sponge.absorb(dr, &a)?;
+    sponge.absorb(dr, &b)?;
+    let _hash = sponge.squeeze(dr)?;
+
+    println!(
+        "gates: {}, constraints: {}",
+        dr.num_gates(),
+        dr.num_constraints()
+    );
+    Ok(())
+})?;
+```
+
+If `num_gates()` exceeds 32, the circuit does not fit in `R<7>` and you
+need `R<13>` (2,048 gates) or a larger rank.
+
+## Summary
+
+The [`Simulator`] answers two questions before you run the prover:
+
+1. **Does this circuit satisfy its own constraints?** If not, you have a
+   witness bug.
+2. **How many gates and constraints does it use?** If the count exceeds
+   your rank's budget, choose a larger rank or optimize the circuit.
+
+Use [`reset()`] to isolate individual operations, and structure tests
+around exact metric assertions so regressions are caught immediately.
+
+[`Simulator`]: ragu_primitives::Simulator
+[`Simulator::simulate`]: ragu_primitives::Simulator::simulate
+[`num_gates()`]: ragu_primitives::Simulator::num_gates
+[`num_allocations()`]: ragu_primitives::Simulator::num_allocations
+[`num_constraints()`]: ragu_primitives::Simulator::num_constraints
+[`reset()`]: ragu_primitives::Simulator::reset
+[`Rank`]: ragu_circuits::polynomials::Rank
+[`mul()`]: ragu_core::drivers::Driver::mul
+[`alloc()`]: ragu_core::drivers::Driver::alloc
+[`enforce_zero()`]: ragu_core::drivers::Driver::enforce_zero
+[`Emulator`]: ragu_core::drivers::emulator::Emulator

--- a/book/src/guide/drivers/simulator.md
+++ b/book/src/guide/drivers/simulator.md
@@ -32,9 +32,10 @@ into `GateBoundExceeded` or `ConstraintBoundExceeded`.
 | `R<7>` | 32 | $2^7 = 128$ | Unit tests |
 | `R<13>` | 2,048 | $2^{13} = 8{,}192$ | Production |
 
-Gates correspond to [`mul()`] calls. Constraints correspond to explicit
-[`enforce_zero()`] calls. The simulator reports both so you can compare
-different circuit designs before committing to a rank.
+Gates correspond to [`mul()`] and [`gate()`] calls. Constraints
+correspond to explicit [`enforce_zero()`] calls. The simulator
+reports both so you can compare different circuit designs before
+committing to a rank.
 
 ## API
 
@@ -62,23 +63,23 @@ accumulated metrics. This is the standard entry point for measurement.
 
 ### Metrics
 
-After synthesis completes, three counters are available:
+After synthesis completes, two counters are available:
 
 | Method | Counts | Driver operation |
 |--------|--------|-----------------|
-| [`num_gates()`] | Multiplication gates | [`mul()`] |
-| [`num_allocations()`] | Single-wire allocations | [`alloc()`] |
+| [`num_gates()`] | Multiplication gates | [`mul()`] / [`gate()`] |
 | [`num_constraints()`] | Linear constraints enforced | [`enforce_zero()`] |
 
 ```rust,ignore
-let sim = Simulator::simulate(my_value, |dr, witness| {
-    let x = Element::alloc(dr, witness)?;
-    let y = x.mul(dr, &x)?;   // 1 gate
+let sim = Simulator::simulate((a, b), |dr, witness| {
+    let (a, b) = witness.cast();
+    let allocator = &mut SimpleAllocator::new();
+    let x = Element::alloc(dr, allocator, a)?;  // 1 gate
+    let y = Element::alloc(dr, allocator, b)?;  // reuses stash
     Ok(())
 })?;
 
-assert_eq!(sim.num_allocations(), 1);
-assert_eq!(sim.num_gates(), 1);
+assert_eq!(sim.num_gates(), 1);  // two allocations share one gate
 ```
 
 ### Resetting
@@ -89,14 +90,14 @@ isolates the cost of a specific operation from setup overhead:
 ```rust,ignore
 let sim = Simulator::simulate((x, z), |dr, witness| {
     let (x, z) = witness.cast();
-    let x = Element::alloc(dr, x)?;
-    let z = Element::alloc(dr, z)?;
+    let allocator = &mut SimpleAllocator::new();
+    let x = Element::alloc(dr, allocator, x)?;
+    let z = Element::alloc(dr, allocator, z)?;
 
     dr.reset();  // ignore allocation cost above
 
     dr.routine(evaluator.clone(), (x, z))?;
 
-    assert_eq!(dr.num_allocations(), 0);
     assert_eq!(dr.num_gates(), 76);
     assert_eq!(dr.num_constraints(), 152);
 
@@ -133,13 +134,14 @@ Suppose you are writing a step that hashes two field elements with
 Poseidon, and you want to know whether it fits in `R<7>` (32 gates):
 
 ```rust,ignore
-use ragu_primitives::Simulator;
+use ragu_primitives::{Simulator, allocator::SimpleAllocator};
 use pasta_curves::Fp;
 
 let sim = Simulator::simulate((Fp::from(1u64), Fp::from(2u64)), |dr, witness| {
     let (a, b) = witness.cast();
-    let a = Element::alloc(dr, a)?;
-    let b = Element::alloc(dr, b)?;
+    let allocator = &mut SimpleAllocator::new();
+    let a = Element::alloc(dr, allocator, a)?;
+    let b = Element::alloc(dr, allocator, b)?;
 
     dr.reset();
 
@@ -175,11 +177,10 @@ around exact metric assertions so regressions are caught immediately.
 [`Simulator`]: ragu_primitives::Simulator
 [`Simulator::simulate`]: ragu_primitives::Simulator::simulate
 [`num_gates()`]: ragu_primitives::Simulator::num_gates
-[`num_allocations()`]: ragu_primitives::Simulator::num_allocations
 [`num_constraints()`]: ragu_primitives::Simulator::num_constraints
 [`reset()`]: ragu_primitives::Simulator::reset
 [`Rank`]: ragu_circuits::polynomials::Rank
 [`mul()`]: ragu_core::drivers::Driver::mul
-[`alloc()`]: ragu_core::drivers::Driver::alloc
+[`gate()`]: ragu_core::drivers::DriverTypes::gate
 [`enforce_zero()`]: ragu_core::drivers::Driver::enforce_zero
 [`Emulator`]: ragu_core::drivers::emulator::Emulator

--- a/book/src/guide/primitives/allocation.md
+++ b/book/src/guide/primitives/allocation.md
@@ -63,7 +63,7 @@ impl<'dr, D: Driver<'dr>> Allocator<'dr, D> for () {
 In exchange for being stateless, this allocator creates a gate for
 every free wire, which is not optimal.
 
-## [`SimpleAllocator`] {#simple-allocator}
+## [`Standard`] {#standard}
 
 Theoretically, an allocator could offer two wires per gate by
 distributing the $A$ and $B$ wires of each [`mul()`], allowing $C$
@@ -74,25 +74,23 @@ and is more expensive to manipulate. Instead, the more general
 and $D$ wires are distributed and the $A$ and $C$ wires are
 assigned to zero.
 
-[`SimpleAllocator`] exploits this by creating gates, assigning the
-$B$ wire, and then stashing the $D$ wire's token for future
-allocation with the [driver's assistance][assign-extra]. In exchange
-for being stateful, it is less wasteful.
-
-Typical usage:
+[`Standard`] exploits this by creating gates, assigning the $B$
+wire, and then stashing the $D$ wire's token for future allocation
+with the [driver's assistance][assign-extra]. In exchange for being
+stateful, it is less wasteful.
 
 ```rust
-let allocator = &mut SimpleAllocator::new();
+let allocator = &mut Standard::new();
 let a = Element::alloc(dr, allocator, witness_a)?;
 let b = Element::alloc(dr, allocator, witness_b)?;
 // Both a and b share one gate.
 ```
 
-## [`PoolAllocator`] {#pool-allocator}
+### Donated Tokens {#donated-tokens}
 
 Some gadgets allocate a gate whose $D$ wire is unconstrained because
 $C$ is constrained to be zero. Rather than waste that wire, they
-can _donate_ the `Extra` token to the allocator. [`PoolAllocator`]
+can _donate_ the `Extra` token to the allocator. [`Standard`]
 collects these donated tokens and hands them out on future `alloc`
 calls before falling back to new gates.
 
@@ -109,11 +107,11 @@ dr.enforce_zero(|lc| lc.add(&c)); // c = 0
 allocator.donate(extra);
 ```
 
-When using `PoolAllocator`, subsequent allocations redeem these
-donated tokens at zero gate cost:
+Subsequent allocations redeem these donated tokens at zero gate
+cost:
 
 ```rust
-let allocator = &mut PoolAllocator::new();
+let allocator = &mut Standard::new();
 let flag = Boolean::alloc(dr, allocator, bit)?;   // 1 gate
 let x = Element::alloc(dr, allocator, witness)?;  // 0 gates
 ```
@@ -127,8 +125,7 @@ but a rough guide:
 
 | Situation | Allocator |
 |-----------|-----------|
-| Two or more consecutive allocations | [`SimpleAllocator`] |
-| Allocations interleaved with donating gadgets | [`PoolAllocator`] |
+| Two or more allocations, or donating gadgets | [`Standard`] |
 | Single isolated allocation | `()` |
 
 ## Cost Accounting {#cost-accounting}
@@ -149,7 +146,7 @@ assert_eq!(sim.num_gates(), 2);
 // Two paired allocations: 1 gate
 let sim = Simulator::simulate((a, b), |dr, witness| {
     let (a, b) = witness.cast();
-    let alloc = &mut SimpleAllocator::new();
+    let alloc = &mut Standard::new();
     let _ = Element::alloc(dr, alloc, a)?;
     let _ = Element::alloc(dr, alloc, b)?;
     Ok(())
@@ -166,8 +163,7 @@ catch unnecessary gate overhead early.
 [`Allocator`]: ragu_primitives::allocator::Allocator
 [`Element::alloc`]: ragu_primitives::Element::alloc
 [`Driver::mul`]: ragu_core::drivers::Driver::mul
-[`SimpleAllocator`]: ragu_primitives::allocator::SimpleAllocator
-[`PoolAllocator`]: ragu_primitives::allocator::PoolAllocator
+[`Standard`]: ragu_primitives::allocator::Standard
 [assign-extra]: ragu_core::drivers::DriverTypes::assign_extra
 [`Boolean::alloc`]: ragu_primitives::Boolean::alloc
 [`Simulator`]: ragu_primitives::Simulator

--- a/book/src/guide/primitives/index.md
+++ b/book/src/guide/primitives/index.md
@@ -28,6 +28,8 @@ The chapters that follow cover individual primitives in detail:
 
 * [**Allocation**](allocation.md) — how gadgets obtain standalone
   wires via the `Allocator` trait.
+* [**Simulator**](simulator.md) — measuring constraint costs and
+  catching witness bugs before proving.
 
 [`ragu_primitives`]: https://docs.rs/ragu_primitives
 [`Element`]: ragu_primitives::Element

--- a/book/src/guide/primitives/simulator.md
+++ b/book/src/guide/primitives/simulator.md
@@ -1,9 +1,10 @@
 # Simulator
 
-The [Concrete Drivers](concrete.md) page introduced the [`Simulator`] as a
-driver that executes circuit code natively while enforcing constraints and
-tracking metrics. This page covers its public API and shows how to use it
-to measure constraint costs before committing to a [`Rank`].
+The [Concrete Drivers](../drivers/concrete.md) page introduced the
+[`Simulator`] as a driver that executes circuit code natively while
+enforcing constraints and tracking metrics. This page covers its
+public API and shows how to use it to measure constraint costs
+before committing to a [`Rank`].
 
 ## Why Measure
 
@@ -17,9 +18,9 @@ Error::GateBoundExceeded { limit: 32 }
 
 The [`Simulator`] helps you catch this early. It runs circuit code exactly
 as the real synthesis drivers do, calling witness closures, enforcing gate
-constraints, and checking linear constraints but reports metrics instead of
-building a proof. You can then compare those counts against the rank limits
-before running the prover.
+constraints, and checking linear constraints, but reports metrics
+instead of building a proof. You can then compare those counts
+against the rank limits before running the prover.
 
 The simulator itself does **not** raise rank-bound errors. It gives you the
 numbers that let you detect the problem before later synthesis code turns it
@@ -39,12 +40,9 @@ committing to a rank.
 
 ## API
 
-[`Simulator`] is provided by `ragu_primitives` and re-exported at crate
-root.
-
 ### Construction
 
-```rust,ignore
+```rust
 use ragu_primitives::Simulator;
 
 // Standalone
@@ -70,10 +68,10 @@ After synthesis completes, two counters are available:
 | [`num_gates()`] | Multiplication gates | [`mul()`] / [`gate()`] |
 | [`num_constraints()`] | Linear constraints enforced | [`enforce_zero()`] |
 
-```rust,ignore
+```rust
 let sim = Simulator::simulate((a, b), |dr, witness| {
     let (a, b) = witness.cast();
-    let allocator = &mut SimpleAllocator::new();
+    let allocator = &mut Standard::new();
     let x = Element::alloc(dr, allocator, a)?;  // 1 gate
     let y = Element::alloc(dr, allocator, b)?;  // reuses stash
     Ok(())
@@ -87,10 +85,10 @@ assert_eq!(sim.num_gates(), 1);  // two allocations share one gate
 [`reset()`] zeroes all counters without discarding the driver state. This
 isolates the cost of a specific operation from setup overhead:
 
-```rust,ignore
+```rust
 let sim = Simulator::simulate((x, z), |dr, witness| {
     let (x, z) = witness.cast();
-    let allocator = &mut SimpleAllocator::new();
+    let allocator = &mut Standard::new();
     let x = Element::alloc(dr, allocator, x)?;
     let z = Element::alloc(dr, allocator, z)?;
 
@@ -110,7 +108,7 @@ run the operation under test, then assert on the counts.
 
 ## Constraint Checking
 
-The [`Simulator`] does not merely count, it verifies. Every gate checks
+The [`Simulator`] does not merely count; it verifies. Every gate checks
 $a \cdot b = c$, and every [`enforce_zero()`] checks that the linear
 combination evaluates to zero. A constraint violation returns
 `Error::InvalidWitness` immediately, pinpointing the failing operation.
@@ -133,13 +131,13 @@ its constraints are enforced.
 Suppose you are writing a step that hashes two field elements with
 Poseidon, and you want to know whether it fits in `R<7>` (32 gates):
 
-```rust,ignore
-use ragu_primitives::{Simulator, allocator::SimpleAllocator};
+```rust
+use ragu_primitives::{Simulator, allocator::Standard};
 use pasta_curves::Fp;
 
 let sim = Simulator::simulate((Fp::from(1u64), Fp::from(2u64)), |dr, witness| {
     let (a, b) = witness.cast();
-    let allocator = &mut SimpleAllocator::new();
+    let allocator = &mut Standard::new();
     let a = Element::alloc(dr, allocator, a)?;
     let b = Element::alloc(dr, allocator, b)?;
 


### PR DESCRIPTION
adds `book/src/guide/drivers/simulator.md` covering the Simulator driver's API, constraint checking, metric collection, and rank budgeting workflow. 

fixes concrete.md to match the actual implementation (prediction is used only for aux data; no consistency check occurs).