### PR TITLE
chore(primitives): replace `SimpleAllocator` with `Standard`

### DIFF
--- a/book/src/guide/getting_started.md
+++ b/book/src/guide/getting_started.md
@@ -64,7 +64,7 @@ use ff::Field;
 use ragu_core::{Result, drivers::{Driver, DriverValue}, gadgets::{Bound, Kind}, maybe::Maybe};
 use ragu_pcd::header::{Header, Suffix};
 use ragu_primitives::Element;
-use ragu_primitives::allocator::{Allocator, SimpleAllocator};
+use ragu_primitives::allocator::{Allocator, PoolAllocator};
 use ragu_primitives::poseidon::Sponge;
 
 // LeafNode: carries a hash of raw data
@@ -149,7 +149,7 @@ impl<'params, C: Cycle> Step<C> for CreateLeaf<'params, C> {
         Self: 'dr,
     {
         // 1. Allocate the witness value in the circuit
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let leaf = Element::alloc(dr, allocator, witness)?;
 
         // 2. Hash it using Poseidon

--- a/book/src/guide/getting_started.md
+++ b/book/src/guide/getting_started.md
@@ -64,7 +64,7 @@ use ff::Field;
 use ragu_core::{Result, drivers::{Driver, DriverValue}, gadgets::{Bound, Kind}, maybe::Maybe};
 use ragu_pcd::header::{Header, Suffix};
 use ragu_primitives::Element;
-use ragu_primitives::allocator::{Allocator, PoolAllocator};
+use ragu_primitives::allocator::{Allocator, Standard};
 use ragu_primitives::poseidon::Sponge;
 
 // LeafNode: carries a hash of raw data
@@ -149,7 +149,7 @@ impl<'params, C: Cycle> Step<C> for CreateLeaf<'params, C> {
         Self: 'dr,
     {
         // 1. Allocate the witness value in the circuit
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let leaf = Element::alloc(dr, allocator, witness)?;
 
         // 2. Hash it using Poseidon

--- a/crates/ragu_circuits/benches/criterion/trace.rs
+++ b/crates/ragu_circuits/benches/criterion/trace.rs
@@ -9,7 +9,7 @@ use ragu_core::{
     routines::{Prediction, Routine},
 };
 use ragu_pasta::Fp;
-use ragu_primitives::{Element, allocator::SimpleAllocator};
+use ragu_primitives::{Element, allocator::PoolAllocator};
 use rand::{SeedableRng, rngs::StdRng};
 
 /// A synthetic routine that does `depth` squarings in `execute()` but
@@ -75,7 +75,7 @@ impl Circuit<Fp> for HeavyRoutineCircuit {
         dr: &mut D,
         instance: DriverValue<D, Self::Instance<'instance>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         Element::alloc(dr, allocator, instance)
     }
 
@@ -84,7 +84,7 @@ impl Circuit<Fp> for HeavyRoutineCircuit {
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'witness>>,
     ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'witness>>>> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let input = Element::alloc(dr, allocator, witness)?;
         let routine = HeavyKnownRoutine { depth: self.depth };
 

--- a/crates/ragu_circuits/benches/criterion/trace.rs
+++ b/crates/ragu_circuits/benches/criterion/trace.rs
@@ -9,7 +9,7 @@ use ragu_core::{
     routines::{Prediction, Routine},
 };
 use ragu_pasta::Fp;
-use ragu_primitives::{Element, allocator::PoolAllocator};
+use ragu_primitives::{Element, allocator::Standard};
 use rand::{SeedableRng, rngs::StdRng};
 
 /// A synthetic routine that does `depth` squarings in `execute()` but
@@ -75,7 +75,7 @@ impl Circuit<Fp> for HeavyRoutineCircuit {
         dr: &mut D,
         instance: DriverValue<D, Self::Instance<'instance>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         Element::alloc(dr, allocator, instance)
     }
 
@@ -84,7 +84,7 @@ impl Circuit<Fp> for HeavyRoutineCircuit {
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'witness>>,
     ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'witness>>>> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let input = Element::alloc(dr, allocator, witness)?;
         let routine = HeavyKnownRoutine { depth: self.depth };
 

--- a/crates/ragu_circuits/src/polynomials/txz.rs
+++ b/crates/ragu_circuits/src/polynomials/txz.rs
@@ -145,7 +145,7 @@ impl<F: Field, R: Rank> Routine<F> for Evaluate<R> {
 #[cfg(test)]
 mod tests {
     use ragu_pasta::Fp;
-    use ragu_primitives::{Simulator, allocator::SimpleAllocator};
+    use ragu_primitives::{Simulator, allocator::PoolAllocator};
 
     use super::*;
     use crate::polynomials::ProductionRank;
@@ -161,7 +161,7 @@ mod tests {
 
         Simulator::simulate((x, z), |dr, witness| {
             let (x, z) = witness.cast();
-            let allocator = &mut SimpleAllocator::new();
+            let allocator = &mut PoolAllocator::new();
             let x = Element::alloc(dr, allocator, x)?;
             let z = Element::alloc(dr, allocator, z)?;
 

--- a/crates/ragu_circuits/src/polynomials/txz.rs
+++ b/crates/ragu_circuits/src/polynomials/txz.rs
@@ -145,7 +145,7 @@ impl<F: Field, R: Rank> Routine<F> for Evaluate<R> {
 #[cfg(test)]
 mod tests {
     use ragu_pasta::Fp;
-    use ragu_primitives::{Simulator, allocator::PoolAllocator};
+    use ragu_primitives::{Simulator, allocator::Standard};
 
     use super::*;
     use crate::polynomials::ProductionRank;
@@ -161,7 +161,7 @@ mod tests {
 
         Simulator::simulate((x, z), |dr, witness| {
             let (x, z) = witness.cast();
-            let allocator = &mut PoolAllocator::new();
+            let allocator = &mut Standard::new();
             let x = Element::alloc(dr, allocator, x)?;
             let z = Element::alloc(dr, allocator, z)?;
 

--- a/crates/ragu_circuits/src/staging/bonding.rs
+++ b/crates/ragu_circuits/src/staging/bonding.rs
@@ -262,7 +262,7 @@ mod tests {
     use ragu_pasta::Fp;
     use ragu_primitives::{
         Element,
-        allocator::{Allocator, SimpleAllocator},
+        allocator::{Allocator, PoolAllocator},
         io::Write,
     };
 
@@ -554,7 +554,7 @@ mod tests {
             _: DriverValue<D, ()>,
         ) -> Result<WithAux<Bound<'dr, D, ()>, DriverValue<D, ()>>> {
             let dr = builder.finish();
-            let allocator = &mut SimpleAllocator::new();
+            let allocator = &mut PoolAllocator::new();
             allocator.alloc(dr, || Ok(Coeff::Zero))?;
             Ok(WithAux::new((), D::unit()))
         }

--- a/crates/ragu_circuits/src/staging/bonding.rs
+++ b/crates/ragu_circuits/src/staging/bonding.rs
@@ -262,7 +262,7 @@ mod tests {
     use ragu_pasta::Fp;
     use ragu_primitives::{
         Element,
-        allocator::{Allocator, PoolAllocator},
+        allocator::{Allocator, Standard},
         io::Write,
     };
 
@@ -554,7 +554,7 @@ mod tests {
             _: DriverValue<D, ()>,
         ) -> Result<WithAux<Bound<'dr, D, ()>, DriverValue<D, ()>>> {
             let dr = builder.finish();
-            let allocator = &mut PoolAllocator::new();
+            let allocator = &mut Standard::new();
             allocator.alloc(dr, || Ok(Coeff::Zero))?;
             Ok(WithAux::new((), D::unit()))
         }

--- a/crates/ragu_circuits/src/staging/builder.rs
+++ b/crates/ragu_circuits/src/staging/builder.rs
@@ -53,7 +53,7 @@ use ragu_core::{
     maybe::Empty,
 };
 use ragu_primitives::{
-    allocator::{Allocator, SimpleAllocator},
+    allocator::{Allocator, PoolAllocator},
     consistent::Consistent,
 };
 
@@ -202,7 +202,7 @@ impl<'a, 'dr, D: Driver<'dr>, R: Rank, Current: Stage<D::F, R>, Target: Stage<D:
         }
 
         // Collect stage wires
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let mut wires = Vec::with_capacity(num_wires);
         for _ in 0..num_wires {
             wires.push(allocator.alloc(self.driver, || Ok(Coeff::Zero))?);

--- a/crates/ragu_circuits/src/staging/builder.rs
+++ b/crates/ragu_circuits/src/staging/builder.rs
@@ -53,7 +53,7 @@ use ragu_core::{
     maybe::Empty,
 };
 use ragu_primitives::{
-    allocator::{Allocator, PoolAllocator},
+    allocator::{Allocator, Standard},
     consistent::Consistent,
 };
 
@@ -202,7 +202,7 @@ impl<'a, 'dr, D: Driver<'dr>, R: Rank, Current: Stage<D::F, R>, Target: Stage<D:
         }
 
         // Collect stage wires
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let mut wires = Vec::with_capacity(num_wires);
         for _ in 0..num_wires {
             wires.push(allocator.alloc(self.driver, || Ok(Coeff::Zero))?);

--- a/crates/ragu_circuits/src/tests/identity.rs
+++ b/crates/ragu_circuits/src/tests/identity.rs
@@ -7,7 +7,7 @@ use ragu_core::{
     routines::{Prediction, Routine},
 };
 use ragu_pasta::Fp;
-use ragu_primitives::{Element, Simulator, allocator::SimpleAllocator};
+use ragu_primitives::{Element, Simulator, allocator::PoolAllocator};
 
 use crate::{
     Circuit, WithAux,
@@ -114,7 +114,7 @@ impl Routine<Fp> for Produce {
         _input: Bound<'dr, D, Self::Input>,
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         Element::alloc(dr, allocator, D::just(|| Fp::ZERO))
     }
 
@@ -405,7 +405,7 @@ impl Routine<Fp> for MixedConstraints {
         input: Bound<'dr, D, Self::Input>,
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let aux = Element::alloc(dr, allocator, D::just(|| Fp::ONE))?;
         let sq = input.square(dr)?;
         sq.enforce_zero(dr)?;
@@ -548,7 +548,7 @@ impl Routine<Fp> for AllocThenEnforce {
         _input: Bound<'dr, D, Self::Input>,
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let _consume_paired_b = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         let fresh = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         fresh.enforce_zero(dr)?;
@@ -582,7 +582,7 @@ impl Routine<Fp> for AllocOnly {
         _input: Bound<'dr, D, Self::Input>,
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let _consume_paired_b = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         Element::alloc(dr, allocator, D::just(|| Fp::ZERO))
     }
@@ -641,7 +641,7 @@ impl Routine<Fp> for AllocThenAddEnforce {
         input: Bound<'dr, D, Self::Input>,
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let _consume_paired_b = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         let fresh = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         let sum = fresh.add(dr, &input);
@@ -708,7 +708,7 @@ impl Routine<Fp> for DelegateEnforceChild {
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         let output = dr.routine(SquareOnce, input)?;
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let _consume_b = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         let _pad = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         output.enforce_zero(dr)?;
@@ -741,7 +741,7 @@ impl Routine<Fp> for DelegateEnforceLocal {
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         let output = dr.routine(SquareOnce, input)?;
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let _consume_b = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         let fresh = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         fresh.enforce_zero(dr)?;
@@ -778,7 +778,7 @@ impl Routine<Fp> for DelegatePadEnforceOutput {
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         let output = dr.routine(SquareOnce, input)?;
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let _pad = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         output.enforce_zero(dr)?;
         Ok(output)
@@ -815,7 +815,7 @@ impl Routine<Fp> for DelegateAllocEnforceFirst {
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         let output = dr.routine(SquareOnce, input)?;
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let local = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         local.enforce_zero(dr)?;
         Ok(output)
@@ -1073,7 +1073,7 @@ impl Routine<Fp> for InternalEnforce {
         input: Bound<'dr, D, Self::Input>,
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let aux = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         aux.enforce_zero(dr)?;
         Ok(input)
@@ -1103,7 +1103,7 @@ impl Routine<Fp> for InternalEnforcePair {
         input: Bound<'dr, D, Self::Input>,
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let aux = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         aux.enforce_zero(dr)?;
         let (a, _) = input;
@@ -1269,7 +1269,7 @@ fn fingerprint_triple(
     routine: &impl Routine<Fp, Input = Kind![Fp; (Element<'_, _>, (Element<'_, _>, Element<'_, _>))]>,
 ) -> RoutineFingerprint {
     let sim = &mut Simulator::<Fp>::new();
-    let allocator = &mut SimpleAllocator::new();
+    let allocator = &mut PoolAllocator::new();
     let a = Element::alloc(sim, allocator, Always::<Fp>::just(|| Fp::ONE)).unwrap();
     let b = Element::alloc(sim, allocator, Always::<Fp>::just(|| Fp::ONE)).unwrap();
     let c = Element::alloc(sim, allocator, Always::<Fp>::just(|| Fp::ONE)).unwrap();
@@ -1288,7 +1288,7 @@ fn fingerprint_quad(
     >,
 ) -> RoutineFingerprint {
     let sim = &mut Simulator::<Fp>::new();
-    let allocator = &mut SimpleAllocator::new();
+    let allocator = &mut PoolAllocator::new();
     let a = Element::alloc(sim, allocator, Always::<Fp>::just(|| Fp::ONE)).unwrap();
     let b = Element::alloc(sim, allocator, Always::<Fp>::just(|| Fp::ONE)).unwrap();
     let c = Element::alloc(sim, allocator, Always::<Fp>::just(|| Fp::ONE)).unwrap();
@@ -1305,7 +1305,7 @@ fn fingerprint_elem(
     routine: &impl Routine<Fp, Input = Kind![Fp; Element<'_, _>]>,
 ) -> RoutineFingerprint {
     let mut sim = Simulator::<Fp>::new();
-    let allocator = &mut SimpleAllocator::new();
+    let allocator = &mut PoolAllocator::new();
     let input = Element::alloc(&mut sim, allocator, Always::<Fp>::just(|| Fp::ONE)).unwrap();
     match metrics::tests::fingerprint_routine::<Fp, Simulator<Fp>, _>(routine, &input).unwrap() {
         RoutineIdentity::Routine(fp) => fp,
@@ -1324,7 +1324,7 @@ fn fingerprint_pair(
     routine: &impl Routine<Fp, Input = Kind![Fp; (Element<'_, _>, Element<'_, _>)]>,
 ) -> RoutineFingerprint {
     let sim = &mut Simulator::<Fp>::new();
-    let allocator = &mut SimpleAllocator::new();
+    let allocator = &mut PoolAllocator::new();
     let a = Element::alloc(sim, allocator, Always::<Fp>::just(|| Fp::ONE)).unwrap();
     let b = Element::alloc(sim, allocator, Always::<Fp>::just(|| Fp::ONE)).unwrap();
     match metrics::tests::fingerprint_routine::<Fp, Simulator<Fp>, _>(routine, &(a, b)).unwrap() {
@@ -1381,7 +1381,7 @@ where
     where
         Self: 'dr,
     {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         Element::alloc(dr, allocator, instance)
     }
 
@@ -1393,7 +1393,7 @@ where
     where
         Self: 'dr,
     {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let input = Element::alloc(dr, allocator, witness)?;
         let output = dr.routine(self.0.clone(), input)?;
         Ok(WithAux::new(output, D::just(|| ())))

--- a/crates/ragu_circuits/src/tests/identity.rs
+++ b/crates/ragu_circuits/src/tests/identity.rs
@@ -7,7 +7,7 @@ use ragu_core::{
     routines::{Prediction, Routine},
 };
 use ragu_pasta::Fp;
-use ragu_primitives::{Element, Simulator, allocator::PoolAllocator};
+use ragu_primitives::{Element, Simulator, allocator::Standard};
 
 use crate::{
     Circuit, WithAux,
@@ -114,7 +114,7 @@ impl Routine<Fp> for Produce {
         _input: Bound<'dr, D, Self::Input>,
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         Element::alloc(dr, allocator, D::just(|| Fp::ZERO))
     }
 
@@ -405,7 +405,7 @@ impl Routine<Fp> for MixedConstraints {
         input: Bound<'dr, D, Self::Input>,
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let aux = Element::alloc(dr, allocator, D::just(|| Fp::ONE))?;
         let sq = input.square(dr)?;
         sq.enforce_zero(dr)?;
@@ -548,7 +548,7 @@ impl Routine<Fp> for AllocThenEnforce {
         _input: Bound<'dr, D, Self::Input>,
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let _consume_paired_b = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         let fresh = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         fresh.enforce_zero(dr)?;
@@ -582,7 +582,7 @@ impl Routine<Fp> for AllocOnly {
         _input: Bound<'dr, D, Self::Input>,
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let _consume_paired_b = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         Element::alloc(dr, allocator, D::just(|| Fp::ZERO))
     }
@@ -641,7 +641,7 @@ impl Routine<Fp> for AllocThenAddEnforce {
         input: Bound<'dr, D, Self::Input>,
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let _consume_paired_b = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         let fresh = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         let sum = fresh.add(dr, &input);
@@ -708,7 +708,7 @@ impl Routine<Fp> for DelegateEnforceChild {
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         let output = dr.routine(SquareOnce, input)?;
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let _consume_b = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         let _pad = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         output.enforce_zero(dr)?;
@@ -741,7 +741,7 @@ impl Routine<Fp> for DelegateEnforceLocal {
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         let output = dr.routine(SquareOnce, input)?;
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let _consume_b = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         let fresh = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         fresh.enforce_zero(dr)?;
@@ -778,7 +778,7 @@ impl Routine<Fp> for DelegatePadEnforceOutput {
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         let output = dr.routine(SquareOnce, input)?;
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let _pad = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         output.enforce_zero(dr)?;
         Ok(output)
@@ -815,7 +815,7 @@ impl Routine<Fp> for DelegateAllocEnforceFirst {
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         let output = dr.routine(SquareOnce, input)?;
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let local = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         local.enforce_zero(dr)?;
         Ok(output)
@@ -1073,7 +1073,7 @@ impl Routine<Fp> for InternalEnforce {
         input: Bound<'dr, D, Self::Input>,
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let aux = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         aux.enforce_zero(dr)?;
         Ok(input)
@@ -1103,7 +1103,7 @@ impl Routine<Fp> for InternalEnforcePair {
         input: Bound<'dr, D, Self::Input>,
         _aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let aux = Element::alloc(dr, allocator, D::just(|| Fp::ZERO))?;
         aux.enforce_zero(dr)?;
         let (a, _) = input;
@@ -1269,7 +1269,7 @@ fn fingerprint_triple(
     routine: &impl Routine<Fp, Input = Kind![Fp; (Element<'_, _>, (Element<'_, _>, Element<'_, _>))]>,
 ) -> RoutineFingerprint {
     let sim = &mut Simulator::<Fp>::new();
-    let allocator = &mut PoolAllocator::new();
+    let allocator = &mut Standard::new();
     let a = Element::alloc(sim, allocator, Always::<Fp>::just(|| Fp::ONE)).unwrap();
     let b = Element::alloc(sim, allocator, Always::<Fp>::just(|| Fp::ONE)).unwrap();
     let c = Element::alloc(sim, allocator, Always::<Fp>::just(|| Fp::ONE)).unwrap();
@@ -1288,7 +1288,7 @@ fn fingerprint_quad(
     >,
 ) -> RoutineFingerprint {
     let sim = &mut Simulator::<Fp>::new();
-    let allocator = &mut PoolAllocator::new();
+    let allocator = &mut Standard::new();
     let a = Element::alloc(sim, allocator, Always::<Fp>::just(|| Fp::ONE)).unwrap();
     let b = Element::alloc(sim, allocator, Always::<Fp>::just(|| Fp::ONE)).unwrap();
     let c = Element::alloc(sim, allocator, Always::<Fp>::just(|| Fp::ONE)).unwrap();
@@ -1305,7 +1305,7 @@ fn fingerprint_elem(
     routine: &impl Routine<Fp, Input = Kind![Fp; Element<'_, _>]>,
 ) -> RoutineFingerprint {
     let mut sim = Simulator::<Fp>::new();
-    let allocator = &mut PoolAllocator::new();
+    let allocator = &mut Standard::new();
     let input = Element::alloc(&mut sim, allocator, Always::<Fp>::just(|| Fp::ONE)).unwrap();
     match metrics::tests::fingerprint_routine::<Fp, Simulator<Fp>, _>(routine, &input).unwrap() {
         RoutineIdentity::Routine(fp) => fp,
@@ -1324,7 +1324,7 @@ fn fingerprint_pair(
     routine: &impl Routine<Fp, Input = Kind![Fp; (Element<'_, _>, Element<'_, _>)]>,
 ) -> RoutineFingerprint {
     let sim = &mut Simulator::<Fp>::new();
-    let allocator = &mut PoolAllocator::new();
+    let allocator = &mut Standard::new();
     let a = Element::alloc(sim, allocator, Always::<Fp>::just(|| Fp::ONE)).unwrap();
     let b = Element::alloc(sim, allocator, Always::<Fp>::just(|| Fp::ONE)).unwrap();
     match metrics::tests::fingerprint_routine::<Fp, Simulator<Fp>, _>(routine, &(a, b)).unwrap() {
@@ -1381,7 +1381,7 @@ where
     where
         Self: 'dr,
     {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         Element::alloc(dr, allocator, instance)
     }
 
@@ -1393,7 +1393,7 @@ where
     where
         Self: 'dr,
     {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let input = Element::alloc(dr, allocator, witness)?;
         let output = dr.routine(self.0.clone(), input)?;
         Ok(WithAux::new(output, D::just(|| ())))

--- a/crates/ragu_circuits/src/tests/mod.rs
+++ b/crates/ragu_circuits/src/tests/mod.rs
@@ -12,7 +12,7 @@ use ragu_core::{
     routines::{Prediction, Routine},
 };
 use ragu_pasta::Fp;
-use ragu_primitives::{Element, Simulator, allocator::SimpleAllocator};
+use ragu_primitives::{Element, Simulator, allocator::PoolAllocator};
 
 use crate::{
     Circuit, CircuitExt, WiringObject, WithAux, floor_planner, into_wiring_object,
@@ -35,7 +35,7 @@ impl Circuit<Fp> for SquareCircuit {
         dr: &mut D,
         instance: DriverValue<D, Self::Instance<'instance>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         Element::alloc(dr, allocator, instance)
     }
 
@@ -44,7 +44,7 @@ impl Circuit<Fp> for SquareCircuit {
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'witness>>,
     ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'witness>>>> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let mut a = Element::alloc(dr, allocator, witness)?;
 
         for _ in 0..self.times {
@@ -97,7 +97,7 @@ fn test_simple_circuit() {
             dr: &mut D,
             instance: DriverValue<D, Self::Instance<'instance>>,
         ) -> Result<Bound<'dr, D, Self::Output>> {
-            let allocator = &mut SimpleAllocator::new();
+            let allocator = &mut PoolAllocator::new();
             let c = Element::alloc(dr, allocator, instance.as_ref().map(|v| v.0))?;
             let d = Element::alloc(dr, allocator, instance.as_ref().map(|v| v.1))?;
 
@@ -110,7 +110,7 @@ fn test_simple_circuit() {
             witness: DriverValue<D, Self::Witness<'witness>>,
         ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'witness>>>>
         {
-            let allocator = &mut SimpleAllocator::new();
+            let allocator = &mut PoolAllocator::new();
             let a = Element::alloc(dr, allocator, witness.as_ref().map(|w| w.0))?;
             let b = Element::alloc(dr, allocator, witness.as_ref().map(|w| w.1))?;
 
@@ -202,7 +202,7 @@ impl Routine<Fp> for TestRoutine {
         aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         let precomputed_value = aux.take();
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let element_from_aux = Element::alloc(dr, allocator, D::just(|| precomputed_value))?;
         let other = Element::alloc(dr, allocator, D::just(|| Fp::from(5u64)))?;
         let result = element_from_aux.add(dr, &other);
@@ -221,7 +221,7 @@ impl Routine<Fp> for TestRoutine {
 #[test]
 fn test_element() {
     let mut simulator = Simulator::<Fp>::new();
-    let allocator = &mut SimpleAllocator::new();
+    let allocator = &mut PoolAllocator::new();
     let input = Element::alloc(
         &mut simulator,
         allocator,

--- a/crates/ragu_circuits/src/tests/mod.rs
+++ b/crates/ragu_circuits/src/tests/mod.rs
@@ -12,7 +12,7 @@ use ragu_core::{
     routines::{Prediction, Routine},
 };
 use ragu_pasta::Fp;
-use ragu_primitives::{Element, Simulator, allocator::PoolAllocator};
+use ragu_primitives::{Element, Simulator, allocator::Standard};
 
 use crate::{
     Circuit, CircuitExt, WiringObject, WithAux, floor_planner, into_wiring_object,
@@ -35,7 +35,7 @@ impl Circuit<Fp> for SquareCircuit {
         dr: &mut D,
         instance: DriverValue<D, Self::Instance<'instance>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         Element::alloc(dr, allocator, instance)
     }
 
@@ -44,7 +44,7 @@ impl Circuit<Fp> for SquareCircuit {
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'witness>>,
     ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'witness>>>> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let mut a = Element::alloc(dr, allocator, witness)?;
 
         for _ in 0..self.times {
@@ -97,7 +97,7 @@ fn test_simple_circuit() {
             dr: &mut D,
             instance: DriverValue<D, Self::Instance<'instance>>,
         ) -> Result<Bound<'dr, D, Self::Output>> {
-            let allocator = &mut PoolAllocator::new();
+            let allocator = &mut Standard::new();
             let c = Element::alloc(dr, allocator, instance.as_ref().map(|v| v.0))?;
             let d = Element::alloc(dr, allocator, instance.as_ref().map(|v| v.1))?;
 
@@ -110,7 +110,7 @@ fn test_simple_circuit() {
             witness: DriverValue<D, Self::Witness<'witness>>,
         ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'witness>>>>
         {
-            let allocator = &mut PoolAllocator::new();
+            let allocator = &mut Standard::new();
             let a = Element::alloc(dr, allocator, witness.as_ref().map(|w| w.0))?;
             let b = Element::alloc(dr, allocator, witness.as_ref().map(|w| w.1))?;
 
@@ -202,7 +202,7 @@ impl Routine<Fp> for TestRoutine {
         aux: DriverValue<D, Self::Aux<'dr>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
         let precomputed_value = aux.take();
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let element_from_aux = Element::alloc(dr, allocator, D::just(|| precomputed_value))?;
         let other = Element::alloc(dr, allocator, D::just(|| Fp::from(5u64)))?;
         let result = element_from_aux.add(dr, &other);
@@ -221,7 +221,7 @@ impl Routine<Fp> for TestRoutine {
 #[test]
 fn test_element() {
     let mut simulator = Simulator::<Fp>::new();
-    let allocator = &mut PoolAllocator::new();
+    let allocator = &mut Standard::new();
     let input = Element::alloc(
         &mut simulator,
         allocator,

--- a/crates/ragu_circuits/src/trace.rs
+++ b/crates/ragu_circuits/src/trace.rs
@@ -417,7 +417,7 @@ pub fn eval<'witness, F: Field, C: Circuit<F>>(
 mod tests {
     use ragu_core::gadgets::Kind;
     use ragu_pasta::Fp;
-    use ragu_primitives::{Element, allocator::SimpleAllocator};
+    use ragu_primitives::{Element, allocator::PoolAllocator};
 
     use super::*;
     use crate::tests::SquareCircuit;
@@ -470,7 +470,7 @@ mod tests {
             dr: &mut D,
             instance: ragu_core::drivers::DriverValue<D, Self::Instance<'instance>>,
         ) -> Result<Bound<'dr, D, Self::Output>> {
-            let allocator = &mut SimpleAllocator::new();
+            let allocator = &mut PoolAllocator::new();
             let element = Element::alloc(dr, allocator, instance)?;
             Ok(MulOnWrite { element })
         }
@@ -485,7 +485,7 @@ mod tests {
                 ragu_core::drivers::DriverValue<D, Self::Aux<'witness>>,
             >,
         > {
-            let allocator = &mut SimpleAllocator::new();
+            let allocator = &mut PoolAllocator::new();
             let element = Element::alloc(dr, allocator, witness)?;
             Ok(WithAux::new(MulOnWrite { element }, D::unit()))
         }

--- a/crates/ragu_circuits/src/trace.rs
+++ b/crates/ragu_circuits/src/trace.rs
@@ -417,7 +417,7 @@ pub fn eval<'witness, F: Field, C: Circuit<F>>(
 mod tests {
     use ragu_core::gadgets::Kind;
     use ragu_pasta::Fp;
-    use ragu_primitives::{Element, allocator::PoolAllocator};
+    use ragu_primitives::{Element, allocator::Standard};
 
     use super::*;
     use crate::tests::SquareCircuit;
@@ -470,7 +470,7 @@ mod tests {
             dr: &mut D,
             instance: ragu_core::drivers::DriverValue<D, Self::Instance<'instance>>,
         ) -> Result<Bound<'dr, D, Self::Output>> {
-            let allocator = &mut PoolAllocator::new();
+            let allocator = &mut Standard::new();
             let element = Element::alloc(dr, allocator, instance)?;
             Ok(MulOnWrite { element })
         }
@@ -485,7 +485,7 @@ mod tests {
                 ragu_core::drivers::DriverValue<D, Self::Aux<'witness>>,
             >,
         > {
-            let allocator = &mut PoolAllocator::new();
+            let allocator = &mut Standard::new();
             let element = Element::alloc(dr, allocator, witness)?;
             Ok(WithAux::new(MulOnWrite { element }, D::unit()))
         }

--- a/crates/ragu_pcd/src/internal/fold_revdot.rs
+++ b/crates/ragu_pcd/src/internal/fold_revdot.rs
@@ -291,7 +291,7 @@ mod tests {
     use ragu_circuits::polynomials::{TestRank, sparse};
     use ragu_core::{drivers::emulator::Emulator, maybe::Maybe};
     use ragu_pasta::Fp;
-    use ragu_primitives::{Simulator, allocator::SimpleAllocator, vec::CollectFixed};
+    use ragu_primitives::{Simulator, allocator::PoolAllocator, vec::CollectFixed};
     use rand::SeedableRng;
 
     use super::*;
@@ -727,7 +727,7 @@ mod tests {
     /// and N combinations. The optimal accounting here is to maximize
     /// M * N, while staying under the circuit budget.
     ///
-    /// [`SimpleAllocator`] pairs consecutive allocations into gates, so
+    /// [`PoolAllocator`] pairs consecutive allocations into gates, so
     /// the total gate count is `muls + allocs / 2` (exact when `allocs`
     /// is even, which holds for the tested parameters). Each gate
     /// consumes two trace slots, giving an effective cost of
@@ -737,7 +737,7 @@ mod tests {
         fn verify<const M: usize, const N: usize>() -> Result<()> {
             let rng = rand::rngs::StdRng::from_rng(&mut rand::rng());
             let sim = Simulator::simulate(rng, |dr, mut rng| {
-                let allocator = &mut SimpleAllocator::new();
+                let allocator = &mut PoolAllocator::new();
                 let mu = Element::alloc(dr, allocator, rng.as_mut().map(Fp::random))?;
                 let nu = Element::alloc(dr, allocator, rng.as_mut().map(Fp::random))?;
                 let mu_prime = Element::alloc(dr, allocator, rng.as_mut().map(Fp::random))?;

--- a/crates/ragu_pcd/src/internal/fold_revdot.rs
+++ b/crates/ragu_pcd/src/internal/fold_revdot.rs
@@ -291,7 +291,7 @@ mod tests {
     use ragu_circuits::polynomials::{TestRank, sparse};
     use ragu_core::{drivers::emulator::Emulator, maybe::Maybe};
     use ragu_pasta::Fp;
-    use ragu_primitives::{Simulator, allocator::PoolAllocator, vec::CollectFixed};
+    use ragu_primitives::{Simulator, allocator::Standard, vec::CollectFixed};
     use rand::SeedableRng;
 
     use super::*;
@@ -727,7 +727,7 @@ mod tests {
     /// and N combinations. The optimal accounting here is to maximize
     /// M * N, while staying under the circuit budget.
     ///
-    /// [`PoolAllocator`] pairs consecutive allocations into gates, so
+    /// [`Standard`] pairs consecutive allocations into gates, so
     /// the total gate count is `muls + allocs / 2` (exact when `allocs`
     /// is even, which holds for the tested parameters). Each gate
     /// consumes two trace slots, giving an effective cost of
@@ -737,7 +737,7 @@ mod tests {
         fn verify<const M: usize, const N: usize>() -> Result<()> {
             let rng = rand::rngs::StdRng::from_rng(&mut rand::rng());
             let sim = Simulator::simulate(rng, |dr, mut rng| {
-                let allocator = &mut PoolAllocator::new();
+                let allocator = &mut Standard::new();
                 let mu = Element::alloc(dr, allocator, rng.as_mut().map(Fp::random))?;
                 let nu = Element::alloc(dr, allocator, rng.as_mut().map(Fp::random))?;
                 let mu_prime = Element::alloc(dr, allocator, rng.as_mut().map(Fp::random))?;

--- a/crates/ragu_pcd/src/internal/native/circuits/compute_v.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/compute_v.rs
@@ -60,7 +60,7 @@ use ragu_core::{
     gadgets::Bound,
     maybe::Maybe,
 };
-use ragu_primitives::{Element, Endoscalar, GadgetExt, allocator::PoolAllocator};
+use ragu_primitives::{Element, Endoscalar, GadgetExt, allocator::Standard};
 
 use super::super::{
     InternalCircuitIndex, InternalCircuitValues, RxComponent, RxIndex,
@@ -159,7 +159,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> MultiStageCircuit<C::CircuitFi
         let query = query.unenforced(dr, witness.as_ref().map(|w| w.query_witness))?;
         let eval = eval.unenforced(dr, witness.as_ref().map(|w| w.eval_witness))?;
 
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let mut unified_output = OutputBuilder::new(witness.map(|w| w.unified));
 
         // Extract endoscalar early: each of the 128 Boolean gates has a

--- a/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
@@ -88,7 +88,7 @@ use ragu_core::{
 };
 use ragu_primitives::{
     Element, GadgetExt, WithSuffix,
-    allocator::SimpleAllocator,
+    allocator::PoolAllocator,
     io::Write,
     vec::{ConstLen, FixedVec},
 };
@@ -230,7 +230,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
             .circuit_id
             .enforce_root_of_unity(dr, self.log2_circuits)?;
 
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let mut unified_output = OutputBuilder::new(witness.map(|w| w.unified));
 
         // Create a transcript for all challenge derivations

--- a/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
@@ -88,7 +88,7 @@ use ragu_core::{
 };
 use ragu_primitives::{
     Element, GadgetExt, WithSuffix,
-    allocator::PoolAllocator,
+    allocator::Standard,
     io::Write,
     vec::{ConstLen, FixedVec},
 };
@@ -230,7 +230,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
             .circuit_id
             .enforce_root_of_unity(dr, self.log2_circuits)?;
 
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let mut unified_output = OutputBuilder::new(witness.map(|w| w.unified));
 
         // Create a transcript for all challenge derivations

--- a/crates/ragu_pcd/src/internal/native/circuits/hashes_2.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/hashes_2.rs
@@ -72,7 +72,7 @@ use ragu_core::{
     gadgets::Bound,
     maybe::Maybe,
 };
-use ragu_primitives::{GadgetExt, allocator::SimpleAllocator};
+use ragu_primitives::{GadgetExt, allocator::PoolAllocator};
 
 use super::super::{
     stages::{outer_error as native_outer_error, preamble as native_preamble},
@@ -161,7 +161,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         let outer_error =
             outer_error.unenforced(dr, witness.as_ref().map(|w| w.outer_error_witness))?;
 
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let mut unified_output = OutputBuilder::new(witness.map(|w| w.unified));
 
         // Resume transcript from saved state (inner_error already absorbed in hashes_1)

--- a/crates/ragu_pcd/src/internal/native/circuits/hashes_2.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/hashes_2.rs
@@ -72,7 +72,7 @@ use ragu_core::{
     gadgets::Bound,
     maybe::Maybe,
 };
-use ragu_primitives::{GadgetExt, allocator::PoolAllocator};
+use ragu_primitives::{GadgetExt, allocator::Standard};
 
 use super::super::{
     stages::{outer_error as native_outer_error, preamble as native_preamble},
@@ -161,7 +161,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         let outer_error =
             outer_error.unenforced(dr, witness.as_ref().map(|w| w.outer_error_witness))?;
 
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let mut unified_output = OutputBuilder::new(witness.map(|w| w.unified));
 
         // Resume transcript from saved state (inner_error already absorbed in hashes_1)

--- a/crates/ragu_pcd/src/internal/native/circuits/inner_collapse.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/inner_collapse.rs
@@ -67,7 +67,7 @@ use ragu_core::{
     gadgets::{Bound, Gadget},
     maybe::Maybe,
 };
-use ragu_primitives::{allocator::SimpleAllocator, vec::FixedVec};
+use ragu_primitives::{allocator::PoolAllocator, vec::FixedVec};
 
 use super::super::{
     claims::{TwoProofKySource, ky_values},
@@ -154,7 +154,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         let inner_error =
             inner_error.enforced(dr, witness.as_ref().map(|w| w.inner_error_witness))?;
 
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let mut unified_output = OutputBuilder::new(witness.map(|w| w.unified));
 
         // Get layer 1 folding challenges from the unified instance.

--- a/crates/ragu_pcd/src/internal/native/circuits/inner_collapse.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/inner_collapse.rs
@@ -67,7 +67,7 @@ use ragu_core::{
     gadgets::{Bound, Gadget},
     maybe::Maybe,
 };
-use ragu_primitives::{allocator::PoolAllocator, vec::FixedVec};
+use ragu_primitives::{allocator::Standard, vec::FixedVec};
 
 use super::super::{
     claims::{TwoProofKySource, ky_values},
@@ -154,7 +154,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         let inner_error =
             inner_error.enforced(dr, witness.as_ref().map(|w| w.inner_error_witness))?;
 
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let mut unified_output = OutputBuilder::new(witness.map(|w| w.unified));
 
         // Get layer 1 folding challenges from the unified instance.

--- a/crates/ragu_pcd/src/internal/native/circuits/outer_collapse.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/outer_collapse.rs
@@ -60,7 +60,7 @@ use ragu_core::{
     gadgets::Bound,
     maybe::Maybe,
 };
-use ragu_primitives::allocator::SimpleAllocator;
+use ragu_primitives::allocator::PoolAllocator;
 
 use super::super::{
     stages::{outer_error, preamble},
@@ -150,7 +150,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         let outer_error =
             outer_error.unenforced(dr, witness.as_ref().map(|w| w.outer_error_witness))?;
 
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let mut unified_output = OutputBuilder::new(witness.map(|w| w.unified));
 
         // Get layer 2 folding challenges. These are distinct from the layer 1

--- a/crates/ragu_pcd/src/internal/native/circuits/outer_collapse.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/outer_collapse.rs
@@ -60,7 +60,7 @@ use ragu_core::{
     gadgets::Bound,
     maybe::Maybe,
 };
-use ragu_primitives::allocator::PoolAllocator;
+use ragu_primitives::allocator::Standard;
 
 use super::super::{
     stages::{outer_error, preamble},
@@ -150,7 +150,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         let outer_error =
             outer_error.unenforced(dr, witness.as_ref().map(|w| w.outer_error_witness))?;
 
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let mut unified_output = OutputBuilder::new(witness.map(|w| w.unified));
 
         // Get layer 2 folding challenges. These are distinct from the layer 1

--- a/crates/ragu_pcd/src/internal/native/unified.rs
+++ b/crates/ragu_pcd/src/internal/native/unified.rs
@@ -604,7 +604,7 @@ mod tests {
     type Sl = Slot<
         'static,
         Dr,
-        ragu_primitives::allocator::SimpleAllocator<()>,
+        ragu_primitives::allocator::PoolAllocator<()>,
         Element<'static, Dr>,
         pasta_curves::Fp,
     >;
@@ -621,7 +621,7 @@ mod tests {
     #[test]
     fn slot_read_allocates_without_coverage() {
         let (mut dr, mut a, mut b) = two_element_slots();
-        let allocator = &mut ragu_primitives::allocator::SimpleAllocator::new();
+        let allocator = &mut ragu_primitives::allocator::PoolAllocator::new();
         a.read(&mut dr, allocator).expect("read a");
         b.read(&mut dr, allocator).expect("read b");
         let (_, a_set) = a.take(&mut dr, allocator).expect("take a");
@@ -634,7 +634,7 @@ mod tests {
     #[test]
     fn slot_provide_stores_value_and_marks_covered() {
         let (mut dr, mut a, b) = two_element_slots();
-        let allocator = &mut ragu_primitives::allocator::SimpleAllocator::new();
+        let allocator = &mut ragu_primitives::allocator::PoolAllocator::new();
         let val_a = Element::alloc(&mut dr, allocator, Empty).expect("alloc a");
         a.provide(val_a);
         // b left untouched — should remain uncovered.
@@ -648,7 +648,7 @@ mod tests {
     #[test]
     fn slot_receive_allocates_and_marks_covered() {
         let (mut dr, mut a, mut b) = two_element_slots();
-        let allocator = &mut ragu_primitives::allocator::SimpleAllocator::new();
+        let allocator = &mut ragu_primitives::allocator::PoolAllocator::new();
         let _ = a.receive(&mut dr, allocator).expect("receive a");
         // b only gets `read` — should remain uncovered.
         b.read(&mut dr, allocator).expect("read b");
@@ -662,7 +662,7 @@ mod tests {
     #[test]
     fn slot_take_untouched_allocates_without_coverage() {
         let (mut dr, a, mut b) = two_element_slots();
-        let allocator = &mut ragu_primitives::allocator::SimpleAllocator::new();
+        let allocator = &mut ragu_primitives::allocator::PoolAllocator::new();
         // a is never touched by the circuit — finish calls take directly.
         b.receive(&mut dr, allocator).expect("receive b");
         let (_, a_set) = a.take(&mut dr, allocator).expect("take a");

--- a/crates/ragu_pcd/src/internal/native/unified.rs
+++ b/crates/ragu_pcd/src/internal/native/unified.rs
@@ -604,7 +604,7 @@ mod tests {
     type Sl = Slot<
         'static,
         Dr,
-        ragu_primitives::allocator::PoolAllocator<()>,
+        ragu_primitives::allocator::Standard<()>,
         Element<'static, Dr>,
         pasta_curves::Fp,
     >;
@@ -621,7 +621,7 @@ mod tests {
     #[test]
     fn slot_read_allocates_without_coverage() {
         let (mut dr, mut a, mut b) = two_element_slots();
-        let allocator = &mut ragu_primitives::allocator::PoolAllocator::new();
+        let allocator = &mut ragu_primitives::allocator::Standard::new();
         a.read(&mut dr, allocator).expect("read a");
         b.read(&mut dr, allocator).expect("read b");
         let (_, a_set) = a.take(&mut dr, allocator).expect("take a");
@@ -634,7 +634,7 @@ mod tests {
     #[test]
     fn slot_provide_stores_value_and_marks_covered() {
         let (mut dr, mut a, b) = two_element_slots();
-        let allocator = &mut ragu_primitives::allocator::PoolAllocator::new();
+        let allocator = &mut ragu_primitives::allocator::Standard::new();
         let val_a = Element::alloc(&mut dr, allocator, Empty).expect("alloc a");
         a.provide(val_a);
         // b left untouched — should remain uncovered.
@@ -648,7 +648,7 @@ mod tests {
     #[test]
     fn slot_receive_allocates_and_marks_covered() {
         let (mut dr, mut a, mut b) = two_element_slots();
-        let allocator = &mut ragu_primitives::allocator::PoolAllocator::new();
+        let allocator = &mut ragu_primitives::allocator::Standard::new();
         let _ = a.receive(&mut dr, allocator).expect("receive a");
         // b only gets `read` — should remain uncovered.
         b.read(&mut dr, allocator).expect("read b");
@@ -662,7 +662,7 @@ mod tests {
     #[test]
     fn slot_take_untouched_allocates_without_coverage() {
         let (mut dr, a, mut b) = two_element_slots();
-        let allocator = &mut ragu_primitives::allocator::PoolAllocator::new();
+        let allocator = &mut ragu_primitives::allocator::Standard::new();
         // a is never touched by the circuit — finish calls take directly.
         b.receive(&mut dr, allocator).expect("receive b");
         let (_, a_set) = a.take(&mut dr, allocator).expect("take a");

--- a/crates/ragu_pcd/src/step/internal/adapter.rs
+++ b/crates/ragu_pcd/src/step/internal/adapter.rs
@@ -121,7 +121,7 @@ mod tests {
         maybe::{Always, Maybe, MaybeKind},
     };
     use ragu_pasta::{Fp, Pasta};
-    use ragu_primitives::allocator::{Allocator, SimpleAllocator};
+    use ragu_primitives::allocator::{Allocator, PoolAllocator};
 
     use super::*;
     use crate::{
@@ -173,7 +173,7 @@ mod tests {
             DriverValue<D, Fp>,
             DriverValue<D, ()>,
         )> {
-            let allocator = &mut SimpleAllocator::new();
+            let allocator = &mut PoolAllocator::new();
             // Allocate elements for left and right
             let left_elem = Element::alloc(dr, allocator, left)?;
             let right_elem = Element::alloc(dr, allocator, right)?;

--- a/crates/ragu_pcd/src/step/internal/adapter.rs
+++ b/crates/ragu_pcd/src/step/internal/adapter.rs
@@ -121,7 +121,7 @@ mod tests {
         maybe::{Always, Maybe, MaybeKind},
     };
     use ragu_pasta::{Fp, Pasta};
-    use ragu_primitives::allocator::{Allocator, PoolAllocator};
+    use ragu_primitives::allocator::{Allocator, Standard};
 
     use super::*;
     use crate::{
@@ -173,7 +173,7 @@ mod tests {
             DriverValue<D, Fp>,
             DriverValue<D, ()>,
         )> {
-            let allocator = &mut PoolAllocator::new();
+            let allocator = &mut Standard::new();
             // Allocate elements for left and right
             let left_elem = Element::alloc(dr, allocator, left)?;
             let right_elem = Element::alloc(dr, allocator, right)?;

--- a/crates/ragu_pcd/src/step/internal/rerandomize.rs
+++ b/crates/ragu_pcd/src/step/internal/rerandomize.rs
@@ -13,7 +13,7 @@ use ragu_core::{
     drivers::{Driver, DriverValue},
     maybe::Maybe,
 };
-use ragu_primitives::allocator::SimpleAllocator;
+use ragu_primitives::allocator::PoolAllocator;
 
 use super::super::{Encoded, Index, Step};
 use crate::Header;
@@ -56,7 +56,7 @@ impl<C: Cycle, H: Header<C::CircuitField>> Step<C> for Rerandomize<H> {
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         // Use uniform encoding for left to ensure circuit uniformity across header types
         let left_encoded = Encoded::new_uniform(dr, allocator, left.clone())?;
         // Use standard encoding for right (trivial header)

--- a/crates/ragu_pcd/src/step/internal/rerandomize.rs
+++ b/crates/ragu_pcd/src/step/internal/rerandomize.rs
@@ -13,7 +13,7 @@ use ragu_core::{
     drivers::{Driver, DriverValue},
     maybe::Maybe,
 };
-use ragu_primitives::allocator::PoolAllocator;
+use ragu_primitives::allocator::Standard;
 
 use super::super::{Encoded, Index, Step};
 use crate::Header;
@@ -56,7 +56,7 @@ impl<C: Cycle, H: Header<C::CircuitField>> Step<C> for Rerandomize<H> {
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         // Use uniform encoding for left to ensure circuit uniformity across header types
         let left_encoded = Encoded::new_uniform(dr, allocator, left.clone())?;
         // Use standard encoding for right (trivial header)

--- a/crates/ragu_pcd/src/step/internal/trivial.rs
+++ b/crates/ragu_pcd/src/step/internal/trivial.rs
@@ -8,7 +8,7 @@ use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
 };
-use ragu_primitives::allocator::SimpleAllocator;
+use ragu_primitives::allocator::PoolAllocator;
 
 use super::super::{Encoded, Index, Step};
 use crate::Header;
@@ -47,7 +47,7 @@ impl<C: Cycle> Step<C> for Trivial {
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let left = Encoded::new(dr, allocator, left)?;
         let right = Encoded::new(dr, allocator, right)?;
         let output = Encoded::from_gadget(());

--- a/crates/ragu_pcd/src/step/internal/trivial.rs
+++ b/crates/ragu_pcd/src/step/internal/trivial.rs
@@ -8,7 +8,7 @@ use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
 };
-use ragu_primitives::allocator::PoolAllocator;
+use ragu_primitives::allocator::Standard;
 
 use super::super::{Encoded, Index, Step};
 use crate::Header;
@@ -47,7 +47,7 @@ impl<C: Cycle> Step<C> for Trivial {
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let left = Encoded::new(dr, allocator, left)?;
         let right = Encoded::new(dr, allocator, right)?;
         let output = Encoded::from_gadget(());

--- a/crates/ragu_pcd/tests/registration_errors.rs
+++ b/crates/ragu_pcd/tests/registration_errors.rs
@@ -11,7 +11,7 @@ use ragu_pcd::{
     header::{Header, Suffix},
     step::{Encoded, Index, Step},
 };
-use ragu_primitives::allocator::{Allocator, SimpleAllocator};
+use ragu_primitives::allocator::{Allocator, PoolAllocator};
 
 // Header A with suffix 0
 struct HSuffixA;
@@ -83,7 +83,7 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step0 {
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let left = Encoded::new(dr, allocator, left)?;
         let right = Encoded::new(dr, allocator, right)?;
         let output = Encoded::from_gadget(());
@@ -116,7 +116,7 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step1 {
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let left = Encoded::new(dr, allocator, left)?;
         let right = Encoded::new(dr, allocator, right)?;
         let output = Encoded::from_gadget(());
@@ -149,7 +149,7 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step1Dup {
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let left = Encoded::new(dr, allocator, left)?;
         let right = Encoded::new(dr, allocator, right)?;
         let output = Encoded::from_gadget(());

--- a/crates/ragu_pcd/tests/registration_errors.rs
+++ b/crates/ragu_pcd/tests/registration_errors.rs
@@ -11,7 +11,7 @@ use ragu_pcd::{
     header::{Header, Suffix},
     step::{Encoded, Index, Step},
 };
-use ragu_primitives::allocator::{Allocator, PoolAllocator};
+use ragu_primitives::allocator::{Allocator, Standard};
 
 // Header A with suffix 0
 struct HSuffixA;
@@ -83,7 +83,7 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step0 {
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let left = Encoded::new(dr, allocator, left)?;
         let right = Encoded::new(dr, allocator, right)?;
         let output = Encoded::from_gadget(());
@@ -116,7 +116,7 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step1 {
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let left = Encoded::new(dr, allocator, left)?;
         let right = Encoded::new(dr, allocator, right)?;
         let output = Encoded::from_gadget(());
@@ -149,7 +149,7 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step1Dup {
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let left = Encoded::new(dr, allocator, left)?;
         let right = Encoded::new(dr, allocator, right)?;
         let output = Encoded::from_gadget(());

--- a/crates/ragu_pcd/tests/rerandomization.rs
+++ b/crates/ragu_pcd/tests/rerandomization.rs
@@ -15,7 +15,7 @@ use ragu_pcd::{
 };
 use ragu_primitives::{
     Element,
-    allocator::{Allocator, SimpleAllocator},
+    allocator::{Allocator, PoolAllocator},
 };
 use rand::{SeedableRng, rngs::StdRng};
 
@@ -75,7 +75,7 @@ impl Step<Pasta> for StepWithData {
         DriverValue<D, <Self::Output as Header<Fp>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let left = Encoded::new(dr, allocator, left)?;
         let right = Encoded::new(dr, allocator, right)?;
         let output = Encoded::new(dr, allocator, witness.clone())?;
@@ -107,7 +107,7 @@ impl<C: Cycle> Step<C> for Step0 {
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let left = Encoded::new(dr, allocator, left)?;
         let right = Encoded::new(dr, allocator, right)?;
         let output = Encoded::from_gadget(());
@@ -138,7 +138,7 @@ impl<C: Cycle> Step<C> for Step1 {
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let left = Encoded::new(dr, allocator, left)?;
         let right = Encoded::new(dr, allocator, right)?;
         let output = Encoded::from_gadget(());

--- a/crates/ragu_pcd/tests/rerandomization.rs
+++ b/crates/ragu_pcd/tests/rerandomization.rs
@@ -15,7 +15,7 @@ use ragu_pcd::{
 };
 use ragu_primitives::{
     Element,
-    allocator::{Allocator, PoolAllocator},
+    allocator::{Allocator, Standard},
 };
 use rand::{SeedableRng, rngs::StdRng};
 
@@ -75,7 +75,7 @@ impl Step<Pasta> for StepWithData {
         DriverValue<D, <Self::Output as Header<Fp>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let left = Encoded::new(dr, allocator, left)?;
         let right = Encoded::new(dr, allocator, right)?;
         let output = Encoded::new(dr, allocator, witness.clone())?;
@@ -107,7 +107,7 @@ impl<C: Cycle> Step<C> for Step0 {
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let left = Encoded::new(dr, allocator, left)?;
         let right = Encoded::new(dr, allocator, right)?;
         let output = Encoded::from_gadget(());
@@ -138,7 +138,7 @@ impl<C: Cycle> Step<C> for Step1 {
         DriverValue<D, <Self::Output as Header<C::CircuitField>>::Data>,
         DriverValue<D, Self::Aux<'source>>,
     )> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let left = Encoded::new(dr, allocator, left)?;
         let right = Encoded::new(dr, allocator, right)?;
         let output = Encoded::from_gadget(());

--- a/crates/ragu_primitives/src/allocator.rs
+++ b/crates/ragu_primitives/src/allocator.rs
@@ -17,13 +17,10 @@
 //! - [`Allocator`] for `()` — stateless; allocates a full gate per wire.
 //!   Simple but wasteful.
 //!
-//! - [`SimpleAllocator`] — pairs consecutive allocations into one gate,
-//!   stashing the spare wire from the first call for the second. Halves
-//!   gate cost for sequences of allocations.
-//!
-//! - [`PoolAllocator`] — pools spare `Extra` tokens
-//!   [`donate`](Allocator::donate)d by external gadgets (e.g.
-//!   [`Boolean::alloc`](crate::Boolean::alloc)) whose $D$ wire is
+//! - [`PoolAllocator`] — the standard allocator. Pairs consecutive
+//!   allocations into one gate (halving gate cost) and also pools spare
+//!   `Extra` tokens [`donate`](Allocator::donate)d by external gadgets
+//!   (e.g. [`Boolean::alloc`](crate::Boolean::alloc)) whose $D$ wire is
 //!   unconstrained. Subsequent allocations redeem pooled tokens before
 //!   falling back to new gates, and self-produced spares enter the pool
 //!   too.
@@ -38,9 +35,9 @@ use ragu_core::{Result, drivers::Driver};
 /// Implementations decide how to turn a witness-producing closure into a
 /// driver wire. The simplest implementation (see the impl for `()`)
 /// allocates a full multiplication gate with zeroed $a$ and $c$ wires.
-/// [`SimpleAllocator`] pairs two consecutive allocations into a
-/// single gate by stashing the [`Extra`](ragu_core::drivers::DriverTypes::Extra)
-/// token that the `()` allocator discards.
+/// [`PoolAllocator`] pairs consecutive allocations into a single gate by
+/// stashing the [`Extra`](ragu_core::drivers::DriverTypes::Extra) token
+/// that the `()` allocator discards, and also accepts donated tokens.
 pub trait Allocator<'dr, D: Driver<'dr>> {
     /// Allocates a new wire whose value is supplied by `value`.
     ///
@@ -69,52 +66,6 @@ impl<'dr, D: Driver<'dr>> Allocator<'dr, D> for () {
     }
 }
 
-/// Allocator that pairs consecutive allocations into a single gate.
-///
-/// Each gate allocates four wires $(A, B, C, D)$ with the constraints
-/// $A \cdot B = C$ and $C \cdot D = 0$. When $A$ and $C$ are both zero the
-/// gate is unconstrained over $B$ and $D$, so two independent values can be
-/// packed into one gate. `SimpleAllocator` exploits this: the first call
-/// allocates a gate with $A = C = 0$, returns the $B$ wire, and stashes the
-/// [`Extra`](ragu_core::drivers::DriverTypes::Extra) token for the $D$ wire.
-/// The second call redeems that token via
-/// [`assign_extra`](ragu_core::drivers::DriverTypes::assign_extra),
-/// returning $D$ without allocating a new gate.
-///
-/// This is the standard paired-allocation strategy. Gadgets that perform
-/// many allocations should use `SimpleAllocator` to halve gate cost.
-///
-/// Dropping a `SimpleAllocator` that still holds a stashed token is safe:
-/// the driver already assigned $D = 0$ for that gate.
-pub struct SimpleAllocator<E> {
-    stash: Option<E>,
-}
-
-impl<E> Default for SimpleAllocator<E> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<E> SimpleAllocator<E> {
-    /// Creates a new `SimpleAllocator` with no stashed token.
-    pub const fn new() -> Self {
-        Self { stash: None }
-    }
-}
-
-impl<'dr, D: Driver<'dr>> Allocator<'dr, D> for SimpleAllocator<D::Extra> {
-    fn alloc(&mut self, dr: &mut D, value: impl Fn() -> Result<Coeff<D::F>>) -> Result<D::Wire> {
-        if let Some(extra) = self.stash.take() {
-            dr.assign_extra(extra, value)
-        } else {
-            let (_, b, _, extra) = dr.gate(|| Ok((Coeff::Zero, value()?, Coeff::Zero)))?;
-            self.stash = Some(extra);
-            Ok(b)
-        }
-    }
-}
-
 /// Allocator that pools spare
 /// [`Extra`](ragu_core::drivers::DriverTypes::Extra) tokens donated by
 /// other gadgets.
@@ -126,7 +77,7 @@ impl<'dr, D: Driver<'dr>> Allocator<'dr, D> for SimpleAllocator<D::Extra> {
 /// [`assign_extra`](ragu_core::drivers::DriverTypes::assign_extra) before
 /// falling back to new gate allocation.
 ///
-/// Like [`SimpleAllocator`], this also pairs its own gate allocations:
+/// This also pairs its own gate allocations:
 /// when the pool is empty and a fresh gate is needed, the spare `Extra`
 /// from that gate enters the pool for the next call.
 ///

--- a/crates/ragu_primitives/src/allocator.rs
+++ b/crates/ragu_primitives/src/allocator.rs
@@ -17,7 +17,7 @@
 //! - [`Allocator`] for `()` — stateless; allocates a full gate per wire.
 //!   Simple but wasteful.
 //!
-//! - [`PoolAllocator`] — the standard allocator. Pairs consecutive
+//! - [`Standard`] — the standard allocator. Pairs consecutive
 //!   allocations into one gate (halving gate cost) and also pools spare
 //!   `Extra` tokens [`donate`](Allocator::donate)d by external gadgets
 //!   (e.g. [`Boolean::alloc`](crate::Boolean::alloc)) whose $D$ wire is
@@ -35,7 +35,7 @@ use ragu_core::{Result, drivers::Driver};
 /// Implementations decide how to turn a witness-producing closure into a
 /// driver wire. The simplest implementation (see the impl for `()`)
 /// allocates a full multiplication gate with zeroed $a$ and $c$ wires.
-/// [`PoolAllocator`] pairs consecutive allocations into a single gate by
+/// [`Standard`] pairs consecutive allocations into a single gate by
 /// stashing the [`Extra`](ragu_core::drivers::DriverTypes::Extra) token
 /// that the `()` allocator discards, and also accepts donated tokens.
 pub trait Allocator<'dr, D: Driver<'dr>> {
@@ -49,7 +49,7 @@ pub trait Allocator<'dr, D: Driver<'dr>> {
     /// Accepts a spare [`Extra`](ragu_core::drivers::DriverTypes::Extra)
     /// token from an external gate whose $D$ wire is unconstrained.
     ///
-    /// Allocators that can pool tokens (like [`PoolAllocator`]) store them
+    /// Allocators that can pool tokens (like [`Standard`]) store them
     /// for future [`alloc`](Self::alloc) calls. The default implementation
     /// drops the token, keeping the driver's default $D = 0$.
     fn donate(&mut self, _extra: D::Extra) {}
@@ -81,26 +81,26 @@ impl<'dr, D: Driver<'dr>> Allocator<'dr, D> for () {
 /// when the pool is empty and a fresh gate is needed, the spare `Extra`
 /// from that gate enters the pool for the next call.
 ///
-/// Dropping a `PoolAllocator` with tokens still in the pool is safe:
+/// Dropping a `Standard` with tokens still in the pool is safe:
 /// the driver already assigned $D = 0$ for those gates.
-pub struct PoolAllocator<E> {
+pub struct Standard<E> {
     pool: Vec<E>,
 }
 
-impl<E> Default for PoolAllocator<E> {
+impl<E> Default for Standard<E> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<E> PoolAllocator<E> {
-    /// Creates a new `PoolAllocator` with an empty pool.
+impl<E> Standard<E> {
+    /// Creates a new `Standard` with an empty pool.
     pub const fn new() -> Self {
         Self { pool: Vec::new() }
     }
 }
 
-impl<'dr, D: Driver<'dr>> Allocator<'dr, D> for PoolAllocator<D::Extra> {
+impl<'dr, D: Driver<'dr>> Allocator<'dr, D> for Standard<D::Extra> {
     fn alloc(&mut self, dr: &mut D, value: impl Fn() -> Result<Coeff<D::F>>) -> Result<D::Wire> {
         if let Some(extra) = self.pool.pop() {
             dr.assign_extra(extra, value)

--- a/crates/ragu_primitives/src/boolean.rs
+++ b/crates/ragu_primitives/src/boolean.rs
@@ -15,7 +15,7 @@ use ragu_core::{
 };
 
 #[cfg(test)]
-use crate::allocator::{PoolAllocator, SimpleAllocator};
+use crate::allocator::PoolAllocator;
 use crate::{
     Element, GadgetExt,
     consistent::Consistent,
@@ -343,7 +343,7 @@ fn test_conditional_select() -> Result<()> {
     // condition = true (returns b)
     Simulator::simulate((true, F::from(1u64), F::from(2u64)), |dr, witness| {
         let (cond, a, b) = witness.cast();
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let cond = Boolean::alloc(dr, &mut (), cond)?;
         let a = Element::alloc(dr, allocator, a)?;
         let b = Element::alloc(dr, allocator, b)?;
@@ -357,7 +357,7 @@ fn test_conditional_select() -> Result<()> {
     // condition = false (returns a)
     Simulator::simulate((false, F::from(1u64), F::from(2u64)), |dr, witness| {
         let (cond, a, b) = witness.cast();
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let cond = Boolean::alloc(dr, &mut (), cond)?;
         let a = Element::alloc(dr, allocator, a)?;
         let b = Element::alloc(dr, allocator, b)?;
@@ -379,7 +379,7 @@ fn test_conditional_enforce_equal() -> Result<()> {
     // When condition is true, a == b should be enforced (and satisfied)
     let sim = Simulator::simulate((true, F::from(42u64), F::from(42u64)), |dr, witness| {
         let (cond, a, b) = witness.cast();
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let cond = Boolean::alloc(dr, &mut (), cond)?;
         let a = Element::alloc(dr, allocator, a)?;
         let b = Element::alloc(dr, allocator, b)?;
@@ -395,7 +395,7 @@ fn test_conditional_enforce_equal() -> Result<()> {
     // When condition is false, constraint is trivially satisfied even if a != b
     Simulator::simulate((false, F::from(1u64), F::from(2u64)), |dr, witness| {
         let (cond, a, b) = witness.cast();
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let cond = Boolean::alloc(dr, &mut (), cond)?;
         let a = Element::alloc(dr, allocator, a)?;
         let b = Element::alloc(dr, allocator, b)?;
@@ -447,7 +447,7 @@ mod tests {
     fn test_is_equal_same() -> Result<()> {
         let sim = Simulator::simulate((F::from(123u64), F::from(123u64)), |dr, witness| {
             let (a_val, b_val) = witness.cast();
-            let allocator = &mut SimpleAllocator::new();
+            let allocator = &mut PoolAllocator::new();
             let a = Element::alloc(dr, allocator, a_val)?;
             let b = Element::alloc(dr, allocator, b_val)?;
 
@@ -468,7 +468,7 @@ mod tests {
     fn test_is_not_equal() -> Result<()> {
         Simulator::simulate((F::from(1u64), F::from(123u64)), |dr, witness| {
             let (a_val, b_val) = witness.cast();
-            let allocator = &mut SimpleAllocator::new();
+            let allocator = &mut PoolAllocator::new();
             let a = Element::alloc(dr, allocator, a_val)?;
             let b = Element::alloc(dr, allocator, b_val)?;
 
@@ -536,7 +536,7 @@ mod proptests {
             let mut actual = None;
             Simulator::simulate((cond, a_fe, b_fe), |dr, witness| {
                 let (c, a, b) = witness.cast();
-                let allocator = &mut SimpleAllocator::new();
+                let allocator = &mut PoolAllocator::new();
                 let c = Boolean::alloc(dr, &mut (), c)?;
                 let a = Element::alloc(dr, allocator, a)?;
                 let b = Element::alloc(dr, allocator, b)?;

--- a/crates/ragu_primitives/src/boolean.rs
+++ b/crates/ragu_primitives/src/boolean.rs
@@ -15,7 +15,7 @@ use ragu_core::{
 };
 
 #[cfg(test)]
-use crate::allocator::PoolAllocator;
+use crate::allocator::Standard;
 use crate::{
     Element, GadgetExt,
     consistent::Consistent,
@@ -285,7 +285,7 @@ fn test_boolean_alloc() -> Result<()> {
     Ok(())
 }
 
-/// PoolAllocator reuses the Boolean gate's spare D wire for the Element.
+/// Standard reuses the Boolean gate's spare D wire for the Element.
 #[test]
 fn test_boolean_alloc_reclaim() -> Result<()> {
     type F = ragu_pasta::Fp;
@@ -297,7 +297,7 @@ fn test_boolean_alloc_reclaim() -> Result<()> {
         Ok(())
     })?;
     let sim_with = Simulator::simulate(true, |dr, bit| {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let _b = Boolean::alloc(dr, allocator, bit)?;
         Element::alloc(dr, allocator, Simulator::just(|| F::from(42u64)))?;
         Ok(())
@@ -317,7 +317,7 @@ fn test_pool_allocator_multiple_donations() -> Result<()> {
 
     let sim = Simulator::simulate((true, false, true), |dr, witness| {
         let (b0, b1, b2) = witness.cast();
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
 
         let _b0 = Boolean::alloc(dr, allocator, b0)?;
         let _b1 = Boolean::alloc(dr, allocator, b1)?;
@@ -343,7 +343,7 @@ fn test_conditional_select() -> Result<()> {
     // condition = true (returns b)
     Simulator::simulate((true, F::from(1u64), F::from(2u64)), |dr, witness| {
         let (cond, a, b) = witness.cast();
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let cond = Boolean::alloc(dr, &mut (), cond)?;
         let a = Element::alloc(dr, allocator, a)?;
         let b = Element::alloc(dr, allocator, b)?;
@@ -357,7 +357,7 @@ fn test_conditional_select() -> Result<()> {
     // condition = false (returns a)
     Simulator::simulate((false, F::from(1u64), F::from(2u64)), |dr, witness| {
         let (cond, a, b) = witness.cast();
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let cond = Boolean::alloc(dr, &mut (), cond)?;
         let a = Element::alloc(dr, allocator, a)?;
         let b = Element::alloc(dr, allocator, b)?;
@@ -379,7 +379,7 @@ fn test_conditional_enforce_equal() -> Result<()> {
     // When condition is true, a == b should be enforced (and satisfied)
     let sim = Simulator::simulate((true, F::from(42u64), F::from(42u64)), |dr, witness| {
         let (cond, a, b) = witness.cast();
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let cond = Boolean::alloc(dr, &mut (), cond)?;
         let a = Element::alloc(dr, allocator, a)?;
         let b = Element::alloc(dr, allocator, b)?;
@@ -395,7 +395,7 @@ fn test_conditional_enforce_equal() -> Result<()> {
     // When condition is false, constraint is trivially satisfied even if a != b
     Simulator::simulate((false, F::from(1u64), F::from(2u64)), |dr, witness| {
         let (cond, a, b) = witness.cast();
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let cond = Boolean::alloc(dr, &mut (), cond)?;
         let a = Element::alloc(dr, allocator, a)?;
         let b = Element::alloc(dr, allocator, b)?;
@@ -447,7 +447,7 @@ mod tests {
     fn test_is_equal_same() -> Result<()> {
         let sim = Simulator::simulate((F::from(123u64), F::from(123u64)), |dr, witness| {
             let (a_val, b_val) = witness.cast();
-            let allocator = &mut PoolAllocator::new();
+            let allocator = &mut Standard::new();
             let a = Element::alloc(dr, allocator, a_val)?;
             let b = Element::alloc(dr, allocator, b_val)?;
 
@@ -468,7 +468,7 @@ mod tests {
     fn test_is_not_equal() -> Result<()> {
         Simulator::simulate((F::from(1u64), F::from(123u64)), |dr, witness| {
             let (a_val, b_val) = witness.cast();
-            let allocator = &mut PoolAllocator::new();
+            let allocator = &mut Standard::new();
             let a = Element::alloc(dr, allocator, a_val)?;
             let b = Element::alloc(dr, allocator, b_val)?;
 
@@ -536,7 +536,7 @@ mod proptests {
             let mut actual = None;
             Simulator::simulate((cond, a_fe, b_fe), |dr, witness| {
                 let (c, a, b) = witness.cast();
-                let allocator = &mut PoolAllocator::new();
+                let allocator = &mut Standard::new();
                 let c = Boolean::alloc(dr, &mut (), c)?;
                 let a = Element::alloc(dr, allocator, a)?;
                 let b = Element::alloc(dr, allocator, b)?;

--- a/crates/ragu_primitives/src/element.rs
+++ b/crates/ragu_primitives/src/element.rs
@@ -441,7 +441,7 @@ mod root_of_unity_tests {
     use ragu_pasta::{Fp, fp};
 
     use super::*;
-    use crate::{Simulator, allocator::SimpleAllocator};
+    use crate::{Simulator, allocator::PoolAllocator};
 
     // (omega, k, should_pass)
     fn test_cases() -> Vec<(Fp, u32, bool)> {
@@ -498,7 +498,7 @@ mod root_of_unity_tests {
     fn test_enforce_root_of_unity() -> Result<()> {
         for (i, (omega, k, should_pass)) in test_cases().into_iter().enumerate() {
             let result = Simulator::simulate(omega, |dr, witness| {
-                let allocator = &mut SimpleAllocator::new();
+                let allocator = &mut PoolAllocator::new();
                 let omega = Element::alloc(dr, allocator, witness)?;
                 omega.enforce_root_of_unity(dr, k)?;
                 Ok(())
@@ -527,7 +527,7 @@ mod proptests {
 
     type F = ragu_pasta::Fp;
     type Simulator = crate::Simulator<F>;
-    use crate::allocator::SimpleAllocator;
+    use crate::allocator::PoolAllocator;
 
     fn arb_fe() -> impl Strategy<Value = F> {
         (any::<u64>(), any::<u64>())
@@ -540,7 +540,7 @@ mod proptests {
             let mut actual = None;
             Simulator::simulate((a_fe, b_fe), |dr, witness| {
                 let (a, b) = witness.cast();
-                let allocator = &mut SimpleAllocator::new();
+                let allocator = &mut PoolAllocator::new();
                 let a = Element::alloc(dr, allocator, a)?;
                 let b = Element::alloc(dr, allocator, b)?;
                 let sum = a.add(dr, &b);
@@ -556,7 +556,7 @@ mod proptests {
             let mut actual = None;
             Simulator::simulate((a_fe, b_fe), |dr, witness| {
                 let (a, b) = witness.cast();
-                let allocator = &mut SimpleAllocator::new();
+                let allocator = &mut PoolAllocator::new();
                 let a = Element::alloc(dr, allocator, a)?;
                 let b = Element::alloc(dr, allocator, b)?;
                 let ab = a.mul(dr, &b)?;
@@ -576,7 +576,7 @@ mod proptests {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::allocator::SimpleAllocator;
+    use crate::allocator::PoolAllocator;
 
     #[test]
     fn test_div_nonzero() -> Result<()> {
@@ -586,7 +586,7 @@ mod tests {
         let alloc = |a: F, b: F| {
             let sim = Simulator::simulate((a, b), |dr, witness| {
                 let (a, b) = witness.cast();
-                let allocator = &mut SimpleAllocator::new();
+                let allocator = &mut PoolAllocator::new();
                 let a = Element::alloc(dr, allocator, a.clone())?;
                 let b = Element::alloc(dr, allocator, b.clone())?;
 
@@ -618,7 +618,7 @@ mod tests {
 
         let inv = |a: F| {
             let sim = Simulator::simulate(a, |dr, witness| {
-                let allocator = &mut SimpleAllocator::new();
+                let allocator = &mut PoolAllocator::new();
                 let a = Element::alloc(dr, allocator, witness.clone())?;
                 dr.reset();
                 let ainv = a.invert(dr)?;

--- a/crates/ragu_primitives/src/element.rs
+++ b/crates/ragu_primitives/src/element.rs
@@ -441,7 +441,7 @@ mod root_of_unity_tests {
     use ragu_pasta::{Fp, fp};
 
     use super::*;
-    use crate::{Simulator, allocator::PoolAllocator};
+    use crate::{Simulator, allocator::Standard};
 
     // (omega, k, should_pass)
     fn test_cases() -> Vec<(Fp, u32, bool)> {
@@ -498,7 +498,7 @@ mod root_of_unity_tests {
     fn test_enforce_root_of_unity() -> Result<()> {
         for (i, (omega, k, should_pass)) in test_cases().into_iter().enumerate() {
             let result = Simulator::simulate(omega, |dr, witness| {
-                let allocator = &mut PoolAllocator::new();
+                let allocator = &mut Standard::new();
                 let omega = Element::alloc(dr, allocator, witness)?;
                 omega.enforce_root_of_unity(dr, k)?;
                 Ok(())
@@ -527,7 +527,7 @@ mod proptests {
 
     type F = ragu_pasta::Fp;
     type Simulator = crate::Simulator<F>;
-    use crate::allocator::PoolAllocator;
+    use crate::allocator::Standard;
 
     fn arb_fe() -> impl Strategy<Value = F> {
         (any::<u64>(), any::<u64>())
@@ -540,7 +540,7 @@ mod proptests {
             let mut actual = None;
             Simulator::simulate((a_fe, b_fe), |dr, witness| {
                 let (a, b) = witness.cast();
-                let allocator = &mut PoolAllocator::new();
+                let allocator = &mut Standard::new();
                 let a = Element::alloc(dr, allocator, a)?;
                 let b = Element::alloc(dr, allocator, b)?;
                 let sum = a.add(dr, &b);
@@ -556,7 +556,7 @@ mod proptests {
             let mut actual = None;
             Simulator::simulate((a_fe, b_fe), |dr, witness| {
                 let (a, b) = witness.cast();
-                let allocator = &mut PoolAllocator::new();
+                let allocator = &mut Standard::new();
                 let a = Element::alloc(dr, allocator, a)?;
                 let b = Element::alloc(dr, allocator, b)?;
                 let ab = a.mul(dr, &b)?;
@@ -576,7 +576,7 @@ mod proptests {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::allocator::PoolAllocator;
+    use crate::allocator::Standard;
 
     #[test]
     fn test_div_nonzero() -> Result<()> {
@@ -586,7 +586,7 @@ mod tests {
         let alloc = |a: F, b: F| {
             let sim = Simulator::simulate((a, b), |dr, witness| {
                 let (a, b) = witness.cast();
-                let allocator = &mut PoolAllocator::new();
+                let allocator = &mut Standard::new();
                 let a = Element::alloc(dr, allocator, a.clone())?;
                 let b = Element::alloc(dr, allocator, b.clone())?;
 
@@ -618,7 +618,7 @@ mod tests {
 
         let inv = |a: F| {
             let sim = Simulator::simulate(a, |dr, witness| {
-                let allocator = &mut PoolAllocator::new();
+                let allocator = &mut Standard::new();
                 let a = Element::alloc(dr, allocator, witness.clone())?;
                 dr.reset();
                 let ainv = a.invert(dr)?;

--- a/crates/ragu_primitives/src/endoscalar.rs
+++ b/crates/ragu_primitives/src/endoscalar.rs
@@ -259,7 +259,7 @@ mod tests {
     use rand::RngExt;
 
     use super::{Element, Endoscalar, Maybe, Point};
-    use crate::{Simulator, allocator::SimpleAllocator};
+    use crate::{Simulator, allocator::PoolAllocator};
 
     pub struct EndoscalarTest {
         pub value: Uendo,
@@ -321,7 +321,7 @@ mod tests {
         Simulator::<Fp>::simulate((r, extracted, p), |dr, witness| {
             let (r, extracted, p) = witness.cast();
             let p = Point::alloc(dr, p)?;
-            let allocator = &mut SimpleAllocator::new();
+            let allocator = &mut PoolAllocator::new();
             let r = Element::alloc(dr, allocator, r)?;
             let my_extracted = Endoscalar::extract(dr, &mut (), r)?;
             let allocated = Endoscalar::alloc(dr, extracted)?;

--- a/crates/ragu_primitives/src/endoscalar.rs
+++ b/crates/ragu_primitives/src/endoscalar.rs
@@ -259,7 +259,7 @@ mod tests {
     use rand::RngExt;
 
     use super::{Element, Endoscalar, Maybe, Point};
-    use crate::{Simulator, allocator::PoolAllocator};
+    use crate::{Simulator, allocator::Standard};
 
     pub struct EndoscalarTest {
         pub value: Uendo,
@@ -321,7 +321,7 @@ mod tests {
         Simulator::<Fp>::simulate((r, extracted, p), |dr, witness| {
             let (r, extracted, p) = witness.cast();
             let p = Point::alloc(dr, p)?;
-            let allocator = &mut PoolAllocator::new();
+            let allocator = &mut Standard::new();
             let r = Element::alloc(dr, allocator, r)?;
             let my_extracted = Endoscalar::extract(dr, &mut (), r)?;
             let allocated = Endoscalar::alloc(dr, extracted)?;

--- a/crates/ragu_primitives/src/poseidon.rs
+++ b/crates/ragu_primitives/src/poseidon.rs
@@ -437,7 +437,7 @@ mod tests {
     use super::*;
 
     type Simulator = crate::Simulator<Fp>;
-    use crate::allocator::SimpleAllocator;
+    use crate::allocator::PoolAllocator;
 
     #[test]
     fn test_permutation_constraints() -> Result<()> {
@@ -448,7 +448,7 @@ mod tests {
                 dr,
                 Pasta::circuit_poseidon(params),
             );
-            let allocator = &mut SimpleAllocator::new();
+            let allocator = &mut PoolAllocator::new();
             let value = Element::alloc(dr, allocator, value)?;
             sponge.absorb(dr, &value)?;
 
@@ -504,7 +504,7 @@ mod tests {
                 dr,
                 Pasta::circuit_poseidon(params),
             );
-            let allocator = &mut SimpleAllocator::new();
+            let allocator = &mut PoolAllocator::new();
             let value = Element::alloc(dr, allocator, value)?;
             sponge.absorb(dr, &value)?;
             // Squeeze to enter squeeze mode
@@ -528,7 +528,7 @@ mod tests {
                 dr,
                 Pasta::circuit_poseidon(params),
             );
-            let allocator = &mut SimpleAllocator::new();
+            let allocator = &mut PoolAllocator::new();
             let value = Element::alloc(dr, allocator, value)?;
             sponge.absorb(dr, &value)?;
             // Save should succeed
@@ -554,7 +554,7 @@ mod tests {
                 dr,
                 Pasta::circuit_poseidon(params),
             );
-            let allocator = &mut SimpleAllocator::new();
+            let allocator = &mut PoolAllocator::new();
             let value = Element::alloc(dr, allocator, value)?;
             sponge.absorb(dr, &value)?;
             let squeezed = sponge.squeeze(dr)?;
@@ -568,7 +568,7 @@ mod tests {
                 dr,
                 Pasta::circuit_poseidon(params),
             );
-            let allocator = &mut SimpleAllocator::new();
+            let allocator = &mut PoolAllocator::new();
             let value = Element::alloc(dr, allocator, value)?;
             sponge.absorb(dr, &value)?;
             let state = sponge.save_state(dr).expect("save_state should succeed");
@@ -601,7 +601,7 @@ mod tests {
                 Pasta::circuit_poseidon(params),
             );
             let (v1, v2) = v.cast();
-            let allocator = &mut SimpleAllocator::new();
+            let allocator = &mut PoolAllocator::new();
             let v1 = Element::alloc(dr, allocator, v1)?;
             let v2 = Element::alloc(dr, allocator, v2)?;
             sponge.absorb(dr, &v1)?;
@@ -621,7 +621,7 @@ mod tests {
                 Pasta::circuit_poseidon(params),
             );
             let (v1, v2) = v.cast();
-            let allocator = &mut SimpleAllocator::new();
+            let allocator = &mut PoolAllocator::new();
             let v1 = Element::alloc(dr, allocator, v1)?;
             let v2 = Element::alloc(dr, allocator, v2)?;
             sponge.absorb(dr, &v1)?;

--- a/crates/ragu_primitives/src/poseidon.rs
+++ b/crates/ragu_primitives/src/poseidon.rs
@@ -437,7 +437,7 @@ mod tests {
     use super::*;
 
     type Simulator = crate::Simulator<Fp>;
-    use crate::allocator::PoolAllocator;
+    use crate::allocator::Standard;
 
     #[test]
     fn test_permutation_constraints() -> Result<()> {
@@ -448,7 +448,7 @@ mod tests {
                 dr,
                 Pasta::circuit_poseidon(params),
             );
-            let allocator = &mut PoolAllocator::new();
+            let allocator = &mut Standard::new();
             let value = Element::alloc(dr, allocator, value)?;
             sponge.absorb(dr, &value)?;
 
@@ -504,7 +504,7 @@ mod tests {
                 dr,
                 Pasta::circuit_poseidon(params),
             );
-            let allocator = &mut PoolAllocator::new();
+            let allocator = &mut Standard::new();
             let value = Element::alloc(dr, allocator, value)?;
             sponge.absorb(dr, &value)?;
             // Squeeze to enter squeeze mode
@@ -528,7 +528,7 @@ mod tests {
                 dr,
                 Pasta::circuit_poseidon(params),
             );
-            let allocator = &mut PoolAllocator::new();
+            let allocator = &mut Standard::new();
             let value = Element::alloc(dr, allocator, value)?;
             sponge.absorb(dr, &value)?;
             // Save should succeed
@@ -554,7 +554,7 @@ mod tests {
                 dr,
                 Pasta::circuit_poseidon(params),
             );
-            let allocator = &mut PoolAllocator::new();
+            let allocator = &mut Standard::new();
             let value = Element::alloc(dr, allocator, value)?;
             sponge.absorb(dr, &value)?;
             let squeezed = sponge.squeeze(dr)?;
@@ -568,7 +568,7 @@ mod tests {
                 dr,
                 Pasta::circuit_poseidon(params),
             );
-            let allocator = &mut PoolAllocator::new();
+            let allocator = &mut Standard::new();
             let value = Element::alloc(dr, allocator, value)?;
             sponge.absorb(dr, &value)?;
             let state = sponge.save_state(dr).expect("save_state should succeed");
@@ -601,7 +601,7 @@ mod tests {
                 Pasta::circuit_poseidon(params),
             );
             let (v1, v2) = v.cast();
-            let allocator = &mut PoolAllocator::new();
+            let allocator = &mut Standard::new();
             let v1 = Element::alloc(dr, allocator, v1)?;
             let v2 = Element::alloc(dr, allocator, v2)?;
             sponge.absorb(dr, &v1)?;
@@ -621,7 +621,7 @@ mod tests {
                 Pasta::circuit_poseidon(params),
             );
             let (v1, v2) = v.cast();
-            let allocator = &mut PoolAllocator::new();
+            let allocator = &mut Standard::new();
             let v1 = Element::alloc(dr, allocator, v1)?;
             let v2 = Element::alloc(dr, allocator, v2)?;
             sponge.absorb(dr, &v1)?;

--- a/crates/ragu_testing/src/circuits/mod.rs
+++ b/crates/ragu_testing/src/circuits/mod.rs
@@ -13,7 +13,7 @@ use ragu_core::{
     gadgets::{Bound, Kind},
     maybe::Maybe,
 };
-use ragu_primitives::{Element, allocator::SimpleAllocator};
+use ragu_primitives::{Element, allocator::PoolAllocator};
 
 /// A simple circuit that proves knowledge of a and b such that a^5 = b^2
 /// and a + b = c and a - b = d where c and d are public inputs.
@@ -30,7 +30,7 @@ impl<F: Field> Circuit<F> for MySimpleCircuit {
         dr: &mut D,
         instance: DriverValue<D, Self::Instance<'instance>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let c = Element::alloc(dr, allocator, instance.as_ref().map(|v| v.0))?;
         let d = Element::alloc(dr, allocator, instance.as_ref().map(|v| v.1))?;
 
@@ -42,7 +42,7 @@ impl<F: Field> Circuit<F> for MySimpleCircuit {
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'witness>>,
     ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'witness>>>> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let a = Element::alloc(dr, allocator, witness.as_ref().map(|w| w.0))?;
         let b = Element::alloc(dr, allocator, witness.as_ref().map(|w| w.1))?;
 
@@ -81,7 +81,7 @@ impl<F: Field> Circuit<F> for SquareCircuit {
         dr: &mut D,
         instance: DriverValue<D, Self::Instance<'instance>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         Element::alloc(dr, allocator, instance)
     }
 
@@ -90,7 +90,7 @@ impl<F: Field> Circuit<F> for SquareCircuit {
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'witness>>,
     ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'witness>>>> {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let mut a = Element::alloc(dr, allocator, witness)?;
 
         for _ in 0..self.times {

--- a/crates/ragu_testing/src/circuits/mod.rs
+++ b/crates/ragu_testing/src/circuits/mod.rs
@@ -13,7 +13,7 @@ use ragu_core::{
     gadgets::{Bound, Kind},
     maybe::Maybe,
 };
-use ragu_primitives::{Element, allocator::PoolAllocator};
+use ragu_primitives::{Element, allocator::Standard};
 
 /// A simple circuit that proves knowledge of a and b such that a^5 = b^2
 /// and a + b = c and a - b = d where c and d are public inputs.
@@ -30,7 +30,7 @@ impl<F: Field> Circuit<F> for MySimpleCircuit {
         dr: &mut D,
         instance: DriverValue<D, Self::Instance<'instance>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let c = Element::alloc(dr, allocator, instance.as_ref().map(|v| v.0))?;
         let d = Element::alloc(dr, allocator, instance.as_ref().map(|v| v.1))?;
 
@@ -42,7 +42,7 @@ impl<F: Field> Circuit<F> for MySimpleCircuit {
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'witness>>,
     ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'witness>>>> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let a = Element::alloc(dr, allocator, witness.as_ref().map(|w| w.0))?;
         let b = Element::alloc(dr, allocator, witness.as_ref().map(|w| w.1))?;
 
@@ -81,7 +81,7 @@ impl<F: Field> Circuit<F> for SquareCircuit {
         dr: &mut D,
         instance: DriverValue<D, Self::Instance<'instance>>,
     ) -> Result<Bound<'dr, D, Self::Output>> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         Element::alloc(dr, allocator, instance)
     }
 
@@ -90,7 +90,7 @@ impl<F: Field> Circuit<F> for SquareCircuit {
         dr: &mut D,
         witness: DriverValue<D, Self::Witness<'witness>>,
     ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'witness>>>> {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let mut a = Element::alloc(dr, allocator, witness)?;
 
         for _ in 0..self.times {

--- a/crates/ragu_testing/src/pcd/nontrivial.rs
+++ b/crates/ragu_testing/src/pcd/nontrivial.rs
@@ -14,7 +14,7 @@ use ragu_pcd::{
 };
 use ragu_primitives::{
     Element,
-    allocator::{Allocator, SimpleAllocator},
+    allocator::{Allocator, PoolAllocator},
     poseidon::Sponge,
 };
 
@@ -80,7 +80,7 @@ impl<C: Cycle> Step<C> for Hash2<'_, C> {
     where
         Self: 'dr,
     {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let left = Encoded::new(dr, allocator, left)?;
         let right = Encoded::new(dr, allocator, right)?;
 
@@ -125,7 +125,7 @@ impl<C: Cycle> Step<C> for WitnessLeaf<'_, C> {
     where
         Self: 'dr,
     {
-        let allocator = &mut SimpleAllocator::new();
+        let allocator = &mut PoolAllocator::new();
         let leaf = Element::alloc(dr, allocator, witness)?;
         let mut sponge = Sponge::new(dr, self.poseidon_params);
         sponge.absorb(dr, &leaf)?;

--- a/crates/ragu_testing/src/pcd/nontrivial.rs
+++ b/crates/ragu_testing/src/pcd/nontrivial.rs
@@ -14,7 +14,7 @@ use ragu_pcd::{
 };
 use ragu_primitives::{
     Element,
-    allocator::{Allocator, PoolAllocator},
+    allocator::{Allocator, Standard},
     poseidon::Sponge,
 };
 
@@ -80,7 +80,7 @@ impl<C: Cycle> Step<C> for Hash2<'_, C> {
     where
         Self: 'dr,
     {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let left = Encoded::new(dr, allocator, left)?;
         let right = Encoded::new(dr, allocator, right)?;
 
@@ -125,7 +125,7 @@ impl<C: Cycle> Step<C> for WitnessLeaf<'_, C> {
     where
         Self: 'dr,
     {
-        let allocator = &mut PoolAllocator::new();
+        let allocator = &mut Standard::new();
         let leaf = Element::alloc(dr, allocator, witness)?;
         let mut sponge = Sponge::new(dr, self.poseidon_params);
         sponge.absorb(dr, &leaf)?;


### PR DESCRIPTION
`PoolAllocator` is a superior allocator and behaves like `SimpleAllocator` when no wire donations are made.