### PR TITLE
chore(primitives): donate more spare d wires to standard allocator

### DIFF
--- a/crates/ragu_pcd/src/internal/native/circuits/outer_collapse.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/outer_collapse.rs
@@ -179,7 +179,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
             preamble
                 .is_base_case(dr, allocator)?
                 .not(dr)
-                .conditional_enforce_equal(dr, &witnessed_c, &computed_c)?;
+                .conditional_enforce_equal(dr, allocator, &witnessed_c, &computed_c)?;
         }
 
         let (output, aux) = unified_output.finish(dr, allocator)?;

--- a/crates/ragu_pcd/src/internal/native/circuits/outer_collapse.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/outer_collapse.rs
@@ -177,7 +177,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
             // In base case (both children are trivial proofs), the prover may
             // witness any c value to seed the recursion.
             preamble
-                .is_base_case(dr)?
+                .is_base_case(dr, allocator)?
                 .not(dr)
                 .conditional_enforce_equal(dr, &witnessed_c, &computed_c)?;
         }

--- a/crates/ragu_pcd/src/internal/native/stages/preamble.rs
+++ b/crates/ragu_pcd/src/internal/native/stages/preamble.rs
@@ -15,6 +15,7 @@ use ragu_core::{
 };
 use ragu_primitives::{
     Boolean, Element, GadgetExt,
+    allocator::Allocator,
     consistent::Consistent,
     vec::{CollectFixed, ConstLen, FixedVec},
 };
@@ -138,9 +139,13 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usiz
     }
 
     /// Returns true if this child proof is a trivial proof (output header suffix == 1).
-    pub fn is_trivial(&self, dr: &mut D) -> Result<Boolean<'dr, D>> {
+    pub fn is_trivial(
+        &self,
+        dr: &mut D,
+        allocator: &mut impl Allocator<'dr, D>,
+    ) -> Result<Boolean<'dr, D>> {
         let suffix = &self.output_header[HEADER_SIZE - 1];
-        suffix.is_equal(dr, &Element::one())
+        suffix.is_equal(dr, allocator, &Element::one())
     }
 }
 
@@ -232,9 +237,13 @@ impl<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usiz
     Output<'dr, D, C, HEADER_SIZE>
 {
     /// Returns true if both child proofs are trivial proofs.
-    pub fn is_base_case(&self, dr: &mut D) -> Result<Boolean<'dr, D>> {
-        let left_is_trivial = self.left.is_trivial(dr)?;
-        let right_is_trivial = self.right.is_trivial(dr)?;
+    pub fn is_base_case(
+        &self,
+        dr: &mut D,
+        allocator: &mut impl Allocator<'dr, D>,
+    ) -> Result<Boolean<'dr, D>> {
+        let left_is_trivial = self.left.is_trivial(dr, allocator)?;
+        let right_is_trivial = self.right.is_trivial(dr, allocator)?;
         left_is_trivial.and(dr, &right_is_trivial)
     }
 }

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -91,7 +91,7 @@ fn test_internal_circuit_constraint_counts() {
     check_constraints!(Hashes1Circuit,         mul = 2045, lin = 3422);
     check_constraints!(Hashes2Circuit,         mul = 1879, lin = 2951);
     check_constraints!(InnerCollapseCircuit,  mul = 1756, lin = 1918);
-    check_constraints!(OuterCollapseCircuit,  mul = 810 , lin = 808);
+    check_constraints!(OuterCollapseCircuit,  mul = 809 , lin = 808);
     check_constraints!(ComputeVCircuit,        mul = 1135, lin = 1773);
 }
 
@@ -197,7 +197,7 @@ fn test_native_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fp!(0x0d232b29367f2526522f82dcd46f0a26ca38a2dd97f7b9e40025008e9dcbbea6);
+    let expected = fp!(0x337ed6c2e3f7b39d6ab3cf8f3127ff327c3474f95e1fdca726dde745b2644c1e);
 
     assert_eq!(
         app.native_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -91,7 +91,7 @@ fn test_internal_circuit_constraint_counts() {
     check_constraints!(Hashes1Circuit,         mul = 2045, lin = 3422);
     check_constraints!(Hashes2Circuit,         mul = 1879, lin = 2951);
     check_constraints!(InnerCollapseCircuit,  mul = 1756, lin = 1918);
-    check_constraints!(OuterCollapseCircuit,  mul = 811 , lin = 808);
+    check_constraints!(OuterCollapseCircuit,  mul = 810 , lin = 808);
     check_constraints!(ComputeVCircuit,        mul = 1135, lin = 1773);
 }
 
@@ -197,7 +197,7 @@ fn test_native_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fp!(0x337e4da97c9fa6921600f92576a552fcbd5b606a5d8a0666c5b48527b2d2f83f);
+    let expected = fp!(0x0d232b29367f2526522f82dcd46f0a26ca38a2dd97f7b9e40025008e9dcbbea6);
 
     assert_eq!(
         app.native_registry.digest(),

--- a/crates/ragu_primitives/benches/primitives.rs
+++ b/crates/ragu_primitives/benches/primitives.rs
@@ -43,7 +43,7 @@ fn element_fold(
 #[library_benchmark(setup = setup_emu)]
 #[bench::element_is_zero((alloc_elem,))]
 fn element_is_zero((mut emu, (elem,)): (BenchEmu, (Element<'static, BenchEmu>,))) {
-    black_box(elem.is_zero(&mut emu)).unwrap();
+    black_box(elem.is_zero(&mut emu, &mut ())).unwrap();
 }
 
 #[library_benchmark(setup = setup_emu)]

--- a/crates/ragu_primitives/src/boolean.rs
+++ b/crates/ragu_primitives/src/boolean.rs
@@ -147,6 +147,7 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
 /// Uses the standard inverse trick for zero checking in arithmetic circuits.
 pub(crate) fn is_zero<'dr, D: Driver<'dr>>(
     dr: &mut D,
+    allocator: &mut impl crate::allocator::Allocator<'dr, D>,
     x: &Element<'dr, D>,
 ) -> Result<Boolean<'dr, D>> {
     // We enforce the constraints:
@@ -164,7 +165,7 @@ pub(crate) fn is_zero<'dr, D: Driver<'dr>>(
     let is_zero = x.value().map(|v| *v == D::F::ZERO);
 
     // Constraint 1: x * is_zero = 0.
-    let (x_wire, is_zero_wire, zero_product) = dr.mul(|| {
+    let (x_wire, is_zero_wire, zero_product, extra) = dr.gate(|| {
         Ok((
             x.value().arbitrary().take(),
             is_zero.coeff().take(),
@@ -173,6 +174,9 @@ pub(crate) fn is_zero<'dr, D: Driver<'dr>>(
     })?;
     dr.enforce_equal(&x_wire, x.wire())?;
     dr.enforce_zero(|lc| lc.add(&zero_product))?;
+
+    // $C = 0$ makes the $D$ wire unconstrained; donate it.
+    allocator.donate(extra);
 
     // Constraint 2: x * inv = 1 - is_zero.
     let (x_wire, _, is_not_zero) = dr.mul(|| {
@@ -452,7 +456,7 @@ mod tests {
             let b = Element::alloc(dr, allocator, b_val)?;
 
             dr.reset();
-            let eq = a.is_equal(dr, &b)?;
+            let eq = a.is_equal(dr, allocator, &b)?;
 
             assert!(eq.value().take(), "Expected a == b");
             Ok(())
@@ -473,7 +477,7 @@ mod tests {
             let b = Element::alloc(dr, allocator, b_val)?;
 
             dr.reset();
-            let eq = a.is_equal(dr, &b)?;
+            let eq = a.is_equal(dr, allocator, &b)?;
 
             assert!(!eq.value().take(), "Expected a != b");
             Ok(())

--- a/crates/ragu_primitives/src/boolean.rs
+++ b/crates/ragu_primitives/src/boolean.rs
@@ -114,6 +114,7 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
     pub fn conditional_enforce_equal(
         &self,
         dr: &mut D,
+        allocator: &mut impl crate::allocator::Allocator<'dr, D>,
         a: &Element<'dr, D>,
         b: &Element<'dr, D>,
     ) -> Result<()> {
@@ -122,8 +123,23 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
         // - When condition = 1: a - b = 0
         // - When condition = 0: 0 = 0 (trivially satisfied)
         let diff = a.sub(dr, b);
-        let product = self.element().mul(dr, &diff)?;
-        product.enforce_zero(dr)
+
+        let (cond_wire, diff_wire, zero_wire, extra) = dr.gate(|| {
+            Ok((
+                self.value().coeff().take(),
+                diff.value().arbitrary().take(),
+                Coeff::Zero,
+            ))
+        })?;
+
+        dr.enforce_equal(&cond_wire, self.wire())?;
+        dr.enforce_equal(&diff_wire, diff.wire())?;
+        dr.enforce_zero(|lc| lc.add(&zero_wire))?;
+
+        // $C = 0$ makes the $D$ wire unconstrained; donate it.
+        allocator.donate(extra);
+
+        Ok(())
     }
 
     /// Returns the witness value of this boolean.
@@ -389,7 +405,7 @@ fn test_conditional_enforce_equal() -> Result<()> {
         let b = Element::alloc(dr, allocator, b)?;
 
         dr.reset();
-        cond.conditional_enforce_equal(dr, &a, &b)?;
+        cond.conditional_enforce_equal(dr, allocator, &a, &b)?;
         Ok(())
     })?;
 
@@ -404,7 +420,7 @@ fn test_conditional_enforce_equal() -> Result<()> {
         let a = Element::alloc(dr, allocator, a)?;
         let b = Element::alloc(dr, allocator, b)?;
 
-        cond.conditional_enforce_equal(dr, &a, &b)?;
+        cond.conditional_enforce_equal(dr, allocator, &a, &b)?;
         Ok(())
     })?;
 

--- a/crates/ragu_primitives/src/boolean.rs
+++ b/crates/ragu_primitives/src/boolean.rs
@@ -18,6 +18,7 @@ use ragu_core::{
 use crate::allocator::Standard;
 use crate::{
     Element, GadgetExt,
+    allocator::Allocator,
     consistent::Consistent,
     io::{Buffer, Write},
     promotion::{Demoted, Promotion},
@@ -114,7 +115,7 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
     pub fn conditional_enforce_equal(
         &self,
         dr: &mut D,
-        allocator: &mut impl crate::allocator::Allocator<'dr, D>,
+        allocator: &mut impl Allocator<'dr, D>,
         a: &Element<'dr, D>,
         b: &Element<'dr, D>,
     ) -> Result<()> {
@@ -122,21 +123,21 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
         // Equivalent to: condition * (a - b) == 0
         // - When condition = 1: a - b = 0
         // - When condition = 0: 0 = 0 (trivially satisfied)
-        let diff = a.sub(dr, b);
-
         let (cond_wire, diff_wire, zero_wire, extra) = dr.gate(|| {
             Ok((
                 self.value().coeff().take(),
-                diff.value().arbitrary().take(),
+                D::just(|| **a.value().snag() - **b.value().snag())
+                    .arbitrary()
+                    .take(),
                 Coeff::Zero,
             ))
         })?;
 
         dr.enforce_equal(&cond_wire, self.wire())?;
-        dr.enforce_equal(&diff_wire, diff.wire())?;
+        dr.enforce_zero(|lc| lc.add(&diff_wire).sub(a.wire()).add(b.wire()))?;
         dr.enforce_zero(|lc| lc.add(&zero_wire))?;
 
-        // $C = 0$ makes the $D$ wire unconstrained; donate it.
+        // C = 0 makes the D wire unconstrained; donate it.
         allocator.donate(extra);
 
         Ok(())
@@ -163,7 +164,7 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
 /// Uses the standard inverse trick for zero checking in arithmetic circuits.
 pub(crate) fn is_zero<'dr, D: Driver<'dr>>(
     dr: &mut D,
-    allocator: &mut impl crate::allocator::Allocator<'dr, D>,
+    allocator: &mut impl Allocator<'dr, D>,
     x: &Element<'dr, D>,
 ) -> Result<Boolean<'dr, D>> {
     // We enforce the constraints:
@@ -191,7 +192,7 @@ pub(crate) fn is_zero<'dr, D: Driver<'dr>>(
     dr.enforce_equal(&x_wire, x.wire())?;
     dr.enforce_zero(|lc| lc.add(&zero_product))?;
 
-    // $C = 0$ makes the $D$ wire unconstrained; donate it.
+    // C = 0 makes the D wire unconstrained; donate it.
     allocator.donate(extra);
 
     // Constraint 2: x * inv = 1 - is_zero.

--- a/crates/ragu_primitives/src/element.rs
+++ b/crates/ragu_primitives/src/element.rs
@@ -309,14 +309,23 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
     }
 
     /// Returns a boolean indicating whether this element is zero.
-    pub fn is_zero(&self, dr: &mut D) -> Result<Boolean<'dr, D>> {
-        crate::boolean::is_zero(dr, self)
+    pub fn is_zero(
+        &self,
+        dr: &mut D,
+        allocator: &mut impl Allocator<'dr, D>,
+    ) -> Result<Boolean<'dr, D>> {
+        crate::boolean::is_zero(dr, allocator, self)
     }
 
     /// Returns a boolean indicating whether this element equals another.
-    pub fn is_equal(&self, dr: &mut D, other: &Self) -> Result<Boolean<'dr, D>> {
+    pub fn is_equal(
+        &self,
+        dr: &mut D,
+        allocator: &mut impl Allocator<'dr, D>,
+        other: &Self,
+    ) -> Result<Boolean<'dr, D>> {
         let diff = self.sub(dr, other);
-        diff.is_zero(dr)
+        diff.is_zero(dr, allocator)
     }
 
     /// Computes a weighted sum of the elements yielded by an iterator by the


### PR DESCRIPTION
Exploiting other gadget candidates where c is structurally zero, similar to the boolean gadget in https://github.com/tachyon-zcash/ragu/pull/643. `is_zero / is_equal` / `conditional_enforce_equal` calls donate an extra token. 