### PR TITLE
pcd: add loading and copying bonding circuits

### DIFF
--- a/crates/ragu_pcd/src/fuse/_03_s_prime.rs
+++ b/crates/ragu_pcd/src/fuse/_03_s_prime.rs
@@ -37,6 +37,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             &nested::stages::s_prime::Witness {
                 registry_wx0: native.registry_wx0_commitment,
                 registry_wx1: native.registry_wx1_commitment,
+                stashed_preamble: builder.native_preamble_commitment(),
             },
         )?;
         let bridge_commitment = bridge_rx.commit_to_affine(C::nested_generators(self.params));

--- a/crates/ragu_pcd/src/fuse/_10_p.rs
+++ b/crates/ragu_pcd/src/fuse/_10_p.rs
@@ -30,7 +30,6 @@ use crate::{
             EndoscalarStage, EndoscalingStep, EndoscalingStepWitness, NumStepsLen, PointsStage,
             PointsWitness,
         },
-        native::{RxComponent, RxIndex},
         nested::NUM_ENDOSCALING_POINTS,
     },
     proof::ProofBuilder,
@@ -93,33 +92,24 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             };
 
             for proof in [left, right] {
-                for &id in &RxIndex::ALL {
-                    acc.acc(&proof[id], proof.native_rx_commitment(id));
+                for (poly, commitment) in proof.polys_for_p() {
+                    acc.acc(poly, commitment);
                 }
-                acc.acc(
-                    &proof[RxComponent::AbA],
-                    proof.native_commitment(RxComponent::AbA),
-                );
-                acc.acc(
-                    &proof[RxComponent::AbB],
-                    proof.native_commitment(RxComponent::AbB),
-                );
-                acc.acc(
-                    proof.native_registry_xy_poly(),
-                    proof.native_registry_xy_commitment(),
-                );
-                acc.acc(proof.native_p_poly(), proof.native_p_commitment());
             }
 
-            acc.acc(&s_prime.registry_wx0_poly, s_prime.registry_wx0_commitment);
-            acc.acc(&s_prime.registry_wx1_poly, s_prime.registry_wx1_commitment);
-            acc.acc(&registry_wy.poly, registry_wy.commitment);
-            acc.acc(builder.native_a_poly(), builder.native_a_commitment());
-            acc.acc(builder.native_b_poly(), builder.native_b_commitment());
-            acc.acc(
-                builder.native_registry_xy_poly(),
-                builder.native_registry_xy_commitment(),
-            );
+            for (poly, commitment) in [
+                (&s_prime.registry_wx0_poly, s_prime.registry_wx0_commitment),
+                (&s_prime.registry_wx1_poly, s_prime.registry_wx1_commitment),
+                (&registry_wy.poly, registry_wy.commitment),
+                (builder.native_a_poly(), builder.native_a_commitment()),
+                (builder.native_b_poly(), builder.native_b_commitment()),
+                (
+                    builder.native_registry_xy_poly(),
+                    builder.native_registry_xy_commitment(),
+                ),
+            ] {
+                acc.acc(poly, commitment);
+            }
         }
 
         // Construct commitment via PointsWitness Horner evaluation.

--- a/crates/ragu_pcd/src/fuse/_10_p.rs
+++ b/crates/ragu_pcd/src/fuse/_10_p.rs
@@ -7,7 +7,9 @@
 //! polynomial commitments using additive homomorphism:
 //! $\text{commit}(\sum\_j \beta^j \cdot p\_j) = \sum\_j \beta^j \cdot C\_j$.
 //!
-//! The commitment is computed via [`PointsWitness`] Horner evaluation.
+//! The commitment is computed via
+//! [`PointsWitness`](crate::internal::endoscalar::PointsWitness)
+//! Horner evaluation.
 
 use alloc::vec::Vec;
 use core::ops::AddAssign;

--- a/crates/ragu_pcd/src/fuse/_10_p.rs
+++ b/crates/ragu_pcd/src/fuse/_10_p.rs
@@ -21,7 +21,14 @@ use ragu_core::{Result, drivers::Driver, maybe::Maybe};
 use ragu_primitives::{Element, extract_endoscalar, lift_endoscalar};
 
 use super::{NativeF, NativeSPrime, RegistryWy};
-use crate::{Application, Proof, internal::nested::NUM_ENDOSCALING_POINTS, proof::ProofBuilder};
+use crate::{
+    Application, Proof,
+    internal::{
+        native::{RxComponent, RxIndex},
+        nested::NUM_ENDOSCALING_POINTS,
+    },
+    proof::ProofBuilder,
+};
 
 /// Accumulates polynomials with their commitments.
 struct Accumulator<'a, C: Cycle, R: Rank> {
@@ -80,24 +87,33 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             };
 
             for proof in [left, right] {
-                for (poly, commitment) in proof.polys_for_p() {
-                    acc.acc(poly, commitment);
+                for &id in &RxIndex::ALL {
+                    acc.acc(&proof[id], proof.native_rx_commitment(id));
                 }
+                acc.acc(
+                    &proof[RxComponent::AbA],
+                    proof.native_commitment(RxComponent::AbA),
+                );
+                acc.acc(
+                    &proof[RxComponent::AbB],
+                    proof.native_commitment(RxComponent::AbB),
+                );
+                acc.acc(
+                    proof.native_registry_xy_poly(),
+                    proof.native_registry_xy_commitment(),
+                );
+                acc.acc(proof.native_p_poly(), proof.native_p_commitment());
             }
 
-            for (poly, commitment) in [
-                (&s_prime.registry_wx0_poly, s_prime.registry_wx0_commitment),
-                (&s_prime.registry_wx1_poly, s_prime.registry_wx1_commitment),
-                (&registry_wy.poly, registry_wy.commitment),
-                (builder.native_a_poly(), builder.native_a_commitment()),
-                (builder.native_b_poly(), builder.native_b_commitment()),
-                (
-                    builder.native_registry_xy_poly(),
-                    builder.native_registry_xy_commitment(),
-                ),
-            ] {
-                acc.acc(poly, commitment);
-            }
+            acc.acc(&s_prime.registry_wx0_poly, s_prime.registry_wx0_commitment);
+            acc.acc(&s_prime.registry_wx1_poly, s_prime.registry_wx1_commitment);
+            acc.acc(&registry_wy.poly, registry_wy.commitment);
+            acc.acc(builder.native_a_poly(), builder.native_a_commitment());
+            acc.acc(builder.native_b_poly(), builder.native_b_commitment());
+            acc.acc(
+                builder.native_registry_xy_poly(),
+                builder.native_registry_xy_commitment(),
+            );
         }
 
         // Build the PointsStage input vector ([f.commitment, commitments..])

--- a/crates/ragu_pcd/src/fuse/_10_p.rs
+++ b/crates/ragu_pcd/src/fuse/_10_p.rs
@@ -14,24 +14,14 @@ use core::ops::AddAssign;
 
 use ff::Field;
 use ragu_arithmetic::Cycle;
-use ragu_circuits::{
-    CircuitExt,
-    polynomials::{Rank, sparse},
-    staging::{MultiStage, StageExt},
-};
+use ragu_circuits::polynomials::{Rank, sparse};
 use ragu_core::{Result, drivers::Driver, maybe::Maybe};
-use ragu_primitives::{Element, extract_endoscalar, lift_endoscalar, vec::Len};
+use ragu_primitives::{Element, extract_endoscalar, lift_endoscalar};
 
 use super::{NativeF, NativeSPrime, RegistryWy};
 use crate::{
     Application, Proof,
-    internal::{
-        endoscalar::{
-            EndoscalarStage, EndoscalingStep, EndoscalingStepWitness, NumStepsLen, PointsStage,
-            PointsWitness,
-        },
-        nested::NUM_ENDOSCALING_POINTS,
-    },
+    internal::nested::NUM_ENDOSCALING_POINTS,
     proof::ProofBuilder,
 };
 
@@ -112,62 +102,26 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             }
         }
 
-        // Construct commitment via PointsWitness Horner evaluation.
-        // Points order: [f.commitment, commitments...] computes β^n·f + β^{n-1}·C₀ + ...
-        let (commitment, endoscalar_rx, points_rx, step_rxs) = {
-            let mut points = Vec::with_capacity(NUM_ENDOSCALING_POINTS);
-            points.push(f.commitment);
-            points.extend_from_slice(&commitments);
+        // Build the PointsStage input vector ([f.commitment, commitments..])
+        // and delegate to the shared endoscaling helper, which also
+        // sets `nested_endoscalar_rx`, `nested_points_rx`, and
+        // `nested_endoscaling_step_rxs` on the builder.
+        let mut points = Vec::with_capacity(NUM_ENDOSCALING_POINTS);
+        points.push(f.commitment);
+        points.extend_from_slice(&commitments);
 
-            let witness =
-                PointsWitness::<C::HostCurve, NUM_ENDOSCALING_POINTS>::new(beta_endo, &points);
+        let endoscalar_alpha = C::ScalarField::random(&mut *rng);
+        let points_alpha = C::ScalarField::random(&mut *rng);
+        let p_commitment = self.compute_endoscaling(
+            rng,
+            beta_endo,
+            &points,
+            endoscalar_alpha,
+            points_alpha,
+            builder,
+        )?;
 
-            let endoscalar_rx = <EndoscalarStage as StageExt<C::ScalarField, R>>::rx(
-                C::ScalarField::random(&mut *rng),
-                beta_endo,
-            )?;
-            let points_rx = <PointsStage<C::HostCurve, NUM_ENDOSCALING_POINTS> as StageExt<
-                C::ScalarField,
-                R,
-            >>::rx(C::ScalarField::random(&mut *rng), &witness)?;
-
-            // Create rx polynomials for each endoscaling step circuit
-            let num_steps = NumStepsLen::<NUM_ENDOSCALING_POINTS>::len();
-            let mut step_rxs = Vec::with_capacity(num_steps);
-            for step in 0..num_steps {
-                let step_circuit =
-                    EndoscalingStep::<C::HostCurve, R, NUM_ENDOSCALING_POINTS>::new(step);
-                let staged = MultiStage::new(step_circuit);
-                let step_trace = staged
-                    .trace(EndoscalingStepWitness {
-                        endoscalar: beta_endo,
-                        points: &witness,
-                    })?
-                    .into_output();
-                let step_rx = self.nested_registry.assemble(
-                    &step_trace,
-                    crate::internal::nested::InternalCircuitIndex::EndoscalingStep(step as u32)
-                        .circuit_index(),
-                    &mut *rng,
-                )?;
-                step_rxs.push(step_rx);
-            }
-
-            (
-                *witness
-                    .interstitials
-                    .last()
-                    .expect("NumStepsLen guarantees at least one interstitial"),
-                endoscalar_rx,
-                points_rx,
-                step_rxs,
-            )
-        };
-
-        builder.set_native_p_poly(poly, commitment);
-        builder.set_nested_endoscaling_step_rxs(step_rxs);
-        builder.set_nested_endoscalar_rx(endoscalar_rx);
-        builder.set_nested_points_rx(points_rx);
+        builder.set_native_p_poly(poly, p_commitment);
 
         Ok(())
     }

--- a/crates/ragu_pcd/src/fuse/_10_p.rs
+++ b/crates/ragu_pcd/src/fuse/_10_p.rs
@@ -19,11 +19,7 @@ use ragu_core::{Result, drivers::Driver, maybe::Maybe};
 use ragu_primitives::{Element, extract_endoscalar, lift_endoscalar};
 
 use super::{NativeF, NativeSPrime, RegistryWy};
-use crate::{
-    Application, Proof,
-    internal::nested::NUM_ENDOSCALING_POINTS,
-    proof::ProofBuilder,
-};
+use crate::{Application, Proof, internal::nested::NUM_ENDOSCALING_POINTS, proof::ProofBuilder};
 
 /// Accumulates polynomials with their commitments.
 struct Accumulator<'a, C: Cycle, R: Rank> {

--- a/crates/ragu_pcd/src/fuse/mod.rs
+++ b/crates/ragu_pcd/src/fuse/mod.rs
@@ -213,6 +213,10 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         builder.set_u(*u.value().take());
         builder.set_pre_beta(*pre_beta.value().take());
 
+        // Store children's stage rx polynomials for copying circuit claims.
+        builder.set_child_left_stage_rx(left.as_child_stage_rx());
+        builder.set_child_right_stage_rx(right.as_child_stage_rx());
+
         self.compute_internal_circuits(
             rng,
             &preamble_witness,

--- a/crates/ragu_pcd/src/internal/mod.rs
+++ b/crates/ragu_pcd/src/internal/mod.rs
@@ -30,7 +30,7 @@ pub mod transcript;
 
 /// Identifies which of the two child proofs a component came from.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum Side {
+pub enum Side {
     Left,
     Right,
 }

--- a/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
@@ -1,0 +1,84 @@
+//! Copying circuit for the nested section.
+//!
+//! Final form relates the current step's preamble to a child proof's
+//! bridge stages, ensuring that child commitments stashed in
+//! [`ChildWitness`](crate::internal::nested::stages::preamble::ChildWitness)
+//! match the actual values committed in the child's bridge stages. One
+//! instance per child proof ([`Side::Left`] and [`Side::Right`]).
+//!
+//! In this initial commit the circuit's stage skeleton is in place but
+//! no `enforce_equal` calls fire — the bonding polynomial folds to zero
+//! so the `grouped_bonding_claim` passes trivially.
+
+use core::marker::PhantomData;
+
+use ragu_arithmetic::CurveAffine;
+use ragu_circuits::{
+    WithAux,
+    polynomials::Rank,
+    staging::{MultiStageCircuit, StageBuilder},
+};
+use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue},
+    gadgets::Bound,
+};
+
+use crate::internal::{
+    Side,
+    endoscalar::{EndoscalarStage, PointsStage},
+    nested::{NUM_ENDOSCALING_POINTS, stages},
+};
+
+/// Copying circuit that relates the current preamble to a child's stages.
+pub struct Circuit<C: CurveAffine, R: Rank> {
+    side: Side,
+    _marker: PhantomData<(C, R)>,
+}
+
+impl<C: CurveAffine, R: Rank> Circuit<C, R> {
+    pub fn new(side: Side) -> Self {
+        Self {
+            side,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
+    type Last = stages::eval::Stage<C, R>;
+    type Instance<'source> = ();
+    type Witness<'source> = ();
+    type Output = ();
+    type Aux<'source> = ();
+
+    fn instance<'dr, 'source: 'dr, D: Driver<'dr, F = C::Base>>(
+        &self,
+        _dr: &mut D,
+        _instance: DriverValue<D, ()>,
+    ) -> Result<Bound<'dr, D, ()>> {
+        Ok(())
+    }
+
+    fn witness<'a, 'dr, 'source: 'dr, D: Driver<'dr, F = C::Base>>(
+        &self,
+        dr: StageBuilder<'a, 'dr, D, R, (), Self::Last>,
+        _witness: DriverValue<D, ()>,
+    ) -> Result<WithAux<Bound<'dr, D, ()>, DriverValue<D, ()>>> {
+        // `side` is recorded for future enforce_equal dispatch.
+        let _ = self.side;
+        let dr = dr.skip_stage::<EndoscalarStage>()?;
+        let (_points_guard, dr) = dr.add_stage::<PointsStage<C, NUM_ENDOSCALING_POINTS>>()?;
+        let (_preamble_guard, dr) = dr.add_stage::<stages::preamble::Stage<C, R>>()?;
+        let dr = dr.skip_stage::<stages::s_prime::Stage<C, R>>()?;
+        let dr = dr.skip_stage::<stages::inner_error::Stage<C, R>>()?;
+        let dr = dr.skip_stage::<stages::outer_error::Stage<C, R>>()?;
+        let dr = dr.skip_stage::<stages::ab::Stage<C, R>>()?;
+        let dr = dr.skip_stage::<stages::query::Stage<C, R>>()?;
+        let dr = dr.skip_stage::<stages::f::Stage<C, R>>()?;
+        let dr = dr.skip_stage::<stages::eval::Stage<C, R>>()?;
+        let _dr = dr.finish();
+
+        Ok(WithAux::new((), D::unit()))
+    }
+}

--- a/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
@@ -21,7 +21,8 @@ use ragu_circuits::{
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::Bound,
+    gadgets::{Bound, Gadget},
+    maybe::Maybe,
 };
 
 use crate::internal::{
@@ -65,19 +66,37 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
         dr: StageBuilder<'a, 'dr, D, R, (), Self::Last>,
         _witness: DriverValue<D, ()>,
     ) -> Result<WithAux<Bound<'dr, D, ()>, DriverValue<D, ()>>> {
-        // `side` is recorded for future enforce_equal dispatch.
-        let _ = self.side;
         let dr = dr.skip_stage::<EndoscalarStage>()?;
         let (_points_guard, dr) = dr.add_stage::<PointsStage<C, NUM_ENDOSCALING_POINTS>>()?;
-        let (_preamble_guard, dr) = dr.add_stage::<stages::preamble::Stage<C, R>>()?;
-        let dr = dr.skip_stage::<stages::s_prime::Stage<C, R>>()?;
+        let (preamble_guard, dr) = dr.add_stage::<stages::preamble::Stage<C, R>>()?;
+        let (s_prime_guard, dr) = dr.add_stage::<stages::s_prime::Stage<C, R>>()?;
         let dr = dr.skip_stage::<stages::inner_error::Stage<C, R>>()?;
         let dr = dr.skip_stage::<stages::outer_error::Stage<C, R>>()?;
         let dr = dr.skip_stage::<stages::ab::Stage<C, R>>()?;
         let dr = dr.skip_stage::<stages::query::Stage<C, R>>()?;
         let dr = dr.skip_stage::<stages::f::Stage<C, R>>()?;
         let dr = dr.skip_stage::<stages::eval::Stage<C, R>>()?;
-        let _dr = dr.finish();
+        let dr = dr.finish();
+
+        macro_rules! w {
+            () => {
+                _witness.as_ref().map(|_| unreachable!())
+            };
+        }
+        let preamble = preamble_guard.unenforced(dr, w!())?;
+        let s_prime = s_prime_guard.unenforced(dr, w!())?;
+
+        let child = match self.side {
+            Side::Left => &preamble.left,
+            Side::Right => &preamble.right,
+        };
+
+        // stashed_preamble: routes through this step's BridgeSPrime,
+        // which was enforced by loading to equal
+        // preamble.native_preamble at proof-generation time.
+        child
+            .stashed_preamble
+            .enforce_equal(dr, &s_prime.stashed_preamble)?;
 
         Ok(WithAux::new((), D::unit()))
     }

--- a/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
@@ -1,14 +1,15 @@
 //! Copying circuit for the nested section.
 //!
-//! Final form relates the current step's preamble to a child proof's
-//! bridge stages, ensuring that child commitments stashed in
-//! [`ChildWitness`](crate::internal::nested::stages::preamble::ChildWitness)
-//! match the actual values committed in the child's bridge stages. One
-//! instance per child proof ([`Side::Left`] and [`Side::Right`]).
+//! Relates the current fuse step's preamble to the child proof's stages,
+//! ensuring that child commitments stashed in
+//! [`ChildWitness`](crate::internal::nested::stages::preamble::ChildWitness) match the
+//! actual values committed in the child's bridge stages. One instance per
+//! child proof ([`Side::Left`] and [`Side::Right`]).
 //!
-//! In this initial commit the circuit's stage skeleton is in place but
-//! no `enforce_equal` calls fire — the bonding polynomial folds to zero
-//! so the `grouped_bonding_claim` passes trivially.
+//! The copying circuit loads the child's bridge stages in its own trace
+//! (no wire-position collision with loading, which loads the current
+//! step's stages) and enforces equality between each `ChildWitness`
+//! stash field and the corresponding child bridge stage field.
 
 use core::marker::PhantomData;
 
@@ -78,6 +79,8 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
         let (eval_guard, dr) = dr.add_stage::<stages::eval::Stage<C, R>>()?;
         let dr = dr.finish();
 
+        // Load stage gadgets. Witness values are never accessed — the circuit
+        // only runs during `into_bonding_object` where MaybeKind = Empty.
         macro_rules! w {
             () => {
                 _witness.as_ref().map(|_| unreachable!())
@@ -92,11 +95,15 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
         let query = query_guard.unenforced(dr, w!())?;
         let eval = eval_guard.unenforced(dr, w!())?;
 
+        // Select the child corresponding to this circuit's side.
         let child = match self.side {
             Side::Left => &preamble.left,
             Side::Right => &preamble.right,
         };
 
+        // Enforce that each ChildWitness stash field matches the
+        // corresponding child bridge stage field.
+        //
         // stashed_preamble: routes through this step's BridgeSPrime,
         // which was enforced by loading to equal
         // preamble.native_preamble at proof-generation time.

--- a/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
@@ -67,7 +67,7 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
         _witness: DriverValue<D, ()>,
     ) -> Result<WithAux<Bound<'dr, D, ()>, DriverValue<D, ()>>> {
         let dr = dr.skip_stage::<EndoscalarStage>()?;
-        let (_points_guard, dr) = dr.add_stage::<PointsStage<C, NUM_ENDOSCALING_POINTS>>()?;
+        let (points_guard, dr) = dr.add_stage::<PointsStage<C, NUM_ENDOSCALING_POINTS>>()?;
         let (preamble_guard, dr) = dr.add_stage::<stages::preamble::Stage<C, R>>()?;
         let (s_prime_guard, dr) = dr.add_stage::<stages::s_prime::Stage<C, R>>()?;
         let (inner_error_guard, dr) = dr.add_stage::<stages::inner_error::Stage<C, R>>()?;
@@ -83,6 +83,7 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
                 _witness.as_ref().map(|_| unreachable!())
             };
         }
+        let points = points_guard.unenforced(dr, w!())?;
         let preamble = preamble_guard.unenforced(dr, w!())?;
         let s_prime = s_prime_guard.unenforced(dr, w!())?;
         let inner_error = inner_error_guard.unenforced(dr, w!())?;
@@ -115,6 +116,14 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
             .stashed_registry_xy
             .enforce_equal(dr, &query.registry_xy)?;
         child.stashed_eval.enforce_equal(dr, &eval.native_eval)?;
+
+        // P: the child's accumulated p commitment is the last interstitial
+        // of the child's PointsStage.
+        let last_interstitial = points
+            .interstitials
+            .last()
+            .expect("NUM_ENDOSCALING_POINTS guarantees >= 1 interstitial");
+        child.stashed_p.enforce_equal(dr, last_interstitial)?;
 
         Ok(WithAux::new((), D::unit()))
     }

--- a/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
@@ -70,12 +70,12 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
         let (_points_guard, dr) = dr.add_stage::<PointsStage<C, NUM_ENDOSCALING_POINTS>>()?;
         let (preamble_guard, dr) = dr.add_stage::<stages::preamble::Stage<C, R>>()?;
         let (s_prime_guard, dr) = dr.add_stage::<stages::s_prime::Stage<C, R>>()?;
-        let dr = dr.skip_stage::<stages::inner_error::Stage<C, R>>()?;
-        let dr = dr.skip_stage::<stages::outer_error::Stage<C, R>>()?;
-        let dr = dr.skip_stage::<stages::ab::Stage<C, R>>()?;
-        let dr = dr.skip_stage::<stages::query::Stage<C, R>>()?;
+        let (inner_error_guard, dr) = dr.add_stage::<stages::inner_error::Stage<C, R>>()?;
+        let (outer_error_guard, dr) = dr.add_stage::<stages::outer_error::Stage<C, R>>()?;
+        let (ab_guard, dr) = dr.add_stage::<stages::ab::Stage<C, R>>()?;
+        let (query_guard, dr) = dr.add_stage::<stages::query::Stage<C, R>>()?;
         let dr = dr.skip_stage::<stages::f::Stage<C, R>>()?;
-        let dr = dr.skip_stage::<stages::eval::Stage<C, R>>()?;
+        let (eval_guard, dr) = dr.add_stage::<stages::eval::Stage<C, R>>()?;
         let dr = dr.finish();
 
         macro_rules! w {
@@ -85,6 +85,11 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
         }
         let preamble = preamble_guard.unenforced(dr, w!())?;
         let s_prime = s_prime_guard.unenforced(dr, w!())?;
+        let inner_error = inner_error_guard.unenforced(dr, w!())?;
+        let outer_error = outer_error_guard.unenforced(dr, w!())?;
+        let ab = ab_guard.unenforced(dr, w!())?;
+        let query = query_guard.unenforced(dr, w!())?;
+        let eval = eval_guard.unenforced(dr, w!())?;
 
         let child = match self.side {
             Side::Left => &preamble.left,
@@ -97,6 +102,19 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
         child
             .stashed_preamble
             .enforce_equal(dr, &s_prime.stashed_preamble)?;
+        child
+            .stashed_inner_error
+            .enforce_equal(dr, &inner_error.native_inner_error)?;
+        child
+            .stashed_outer_error
+            .enforce_equal(dr, &outer_error.native_outer_error)?;
+        child.stashed_ab_a.enforce_equal(dr, &ab.a)?;
+        child.stashed_ab_b.enforce_equal(dr, &ab.b)?;
+        child.stashed_query.enforce_equal(dr, &query.native_query)?;
+        child
+            .stashed_registry_xy
+            .enforce_equal(dr, &query.registry_xy)?;
+        child.stashed_eval.enforce_equal(dr, &eval.native_eval)?;
 
         Ok(WithAux::new((), D::unit()))
     }

--- a/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
@@ -18,7 +18,8 @@ use ragu_circuits::{
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::Bound,
+    gadgets::{Bound, Gadget},
+    maybe::Maybe,
 };
 
 use crate::internal::{
@@ -60,16 +61,29 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
         _witness: DriverValue<D, ()>,
     ) -> Result<WithAux<Bound<'dr, D, ()>, DriverValue<D, ()>>> {
         let dr = dr.skip_stage::<EndoscalarStage>()?;
-        let (_points_guard, dr) = dr.add_stage::<PointsStage<C, NUM_ENDOSCALING_POINTS>>()?;
+        let (points_guard, dr) = dr.add_stage::<PointsStage<C, NUM_ENDOSCALING_POINTS>>()?;
         let (_preamble_guard, dr) = dr.add_stage::<stages::preamble::Stage<C, R>>()?;
         let dr = dr.skip_stage::<stages::s_prime::Stage<C, R>>()?;
         let dr = dr.skip_stage::<stages::inner_error::Stage<C, R>>()?;
         let dr = dr.skip_stage::<stages::outer_error::Stage<C, R>>()?;
         let dr = dr.skip_stage::<stages::ab::Stage<C, R>>()?;
         let dr = dr.skip_stage::<stages::query::Stage<C, R>>()?;
-        let dr = dr.skip_stage::<stages::f::Stage<C, R>>()?;
+        let (f_guard, dr) = dr.add_stage::<stages::f::Stage<C, R>>()?;
         let dr = dr.skip_stage::<stages::eval::Stage<C, R>>()?;
-        let _dr = dr.finish();
+        let dr = dr.finish();
+
+        // Load stage gadgets. Witness values are never accessed — the circuit
+        // only runs during `into_bonding_object` where MaybeKind = Empty.
+        macro_rules! w {
+            () => {
+                _witness.as_ref().map(|_| unreachable!())
+            };
+        }
+        let points = points_guard.unenforced(dr, w!())?;
+        let f_stage = f_guard.unenforced(dr, w!())?;
+
+        // The initial point (f.commitment) must match BridgeF.native_f.
+        points.initial.enforce_equal(dr, &f_stage.native_f)?;
 
         Ok(WithAux::new((), D::unit()))
     }

--- a/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
@@ -1,0 +1,76 @@
+//! Loading circuit for the nested section.
+//!
+//! Final form walks every input of [`PointsStage`] and enforces equality
+//! against the corresponding bridge stage values in the same order that
+//! `compute_p` accumulates them. In this initial commit the circuit's
+//! stage skeleton is in place but no `enforce_equal` calls fire — the
+//! bonding polynomial folds to zero so the `grouped_bonding_claim` is
+//! trivially satisfied.
+
+use core::marker::PhantomData;
+
+use ragu_arithmetic::CurveAffine;
+use ragu_circuits::{
+    WithAux,
+    polynomials::Rank,
+    staging::{MultiStageCircuit, StageBuilder},
+};
+use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue},
+    gadgets::Bound,
+};
+
+use crate::internal::{
+    endoscalar::{EndoscalarStage, PointsStage},
+    nested::{NUM_ENDOSCALING_POINTS, stages},
+};
+
+/// Loading circuit that loads the entire nested stage hierarchy.
+pub struct Circuit<C: CurveAffine, R: Rank> {
+    _marker: PhantomData<(C, R)>,
+}
+
+impl<C: CurveAffine, R: Rank> Circuit<C, R> {
+    pub fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
+    type Last = stages::eval::Stage<C, R>;
+    type Instance<'source> = ();
+    type Witness<'source> = ();
+    type Output = ();
+    type Aux<'source> = ();
+
+    fn instance<'dr, 'source: 'dr, D: Driver<'dr, F = C::Base>>(
+        &self,
+        _dr: &mut D,
+        _instance: DriverValue<D, ()>,
+    ) -> Result<Bound<'dr, D, ()>> {
+        Ok(())
+    }
+
+    fn witness<'a, 'dr, 'source: 'dr, D: Driver<'dr, F = C::Base>>(
+        &self,
+        dr: StageBuilder<'a, 'dr, D, R, (), Self::Last>,
+        _witness: DriverValue<D, ()>,
+    ) -> Result<WithAux<Bound<'dr, D, ()>, DriverValue<D, ()>>> {
+        let dr = dr.skip_stage::<EndoscalarStage>()?;
+        let (_points_guard, dr) = dr.add_stage::<PointsStage<C, NUM_ENDOSCALING_POINTS>>()?;
+        let (_preamble_guard, dr) = dr.add_stage::<stages::preamble::Stage<C, R>>()?;
+        let dr = dr.skip_stage::<stages::s_prime::Stage<C, R>>()?;
+        let dr = dr.skip_stage::<stages::inner_error::Stage<C, R>>()?;
+        let dr = dr.skip_stage::<stages::outer_error::Stage<C, R>>()?;
+        let dr = dr.skip_stage::<stages::ab::Stage<C, R>>()?;
+        let dr = dr.skip_stage::<stages::query::Stage<C, R>>()?;
+        let dr = dr.skip_stage::<stages::f::Stage<C, R>>()?;
+        let dr = dr.skip_stage::<stages::eval::Stage<C, R>>()?;
+        let _dr = dr.finish();
+
+        Ok(WithAux::new((), D::unit()))
+    }
+}

--- a/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
@@ -47,6 +47,15 @@ impl<'pts, 'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> Walker<'pts, 'dr, D
         self.index += 1;
         Ok(())
     }
+
+    /// Assert that every [`PointsStage`] input has been enforced.
+    fn finish(self) {
+        assert_eq!(
+            self.index,
+            self.points.inputs.len(),
+            "walker did not exhaust all PointsStage inputs"
+        );
+    }
 }
 
 /// Loading circuit that loads the entire nested stage hierarchy.
@@ -86,10 +95,10 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
         let (points_guard, dr) = dr.add_stage::<PointsStage<C, NUM_ENDOSCALING_POINTS>>()?;
         let (preamble_guard, dr) = dr.add_stage::<stages::preamble::Stage<C, R>>()?;
         let (s_prime_guard, dr) = dr.add_stage::<stages::s_prime::Stage<C, R>>()?;
-        let dr = dr.skip_stage::<stages::inner_error::Stage<C, R>>()?;
+        let (inner_error_guard, dr) = dr.add_stage::<stages::inner_error::Stage<C, R>>()?;
         let dr = dr.skip_stage::<stages::outer_error::Stage<C, R>>()?;
-        let dr = dr.skip_stage::<stages::ab::Stage<C, R>>()?;
-        let dr = dr.skip_stage::<stages::query::Stage<C, R>>()?;
+        let (ab_guard, dr) = dr.add_stage::<stages::ab::Stage<C, R>>()?;
+        let (query_guard, dr) = dr.add_stage::<stages::query::Stage<C, R>>()?;
         let (f_guard, dr) = dr.add_stage::<stages::f::Stage<C, R>>()?;
         let dr = dr.skip_stage::<stages::eval::Stage<C, R>>()?;
         let dr = dr.finish();
@@ -104,6 +113,9 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
         let points = points_guard.unenforced(dr, w!())?;
         let preamble = preamble_guard.unenforced(dr, w!())?;
         let s_prime = s_prime_guard.unenforced(dr, w!())?;
+        let inner_error = inner_error_guard.unenforced(dr, w!())?;
+        let ab = ab_guard.unenforced(dr, w!())?;
+        let query = query_guard.unenforced(dr, w!())?;
         let f_stage = f_guard.unenforced(dr, w!())?;
 
         // Walk through PointsStage inputs, mirroring the accumulation
@@ -119,6 +131,15 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
             walker.enforce_equal(dr, &child.stashed_registry_xy)?;
             walker.enforce_equal(dr, &child.stashed_p)?;
         }
+
+        walker.enforce_equal(dr, &s_prime.registry_wx0)?;
+        walker.enforce_equal(dr, &s_prime.registry_wx1)?;
+        walker.enforce_equal(dr, &inner_error.registry_wy)?;
+        walker.enforce_equal(dr, &ab.a)?;
+        walker.enforce_equal(dr, &ab.b)?;
+        walker.enforce_equal(dr, &query.registry_xy)?;
+
+        walker.finish();
 
         // Relay: the current step's native_preamble is stashed in
         // BridgeSPrime so that a future copying circuit can verify it

--- a/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
@@ -33,6 +33,7 @@ use ragu_primitives::Point;
 
 use crate::internal::{
     endoscalar::{EndoscalarStage, Points, PointsStage},
+    native::RxIndex,
     nested::{NUM_ENDOSCALING_POINTS, stages},
 };
 
@@ -130,21 +131,21 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
         let mut walker = Walker::new(&points);
 
         for child in [&preamble.left, &preamble.right] {
-            for point in child.points_for_p() {
-                walker.enforce_equal(dr, point)?;
+            for &id in &RxIndex::ALL {
+                walker.enforce_equal(dr, &child[id])?;
             }
+            walker.enforce_equal(dr, &child.stashed_ab_a)?;
+            walker.enforce_equal(dr, &child.stashed_ab_b)?;
+            walker.enforce_equal(dr, &child.stashed_registry_xy)?;
+            walker.enforce_equal(dr, &child.stashed_p)?;
         }
 
-        for point in [
-            &s_prime.registry_wx0,
-            &s_prime.registry_wx1,
-            &inner_error.registry_wy,
-            &ab.a,
-            &ab.b,
-            &query.registry_xy,
-        ] {
-            walker.enforce_equal(dr, point)?;
-        }
+        walker.enforce_equal(dr, &s_prime.registry_wx0)?;
+        walker.enforce_equal(dr, &s_prime.registry_wx1)?;
+        walker.enforce_equal(dr, &inner_error.registry_wy)?;
+        walker.enforce_equal(dr, &ab.a)?;
+        walker.enforce_equal(dr, &ab.b)?;
+        walker.enforce_equal(dr, &query.registry_xy)?;
 
         walker.finish();
 

--- a/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
@@ -33,7 +33,6 @@ use ragu_primitives::Point;
 
 use crate::internal::{
     endoscalar::{EndoscalarStage, Points, PointsStage},
-    native::RxIndex,
     nested::{NUM_ENDOSCALING_POINTS, stages},
 };
 
@@ -131,21 +130,21 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
         let mut walker = Walker::new(&points);
 
         for child in [&preamble.left, &preamble.right] {
-            for &id in &RxIndex::ALL {
-                walker.enforce_equal(dr, &child[id])?;
+            for point in child.points_for_p() {
+                walker.enforce_equal(dr, point)?;
             }
-            walker.enforce_equal(dr, &child.stashed_ab_a)?;
-            walker.enforce_equal(dr, &child.stashed_ab_b)?;
-            walker.enforce_equal(dr, &child.stashed_registry_xy)?;
-            walker.enforce_equal(dr, &child.stashed_p)?;
         }
 
-        walker.enforce_equal(dr, &s_prime.registry_wx0)?;
-        walker.enforce_equal(dr, &s_prime.registry_wx1)?;
-        walker.enforce_equal(dr, &inner_error.registry_wy)?;
-        walker.enforce_equal(dr, &ab.a)?;
-        walker.enforce_equal(dr, &ab.b)?;
-        walker.enforce_equal(dr, &query.registry_xy)?;
+        for point in [
+            &s_prime.registry_wx0,
+            &s_prime.registry_wx1,
+            &inner_error.registry_wy,
+            &ab.a,
+            &ab.b,
+            &query.registry_xy,
+        ] {
+            walker.enforce_equal(dr, point)?;
+        }
 
         walker.finish();
 

--- a/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
@@ -62,8 +62,8 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
     ) -> Result<WithAux<Bound<'dr, D, ()>, DriverValue<D, ()>>> {
         let dr = dr.skip_stage::<EndoscalarStage>()?;
         let (points_guard, dr) = dr.add_stage::<PointsStage<C, NUM_ENDOSCALING_POINTS>>()?;
-        let (_preamble_guard, dr) = dr.add_stage::<stages::preamble::Stage<C, R>>()?;
-        let dr = dr.skip_stage::<stages::s_prime::Stage<C, R>>()?;
+        let (preamble_guard, dr) = dr.add_stage::<stages::preamble::Stage<C, R>>()?;
+        let (s_prime_guard, dr) = dr.add_stage::<stages::s_prime::Stage<C, R>>()?;
         let dr = dr.skip_stage::<stages::inner_error::Stage<C, R>>()?;
         let dr = dr.skip_stage::<stages::outer_error::Stage<C, R>>()?;
         let dr = dr.skip_stage::<stages::ab::Stage<C, R>>()?;
@@ -80,7 +80,16 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
             };
         }
         let points = points_guard.unenforced(dr, w!())?;
+        let preamble = preamble_guard.unenforced(dr, w!())?;
+        let s_prime = s_prime_guard.unenforced(dr, w!())?;
         let f_stage = f_guard.unenforced(dr, w!())?;
+
+        // Relay: the current step's native_preamble is stashed in
+        // BridgeSPrime so that a future copying circuit can verify it
+        // from the child's BridgeSPrime without BridgePreamble collision.
+        s_prime
+            .stashed_preamble
+            .enforce_equal(dr, &preamble.native_preamble)?;
 
         // The initial point (f.commitment) must match BridgeF.native_f.
         points.initial.enforce_equal(dr, &f_stage.native_f)?;

--- a/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
@@ -21,11 +21,33 @@ use ragu_core::{
     gadgets::{Bound, Gadget},
     maybe::Maybe,
 };
+use ragu_primitives::Point;
 
 use crate::internal::{
-    endoscalar::{EndoscalarStage, PointsStage},
+    endoscalar::{EndoscalarStage, Points, PointsStage},
+    native::RxIndex,
     nested::{NUM_ENDOSCALING_POINTS, stages},
 };
+
+/// A cursor over [`PointsStage`] inputs that enforces equality against
+/// corresponding bridge stage elements.
+struct Walker<'pts, 'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
+    points: &'pts Points<'dr, D, C, NUM_ENDOSCALING_POINTS>,
+    index: usize,
+}
+
+impl<'pts, 'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> Walker<'pts, 'dr, D, C> {
+    fn new(points: &'pts Points<'dr, D, C, NUM_ENDOSCALING_POINTS>) -> Self {
+        Self { points, index: 0 }
+    }
+
+    /// Enforce that the current [`PointsStage`] input equals `point`.
+    fn enforce_equal(&mut self, dr: &mut D, point: &Point<'dr, D, C>) -> Result<()> {
+        self.points.inputs[self.index].enforce_equal(dr, point)?;
+        self.index += 1;
+        Ok(())
+    }
+}
 
 /// Loading circuit that loads the entire nested stage hierarchy.
 pub struct Circuit<C: CurveAffine, R: Rank> {
@@ -83,6 +105,20 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
         let preamble = preamble_guard.unenforced(dr, w!())?;
         let s_prime = s_prime_guard.unenforced(dr, w!())?;
         let f_stage = f_guard.unenforced(dr, w!())?;
+
+        // Walk through PointsStage inputs, mirroring the accumulation
+        // order in `compute_p` (_10_p.rs).
+        let mut walker = Walker::new(&points);
+
+        for child in [&preamble.left, &preamble.right] {
+            for &id in &RxIndex::ALL {
+                walker.enforce_equal(dr, &child[id])?;
+            }
+            walker.enforce_equal(dr, &child.stashed_ab_a)?;
+            walker.enforce_equal(dr, &child.stashed_ab_b)?;
+            walker.enforce_equal(dr, &child.stashed_registry_xy)?;
+            walker.enforce_equal(dr, &child.stashed_p)?;
+        }
 
         // Relay: the current step's native_preamble is stashed in
         // BridgeSPrime so that a future copying circuit can verify it

--- a/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
@@ -1,11 +1,19 @@
 //! Loading circuit for the nested section.
 //!
-//! Final form walks every input of [`PointsStage`] and enforces equality
-//! against the corresponding bridge stage values in the same order that
-//! `compute_p` accumulates them. In this initial commit the circuit's
-//! stage skeleton is in place but no `enforce_equal` calls fire — the
-//! bonding polynomial folds to zero so the `grouped_bonding_claim` is
-//! trivially satisfied.
+//! Loads [`PointsStage`] and bridge stages (`preamble`, `s_prime`,
+//! `inner_error`, `ab`, `query`, `f`) and enforces equality for all
+//! [`PointsStage`] positions: every input (matched against
+//! [`ChildWitness`](crate::internal::nested::stages::preamble::ChildWitness)
+//! stash fields and current-step bridge stage fields) plus `initial`
+//! (matched against `BridgeF.native_f`). The accumulation walk mirrors
+//! `compute_p` in `_10_p` so that correctness can be verified by visual
+//! comparison.
+//!
+//! Also enforces: `BridgeSPrime.stashed_preamble` ==
+//! `BridgePreamble.native_preamble`, stashing the current step's native
+//! preamble so that a parent's [`copying`](super::copying) circuit can
+//! read it from `BridgeSPrime` instead of `BridgePreamble` (avoiding a
+//! wire-position collision).
 
 use core::marker::PhantomData;
 
@@ -118,8 +126,8 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
         let query = query_guard.unenforced(dr, w!())?;
         let f_stage = f_guard.unenforced(dr, w!())?;
 
-        // Walk through PointsStage inputs, mirroring the accumulation
-        // order in `compute_p` (_10_p.rs).
+        // Walk through PointsStage inputs, mirroring the accumulation order
+        // in `compute_p` (_10_p.rs).
         let mut walker = Walker::new(&points);
 
         for child in [&preamble.left, &preamble.right] {

--- a/crates/ragu_pcd/src/internal/nested/claims.rs
+++ b/crates/ragu_pcd/src/internal/nested/claims.rs
@@ -139,6 +139,20 @@ where
             BridgeEval => {
                 processor.bonding_claim(id, source.rx(RxIndex::BridgeEval))?;
             }
+            Loading => {
+                let groups = source
+                    .rx(RxIndex::PointsStage)
+                    .zip(source.rx(RxIndex::BridgePreamble))
+                    .zip(source.rx(RxIndex::BridgeSPrime))
+                    .zip(source.rx(RxIndex::BridgeInnerError))
+                    .zip(source.rx(RxIndex::BridgeAB))
+                    .zip(source.rx(RxIndex::BridgeQuery))
+                    .zip(source.rx(RxIndex::BridgeF))
+                    .map(|((((((ps, bp), bs), bi), ba), bq), bf)| {
+                        [ps, bp, bs, bi, ba, bq, bf].into_iter()
+                    });
+                processor.grouped_bonding_claim(id, groups)?;
+            }
         }
     }
 

--- a/crates/ragu_pcd/src/internal/nested/claims.rs
+++ b/crates/ragu_pcd/src/internal/nested/claims.rs
@@ -153,6 +153,21 @@ where
                     });
                 processor.grouped_bonding_claim(id, groups)?;
             }
+            Copying(side) => {
+                let groups = source
+                    .rx(RxIndex::ChildPointsStage(side))
+                    .zip(source.rx(RxIndex::BridgePreamble))
+                    .zip(source.rx(RxIndex::ChildBridgeSPrime(side)))
+                    .zip(source.rx(RxIndex::ChildBridgeInnerError(side)))
+                    .zip(source.rx(RxIndex::ChildBridgeOuterError(side)))
+                    .zip(source.rx(RxIndex::ChildBridgeAB(side)))
+                    .zip(source.rx(RxIndex::ChildBridgeQuery(side)))
+                    .zip(source.rx(RxIndex::ChildBridgeEval(side)))
+                    .map(|(((((((cp, bp), cs), ci), co), ca), cq), ce)| {
+                        [cp, bp, cs, ci, co, ca, cq, ce].into_iter()
+                    });
+                processor.grouped_bonding_claim(id, groups)?;
+            }
         }
     }
 

--- a/crates/ragu_pcd/src/internal/nested/claims.rs
+++ b/crates/ragu_pcd/src/internal/nested/claims.rs
@@ -15,7 +15,7 @@ use ff::PrimeField;
 use ragu_circuits::polynomials::{Rank, sparse};
 use ragu_core::Result;
 
-use super::{InternalCircuitIndex, RxIndex};
+use super::{ChildBridgeKind, InternalCircuitIndex, RxIndex};
 use crate::internal::claims::{Builder, Source, sum_polynomials};
 
 /// Trait for processing nested claim values into accumulated outputs.
@@ -157,12 +157,12 @@ where
                 let groups = source
                     .rx(RxIndex::ChildPointsStage(side))
                     .zip(source.rx(RxIndex::BridgePreamble))
-                    .zip(source.rx(RxIndex::ChildBridgeSPrime(side)))
-                    .zip(source.rx(RxIndex::ChildBridgeInnerError(side)))
-                    .zip(source.rx(RxIndex::ChildBridgeOuterError(side)))
-                    .zip(source.rx(RxIndex::ChildBridgeAB(side)))
-                    .zip(source.rx(RxIndex::ChildBridgeQuery(side)))
-                    .zip(source.rx(RxIndex::ChildBridgeEval(side)))
+                    .zip(source.rx(RxIndex::ChildBridge(ChildBridgeKind::SPrime, side)))
+                    .zip(source.rx(RxIndex::ChildBridge(ChildBridgeKind::InnerError, side)))
+                    .zip(source.rx(RxIndex::ChildBridge(ChildBridgeKind::OuterError, side)))
+                    .zip(source.rx(RxIndex::ChildBridge(ChildBridgeKind::AB, side)))
+                    .zip(source.rx(RxIndex::ChildBridge(ChildBridgeKind::Query, side)))
+                    .zip(source.rx(RxIndex::ChildBridge(ChildBridgeKind::Eval, side)))
                     .map(|(((((((cp, bp), cs), ci), co), ca), cq), ce)| {
                         [cp, bp, cs, ci, co, ca, cq, ce].into_iter()
                     });

--- a/crates/ragu_pcd/src/internal/nested/mod.rs
+++ b/crates/ragu_pcd/src/internal/nested/mod.rs
@@ -1,7 +1,13 @@
-//! Nested field circuits for endoscaling verification.
+//! Nested field circuits for the scalar field.
 //!
-//! These circuits operate over the scalar field and verify that the
-//! commitment accumulation was computed correctly via Horner's rule.
+//! Contains two groups of circuits:
+//!
+//! - **Endoscaling**: verifies that the commitment accumulation
+//!   in `compute_p` was computed correctly via Horner's rule.
+//! - **Loading**: enforces consistency between [`PointsStage`]
+//!   inputs and the bridge stage commitments for the current step.
+//!
+//! [`PointsStage`]: crate::internal::endoscalar::PointsStage
 
 use ragu_arithmetic::Cycle;
 use ragu_circuits::{
@@ -10,6 +16,10 @@ use ragu_circuits::{
     staging::{MultiStage, StageExt},
 };
 use ragu_core::Result;
+
+pub mod circuits {
+    pub mod loading;
+}
 
 use crate::internal::{Side, endoscalar};
 
@@ -58,12 +68,14 @@ pub enum InternalCircuitIndex {
     BridgeF,
     /// Bridge `eval` stage mask.
     BridgeEval,
+    /// Loading circuit over all nested stages.
+    Loading,
 }
 
 impl InternalCircuitIndex {
     /// The number of internal circuits registered by [`register_all`],
     /// equal to the number of entries in [`InternalCircuitIndex::ALL`].
-    pub const NUM: usize = NUM_ENDOSCALING_STEPS + 11;
+    pub const NUM: usize = NUM_ENDOSCALING_STEPS + 12;
 
     /// All variants in canonical iteration order.
     ///
@@ -96,6 +108,7 @@ impl InternalCircuitIndex {
         push(&mut slots, &mut c, Self::BridgeQuery);
         push(&mut slots, &mut c, Self::BridgeF);
         push(&mut slots, &mut c, Self::BridgeEval);
+        push(&mut slots, &mut c, Self::Loading);
         assert!(c == Self::NUM);
         slots
     }
@@ -273,6 +286,10 @@ pub fn register_all<'params, C: Cycle, R: Rank>(
             BridgeF => registry.register_bonding(stages::f::Stage::<C::HostCurve, R>::mask()?),
             BridgeEval => {
                 registry.register_bonding(stages::eval::Stage::<C::HostCurve, R>::mask()?)
+            }
+            Loading => {
+                let circuit = circuits::loading::Circuit::<C::HostCurve, R>::new();
+                registry.register_bonding(MultiStage::new(circuit).into_bonding_object()?)
             }
         };
     }

--- a/crates/ragu_pcd/src/internal/nested/mod.rs
+++ b/crates/ragu_pcd/src/internal/nested/mod.rs
@@ -1,12 +1,16 @@
 //! Nested field circuits for the scalar field.
 //!
-//! Contains two groups of circuits:
+//! Contains three groups of circuits:
 //!
 //! - **Endoscaling**: verifies that the commitment accumulation
 //!   in `compute_p` was computed correctly via Horner's rule.
 //! - **Loading**: enforces consistency between [`PointsStage`]
 //!   inputs and the bridge stage commitments for the current step.
+//! - **Copying**: enforces that [`ChildWitness`] stash fields in
+//!   `BridgePreamble` match the corresponding child proof's bridge
+//!   stage contents.
 //!
+//! [`ChildWitness`]: stages::preamble::ChildWitness
 //! [`PointsStage`]: crate::internal::endoscalar::PointsStage
 
 use ragu_arithmetic::Cycle;
@@ -18,6 +22,7 @@ use ragu_circuits::{
 use ragu_core::Result;
 
 pub mod circuits {
+    pub mod copying;
     pub mod loading;
 }
 
@@ -70,12 +75,14 @@ pub enum InternalCircuitIndex {
     BridgeEval,
     /// Loading circuit over all nested stages.
     Loading,
+    /// Copying circuit relating current preamble to a child proof's stages.
+    Copying(Side),
 }
 
 impl InternalCircuitIndex {
     /// The number of internal circuits registered by [`register_all`],
     /// equal to the number of entries in [`InternalCircuitIndex::ALL`].
-    pub const NUM: usize = NUM_ENDOSCALING_STEPS + 12;
+    pub const NUM: usize = NUM_ENDOSCALING_STEPS + 14;
 
     /// All variants in canonical iteration order.
     ///
@@ -109,6 +116,8 @@ impl InternalCircuitIndex {
         push(&mut slots, &mut c, Self::BridgeF);
         push(&mut slots, &mut c, Self::BridgeEval);
         push(&mut slots, &mut c, Self::Loading);
+        push(&mut slots, &mut c, Self::Copying(Side::Left));
+        push(&mut slots, &mut c, Self::Copying(Side::Right));
         assert!(c == Self::NUM);
         slots
     }
@@ -289,6 +298,10 @@ pub fn register_all<'params, C: Cycle, R: Rank>(
             }
             Loading => {
                 let circuit = circuits::loading::Circuit::<C::HostCurve, R>::new();
+                registry.register_bonding(MultiStage::new(circuit).into_bonding_object()?)
+            }
+            Copying(side) => {
+                let circuit = circuits::copying::Circuit::<C::HostCurve, R>::new(side);
                 registry.register_bonding(MultiStage::new(circuit).into_bonding_object()?)
             }
         };

--- a/crates/ragu_pcd/src/internal/nested/mod.rs
+++ b/crates/ragu_pcd/src/internal/nested/mod.rs
@@ -11,7 +11,7 @@ use ragu_circuits::{
 };
 use ragu_core::Result;
 
-use crate::internal::endoscalar;
+use crate::internal::{Side, endoscalar};
 
 /// Number of curve points accumulated during `compute_p` for nested field
 /// endoscaling verification.
@@ -142,12 +142,26 @@ pub enum RxIndex {
     BridgeF,
     /// Bridge `eval` rx polynomial.
     BridgeEval,
+    /// Child proof's `PointsStage` rx polynomial (per-side, for copying).
+    ChildPointsStage(Side),
+    /// Child proof's `BridgeSPrime` rx polynomial (per-side, for copying).
+    ChildBridgeSPrime(Side),
+    /// Child proof's `BridgeInnerError` rx polynomial (per-side, for copying).
+    ChildBridgeInnerError(Side),
+    /// Child proof's `BridgeOuterError` rx polynomial (per-side, for copying).
+    ChildBridgeOuterError(Side),
+    /// Child proof's `BridgeAB` rx polynomial (per-side, for copying).
+    ChildBridgeAB(Side),
+    /// Child proof's `BridgeQuery` rx polynomial (per-side, for copying).
+    ChildBridgeQuery(Side),
+    /// Child proof's `BridgeEval` rx polynomial (per-side, for copying).
+    ChildBridgeEval(Side),
 }
 
 impl RxIndex {
     /// The number of rx components in the nested field,
     /// equal to the number of entries in [`RxIndex::ALL`].
-    pub const NUM: usize = NUM_ENDOSCALING_STEPS + 10;
+    pub const NUM: usize = NUM_ENDOSCALING_STEPS + 24;
 
     /// All variants in canonical order (circuits, then stages).
     ///
@@ -177,6 +191,20 @@ impl RxIndex {
         push(&mut slots, &mut c, Self::BridgeQuery);
         push(&mut slots, &mut c, Self::BridgeF);
         push(&mut slots, &mut c, Self::BridgeEval);
+        push(&mut slots, &mut c, Self::ChildPointsStage(Side::Left));
+        push(&mut slots, &mut c, Self::ChildPointsStage(Side::Right));
+        push(&mut slots, &mut c, Self::ChildBridgeSPrime(Side::Left));
+        push(&mut slots, &mut c, Self::ChildBridgeSPrime(Side::Right));
+        push(&mut slots, &mut c, Self::ChildBridgeInnerError(Side::Left));
+        push(&mut slots, &mut c, Self::ChildBridgeInnerError(Side::Right));
+        push(&mut slots, &mut c, Self::ChildBridgeOuterError(Side::Left));
+        push(&mut slots, &mut c, Self::ChildBridgeOuterError(Side::Right));
+        push(&mut slots, &mut c, Self::ChildBridgeAB(Side::Left));
+        push(&mut slots, &mut c, Self::ChildBridgeAB(Side::Right));
+        push(&mut slots, &mut c, Self::ChildBridgeQuery(Side::Left));
+        push(&mut slots, &mut c, Self::ChildBridgeQuery(Side::Right));
+        push(&mut slots, &mut c, Self::ChildBridgeEval(Side::Left));
+        push(&mut slots, &mut c, Self::ChildBridgeEval(Side::Right));
         assert!(c == Self::NUM);
         slots
     }

--- a/crates/ragu_pcd/src/internal/nested/mod.rs
+++ b/crates/ragu_pcd/src/internal/nested/mod.rs
@@ -31,10 +31,9 @@ use crate::internal::{Side, endoscalar};
 /// Number of curve points accumulated during `compute_p` for nested field
 /// endoscaling verification.
 ///
-/// This is the sum of:
-/// - 2 proofs × 15 commitment components = 30
-/// - 6 stage proof components (registry_wx0, registry_wx1, registry_wy, ab.a, ab.b, registry_xy)
-/// - 1 f.commitment (base polynomial)
+/// This is the sum of per-child commitment components (for both proofs),
+/// current-step stage proof components, and the `f.commitment` base
+/// polynomial. See `_10_p` for the canonical accumulation order.
 ///
 /// The endoscaling circuits process these points across
 /// [`NUM_ENDOSCALING_STEPS`] steps.

--- a/crates/ragu_pcd/src/internal/nested/mod.rs
+++ b/crates/ragu_pcd/src/internal/nested/mod.rs
@@ -139,6 +139,40 @@ impl InternalCircuitIndex {
 /// Analogous to [`native::RxIndex`](super::native::RxIndex) for the scalar
 /// field. Each variant maps to a polynomial in
 /// the proof's nested-field polynomial storage.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChildBridgeKind {
+    /// Child proof's `BridgeSPrime` rx polynomial.
+    SPrime,
+    /// Child proof's `BridgeInnerError` rx polynomial.
+    InnerError,
+    /// Child proof's `BridgeOuterError` rx polynomial.
+    OuterError,
+    /// Child proof's `BridgeAB` rx polynomial.
+    AB,
+    /// Child proof's `BridgeQuery` rx polynomial.
+    Query,
+    /// Child proof's `BridgeEval` rx polynomial.
+    Eval,
+}
+
+impl ChildBridgeKind {
+    /// All kinds in the canonical slot order.
+    ///
+    /// This constant is the source of truth for the relative order of
+    /// `RxIndex::ChildBridge(kind, side)` entries in [`RxIndex::ALL`]
+    /// (see [`RxIndex::all_slots`]), and is therefore pinned by
+    /// `test_nested_registry_digest` — re-ordering these variants
+    /// changes the nested registry digest.
+    pub const ALL: [Self; 6] = [
+        Self::SPrime,
+        Self::InnerError,
+        Self::OuterError,
+        Self::AB,
+        Self::Query,
+        Self::Eval,
+    ];
+}
+
 #[derive(Clone, Copy, Debug)]
 pub enum RxIndex {
     /// EndoscalingStep circuit rx polynomial (indexed by step number).
@@ -165,18 +199,9 @@ pub enum RxIndex {
     BridgeEval,
     /// Child proof's `PointsStage` rx polynomial (per-side, for copying).
     ChildPointsStage(Side),
-    /// Child proof's `BridgeSPrime` rx polynomial (per-side, for copying).
-    ChildBridgeSPrime(Side),
-    /// Child proof's `BridgeInnerError` rx polynomial (per-side, for copying).
-    ChildBridgeInnerError(Side),
-    /// Child proof's `BridgeOuterError` rx polynomial (per-side, for copying).
-    ChildBridgeOuterError(Side),
-    /// Child proof's `BridgeAB` rx polynomial (per-side, for copying).
-    ChildBridgeAB(Side),
-    /// Child proof's `BridgeQuery` rx polynomial (per-side, for copying).
-    ChildBridgeQuery(Side),
-    /// Child proof's `BridgeEval` rx polynomial (per-side, for copying).
-    ChildBridgeEval(Side),
+    /// Child proof's bridge rx polynomial (per-side, for copying),
+    /// keyed by which bridge stage it comes from.
+    ChildBridge(ChildBridgeKind, Side),
 }
 
 impl RxIndex {
@@ -214,18 +239,15 @@ impl RxIndex {
         push(&mut slots, &mut c, Self::BridgeEval);
         push(&mut slots, &mut c, Self::ChildPointsStage(Side::Left));
         push(&mut slots, &mut c, Self::ChildPointsStage(Side::Right));
-        push(&mut slots, &mut c, Self::ChildBridgeSPrime(Side::Left));
-        push(&mut slots, &mut c, Self::ChildBridgeSPrime(Side::Right));
-        push(&mut slots, &mut c, Self::ChildBridgeInnerError(Side::Left));
-        push(&mut slots, &mut c, Self::ChildBridgeInnerError(Side::Right));
-        push(&mut slots, &mut c, Self::ChildBridgeOuterError(Side::Left));
-        push(&mut slots, &mut c, Self::ChildBridgeOuterError(Side::Right));
-        push(&mut slots, &mut c, Self::ChildBridgeAB(Side::Left));
-        push(&mut slots, &mut c, Self::ChildBridgeAB(Side::Right));
-        push(&mut slots, &mut c, Self::ChildBridgeQuery(Side::Left));
-        push(&mut slots, &mut c, Self::ChildBridgeQuery(Side::Right));
-        push(&mut slots, &mut c, Self::ChildBridgeEval(Side::Left));
-        push(&mut slots, &mut c, Self::ChildBridgeEval(Side::Right));
+        {
+            let mut i = 0;
+            while i < ChildBridgeKind::ALL.len() {
+                let kind = ChildBridgeKind::ALL[i];
+                push(&mut slots, &mut c, Self::ChildBridge(kind, Side::Left));
+                push(&mut slots, &mut c, Self::ChildBridge(kind, Side::Right));
+                i += 1;
+            }
+        }
         assert!(c == Self::NUM);
         slots
     }

--- a/crates/ragu_pcd/src/internal/nested/stages/preamble.rs
+++ b/crates/ragu_pcd/src/internal/nested/stages/preamble.rs
@@ -16,16 +16,23 @@ use ragu_primitives::{Point, io::Write};
 
 use crate::{
     Proof,
-    internal::{endoscalar::PointsStage, nested::NUM_ENDOSCALING_POINTS},
+    internal::{endoscalar::PointsStage, native::RxIndex, nested::NUM_ENDOSCALING_POINTS},
 };
 
 /// Number of curve points in this stage.
-pub const NUM_POINTS: usize = 13;
+pub const NUM_POINTS: usize = 31;
 
 /// Witness data for a single child proof in the preamble bridge stage.
 ///
-/// Contains commitments from the child proof's circuits component.
+/// The initial fields (application through compute_v) are the primary
+/// introduction of child circuit commitments into the nested transcript.
+/// The remaining `stashed_*` fields are copies of values that already
+/// exist in the child's unified instance or bridge stages, placed here
+/// so that loading can enforce them against [`PointsStage`] and copying
+/// can verify them against the child's bridge stage content.
+#[derive(Clone)]
 pub struct ChildWitness<C: CurveAffine> {
+    // Field order matches the `_10_p` accumulation order.
     /// Commitment from the child's application circuit.
     pub application: C,
     /// Commitment from the child's first hashes circuit.
@@ -38,12 +45,31 @@ pub struct ChildWitness<C: CurveAffine> {
     pub outer_collapse: C,
     /// Commitment from the child's compute_v circuit.
     pub compute_v: C,
+
+    /// Stashed commitment from the child's preamble bridge stage.
+    pub stashed_preamble: C,
+    /// Stashed commitment from the child's inner error bridge stage.
+    pub stashed_inner_error: C,
+    /// Stashed commitment from the child's outer error bridge stage.
+    pub stashed_outer_error: C,
+    /// Stashed commitment from the child's query bridge stage.
+    pub stashed_query: C,
+    /// Stashed commitment from the child's eval bridge stage.
+    pub stashed_eval: C,
+    /// Stashed `a` commitment from the child's AB bridge stage.
+    pub stashed_ab_a: C,
+    /// Stashed `b` commitment from the child's AB bridge stage.
+    pub stashed_ab_b: C,
+    /// Stashed registry XY commitment from the child.
+    pub stashed_registry_xy: C,
+    /// Stashed accumulated P commitment from the child.
+    pub stashed_p: C,
 }
 
 impl<C: CurveAffine> ChildWitness<C> {
     /// Construct from a child proof's commitments.
     pub fn from_proof<CC: Cycle<HostCurve = C>, R: Rank>(proof: &Proof<CC, R>) -> Self {
-        use crate::internal::native::RxIndex;
+        use crate::internal::native::RxComponent;
         Self {
             application: proof.native_rx_commitment(RxIndex::Application),
             hashes_1: proof.native_rx_commitment(RxIndex::Hashes1),
@@ -51,6 +77,15 @@ impl<C: CurveAffine> ChildWitness<C> {
             inner_collapse: proof.native_rx_commitment(RxIndex::InnerCollapse),
             outer_collapse: proof.native_rx_commitment(RxIndex::OuterCollapse),
             compute_v: proof.native_rx_commitment(RxIndex::ComputeV),
+            stashed_preamble: proof.native_rx_commitment(RxIndex::Preamble),
+            stashed_inner_error: proof.native_rx_commitment(RxIndex::InnerError),
+            stashed_outer_error: proof.native_rx_commitment(RxIndex::OuterError),
+            stashed_query: proof.native_rx_commitment(RxIndex::Query),
+            stashed_eval: proof.native_rx_commitment(RxIndex::Eval),
+            stashed_ab_a: proof.native_commitment(RxComponent::AbA),
+            stashed_ab_b: proof.native_commitment(RxComponent::AbB),
+            stashed_registry_xy: proof.native_registry_xy_commitment(),
+            stashed_p: proof.native_p_commitment(),
         }
     }
 }
@@ -68,6 +103,7 @@ pub struct Witness<C: CurveAffine> {
 /// Output gadget for a single child proof in the preamble bridge stage.
 #[derive(Gadget, Write)]
 pub struct ChildOutput<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
+    // Field order matches `_10_p` accumulation order.
     /// Point commitment from the child's application circuit.
     #[ragu(gadget)]
     pub application: Point<'dr, D, C>,
@@ -86,6 +122,57 @@ pub struct ChildOutput<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
     /// Point commitment from the child's compute_v circuit.
     #[ragu(gadget)]
     pub compute_v: Point<'dr, D, C>,
+
+    /// Stashed commitment from the child's preamble bridge stage.
+    #[ragu(gadget)]
+    pub stashed_preamble: Point<'dr, D, C>,
+    /// Stashed commitment from the child's inner error bridge stage.
+    #[ragu(gadget)]
+    pub stashed_inner_error: Point<'dr, D, C>,
+    /// Stashed commitment from the child's outer error bridge stage.
+    #[ragu(gadget)]
+    pub stashed_outer_error: Point<'dr, D, C>,
+    /// Stashed commitment from the child's query bridge stage.
+    #[ragu(gadget)]
+    pub stashed_query: Point<'dr, D, C>,
+    /// Stashed commitment from the child's eval bridge stage.
+    #[ragu(gadget)]
+    pub stashed_eval: Point<'dr, D, C>,
+    /// Stashed `a` commitment from the child's AB bridge stage.
+    #[ragu(gadget)]
+    pub stashed_ab_a: Point<'dr, D, C>,
+    /// Stashed `b` commitment from the child's AB bridge stage.
+    #[ragu(gadget)]
+    pub stashed_ab_b: Point<'dr, D, C>,
+    /// Stashed registry XY commitment from the child.
+    #[ragu(gadget)]
+    pub stashed_registry_xy: Point<'dr, D, C>,
+    /// Stashed accumulated P commitment from the child.
+    #[ragu(gadget)]
+    pub stashed_p: Point<'dr, D, C>,
+}
+
+impl<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> core::ops::Index<RxIndex>
+    for ChildOutput<'dr, D, C>
+{
+    type Output = Point<'dr, D, C>;
+
+    fn index(&self, idx: RxIndex) -> &Point<'dr, D, C> {
+        use RxIndex::*;
+        match idx {
+            Application => &self.application,
+            Hashes1 => &self.hashes_1,
+            Hashes2 => &self.hashes_2,
+            InnerCollapse => &self.inner_collapse,
+            OuterCollapse => &self.outer_collapse,
+            ComputeV => &self.compute_v,
+            Preamble => &self.stashed_preamble,
+            InnerError => &self.stashed_inner_error,
+            OuterError => &self.stashed_outer_error,
+            Query => &self.stashed_query,
+            Eval => &self.stashed_eval,
+        }
+    }
 }
 
 impl<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> ChildOutput<'dr, D, C> {
@@ -97,6 +184,15 @@ impl<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> ChildOutput<'dr, D, C> {
             inner_collapse: Point::alloc(dr, witness.as_ref().map(|w| w.inner_collapse))?,
             outer_collapse: Point::alloc(dr, witness.as_ref().map(|w| w.outer_collapse))?,
             compute_v: Point::alloc(dr, witness.as_ref().map(|w| w.compute_v))?,
+            stashed_preamble: Point::alloc(dr, witness.as_ref().map(|w| w.stashed_preamble))?,
+            stashed_inner_error: Point::alloc(dr, witness.as_ref().map(|w| w.stashed_inner_error))?,
+            stashed_outer_error: Point::alloc(dr, witness.as_ref().map(|w| w.stashed_outer_error))?,
+            stashed_query: Point::alloc(dr, witness.as_ref().map(|w| w.stashed_query))?,
+            stashed_eval: Point::alloc(dr, witness.as_ref().map(|w| w.stashed_eval))?,
+            stashed_ab_a: Point::alloc(dr, witness.as_ref().map(|w| w.stashed_ab_a))?,
+            stashed_ab_b: Point::alloc(dr, witness.as_ref().map(|w| w.stashed_ab_b))?,
+            stashed_registry_xy: Point::alloc(dr, witness.as_ref().map(|w| w.stashed_registry_xy))?,
+            stashed_p: Point::alloc(dr, witness.as_ref().map(|w| w.stashed_p))?,
         })
     }
 }

--- a/crates/ragu_pcd/src/internal/nested/stages/preamble.rs
+++ b/crates/ragu_pcd/src/internal/nested/stages/preamble.rs
@@ -14,7 +14,10 @@ use ragu_core::{
 };
 use ragu_primitives::{Point, io::Write};
 
-use crate::Proof;
+use crate::{
+    Proof,
+    internal::{endoscalar::PointsStage, nested::NUM_ENDOSCALING_POINTS},
+};
 
 /// Number of curve points in this stage.
 pub const NUM_POINTS: usize = 13;
@@ -120,7 +123,7 @@ pub struct Stage<C: CurveAffine, R> {
 }
 
 impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stage<C, R> {
-    type Parent = ();
+    type Parent = PointsStage<C, NUM_ENDOSCALING_POINTS>;
     type Witness<'source> = &'source Witness<C>;
     type OutputKind = Kind![C::Base; Output<'_, _, C>];
 

--- a/crates/ragu_pcd/src/internal/nested/stages/preamble.rs
+++ b/crates/ragu_pcd/src/internal/nested/stages/preamble.rs
@@ -176,20 +176,6 @@ impl<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> core::ops::Index<RxIndex>
 }
 
 impl<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> ChildOutput<'dr, D, C> {
-    /// Yields all per-child commitment points in the order in which
-    /// `compute_p` (`_10_p.rs`) accumulates them into `native_p`: the
-    /// rx commitments indexed by [`RxIndex::ALL`], followed by
-    /// `stashed_ab_a`, `stashed_ab_b`, `stashed_registry_xy`, and
-    /// `stashed_p`.
-    pub fn points_for_p(&self) -> impl Iterator<Item = &Point<'dr, D, C>> {
-        RxIndex::ALL.iter().map(move |&id| &self[id]).chain([
-            &self.stashed_ab_a,
-            &self.stashed_ab_b,
-            &self.stashed_registry_xy,
-            &self.stashed_p,
-        ])
-    }
-
     fn alloc(dr: &mut D, witness: DriverValue<D, &ChildWitness<C>>) -> Result<Self> {
         Ok(ChildOutput {
             application: Point::alloc(dr, witness.as_ref().map(|w| w.application))?,

--- a/crates/ragu_pcd/src/internal/nested/stages/preamble.rs
+++ b/crates/ragu_pcd/src/internal/nested/stages/preamble.rs
@@ -176,6 +176,20 @@ impl<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> core::ops::Index<RxIndex>
 }
 
 impl<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> ChildOutput<'dr, D, C> {
+    /// Yields all per-child commitment points in the order in which
+    /// `compute_p` (`_10_p.rs`) accumulates them into `native_p`: the
+    /// rx commitments indexed by [`RxIndex::ALL`], followed by
+    /// `stashed_ab_a`, `stashed_ab_b`, `stashed_registry_xy`, and
+    /// `stashed_p`.
+    pub fn points_for_p(&self) -> impl Iterator<Item = &Point<'dr, D, C>> {
+        RxIndex::ALL.iter().map(move |&id| &self[id]).chain([
+            &self.stashed_ab_a,
+            &self.stashed_ab_b,
+            &self.stashed_registry_xy,
+            &self.stashed_p,
+        ])
+    }
+
     fn alloc(dr: &mut D, witness: DriverValue<D, &ChildWitness<C>>) -> Result<Self> {
         Ok(ChildOutput {
             application: Point::alloc(dr, witness.as_ref().map(|w| w.application))?,

--- a/crates/ragu_pcd/src/internal/nested/stages/s_prime.rs
+++ b/crates/ragu_pcd/src/internal/nested/stages/s_prime.rs
@@ -13,12 +13,20 @@ use ragu_core::{
 use ragu_primitives::{Point, io::Write};
 
 /// Number of curve points in this stage.
-const NUM: usize = 2;
+const NUM: usize = 3;
 
 /// Witness data for this bridge stage.
 pub struct Witness<C: CurveAffine> {
     pub registry_wx0: C,
     pub registry_wx1: C,
+    /// Stashed copy of the current step's native preamble commitment.
+    ///
+    /// The copying circuit loads a fresh trace of the child's stages
+    /// and cannot access `BridgePreamble.native_preamble` at a
+    /// different wire position from its own `BridgePreamble`. Stashing
+    /// the value here lets a parent's copying circuit read it from
+    /// `BridgeSPrime` instead.
+    pub stashed_preamble: C,
 }
 
 /// Prover-internal output gadget for this bridge stage.
@@ -31,6 +39,8 @@ pub struct Output<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
     pub registry_wx0: Point<'dr, D, C>,
     #[ragu(gadget)]
     pub registry_wx1: Point<'dr, D, C>,
+    #[ragu(gadget)]
+    pub stashed_preamble: Point<'dr, D, C>,
 }
 
 #[derive(Default)]
@@ -58,6 +68,7 @@ impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stag
         Ok(Output {
             registry_wx0: Point::alloc(dr, witness.as_ref().map(|w| w.registry_wx0))?,
             registry_wx1: Point::alloc(dr, witness.as_ref().map(|w| w.registry_wx1))?,
+            stashed_preamble: Point::alloc(dr, witness.as_ref().map(|w| w.stashed_preamble))?,
         })
     }
 }

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -221,7 +221,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x01473da623ef25e8074c842c64e83f7563809a1a5d6857cbf658beb22d1d4fac);
+    let expected = fq!(0x010ea80b4d708616b183bebb7740b0747ddf26fed8e06612273d47a2a34c4082);
 
     assert_eq!(
         app.nested_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -221,7 +221,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x262e5b8224cedd313f74101465df1fcfcbf85cc35db7301056bf3f1fb3f93e35);
+    let expected = fq!(0x284f7e9c507aed1e0d8134c39f6d1001ff7efe67bb8c44ac1241d72c99f8b586);
 
     assert_eq!(
         app.nested_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -221,7 +221,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x31cda5818b2554cf6064590380712d5d44461fb3bc0628ac8742343eb731d271);
+    let expected = fq!(0x026ffaf97c52cfeaa85928ed91dc1b8c7e8112d23bb3dff9d933880317251468);
 
     assert_eq!(
         app.nested_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -221,7 +221,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x026ffaf97c52cfeaa85928ed91dc1b8c7e8112d23bb3dff9d933880317251468);
+    let expected = fq!(0x0226858b4b21ea2693e20ef1711f7ae6ad9600b372dfaf2d53d2a9d348c9738f);
 
     assert_eq!(
         app.nested_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -221,7 +221,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x35c675e02ced1d5decf5d10c18045d64d54949cdaabae86960d0c5484355a913);
+    let expected = fq!(0x3dc12ef933cfdeb748c1676f03ea8ef3047f766683909d90fc98bc1238d77bcc);
 
     assert_eq!(
         app.nested_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -221,7 +221,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x2b96e37524c6ab000ab1d886e4faf47f4ad5fb8e45b72fb5d83f88e69d6f3333);
+    let expected = fq!(0x35c675e02ced1d5decf5d10c18045d64d54949cdaabae86960d0c5484355a913);
 
     assert_eq!(
         app.nested_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -221,7 +221,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x3dc12ef933cfdeb748c1676f03ea8ef3047f766683909d90fc98bc1238d77bcc);
+    let expected = fq!(0x262e5b8224cedd313f74101465df1fcfcbf85cc35db7301056bf3f1fb3f93e35);
 
     assert_eq!(
         app.nested_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -221,7 +221,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x010ea80b4d708616b183bebb7740b0747ddf26fed8e06612273d47a2a34c4082);
+    let expected = fq!(0x2b96e37524c6ab000ab1d886e4faf47f4ad5fb8e45b72fb5d83f88e69d6f3333);
 
     assert_eq!(
         app.nested_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -221,7 +221,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x0226858b4b21ea2693e20ef1711f7ae6ad9600b372dfaf2d53d2a9d348c9738f);
+    let expected = fq!(0x01473da623ef25e8074c842c64e83f7563809a1a5d6857cbf658beb22d1d4fac);
 
     assert_eq!(
         app.nested_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -221,7 +221,7 @@ fn test_nested_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fq!(0x284f7e9c507aed1e0d8134c39f6d1001ff7efe67bb8c44ac1241d72c99f8b586);
+    let expected = fq!(0x3e8a0fea0d4b85169e888155c4632052de2267f1f845191ad99cbfdb34d98e02);
 
     assert_eq!(
         app.nested_registry.digest(),

--- a/crates/ragu_pcd/src/proof/builder.rs
+++ b/crates/ragu_pcd/src/proof/builder.rs
@@ -299,6 +299,10 @@ pub(crate) struct ProofBuilder<'params, C: Cycle, R: Rank> {
     bridge_ab_commitment: OnceCell<C::NestedCurve>,
     bridge_query_commitment: OnceCell<C::NestedCurve>,
     bridge_eval_commitment: OnceCell<C::NestedCurve>,
+
+    // Children's stage rx (for copying circuit claims)
+    child_left_stage_rx: Option<super::ChildStageRx<C::ScalarField, R>>,
+    child_right_stage_rx: Option<super::ChildStageRx<C::ScalarField, R>>,
 }
 
 impl<'params, C: Cycle, R: Rank> ProofBuilder<'params, C, R> {
@@ -374,6 +378,8 @@ impl<'params, C: Cycle, R: Rank> ProofBuilder<'params, C, R> {
             bridge_ab_commitment: OnceCell::new(),
             bridge_query_commitment: OnceCell::new(),
             bridge_eval_commitment: OnceCell::new(),
+            child_left_stage_rx: None,
+            child_right_stage_rx: None,
         }
     }
 
@@ -410,6 +416,9 @@ impl<'params, C: Cycle, R: Rank> ProofBuilder<'params, C, R> {
     ref_getter!(native_b_poly, native_b_poly, sparse::Polynomial<C::CircuitField, R>);
     ref_getter!(native_registry_xy_poly, native_registry_xy_poly, sparse::Polynomial<C::CircuitField, R>);
     ref_getter!(native_p_poly, native_p_poly, sparse::Polynomial<C::CircuitField, R>);
+    ref_getter!(nested_points_rx, nested_points_rx, sparse::Polynomial<C::ScalarField, R>);
+    ref_getter!(bridge_s_prime_rx, bridge_s_prime_rx, sparse::Polynomial<C::ScalarField, R>);
+    ref_getter!(bridge_inner_error_rx, bridge_inner_error_rx, sparse::Polynomial<C::ScalarField, R>);
 
     lazy_commitment!(
         native,
@@ -605,6 +614,17 @@ impl<'params, C: Cycle, R: Rank> ProofBuilder<'params, C, R> {
     setter!(set_u, u, C::CircuitField);
     setter!(set_pre_beta, pre_beta, C::CircuitField);
 
+    setter!(
+        set_child_left_stage_rx,
+        child_left_stage_rx,
+        super::ChildStageRx<C::ScalarField, R>
+    );
+    setter!(
+        set_child_right_stage_rx,
+        child_right_stage_rx,
+        super::ChildStageRx<C::ScalarField, R>
+    );
+
     getter!(w, w, C::CircuitField);
     getter!(y, y, C::CircuitField);
     getter!(z, z, C::CircuitField);
@@ -755,6 +775,9 @@ impl<'params, C: Cycle, R: Rank> ProofBuilder<'params, C, R> {
             native_inner_collapse_commitment: cached!(native_inner_collapse_commitment),
             native_outer_collapse_commitment: cached!(native_outer_collapse_commitment),
             native_compute_v_commitment: cached!(native_compute_v_commitment),
+
+            child_left_stage_rx: take!(child_left_stage_rx),
+            child_right_stage_rx: take!(child_right_stage_rx),
         })
     }
 }

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -14,15 +14,20 @@ pub(crate) use builder::ProofBuilder;
 use ff::Field;
 use ragu_arithmetic::Cycle;
 use ragu_circuits::{
+    CircuitExt,
     polynomials::{Rank, sparse},
     registry::CircuitIndex,
+    staging::{MultiStage, StageExt},
 };
-use ragu_primitives::vec::Len;
+use ragu_primitives::{extract_endoscalar, vec::Len};
 
 use crate::{
     header::Header,
     internal::{
-        endoscalar::NumStepsLen,
+        endoscalar::{
+            EndoscalarStage, EndoscalingStep, EndoscalingStepWitness, NumStepsLen, PointsStage,
+            PointsWitness,
+        },
         native::{RxComponent, RxIndex},
         nested,
         nested::NUM_ENDOSCALING_POINTS,
@@ -475,27 +480,122 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
         builder.set_native_query_rx(ones_host.clone());
         builder.set_native_registry_xy_poly(registry_xy_poly);
         builder.set_native_eval_rx(ones_host.clone());
-        builder.set_native_p_poly(ones_host.clone(), host_commitment);
+        // native_p_poly: deferred until after endoscaling computation,
+        // since the real p commitment is the PointsStage last interstitial.
         builder.set_native_hashes_1_rx(ones_host.clone());
         builder.set_native_hashes_2_rx(ones_host.clone());
         builder.set_native_inner_collapse_rx(ones_host.clone());
         builder.set_native_outer_collapse_rx(ones_host.clone());
-        builder.set_native_compute_v_rx(ones_host);
+        builder.set_native_compute_v_rx(ones_host.clone());
 
-        // Non-cached bridge polynomials (trivial)
+        // Non-cached bridge polynomials (trivial placeholders for stages
+        // that no circuit constrains yet). Cached bridges (outer_error, ab,
+        // query, eval) are computed lazily by the builder via cached_bridge!
+        // using their real Stage::rx call.
         builder.set_bridge_preamble_rx(ones_nested.clone(), bridge_commitment);
         builder.set_bridge_s_prime_rx(ones_nested.clone(), bridge_commitment);
         builder.set_bridge_inner_error_rx(ones_nested.clone(), bridge_commitment);
-        builder.set_bridge_f_rx(ones_nested.clone(), bridge_commitment);
-        // Cached bridges (outer_error, ab, query, eval) are computed lazily by the builder.
 
-        // Nested endoscaling
-        builder.set_nested_endoscaling_step_rxs(vec![
-            ones_nested.clone();
-            NumStepsLen::<NUM_ENDOSCALING_POINTS>::len()
-        ]);
-        builder.set_nested_endoscalar_rx(ones_nested.clone());
-        builder.set_nested_points_rx(ones_nested);
+        // Bridge `f`: real trace because the Loading circuit enforces
+        // points.initial == f.native_f against this rx.
+        let nested_gen = C::nested_generators(self.params);
+        {
+            let rx = nested::stages::f::Stage::<C::HostCurve, R>::rx(
+                C::ScalarField::ONE,
+                &nested::stages::f::Witness {
+                    native_f: host_commitment,
+                },
+            )
+            .expect("trivial f rx");
+            let commitment = rx.commit_to_affine(nested_gen);
+            builder.set_bridge_f_rx(rx, commitment);
+        }
+
+        // Nested endoscaling: compute from dummy commitments so that the
+        // PointsStage trace is valid (Loading enforces initial == f.native_f
+        // at the first PointsStage position). Mirrors `compute_p` (_10_p.rs).
+        let beta_endo = extract_endoscalar(C::CircuitField::ONE);
+        let p_commitment = {
+            let mut points = alloc::vec::Vec::with_capacity(NUM_ENDOSCALING_POINTS);
+
+            // Initial: native_f commitment.
+            points.push(host_commitment);
+
+            let registry_xy_commitment = builder.native_registry_xy_commitment();
+
+            // Per child × 2: 15 commitments each.
+            // All native rx commitments are host_commitment (ones_host),
+            // except registry_xy which has its own commitment.
+            for _ in 0..2 {
+                for _ in &RxIndex::ALL {
+                    points.push(host_commitment);
+                }
+                points.push(host_commitment); // AbA
+                points.push(host_commitment); // AbB
+                points.push(registry_xy_commitment); // RegistryXY
+                points.push(host_commitment); // P placeholder
+            }
+
+            // 6 current-step stage proof components.
+            points.push(host_commitment); // registry_wx0
+            points.push(host_commitment); // registry_wx1
+            points.push(host_commitment); // registry_wy
+            points.push(host_commitment); // a
+            points.push(host_commitment); // b
+            points.push(registry_xy_commitment);
+
+            assert_eq!(points.len(), NUM_ENDOSCALING_POINTS);
+
+            let witness =
+                PointsWitness::<C::HostCurve, NUM_ENDOSCALING_POINTS>::new(beta_endo, &points);
+
+            let endoscalar_rx = <EndoscalarStage as StageExt<C::ScalarField, R>>::rx(
+                C::ScalarField::ONE,
+                beta_endo,
+            )
+            .expect("trivial endoscalar rx");
+            let points_rx = <PointsStage<C::HostCurve, NUM_ENDOSCALING_POINTS> as StageExt<
+                C::ScalarField,
+                R,
+            >>::rx(C::ScalarField::ONE, &witness)
+            .expect("trivial points rx");
+
+            let num_steps = NumStepsLen::<NUM_ENDOSCALING_POINTS>::len();
+            let mut step_rxs = alloc::vec::Vec::with_capacity(num_steps);
+            for step in 0..num_steps {
+                let step_circuit =
+                    EndoscalingStep::<C::HostCurve, R, NUM_ENDOSCALING_POINTS>::new(step);
+                let staged = MultiStage::new(step_circuit);
+                let step_trace = staged
+                    .trace(EndoscalingStepWitness {
+                        endoscalar: beta_endo,
+                        points: &witness,
+                    })
+                    .expect("trivial step trace")
+                    .into_output();
+                let step_rx = self
+                    .nested_registry
+                    .assemble(
+                        &step_trace,
+                        nested::InternalCircuitIndex::EndoscalingStep(step as u32).circuit_index(),
+                        &mut <rand::rngs::StdRng as rand::SeedableRng>::from_seed([0u8; 32]),
+                    )
+                    .expect("trivial step rx");
+                step_rxs.push(step_rx);
+            }
+
+            builder.set_nested_endoscaling_step_rxs(step_rxs);
+            builder.set_nested_endoscalar_rx(endoscalar_rx);
+            builder.set_nested_points_rx(points_rx);
+
+            *witness
+                .interstitials
+                .last()
+                .expect("at least one interstitial")
+        };
+
+        // Set native_p_poly with the real accumulated commitment.
+        builder.set_native_p_poly(ones_host, p_commitment);
 
         // Children's stage rx: a trivial proof is its own "child", so
         // child rx must match the proof's own rx. Force lazy evaluation of

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -401,40 +401,6 @@ impl<C: Cycle, R: Rank> Proof<C, R> {
         self.native_p_commitment.0
     }
 
-    /// Yields every `(polynomial, commitment)` pair this proof
-    /// contributes to the parent's `native_p` accumulation, in the
-    /// order `compute_p` (`_10_p.rs`) applies them: the rx polynomials
-    /// indexed by [`RxIndex::ALL`], followed by `AbA`, `AbB`,
-    /// `native_registry_xy`, and `native_p`.
-    ///
-    /// Mirrors [`ChildOutput::points_for_p`] so the accumulation order
-    /// lives in parallel on the polynomial side (prover, `_10_p.rs`)
-    /// and the point-gadget side (loading circuit).
-    ///
-    /// [`ChildOutput::points_for_p`]: crate::internal::nested::stages::preamble::ChildOutput::points_for_p
-    pub(crate) fn polys_for_p(
-        &self,
-    ) -> impl Iterator<Item = (&sparse::Polynomial<C::CircuitField, R>, C::HostCurve)> {
-        RxIndex::ALL
-            .iter()
-            .map(move |&id| (&self[id], self.native_rx_commitment(id)))
-            .chain([
-                (
-                    &self[RxComponent::AbA],
-                    self.native_commitment(RxComponent::AbA),
-                ),
-                (
-                    &self[RxComponent::AbB],
-                    self.native_commitment(RxComponent::AbB),
-                ),
-                (
-                    self.native_registry_xy_poly(),
-                    self.native_registry_xy_commitment(),
-                ),
-                (self.native_p_poly(), self.native_p_commitment()),
-            ])
-    }
-
     pub(crate) fn bridge_preamble_commitment(&self) -> C::NestedCurve {
         self.bridge_preamble_commitment
     }

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -92,6 +92,9 @@ pub(crate) struct ChildStageRx<F: ff::PrimeField, R: Rank> {
 impl<C: Cycle, R: Rank> Proof<C, R> {
     /// Extract stage rx polynomials from this proof for storage as child
     /// data in a parent proof.
+    //
+    // TODO: wrap each child polynomial in `Arc` so this extraction can
+    // share ownership instead of cloning every rx polynomial.
     pub(crate) fn as_child_stage_rx(&self) -> ChildStageRx<C::ScalarField, R> {
         ChildStageRx {
             points_stage: self.nested_points_rx.clone(),

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -502,13 +502,10 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
     ) -> Result<C::HostCurve> {
         assert_eq!(points.len(), NUM_ENDOSCALING_POINTS);
 
-        let witness =
-            PointsWitness::<C::HostCurve, NUM_ENDOSCALING_POINTS>::new(beta_endo, points);
+        let witness = PointsWitness::<C::HostCurve, NUM_ENDOSCALING_POINTS>::new(beta_endo, points);
 
-        let endoscalar_rx = <EndoscalarStage as StageExt<C::ScalarField, R>>::rx(
-            endoscalar_alpha,
-            beta_endo,
-        )?;
+        let endoscalar_rx =
+            <EndoscalarStage as StageExt<C::ScalarField, R>>::rx(endoscalar_alpha, beta_endo)?;
         let points_rx = <PointsStage<C::HostCurve, NUM_ENDOSCALING_POINTS> as StageExt<
             C::ScalarField,
             R,
@@ -667,8 +664,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
             points.push(host_commitment); // b
             points.push(registry_xy_commitment); // native_registry_xy
 
-            let mut trivial_rng =
-                <rand::rngs::StdRng as rand::SeedableRng>::from_seed([0u8; 32]);
+            let mut trivial_rng = <rand::rngs::StdRng as rand::SeedableRng>::from_seed([0u8; 32]);
             self.compute_endoscaling(
                 &mut trivial_rng,
                 beta_endo,

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -488,17 +488,27 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
         builder.set_native_outer_collapse_rx(ones_host.clone());
         builder.set_native_compute_v_rx(ones_host.clone());
 
-        // Non-cached bridge polynomials (trivial placeholders for stages
-        // that no circuit constrains yet). Cached bridges (outer_error, ab,
-        // query, eval) are computed lazily by the builder via cached_bridge!
-        // using their real Stage::rx call.
-        builder.set_bridge_preamble_rx(ones_nested.clone(), bridge_commitment);
-        builder.set_bridge_s_prime_rx(ones_nested.clone(), bridge_commitment);
+        // Non-cached bridge polynomials: real traces for stages that
+        // Loading enforces against (s_prime, f); placeholder for stages
+        // that no circuit constrains yet (inner_error). Cached bridges
+        // (outer_error, ab, query, eval) are computed lazily by the
+        // builder via cached_bridge! using their real Stage::rx call.
         builder.set_bridge_inner_error_rx(ones_nested.clone(), bridge_commitment);
 
-        // Bridge `f`: real trace because the Loading circuit enforces
-        // points.initial == f.native_f against this rx.
         let nested_gen = C::nested_generators(self.params);
+        {
+            let rx = nested::stages::s_prime::Stage::<C::HostCurve, R>::rx(
+                C::ScalarField::ONE,
+                &nested::stages::s_prime::Witness {
+                    registry_wx0: host_commitment,
+                    registry_wx1: host_commitment,
+                    stashed_preamble: host_commitment,
+                },
+            )
+            .expect("trivial s_prime rx");
+            let commitment = rx.commit_to_affine(nested_gen);
+            builder.set_bridge_s_prime_rx(rx, commitment);
+        }
         {
             let rx = nested::stages::f::Stage::<C::HostCurve, R>::rx(
                 C::ScalarField::ONE,
@@ -596,6 +606,40 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
 
         // Set native_p_poly with the real accumulated commitment.
         builder.set_native_p_poly(ones_host, p_commitment);
+
+        // Preamble bridge: computed last because ChildWitness.stashed_p
+        // needs the real p_commitment from endoscaling.
+        {
+            let registry_xy_commitment = builder.native_registry_xy_commitment();
+            let trivial_child_witness = nested::stages::preamble::ChildWitness {
+                application: host_commitment,
+                hashes_1: host_commitment,
+                hashes_2: host_commitment,
+                inner_collapse: host_commitment,
+                outer_collapse: host_commitment,
+                compute_v: host_commitment,
+                stashed_preamble: host_commitment,
+                stashed_inner_error: host_commitment,
+                stashed_outer_error: host_commitment,
+                stashed_query: host_commitment,
+                stashed_eval: host_commitment,
+                stashed_ab_a: host_commitment,
+                stashed_ab_b: host_commitment,
+                stashed_registry_xy: registry_xy_commitment,
+                stashed_p: p_commitment,
+            };
+            let rx = nested::stages::preamble::Stage::<C::HostCurve, R>::rx(
+                C::ScalarField::ONE,
+                &nested::stages::preamble::Witness {
+                    native_preamble: host_commitment,
+                    left: trivial_child_witness.clone(),
+                    right: trivial_child_witness,
+                },
+            )
+            .expect("trivial preamble rx");
+            let commitment = rx.commit_to_affine(nested_gen);
+            builder.set_bridge_preamble_rx(rx, commitment);
+        }
 
         // Children's stage rx: a trivial proof is its own "child", so
         // child rx must match the proof's own rx. Force lazy evaluation of

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -12,13 +12,14 @@ use alloc::{vec, vec::Vec};
 
 pub(crate) use builder::ProofBuilder;
 use ff::Field;
-use ragu_arithmetic::Cycle;
+use ragu_arithmetic::{Cycle, Uendo};
 use ragu_circuits::{
     CircuitExt,
     polynomials::{Rank, sparse},
     registry::CircuitIndex,
     staging::{MultiStage, StageExt},
 };
+use ragu_core::Result;
 use ragu_primitives::{extract_endoscalar, vec::Len};
 
 use crate::{
@@ -471,6 +472,69 @@ impl<C: Cycle, R: Rank> Proof<C, R> {
 }
 
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, HEADER_SIZE> {
+    /// Runs endoscaling over the host-curve commitments that feed
+    /// `PointsStage`, in the order `compute_p` (`_10_p.rs`)
+    /// accumulates them. Writes `nested_endoscalar_rx`,
+    /// `nested_points_rx`, and `nested_endoscaling_step_rxs` onto
+    /// `builder`, and returns the accumulated `p` commitment (last
+    /// `PointsStage` interstitial).
+    ///
+    /// Shared by `compute_p` (in `fuse/_10_p.rs`) and by
+    /// [`trivial_proof`](Self::trivial_proof), so the nested
+    /// endoscaling setup lives in one place.
+    pub(crate) fn compute_endoscaling<RNG: rand::CryptoRng>(
+        &self,
+        rng: &mut RNG,
+        beta_endo: Uendo,
+        points: &[C::HostCurve],
+        endoscalar_alpha: C::ScalarField,
+        points_alpha: C::ScalarField,
+        builder: &mut ProofBuilder<'_, C, R>,
+    ) -> Result<C::HostCurve> {
+        assert_eq!(points.len(), NUM_ENDOSCALING_POINTS);
+
+        let witness =
+            PointsWitness::<C::HostCurve, NUM_ENDOSCALING_POINTS>::new(beta_endo, points);
+
+        let endoscalar_rx = <EndoscalarStage as StageExt<C::ScalarField, R>>::rx(
+            endoscalar_alpha,
+            beta_endo,
+        )?;
+        let points_rx = <PointsStage<C::HostCurve, NUM_ENDOSCALING_POINTS> as StageExt<
+            C::ScalarField,
+            R,
+        >>::rx(points_alpha, &witness)?;
+
+        let num_steps = NumStepsLen::<NUM_ENDOSCALING_POINTS>::len();
+        let mut step_rxs = Vec::with_capacity(num_steps);
+        for step in 0..num_steps {
+            let step_circuit =
+                EndoscalingStep::<C::HostCurve, R, NUM_ENDOSCALING_POINTS>::new(step);
+            let staged = MultiStage::new(step_circuit);
+            let step_trace = staged
+                .trace(EndoscalingStepWitness {
+                    endoscalar: beta_endo,
+                    points: &witness,
+                })?
+                .into_output();
+            let step_rx = self.nested_registry.assemble(
+                &step_trace,
+                nested::InternalCircuitIndex::EndoscalingStep(step as u32).circuit_index(),
+                rng,
+            )?;
+            step_rxs.push(step_rx);
+        }
+
+        builder.set_nested_endoscaling_step_rxs(step_rxs);
+        builder.set_nested_endoscalar_rx(endoscalar_rx);
+        builder.set_nested_points_rx(points_rx);
+
+        Ok(*witness
+            .interstitials
+            .last()
+            .expect("NUM_ENDOSCALING_POINTS guarantees at least one interstitial"))
+    }
+
     pub(crate) fn trivial_pcd(&self) -> Pcd<C, R, ()> {
         self.trivial_proof().carry(())
     }
@@ -561,21 +625,21 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
             builder.set_bridge_f_rx(rx, commitment);
         }
 
-        // Nested endoscaling: compute properly from dummy commitments so
-        // that PointsStage traces are valid (required for copying circuit).
-        // Mirrors the accumulation order in `compute_p` (_10_p.rs).
+        // Build dummy PointsStage inputs in `_10_p` accumulation order
+        // and delegate to `compute_endoscaling` so this trivial setup
+        // cannot silently drift from the real prover path.
         let beta_endo = extract_endoscalar(C::CircuitField::ONE);
         let p_commitment = {
-            let mut points = alloc::vec::Vec::with_capacity(NUM_ENDOSCALING_POINTS);
+            let mut points = Vec::with_capacity(NUM_ENDOSCALING_POINTS);
 
             // Initial: native_f commitment.
             points.push(host_commitment);
 
             let registry_xy_commitment = builder.native_registry_xy_commitment();
 
-            // Per child × 2: 15 commitments each.
-            // All native rx commitments are host_commitment (ones_host),
-            // except registry_xy which has its own commitment.
+            // Per-child block: all per-child commitments are
+            // `host_commitment` (ones_host), except registry_xy which
+            // has its own commitment.
             for _ in 0..2 {
                 for _ in &RxIndex::ALL {
                     points.push(host_commitment);
@@ -586,62 +650,25 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
                 points.push(host_commitment); // P placeholder
             }
 
-            // 6 current-step stage proof components.
+            // Current-step bridge inputs.
             points.push(host_commitment); // registry_wx0
             points.push(host_commitment); // registry_wx1
             points.push(host_commitment); // registry_wy
             points.push(host_commitment); // a
             points.push(host_commitment); // b
-            points.push(registry_xy_commitment);
+            points.push(registry_xy_commitment); // native_registry_xy
 
-            assert_eq!(points.len(), NUM_ENDOSCALING_POINTS);
-
-            let witness =
-                PointsWitness::<C::HostCurve, NUM_ENDOSCALING_POINTS>::new(beta_endo, &points);
-
-            let endoscalar_rx = <EndoscalarStage as StageExt<C::ScalarField, R>>::rx(
-                C::ScalarField::ONE,
+            let mut trivial_rng =
+                <rand::rngs::StdRng as rand::SeedableRng>::from_seed([0u8; 32]);
+            self.compute_endoscaling(
+                &mut trivial_rng,
                 beta_endo,
+                &points,
+                C::ScalarField::ONE,
+                C::ScalarField::ONE,
+                &mut builder,
             )
-            .expect("trivial endoscalar rx");
-            let points_rx = <PointsStage<C::HostCurve, NUM_ENDOSCALING_POINTS> as StageExt<
-                C::ScalarField,
-                R,
-            >>::rx(C::ScalarField::ONE, &witness)
-            .expect("trivial points rx");
-
-            let num_steps = NumStepsLen::<NUM_ENDOSCALING_POINTS>::len();
-            let mut step_rxs = alloc::vec::Vec::with_capacity(num_steps);
-            for step in 0..num_steps {
-                let step_circuit =
-                    EndoscalingStep::<C::HostCurve, R, NUM_ENDOSCALING_POINTS>::new(step);
-                let staged = MultiStage::new(step_circuit);
-                let step_trace = staged
-                    .trace(EndoscalingStepWitness {
-                        endoscalar: beta_endo,
-                        points: &witness,
-                    })
-                    .expect("trivial step trace")
-                    .into_output();
-                let step_rx = self
-                    .nested_registry
-                    .assemble(
-                        &step_trace,
-                        nested::InternalCircuitIndex::EndoscalingStep(step as u32).circuit_index(),
-                        &mut <rand::rngs::StdRng as rand::SeedableRng>::from_seed([0u8; 32]),
-                    )
-                    .expect("trivial step rx");
-                step_rxs.push(step_rx);
-            }
-
-            builder.set_nested_endoscaling_step_rxs(step_rxs);
-            builder.set_nested_endoscalar_rx(endoscalar_rx);
-            builder.set_nested_points_rx(points_rx);
-
-            *witness
-                .interstitials
-                .last()
-                .expect("at least one interstitial")
+            .expect("trivial endoscaling")
         };
 
         // Set native_p_poly with the real accumulated commitment.

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -478,14 +478,14 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
         builder.set_native_outer_collapse_rx(ones_host.clone());
         builder.set_native_compute_v_rx(ones_host.clone());
 
-        // Non-cached bridge polynomials: all computed via Stage::rx so
-        // that traces are valid for their witnesses (not just ones).
-        // Cached bridges (outer_error, ab, query, eval) are computed
-        // lazily by the builder via cached_bridge! using Stage::rx.
+        // Bridge polynomials: compute via Stage::rx() with trivial witnesses
+        // so that traces are valid for their witnesses (not just ones).
+        // Cached bridges (outer_error, ab, query, eval) are already computed
+        // lazily by the builder via cached_bridge! with proper witnesses.
         //
-        // Order: s_prime, inner_error, f first (independent of
-        // p_commitment), then endoscaling (computes p_commitment),
-        // then preamble (needs p_commitment for ChildWitness.p).
+        // Order: s_prime, inner_error, f first (independent of p_commitment),
+        // then endoscaling (computes p_commitment), then preamble (needs
+        // p_commitment for ChildWitness.p), then native_p_poly.
         let nested_gen = C::nested_generators(self.params);
         {
             let rx = nested::stages::s_prime::Stage::<C::HostCurve, R>::rx(
@@ -524,9 +524,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
             builder.set_bridge_f_rx(rx, commitment);
         }
 
-        // Nested endoscaling: compute from dummy commitments so that the
-        // PointsStage trace is valid (Loading enforces initial == f.native_f
-        // at the first PointsStage position). Mirrors `compute_p` (_10_p.rs).
+        // Nested endoscaling: compute properly from dummy commitments so
+        // that PointsStage traces are valid (required for copying circuit).
+        // Mirrors the accumulation order in `compute_p` (_10_p.rs).
         let beta_endo = extract_endoscalar(C::CircuitField::ONE);
         let p_commitment = {
             let mut points = alloc::vec::Vec::with_capacity(NUM_ENDOSCALING_POINTS);
@@ -610,8 +610,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
         // Set native_p_poly with the real accumulated commitment.
         builder.set_native_p_poly(ones_host, p_commitment);
 
-        // Preamble bridge: computed last because ChildWitness.stashed_p
-        // needs the real p_commitment from endoscaling.
+        // Preamble bridge: computed last because ChildWitness.p needs
+        // the real p_commitment from endoscaling.
         {
             let registry_xy_commitment = builder.native_registry_xy_commitment();
             let trivial_child_witness = nested::stages::preamble::ChildWitness {

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -447,17 +447,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
             view.d.push(C::CircuitField::ONE);
             view.build()
         };
-        let ones_nested = {
-            let mut view = sparse::View::<_, R, _>::trace();
-            view.a.push(C::ScalarField::ONE);
-            view.b.push(C::ScalarField::ONE);
-            view.c.push(C::ScalarField::ONE);
-            view.d.push(C::ScalarField::ONE);
-            view.build()
-        };
-
         let host_commitment = ones_host.commit_to_affine(C::host_generators(self.params));
-        let bridge_commitment = ones_nested.commit_to_affine(C::nested_generators(self.params));
 
         // registry_xy must be the actual registry evaluation (fuse cross-checks it).
         let registry_xy_poly = self
@@ -488,13 +478,14 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
         builder.set_native_outer_collapse_rx(ones_host.clone());
         builder.set_native_compute_v_rx(ones_host.clone());
 
-        // Non-cached bridge polynomials: real traces for stages that
-        // Loading enforces against (s_prime, f); placeholder for stages
-        // that no circuit constrains yet (inner_error). Cached bridges
-        // (outer_error, ab, query, eval) are computed lazily by the
-        // builder via cached_bridge! using their real Stage::rx call.
-        builder.set_bridge_inner_error_rx(ones_nested.clone(), bridge_commitment);
-
+        // Non-cached bridge polynomials: all computed via Stage::rx so
+        // that traces are valid for their witnesses (not just ones).
+        // Cached bridges (outer_error, ab, query, eval) are computed
+        // lazily by the builder via cached_bridge! using Stage::rx.
+        //
+        // Order: s_prime, inner_error, f first (independent of
+        // p_commitment), then endoscaling (computes p_commitment),
+        // then preamble (needs p_commitment for ChildWitness.p).
         let nested_gen = C::nested_generators(self.params);
         {
             let rx = nested::stages::s_prime::Stage::<C::HostCurve, R>::rx(
@@ -508,6 +499,18 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
             .expect("trivial s_prime rx");
             let commitment = rx.commit_to_affine(nested_gen);
             builder.set_bridge_s_prime_rx(rx, commitment);
+        }
+        {
+            let rx = nested::stages::inner_error::Stage::<C::HostCurve, R>::rx(
+                C::ScalarField::ONE,
+                &nested::stages::inner_error::Witness {
+                    native_inner_error: host_commitment,
+                    registry_wy: host_commitment,
+                },
+            )
+            .expect("trivial inner_error rx");
+            let commitment = rx.commit_to_affine(nested_gen);
+            builder.set_bridge_inner_error_rx(rx, commitment);
         }
         {
             let rx = nested::stages::f::Stage::<C::HostCurve, R>::rx(

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -388,6 +388,40 @@ impl<C: Cycle, R: Rank> Proof<C, R> {
         self.native_p_commitment.0
     }
 
+    /// Yields every `(polynomial, commitment)` pair this proof
+    /// contributes to the parent's `native_p` accumulation, in the
+    /// order `compute_p` (`_10_p.rs`) applies them: the rx polynomials
+    /// indexed by [`RxIndex::ALL`], followed by `AbA`, `AbB`,
+    /// `native_registry_xy`, and `native_p`.
+    ///
+    /// Mirrors [`ChildOutput::points_for_p`] so the accumulation order
+    /// lives in parallel on the polynomial side (prover, `_10_p.rs`)
+    /// and the point-gadget side (loading circuit).
+    ///
+    /// [`ChildOutput::points_for_p`]: crate::internal::nested::stages::preamble::ChildOutput::points_for_p
+    pub(crate) fn polys_for_p(
+        &self,
+    ) -> impl Iterator<Item = (&sparse::Polynomial<C::CircuitField, R>, C::HostCurve)> {
+        RxIndex::ALL
+            .iter()
+            .map(move |&id| (&self[id], self.native_rx_commitment(id)))
+            .chain([
+                (
+                    &self[RxComponent::AbA],
+                    self.native_commitment(RxComponent::AbA),
+                ),
+                (
+                    &self[RxComponent::AbB],
+                    self.native_commitment(RxComponent::AbB),
+                ),
+                (
+                    self.native_registry_xy_poly(),
+                    self.native_registry_xy_commitment(),
+                ),
+                (self.native_p_poly(), self.native_p_commitment()),
+            ])
+    }
+
     pub(crate) fn bridge_preamble_commitment(&self) -> C::NestedCurve {
         self.bridge_preamble_commitment
     }

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -71,6 +71,36 @@ impl<C: Cycle, R: Rank, H: Header<C::CircuitField>> Clone for Pcd<C, R, H> {
     }
 }
 
+/// Stage rx polynomials from a child proof, stored so the verifier can
+/// check copying circuit claims.
+#[derive(Clone)]
+pub(crate) struct ChildStageRx<F: ff::PrimeField, R: Rank> {
+    pub points_stage: sparse::Polynomial<F, R>,
+    pub bridge_s_prime: sparse::Polynomial<F, R>,
+    pub bridge_inner_error: sparse::Polynomial<F, R>,
+    pub bridge_outer_error: sparse::Polynomial<F, R>,
+    pub bridge_ab: sparse::Polynomial<F, R>,
+    pub bridge_query: sparse::Polynomial<F, R>,
+    pub bridge_eval: sparse::Polynomial<F, R>,
+}
+
+impl<C: Cycle, R: Rank> Proof<C, R> {
+    /// Extract stage rx polynomials from this proof for storage as child
+    /// data in a parent proof.
+    pub(crate) fn as_child_stage_rx(&self) -> ChildStageRx<C::ScalarField, R> {
+        ChildStageRx {
+            points_stage: self.nested_points_rx.clone(),
+            bridge_s_prime: self.bridge_s_prime_rx.clone(),
+            bridge_inner_error: self.bridge_inner_error_rx.clone(),
+            // .0 = polynomial (these are (poly, commitment) tuples from cached_bridge!)
+            bridge_outer_error: self.bridge_outer_error_rx.0.clone(),
+            bridge_ab: self.bridge_ab_rx.0.clone(),
+            bridge_query: self.bridge_query_rx.0.clone(),
+            bridge_eval: self.bridge_eval_rx.0.clone(),
+        }
+    }
+}
+
 /// Represents a recursive proof for the correctness of some computation.
 ///
 /// All fields are flat (no nested component structs). Polynomial fields are
@@ -167,6 +197,10 @@ pub struct Proof<C: Cycle, R: Rank> {
     bridge_ab_commitment: Cached<C::NestedCurve>,
     bridge_query_commitment: Cached<C::NestedCurve>,
     bridge_eval_commitment: Cached<C::NestedCurve>,
+
+    // Children's stage rx polynomials (for copying circuit claims)
+    pub(crate) child_left_stage_rx: ChildStageRx<C::ScalarField, R>,
+    pub(crate) child_right_stage_rx: ChildStageRx<C::ScalarField, R>,
 }
 
 impl<C: Cycle, R: Rank> core::ops::Index<RxIndex> for Proof<C, R> {
@@ -216,11 +250,25 @@ impl<C: Cycle, R: Rank> core::ops::Index<nested::RxIndex> for Proof<C, R> {
             BridgeQuery => &self.bridge_query_rx.0,
             BridgeF => &self.bridge_f_rx,
             BridgeEval => &self.bridge_eval_rx.0,
+            ChildPointsStage(side) => &self.child_stage_rx(side).points_stage,
+            ChildBridgeSPrime(side) => &self.child_stage_rx(side).bridge_s_prime,
+            ChildBridgeInnerError(side) => &self.child_stage_rx(side).bridge_inner_error,
+            ChildBridgeOuterError(side) => &self.child_stage_rx(side).bridge_outer_error,
+            ChildBridgeAB(side) => &self.child_stage_rx(side).bridge_ab,
+            ChildBridgeQuery(side) => &self.child_stage_rx(side).bridge_query,
+            ChildBridgeEval(side) => &self.child_stage_rx(side).bridge_eval,
         }
     }
 }
 
 impl<C: Cycle, R: Rank> Proof<C, R> {
+    fn child_stage_rx(&self, side: crate::internal::Side) -> &ChildStageRx<C::ScalarField, R> {
+        match side {
+            crate::internal::Side::Left => &self.child_left_stage_rx,
+            crate::internal::Side::Right => &self.child_right_stage_rx,
+        }
+    }
+
     /// Augment a recursive proof with some data, described by a [`Header`].
     pub fn carry<H: Header<C::CircuitField>>(self, data: H::Data) -> Pcd<C, R, H> {
         Pcd { proof: self, data }
@@ -448,6 +496,33 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
         ]);
         builder.set_nested_endoscalar_rx(ones_nested.clone());
         builder.set_nested_points_rx(ones_nested);
+
+        // Children's stage rx: a trivial proof is its own "child", so
+        // child rx must match the proof's own rx. Force lazy evaluation of
+        // cached bridges first so we can clone them.
+        let trivial_child = ChildStageRx {
+            points_stage: builder.nested_points_rx().clone(),
+            bridge_s_prime: builder.bridge_s_prime_rx().clone(),
+            bridge_inner_error: builder.bridge_inner_error_rx().clone(),
+            bridge_outer_error: builder
+                .bridge_outer_error_rx()
+                .expect("trivial bridge_outer_error_rx")
+                .clone(),
+            bridge_ab: builder
+                .bridge_ab_rx()
+                .expect("trivial bridge_ab_rx")
+                .clone(),
+            bridge_query: builder
+                .bridge_query_rx()
+                .expect("trivial bridge_query_rx")
+                .clone(),
+            bridge_eval: builder
+                .bridge_eval_rx()
+                .expect("trivial bridge_eval_rx")
+                .clone(),
+        };
+        builder.set_child_left_stage_rx(trivial_child.clone());
+        builder.set_child_right_stage_rx(trivial_child);
 
         // Challenges (all ones for trivial)
         builder.set_w(C::CircuitField::ONE);

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -31,7 +31,7 @@ use crate::{
         },
         native::{RxComponent, RxIndex},
         nested,
-        nested::NUM_ENDOSCALING_POINTS,
+        nested::{ChildBridgeKind, NUM_ENDOSCALING_POINTS},
     },
 };
 
@@ -88,6 +88,20 @@ pub(crate) struct ChildStageRx<F: ff::PrimeField, R: Rank> {
     pub bridge_ab: sparse::Polynomial<F, R>,
     pub bridge_query: sparse::Polynomial<F, R>,
     pub bridge_eval: sparse::Polynomial<F, R>,
+}
+
+impl<F: ff::PrimeField, R: Rank> ChildStageRx<F, R> {
+    /// Dispatch to the bridge-stage rx polynomial named by `kind`.
+    pub(crate) fn bridge_at(&self, kind: ChildBridgeKind) -> &sparse::Polynomial<F, R> {
+        match kind {
+            ChildBridgeKind::SPrime => &self.bridge_s_prime,
+            ChildBridgeKind::InnerError => &self.bridge_inner_error,
+            ChildBridgeKind::OuterError => &self.bridge_outer_error,
+            ChildBridgeKind::AB => &self.bridge_ab,
+            ChildBridgeKind::Query => &self.bridge_query,
+            ChildBridgeKind::Eval => &self.bridge_eval,
+        }
+    }
 }
 
 impl<C: Cycle, R: Rank> Proof<C, R> {
@@ -260,12 +274,7 @@ impl<C: Cycle, R: Rank> core::ops::Index<nested::RxIndex> for Proof<C, R> {
             BridgeF => &self.bridge_f_rx,
             BridgeEval => &self.bridge_eval_rx.0,
             ChildPointsStage(side) => &self.child_stage_rx(side).points_stage,
-            ChildBridgeSPrime(side) => &self.child_stage_rx(side).bridge_s_prime,
-            ChildBridgeInnerError(side) => &self.child_stage_rx(side).bridge_inner_error,
-            ChildBridgeOuterError(side) => &self.child_stage_rx(side).bridge_outer_error,
-            ChildBridgeAB(side) => &self.child_stage_rx(side).bridge_ab,
-            ChildBridgeQuery(side) => &self.child_stage_rx(side).bridge_query,
-            ChildBridgeEval(side) => &self.child_stage_rx(side).bridge_eval,
+            ChildBridge(kind, side) => self.child_stage_rx(side).bridge_at(kind),
         }
     }
 }


### PR DESCRIPTION
This will replace #625. It's a vibe-coded alternative used to check my work and changes. I have a more cleaned up branch but it changed significantly and just wanted to get this branch up for some review/analysis/comparison first before I rebased it again.

-----

### Loading and copying circuits

Two new bonding circuits in the nested section work together to constrain every `PointsStage` position.

- **Loading** loads the current step's bridge stages (`preamble`, `s_prime`, `inner_error`, `ab`, `query`, `f`) alongside `PointsStage`, then walks through every `PointsStage` entry and enforces that it equals the corresponding value from somewhere in the bridge stages:
  - Per-child entries match `ChildWitness` fields in the preamble.
  - Current-step entries match their respective bridge stage fields.
  - The `initial` entry matches `BridgeF.native_f`.
  - A `Walker` cursor steps through these inputs sequentially, and its consuming `finish()` method asserts that every input was covered — so if `ChildWitness` or a stage grows a new field without a matching `enforce_equal` call, the circuit fails loudly rather than silently under-constraining.
  - The loading circuit also enforces a relay: `BridgeSPrime.stashed_preamble` must equal `BridgePreamble.native_preamble`. This stashes the current step's native preamble commitment into a different stage type, so that when a parent step's copying circuit later needs to verify it, it can read from `BridgeSPrime` without a wire-position collision on `BridgePreamble`.

- **Copying** handles the other half of the cross-step check. It's parameterized by `Side` (one instance per child proof), and loads the child's bridge stages and `PointsStage` in its own separate trace. It then enforces that each `stashed_*` field in the current step's `ChildWitness` equals the corresponding field from the child's actual bridge stage, with `stashed_p` checked against the last interstitial of the child's `PointsStage`.

- **Why two circuits?** A single trace can't hold both the current and child versions of the same stage type at the same wire positions.

- **Registration and claims.** Both circuits register as bonding objects via `into_bonding_object()` and emit `grouped_bonding_claim`s in `nested::claims::build`, referencing the rx indices of every stage they load.

- **Naming convention.** The `stashed_` prefix uniformly marks fields that are copies placed for cross-circuit verification, distinguishing them from primary introductions like the circuit commitments.

### Proof and claim extensions

- **`ChildWitness`** gains a set of `stashed_*` fields alongside the original fields (application through compute_v) that serve as the primary introduction of child circuit commitments into the nested transcript. The new stashed fields are copies of values that already exist in the child's unified instance or bridge stages, placed here so that loading and copying can enforce them.

- **`BridgeSPrime`** similarly gains a `stashed_preamble` field, populated during fuse from the builder's native preamble commitment — the same convention and concept as the `ChildWitness` stash fields.

- **`ChildStageRx`** is a new struct holding one rx polynomial per stage that the copying circuit loads. It lives in the `Proof` and is populated during fuse via `as_child_stage_rx()`, which clones the relevant polynomials from the child proof so the verifier can later reconstruct the copying circuit's bonding claims.

- **`RxIndex` / plumbing.** Corresponding per-side `Child*` variants are added to `RxIndex` (one per stage in `ChildStageRx`), with matching `Index` impl, `ProofBuilder` storage and setters, and `SingleProofSource` plumbing.

- **`InternalCircuitIndex`.** `Loading` and `Copying(Side)` are registered with their bonding objects wired up in `register_all`.

- **Field order.** `ChildWitness` and `ChildOutput` field order matches the `_10_p` accumulation order so the loading walker can iterate in declaration order.

### Trivial proof

The trivial proof can no longer get away with all-ones polynomials for nested rx, because multi-stage bonding masks require traces that actually satisfy their witness constraints.

- Every bridge rx is now computed via `Stage::rx()` with dummy `host_commitment` witnesses.
- All endoscaling rx (endoscalar stage, points stage, step circuits) are computed by constructing a real `PointsWitness` from the dummy points and tracing each `EndoscalingStep`.
- The computation order matters:
  1. s_prime, inner_error, and f bridges first.
  2. Endoscaling next (Horner-evaluates the dummy points to produce `p_commitment`).
  3. `native_p_poly` (needs the real `p_commitment`).
  4. Preamble bridge last (needs `p_commitment` for `ChildWitness.stashed_p`).
- Both `child_left_stage_rx` and `child_right_stage_rx` are set to match the proof's own stage rx, since a trivial proof is its own child.
- The old `ones_nested` polynomial is eliminated entirely — every nested rx is now properly derived from witness data.
