### PR TITLE
chore(pcd): reorganize circuit internals

### DIFF
--- a/crates/ragu_pcd/src/fuse/_05_outer_error.rs
+++ b/crates/ragu_pcd/src/fuse/_05_outer_error.rs
@@ -10,7 +10,7 @@ use ff::Field;
 use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::{Rank, sparse},
-    staging::{Stage as StageTrait, StageExt},
+    staging::StageExt,
 };
 use ragu_core::{
     Result,
@@ -76,22 +76,33 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                 let (preamble_witness, inner_error_terms, y, mu, nu) = witness.cast();
                 let allocator = &mut ();
 
-                let preamble = native::stages::preamble::Stage::<C, R, HEADER_SIZE>::default()
-                    .witness(dr, preamble_witness.as_ref().map(|w| *w))?;
+                // Allocate full proof inputs directly (not via the preamble
+                // stage, which only allocates core data). We need full headers
+                // here to compute `application_ky` and `unified_bridge_ky`.
+                let left_inputs = native::stages::preamble::ProofInputs::<_, C, HEADER_SIZE>::alloc(
+                    dr,
+                    preamble_witness.as_ref().map(|w| w.left.proof),
+                    preamble_witness.as_ref().map(|w| &w.left.output_header),
+                )?;
+                let right_inputs = native::stages::preamble::ProofInputs::<_, C, HEADER_SIZE>::alloc(
+                    dr,
+                    preamble_witness.as_ref().map(|w| w.right.proof),
+                    preamble_witness.as_ref().map(|w| &w.right.output_header),
+                )?;
 
                 let y = Element::alloc(dr, allocator, y)?;
                 let (left_unified_ky, left_unified_bridge_ky) =
-                    preamble.left.unified_ky_values(dr, &y)?;
+                    left_inputs.unified_ky_values(dr, &y)?;
                 let (right_unified_ky, right_unified_bridge_ky) =
-                    preamble.right.unified_ky_values(dr, &y)?;
+                    right_inputs.unified_ky_values(dr, &y)?;
 
                 let left_ky = native::stages::outer_error::ChildKyOutputs {
-                    application: preamble.left.application_ky(dr, &y)?,
+                    application: left_inputs.application_ky(dr, &y)?,
                     unified: left_unified_ky,
                     unified_bridge: left_unified_bridge_ky,
                 };
                 let right_ky = native::stages::outer_error::ChildKyOutputs {
-                    application: preamble.right.application_ky(dr, &y)?,
+                    application: right_inputs.application_ky(dr, &y)?,
                     unified: right_unified_ky,
                     unified_bridge: right_unified_bridge_ky,
                 };
@@ -102,8 +113,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                 // Build k(y) values in claim order.
                 let ky_source = native::claims::TwoProofKySource::new(
                     dr,
-                    preamble.left.unified.c.clone(),
-                    preamble.right.unified.c.clone(),
+                    left_inputs.unified.c.clone(),
+                    right_inputs.unified.c.clone(),
                     &left_ky,
                     &right_ky,
                 );

--- a/crates/ragu_pcd/src/internal/native/circuits/compute_v.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/compute_v.rs
@@ -281,14 +281,14 @@ struct Denominators<'dr, D: Driver<'dr>> {
 }
 
 impl<'dr, D: Driver<'dr>> Denominators<'dr, D> {
-    fn new<C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usize>(
+    fn new<C: Cycle<CircuitField = D::F>>(
         dr: &mut D,
         u: &Element<'dr, D>,
         w: &Element<'dr, D>,
         x: &Element<'dr, D>,
         y: &Element<'dr, D>,
         z: &Element<'dr, D>,
-        preamble: &native_preamble::Output<'dr, D, C, HEADER_SIZE>,
+        preamble: &native_preamble::Output<'dr, D, C>,
     ) -> Result<Self>
     where
         D::F: ff::PrimeField,
@@ -561,10 +561,10 @@ fn compute_axbx<'dr, D: Driver<'dr>, P: Parameters>(
 /// [`compute_f`]: crate::Application::compute_f
 /// [$\alpha$]: unified::Output::alpha
 #[rustfmt::skip]
-fn poly_queries<'a, 'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usize>(
+fn poly_queries<'a, 'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>>(
     eval: &'a native_eval::Output<'dr, D>,
     query: &'a native_query::Output<'dr, D>,
-    preamble: &'a native_preamble::Output<'dr, D, C, HEADER_SIZE>,
+    preamble: &'a native_preamble::Output<'dr, D, C>,
     d: &'a Denominators<'dr, D>,
     computed_ax: &'a Element<'dr, D>,
     computed_bx: &'a Element<'dr, D>,

--- a/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
@@ -231,6 +231,32 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
             .enforce_root_of_unity(dr, self.log2_circuits)?;
 
         let allocator = &mut Standard::new();
+
+        // Allocate full proof inputs (with grandchild headers and output header
+        // prefix) in this circuit's body — no other circuit reads header data,
+        // so these wires live outside the shared preamble stage. The output
+        // header's last element reuses the stage's `output_suffix` wire, so
+        // outer_collapse's base-case check sees the same value this circuit
+        // serializes into its public instance.
+        let left_inputs = native_preamble::ProofInputs::alloc_reusing_core(
+            dr,
+            allocator,
+            witness.as_ref().map(|w| w.preamble_witness.left.proof),
+            witness
+                .as_ref()
+                .map(|w| &w.preamble_witness.left.output_header),
+            &preamble.left,
+        )?;
+        let right_inputs = native_preamble::ProofInputs::alloc_reusing_core(
+            dr,
+            allocator,
+            witness.as_ref().map(|w| w.preamble_witness.right.proof),
+            witness
+                .as_ref()
+                .map(|w| &w.preamble_witness.right.output_header),
+            &preamble.right,
+        )?;
+
         let mut unified_output = OutputBuilder::new(witness.map(|w| w.unified));
 
         // Create a transcript for all challenge derivations
@@ -259,19 +285,18 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         unified_output.y.provide(y.clone());
         unified_output.z.provide(z);
 
-        // Compute k(y) values from preamble and enforce equality with staged
-        // values.
+        // Compute k(y) values from proof inputs and enforce equality with
+        // staged values.
         {
-            let left_application_ky = preamble.left.application_ky(dr, &y)?;
-            let right_application_ky = preamble.right.application_ky(dr, &y)?;
+            let left_application_ky = left_inputs.application_ky(dr, &y)?;
+            let right_application_ky = right_inputs.application_ky(dr, &y)?;
 
             left_application_ky.enforce_equal(dr, &outer_error.left.application)?;
             right_application_ky.enforce_equal(dr, &outer_error.right.application)?;
 
-            let (left_unified_ky, left_unified_bridge_ky) =
-                preamble.left.unified_ky_values(dr, &y)?;
+            let (left_unified_ky, left_unified_bridge_ky) = left_inputs.unified_ky_values(dr, &y)?;
             let (right_unified_ky, right_unified_bridge_ky) =
-                preamble.right.unified_ky_values(dr, &y)?;
+                right_inputs.unified_ky_values(dr, &y)?;
 
             left_unified_ky.enforce_equal(dr, &outer_error.left.unified)?;
             right_unified_ky.enforce_equal(dr, &outer_error.right.unified)?;
@@ -294,13 +319,13 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
                 .enforce_equal(dr, &outer_error.sponge_state)?;
         }
 
-        // Output headers from preamble + unified instance. Verification with
-        // `unified_bridge_ky` ensures preamble headers match ApplicationProof
+        // Output headers + unified instance. Verification with
+        // `unified_bridge_ky` ensures proof-input headers match ApplicationProof
         // headers.
         let (unified, updated) = unified_output.finish_no_suffix(dr, allocator)?;
         let output = Output {
-            left_header: preamble.left.output_header,
-            right_header: preamble.right.output_header,
+            left_header: left_inputs.output_header,
+            right_header: right_inputs.output_header,
             unified,
         };
 

--- a/crates/ragu_pcd/src/internal/native/stages/preamble.rs
+++ b/crates/ragu_pcd/src/internal/native/stages/preamble.rs
@@ -15,6 +15,7 @@ use ragu_core::{
 };
 use ragu_primitives::{
     Boolean, Element, GadgetExt,
+    allocator::Allocator,
     consistent::Consistent,
     vec::{CollectFixed, ConstLen, FixedVec},
 };
@@ -136,12 +137,6 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usiz
         self.output_header.write(dr, &mut ky)?;
         ky.finish_ky(dr)
     }
-
-    /// Returns true if this child proof is a trivial proof (output header suffix == 1).
-    pub fn is_trivial(&self, dr: &mut D) -> Result<Boolean<'dr, D>> {
-        let suffix = &self.output_header[HEADER_SIZE - 1];
-        suffix.is_equal(dr, &Element::one())
-    }
 }
 
 impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usize>
@@ -189,6 +184,72 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usiz
         })
     }
 
+    /// Allocate [`ProofInputs`] reusing core wires from the preamble [`Stage`].
+    ///
+    /// Only the headers (grandchild headers and output header prefix) are newly
+    /// allocated via `allocator`; `circuit_id`, `unified`, and the output
+    /// header's last element (suffix) come from `core`. This avoids duplicating
+    /// the core allocations done by the stage.
+    ///
+    /// Pass a pairing allocator (e.g. [`Standard`]) to keep the header
+    /// allocation cost at one gate per two wires.
+    ///
+    /// [`Standard`]: ragu_primitives::allocator::Standard
+    pub fn alloc_reusing_core<R: Rank, A: Allocator<'dr, D>>(
+        dr: &mut D,
+        allocator: &mut A,
+        proof: DriverValue<D, &Proof<C, R>>,
+        output_header: DriverValue<D, &FixedVec<D::F, ConstLen<HEADER_SIZE>>>,
+        core: &CoreInputs<'dr, D, C>,
+    ) -> Result<Self> {
+        fn alloc_header<'dr, D: Driver<'dr>, A: Allocator<'dr, D>, const N: usize>(
+            dr: &mut D,
+            allocator: &mut A,
+            data: DriverValue<D, &[D::F]>,
+        ) -> Result<FixedVec<Element<'dr, D>, ConstLen<N>>> {
+            D::try_just(|| {
+                if data.as_ref().take().len() != N {
+                    return Err(Error::MalformedEncoding(
+                        "Header data length does not match HEADER_SIZE".into(),
+                    ));
+                }
+
+                Ok(())
+            })?;
+
+            (0..N)
+                .map(|i| Element::alloc(dr, allocator, data.as_ref().map(|d| d[i])))
+                .try_collect_fixed()
+        }
+
+        let children = ChildHeaders {
+            left: alloc_header(dr, allocator, proof.as_ref().map(|p| p.left_header()))?,
+            right: alloc_header(dr, allocator, proof.as_ref().map(|p| p.right_header()))?,
+        };
+
+        // Allocate the first HEADER_SIZE - 1 elements of the output header.
+        // The last element reuses `core.output_suffix` so that the shared-stage
+        // wire is the same wire hashes_1's public instance serialization
+        // exposes — no extra enforce_equal needed.
+        let mut elems: Vec<Element<'dr, D>> = Vec::with_capacity(HEADER_SIZE);
+        for i in 0..HEADER_SIZE - 1 {
+            elems.push(Element::alloc(
+                dr,
+                allocator,
+                output_header.as_ref().map(|h| h[i]),
+            )?);
+        }
+        elems.push(core.output_suffix.clone());
+        let output_header: HeaderVec<'dr, D, HEADER_SIZE> = FixedVec::try_from(elems)?;
+
+        Ok(ProofInputs {
+            children,
+            output_header,
+            circuit_id: core.circuit_id.clone(),
+            unified: core.unified.clone(),
+        })
+    }
+
     /// Allocate ProofInputs from a proof reference and some unprocessed header
     /// data.
     pub fn alloc_for_verify<R: Rank, H: Header<C::CircuitField>>(
@@ -216,21 +277,68 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usiz
     }
 }
 
+/// Core inputs from a single child proof allocated by the preamble [`Stage`].
+///
+/// Holds the data shared across multiple circuits: the child's circuit ID, its
+/// unified instance, and the output header's last element (the trivial-proof
+/// indicator). The full output header and grandchild headers are allocated
+/// on-demand by [`hashes_1`] only, since no other circuit reads them.
+///
+/// [`hashes_1`]: super::super::circuits::hashes_1
+#[derive(Gadget, Consistent)]
+pub struct CoreInputs<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>> {
+    #[ragu(gadget)]
+    pub circuit_id: Element<'dr, D>,
+    #[ragu(gadget)]
+    pub unified: unified::Output<'dr, D, C>,
+    /// Last element of the child's output header. Used by [`outer_collapse`] to
+    /// detect the base case (trivial proof). Kept in the shared stage so
+    /// [`hashes_1`] and [`outer_collapse`] see the same wire.
+    ///
+    /// [`outer_collapse`]: super::super::circuits::outer_collapse
+    /// [`hashes_1`]: super::super::circuits::hashes_1
+    #[ragu(gadget)]
+    pub output_suffix: Element<'dr, D>,
+}
+
+impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle> CoreInputs<'dr, D, C> {
+    /// Returns true if this child proof is a trivial proof (output header suffix == 1).
+    pub fn is_trivial(&self, dr: &mut D) -> Result<Boolean<'dr, D>> {
+        self.output_suffix.is_equal(dr, &Element::one())
+    }
+
+    /// Allocate [`CoreInputs`] from a proof reference and the suffix element.
+    fn alloc<R: Rank>(
+        dr: &mut D,
+        proof: DriverValue<D, &Proof<C, R>>,
+        output_suffix: DriverValue<D, C::CircuitField>,
+    ) -> Result<Self> {
+        let allocator = &mut ();
+        Ok(CoreInputs {
+            circuit_id: Element::alloc(
+                dr,
+                allocator,
+                proof.as_ref().map(|p| p.circuit_id().omega_j()),
+            )?,
+            unified: unified::Output::alloc_from_proof(dr, allocator, proof)?,
+            output_suffix: Element::alloc(dr, allocator, output_suffix)?,
+        })
+    }
+}
+
 /// Prover-internal output of the native preamble stage.
 ///
 /// This is stage communication data, not part of the circuit's public instance.
 /// The verifier never sees these values directly.
 #[derive(Gadget, Consistent)]
-pub struct Output<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usize> {
+pub struct Output<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>> {
     #[ragu(gadget)]
-    pub left: ProofInputs<'dr, D, C, HEADER_SIZE>,
+    pub left: CoreInputs<'dr, D, C>,
     #[ragu(gadget)]
-    pub right: ProofInputs<'dr, D, C, HEADER_SIZE>,
+    pub right: CoreInputs<'dr, D, C>,
 }
 
-impl<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usize>
-    Output<'dr, D, C, HEADER_SIZE>
-{
+impl<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>> Output<'dr, D, C> {
     /// Returns true if both child proofs are trivial proofs.
     pub fn is_base_case(&self, dr: &mut D) -> Result<Boolean<'dr, D>> {
         let left_is_trivial = self.left.is_trivial(dr)?;
@@ -249,11 +357,11 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> staging::Stage<C::CircuitField
 {
     type Parent = ();
     type Witness<'source> = &'source Witness<'source, C, R, HEADER_SIZE>;
-    type OutputKind = Kind![C::CircuitField; Output<'_, _, C, HEADER_SIZE>];
+    type OutputKind = Kind![C::CircuitField; Output<'_, _, C>];
 
     fn values() -> usize {
-        // 2 proofs * (3 headers * HEADER_SIZE + 1 circuit_id + unified instance wires)
-        2 * (3 * HEADER_SIZE + 1 + unified::NUM_WIRES)
+        // 2 proofs * (1 circuit_id + unified instance wires + 1 output_suffix)
+        2 * (1 + unified::NUM_WIRES + 1)
     }
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>>(
@@ -264,16 +372,16 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> staging::Stage<C::CircuitField
     where
         Self: 'dr,
     {
-        let left = ProofInputs::alloc(
+        let left = CoreInputs::alloc(
             dr,
             witness.as_ref().map(|w| w.left.proof),
-            witness.as_ref().map(|w| &w.left.output_header),
+            witness.as_ref().map(|w| w.left.output_header[HEADER_SIZE - 1]),
         )?;
 
-        let right = ProofInputs::alloc(
+        let right = CoreInputs::alloc(
             dr,
             witness.as_ref().map(|w| w.right.proof),
-            witness.as_ref().map(|w| &w.right.output_header),
+            witness.as_ref().map(|w| w.right.output_header[HEADER_SIZE - 1]),
         )?;
 
         Ok(Output { left, right })

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -89,10 +89,10 @@ fn test_internal_circuit_constraint_counts() {
     }
 
     check_constraints!(Hashes1Circuit,         mul = 2045, lin = 3422);
-    check_constraints!(Hashes2Circuit,         mul = 1879, lin = 2951);
-    check_constraints!(InnerCollapseCircuit,  mul = 1756, lin = 1918);
-    check_constraints!(OuterCollapseCircuit,  mul = 811 , lin = 808);
-    check_constraints!(ComputeVCircuit,        mul = 1135, lin = 1773);
+    check_constraints!(Hashes2Circuit,         mul = 1685, lin = 2951);
+    check_constraints!(InnerCollapseCircuit,  mul = 1562, lin = 1918);
+    check_constraints!(OuterCollapseCircuit,  mul = 617 , lin = 808);
+    check_constraints!(ComputeVCircuit,        mul = 941 , lin = 1773);
 }
 
 #[rustfmt::skip]
@@ -105,11 +105,11 @@ fn test_internal_stage_parameters() {
         }};
     }
 
-    check_stage!(Preamble, skip =   1, num = 225);
-    check_stage!(OuterError,  skip = 226, num = 186);
-    check_stage!(InnerError,  skip = 412, num = 399);
-    check_stage!(Query,   skip = 226, num =  23);
-    check_stage!(Eval,    skip = 249, num =  18);
+    check_stage!(Preamble, skip =   1, num =  31);
+    check_stage!(OuterError,  skip =  32, num = 186);
+    check_stage!(InnerError,  skip = 218, num = 399);
+    check_stage!(Query,   skip =  32, num =  23);
+    check_stage!(Eval,    skip =  55, num =  18);
 }
 
 /// Helper test to print current constraint counts in copy-pasteable format.
@@ -197,7 +197,7 @@ fn test_native_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fp!(0x337e4da97c9fa6921600f92576a552fcbd5b606a5d8a0666c5b48527b2d2f83f);
+    let expected = fp!(0x175af3a5c0f67d0a314744dcc58eca459d940b137f70014cde15db3a46e170af);
 
     assert_eq!(
         app.native_registry.digest(),


### PR DESCRIPTION
**Experimental ruminations for clarifying assumptions, not intended to be merged.**

Headers are already bound _transitively_ via the child's application commitment (which becomes a coefficient of the `bridge_preamble` polynomial whose commitment is absorbed before challenge y is derived). Why isn’t that alone sufficient binding in this context, rather than also requiring the headers to be embedded in the preamble? Public inputs _must_ be committed before challenges in the subprotocol, but "committed in the preamble" and "committed via the child's application commitment wrapped in `bridge_preamble`" feel like two routes to the same property. Discussed the standard adaptive attack vector OOB, but opened anyway to poke at some design principles. cc @ebfull, @alxiong 
