### PR TITLE
doc: fix stale allocator signatures in book pages

### DIFF
--- a/book/src/guide/getting_started.md
+++ b/book/src/guide/getting_started.md
@@ -63,8 +63,8 @@ types:
 use ff::Field;
 use ragu_core::{Result, drivers::{Driver, DriverValue}, gadgets::{Bound, Kind}, maybe::Maybe};
 use ragu_pcd::header::{Header, Suffix};
-use ragu_primitives::Element;
 use ragu_primitives::allocator::{Allocator, Standard};
+use ragu_primitives::Element;
 use ragu_primitives::poseidon::Sponge;
 
 // LeafNode: carries a hash of raw data
@@ -106,7 +106,9 @@ impl<F: Field> Header<F> for InternalNode {
 - `SUFFIX`: Unique identifier for each header type
 - `Data`: The Rust type for this header's data (field elements)
 - `Output`: The circuit representation (Element gadget)
-- `encode`: How to convert Data into circuit form
+- `encode`: How to convert `Data` into circuit form. The `allocator`
+  parameter controls allocation; see
+  [Allocation](primitives/allocation.md)
 
 ## Step 2: Implement CreateLeaf Step
 
@@ -221,8 +223,8 @@ impl<'params, C: Cycle> Step<C> for CombineNodes<'params, C> {
         Self: 'dr,
     {
         // 1. Encode input proofs
-        let left = Encoded::new(dr, left)?;
-        let right = Encoded::new(dr, right)?;
+        let left = Encoded::new(dr, &mut (), left)?;
+        let right = Encoded::new(dr, &mut (), right)?;
 
         // 2. Hash both headers together
         let mut sponge = Sponge::new(dr, self.poseidon_params);
@@ -240,10 +242,10 @@ impl<'params, C: Cycle> Step<C> for CombineNodes<'params, C> {
 }
 ```
 
-**What `Encoded::new(dr, left)?` does:** Converts the header data into a
-circuit gadget by allocating field elements. This makes the input proof's
-header data available for use in the circuit logic (e.g., hashing the two
-headers together).
+**What `Encoded::new(dr, &mut (), left)?` does:** Converts the header data
+into a circuit gadget by allocating field elements. This makes the input
+proof's header data available for use in the circuit logic (e.g., hashing
+the two headers together).
 
 ## Step 4: Build the Application
 

--- a/book/src/guide/getting_started.md
+++ b/book/src/guide/getting_started.md
@@ -30,6 +30,17 @@ ff = "0.13"
 rand = "0.8"
 ```
 
+## Overview: Building a Merkle Tree with Proofs
+
+This application implements two core operations:
+
+1. **CreateLeaf**: Takes a value, hashes it, and produces a leaf proof
+2. **CombineNodes**: Takes two leaf proofs and combines them into an internal
+   node proof
+
+The result is a proof tree where each node proves it was correctly computed
+from its children.
+
 ## Configuration at a Glance
 
 This guide uses `ApplicationBuilder::<Pasta, R<13>, 4>`:
@@ -42,17 +53,6 @@ This guide uses `ApplicationBuilder::<Pasta, R<13>, 4>`:
 
 These defaults work for most applications. See
 [Configuration](configuration.md) for guidance on choosing different values.
-
-## Overview: Building a Merkle Tree with Proofs
-
-This application implements two core operations:
-
-1. **CreateLeaf**: Takes a value, hashes it, and produces a leaf proof
-2. **CombineNodes**: Takes two leaf proofs and combines them into an internal
-   node proof
-
-The result is a proof tree where each node proves it was correctly computed
-from its children.
 
 ## Step 1: Define Header Types
 

--- a/book/src/guide/writing_circuits.md
+++ b/book/src/guide/writing_circuits.md
@@ -123,7 +123,7 @@ type Output = InternalNode;  // Produces InternalNode
 
 The key operations in a fuse step:
 1. **Encode inputs** - Convert input proof headers to circuit gadgets via
-   `Encoded::new(dr, left)?`
+   `Encoded::new(dr, &mut (), left)?`
 2. **Extract data** - Get header values with `.as_gadget()`
 3. **Combine** - Hash or process the data together
 4. **Encode output** - Package combined result as a new proof
@@ -135,12 +135,14 @@ These proofs are created using `app.fuse()`.
 When working with input proofs in a fuse step:
 
 ```rust
-let left = Encoded::new(dr, left)?;
-let right = Encoded::new(dr, right)?;
+let left = Encoded::new(dr, &mut (), left)?;
+let right = Encoded::new(dr, &mut (), right)?;
 ```
 
 The `Encoded::new()` call:
-- Converts the header data into circuit gadgets (allocates field elements)
+- Takes an allocator (`&mut ()` uses the default) that controls wire
+  allocation — see [Allocation](primitives/allocation.md)
+- Converts the header data into circuit gadgets
 - Makes the proof's header data available for use in circuit logic
 - Returns an `Encoded` proof that can be passed to the next step
 
@@ -175,7 +177,9 @@ impl<F: Field> Header<F> for LeafNode {
 **SUFFIX**: Unique identifier for this header type (used for type safety)
 **Data**: The native Rust type for this header's data
 **Output**: The gadget representation (circuit elements)
-**encode**: How to convert `Data` into `Output`
+**encode**: How to convert `Data` into `Output`. The `allocator` parameter
+controls how field elements are allocated; see
+[Allocation](primitives/allocation.md) for details on choosing an allocator.
 
 ## Common Patterns
 

--- a/book/src/guide/writing_circuits.md
+++ b/book/src/guide/writing_circuits.md
@@ -154,30 +154,14 @@ let right_data = right.as_gadget();
 
 ## Working with Headers
 
-Headers define what data flows through the proof tree:
+Headers define what data flows through the proof tree. Each header
+implementation specifies a `SUFFIX` (unique identifier), a `Data` type
+(the native Rust value), an `Output` type (the circuit gadget
+representation), and an `encode` function that converts `Data` into
+`Output` by allocating circuit elements.
 
-```rust
-struct LeafNode;
-
-impl<F: Field> Header<F> for LeafNode {
-    const SUFFIX: Suffix = Suffix::new(0);  // Unique ID
-    type Data = F;                 // Data type
-    type Output = Kind![F; Element<'_, _>]; // Gadget output
-
-    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
-        dr: &mut D,
-        allocator: &mut A,
-        witness: DriverValue<D, Self::Data>,
-    ) -> Result<Bound<'dr, D, Self::Output>> {
-        Element::alloc(dr, allocator, witness)
-    }
-}
-```
-
-**SUFFIX**: Unique identifier for this header type (used for type safety)
-**Data**: The native Rust type for this header's data
-**Output**: The gadget representation (circuit elements)
-**encode**: How to convert `Data` into `Output`. The `allocator` parameter
+For a complete example with multiple header types, see
+[Getting Started — Define Header Types](getting_started.md#step-1-define-header-types).. The `allocator` parameter
 controls how field elements are allocated; see
 [Allocation](primitives/allocation.md) for details on choosing an allocator.
 


### PR DESCRIPTION
updates getting_started.md and writing_circuits.md to match post-PR #647 allocator API signatures.