### PR TITLE
book: routine implementation page

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -50,6 +50,7 @@
 - [Part III: Implementation]()
   - [Architecture Overview](implementation/arch.md) <!-- todo -->
   - [Circuits](implementation/circuits.md) <!-- todo -->
+  - [Routines](implementation/routines.md) <!-- todo -->
   - [Polynomial Management](implementation/polynomials.md) <!-- todo -->
   - [PCD Step and Proofs](implementation/proofs.md) <!-- todo -->
   - [Staging](implementation/staging.md) <!-- todo -->

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -54,6 +54,7 @@
   - [Architecture Overview](implementation/arch.md) <!-- todo -->
   - [Documenting Circuit Code](implementation/circuit-code-documentation.md)
   - [Circuits](implementation/circuits.md) <!-- todo -->
+  - [Routines](implementation/routines.md) <!-- todo -->
   - [Polynomial Management](implementation/polynomials.md) <!-- todo -->
   - [PCD Step and Proofs](implementation/proofs.md) <!-- todo -->
   - [Staging](implementation/staging.md) <!-- todo -->

--- a/book/src/guide/routines.md
+++ b/book/src/guide/routines.md
@@ -74,7 +74,7 @@ expressions][poly-synthesis], and equivalent routines contribute structurally
 identical terms at different positions. The driver can derive one invocation's
 contribution from another without re-executing the body.
 
-### Parameterization
+### Parameterization {#param}
 
 Unlike gadgets, routines are not parameterized by a driver and are free to carry
 non-trivial state. This allows them to hold configuration, references, or

--- a/book/src/implementation/routines.md
+++ b/book/src/implementation/routines.md
@@ -4,7 +4,7 @@
 that satisfy a simple function-like interface: they take a single [`Input`]
 gadget and a [`Driver`] handle, and return a single [`Output`] gadget. They are
 permitted to do anything that normal circuit code can do with a
-[driver](../guide/drivers.md), such as making gates ([`mul`], [`alloc`]) and
+[driver](../guide/drivers.md), such as making gates ([`gate`], [`mul`], [`alloc`]) and
 constraining their wires ([`enforce_zero`]).
 
 It is possible to invoke them by manually calling their [`Routine::execute`]
@@ -32,7 +32,7 @@ algebraic properties at routine boundaries.
 Routines exploit the fact that contiguous sections of code tend to have
 algebraically convenient structure in the resulting wiring polynomial $s(X, Y)$:
 
-* `mul` advances an $i$ counter and returns $(X^{2n - 1 - i}, X^{2n + i}, X^{4n - 1 - i})$ wires.
+* [`gate`] advances an $i$ counter and returns $(X^{2n - 1 - i}, X^{2n + i}, X^{4n - 1 - i}, X^i)$ wires.
 * `enforce_zero` advances a counter $j$ and adds a fresh linear combination of previous wires multiplied by $Y^j$.
 
 Most of the linear constraints created within a routine consist purely of wires
@@ -160,6 +160,7 @@ out-of-line.**
 [`Output`]: ragu_core::routines::Routine::Output
 [`Routine::execute`]: ragu_core::routines::Routine::execute
 [`enforce_zero`]: ragu_core::drivers::Driver::enforce_zero
+[`gate`]: ragu_core::drivers::DriverTypes::gate
 [`mul`]: ragu_core::drivers::Driver::mul
 [`alloc`]: ragu_core::drivers::Driver::alloc
 [`Any`]: core::any::Any

--- a/book/src/implementation/routines.md
+++ b/book/src/implementation/routines.md
@@ -277,6 +277,24 @@ cached subtree cannot be reused). Consolidating both levels into a single
 identity type loses this distinction and forces the floor planner to
 treat segments as different when only their subtrees differ.
 
+The two-level design avoids four conflation risks that arise when a single
+fingerprint type serves both roles. First, [`TypeId`] pairs do not affect
+what a segment contributes to $s(X, Y)$, so including them in the
+polynomial-equivalence key would prevent the floor planner from grouping
+type-distinct routines that contribute identically. Second, tests that
+assert "different TypeIds ⇒ different fingerprints" are testing memoization
+safety, not polynomial correctness; naming them as if TypeIds were
+necessary for fingerprint correctness obscures which invariant is actually
+being verified. Third, the `Counter` and the wiring polynomial evaluators
+compute fundamentally different things — a context-independent structural
+hash versus an actual polynomial contribution — so bundling both concerns
+into one type hides the boundary between them. Fourth, without an
+independent reference evaluation to compare against, a memoization cache
+that silently returns wrong results could go undetected; the separation
+makes it possible to test polynomial equivalence (via
+[`RoutineFingerprint`]) and memoization substitutability (via
+[`MemoFingerprint`]) with distinct, targeted assertions.
+
 ### Repositioning {#repositioning}
 
 Each segment occupies a **non-overlapping** range of gates and constraints in

--- a/book/src/implementation/routines.md
+++ b/book/src/implementation/routines.md
@@ -24,13 +24,6 @@ drivers use manual `mem::replace` on the scoped state instead when they need to
 inspect the child scope's result before restoring.
 We refer our invocation-depth-independent drivers as being _context insensitive_.
 
-Drivers cannot distinguish routines themselves but merely their **invocations**;
-in each `routine` call, they learn the [`TypeId`] of their [`Input`] and
-[`Output`] gadgets, and thanks to
-[fungibility](../guide/gadgets/index.md#fungibility) this is very
-useful for their structural analysis (via [conversions]) and induces stable
-algebraic properties at routine boundaries.
-
 ## Algebraic Description {#algebraic-description}
 
 Routines exploit the fact that contiguous sections of code tend to have
@@ -98,7 +91,7 @@ Similarly, we can extract the common factor $X^{2n}Y^j$ for the starting
 constraint index $j$ and the remaining univariate $g_3$ is invariant to the
 routine invocation.
 
-## Example: Synthesis Trace
+## Example: Synthesis Trace {#example}
 
 The following circuit serves as a concrete example for all upcoming discussion:
 
@@ -167,17 +160,43 @@ Let's start with some naive but incorrect ways to identify a routine:
   even the same `ScaledTxz` routine type (or `RoutineB` in our example)
   can synthesize to different traces.
   
-In short, drivers cannot distinguish routines themselves but merely their
-**invocations**. Fingerprinting is the process by which a routine invocation is
-succinctly encapsulated so that _matching fingerprints implies opportunities for
-routine memoization_. There could be multiple fingerprints for one invocation,
-each fingerprint signals a different memoization strategy or aggressive level.
+In short, drivers cannot distinguish routines statically alone, but must also 
+consider their **invocations**. Fingerprinting is the process by which a routine
+invocation is succinctly encapsulated so that _matching fingerprints implies
+opportunities for routine memoization_. There could be multiple fingerprints for
+an invocation, each signals a different memoization strategy or aggressive level.
 Ragu produces two fingerprints: a **base fingerprint** that captures _segment-level
 equivalence_ and signals memoization of only the base segment of an invocation;
-and a **deep fingerprint** that captures _subtree-level equivalence_ and signals
-memoization of the entire routine, recursively include all nested sub-routines.
+and a **deep fingerprint** that captures _tree-level equivalence_ and signals
+memoization of the entire routine, recursively including all nested sub-routines.
 
-Conceptually, the simplest approach is to pick a random point $(x_r, y_r)$
+### Base fingerprint {#base-fingerprint}
+
+Ragu tracks the gates and constraint counts of the local/base segment of a
+routine invocation and its polynomial contribution for `BaseFingerprint`.
+In the [example above](#example), although the two invocations of `RoutineB`
+are obviously different, it's possible that the internal contribution of their
+base segments are identical thus memoizable (i.e., `b0 + b1 = b2`).
+
+Note that the polynomial contribution only include invocation's internal and
+system contributions, those invariant to the invocation's context and location,
+and exclude all interface contributions. Further note that polynomial evaluation
+alone is insufficient because it only captures `enforce_zero` calls, not gate
+count which is crucial for floor planner later. Technically, the constraint
+count, already bounded in the contribution scalar, is purely defense-in-depth.
+
+```rust
+struct BaseFingerprint {
+    /// shape of the **base segment** of a routine
+    num_gates: usize,
+    num_constraints: usize,
+    /// polynomial contribution of the base segment
+    /// in practice, we use `low_u64<F>(eval) -> u64`
+    eval: F,
+}
+```
+
+Conceptually, the simplest approach to `eval` is to pick a random $(x_r, y_r)$
 and use the internal contribution of each routine invocation to $s(x_r, y_r)$
 as its fingerprint. By Schwartz-Zippel lemma, two different invocations will
 produce different polynomial contribution with overwhelming probability.
@@ -186,9 +205,88 @@ forward direction ($X^i$ terms) and backward direction ($X^{4n-1-i}$ terms); and
 involves scalar multiplications (for $X^{2n}$ and $X^{4n}$) and expensive
 inversion (for $X^{-1}$) during initialization.
 
-In contrast, Ragu takes a more efficient approach where fingerprints 
-TODO
+Instead, Ragu takes a more efficient approach: use 4 _independent_ geometric
+sequences for wire values (one for each of `a/b/c/d`-wires) and Horner-accumulate
+contribution of `enforce_zero` constraints with $Y$ powers of a random $Y=y_r$.
+Wires from the $i$-th gate corresponds to $(x_0^i, x_1^i, x_2^i, x_3^i)$ monomial
+evaluations for a random $(x_0, x_1, x_2, x_3)$ picked at initialization.
+This simplification is possible thanks to the relaxed requirement on the
+fingerprint: characterize the constraints in any binding way, not necessarily in
+the same way as the wiring polynomial $s(X, Y)$.
 
+Handling interface contributions is the most subtle logic. In our example, the
+first invocation of `RoutineB` accepts an input gadget from the parent routine
+on enter and receives an output gadget from the child `RoutineA` in the middle.
+Both gadgets are allocated outside the scope of the base segment of `RoutineB`,
+thus any constraint on them belongs to interface contributions and should not
+meaningfully affect the `eval` computation. Concretely, relocating wires in these
+interface gadgets should not affect the `eval` fingerprint.
+
+There are two approaches to dealing with wires in these interface gadgets:
+
+1. discriminate them as a separate wire type:
+   (e.g. `enum WireEval { Value, One, Interface }`) so that routines can flag
+   them as `WireEval::Interface(F)` and drivers can drop their contribution.
+2. assign context-insensitive values to them so that their contributions are
+   cancelled out among otherwise equivalent invocations, thus cannot impact
+   equivalence meaningfully.
+
+Ragu takes the second approach, implemented via a wire remapping [`WireMap`]:
+all wires in interface gadgets are remapped to hold values from an independent
+geometric sequence with another random base.[^x-remap] Importantly, every
+routine, no matter at which invocation depth, starts with the same geometric
+sequence re-initialized so that the input gadget wires holds a positional value
+that is context-insensitive. Furthermore, before exit, every routine remap
+the output gadget and appended to its parent's context.
+
+[^x-remap]: For code reference, the variable is named `x_remap` and remapped 
+    wires take on values `x_remap^i` which is independent of normal sequences
+    $(x_0^i, x_1^i, x_2^i, x_3^i)$. Intuitively, every routine starts with a
+    blank page for interface gadget wires written sequentially from the page;
+    and their output gadget wires are appended to the parent's page.
+
+### Deep fingerprint {#deep-fingerprint}
+
+The most aggressive memoization is possible when two routine invocations are
+tree-level equivalent with the structurally identical base and subroutines.
+Intuitively, two invocations with identical deep fingerprints means that their
+shapes (gate and constraint counts) and their polynomial contributions are
+identical if we _flatten and inline all their nested subroutines_.
+
+The main gap from [base fingerprint](#base-fingerprint) is how to handle wires
+of output gadgets from the child subroutines. In base fingerprint, output wires
+are remapped in their parent's context. This remapping erases their positions
+relative to the start of the base/parent routine, which is necessary to test
+equivalence of the inlined routine.[^swapped] Therefore, we must capture the
+positional values of these output wires in the parent's deep fingerprint.
+
+```rust
+struct DeepFingerprint {
+    base: BaseFingerprint,
+    /// deep hash: 
+    /// H(self.base, output_gadget, child_deep_hashes, input_type, output_type)
+    deep: u64,
+}
+```
+
+Ragu augments the base fingerprint with the wire values of the output gadget,
+the deep fingerprint of all its child invocations (one level deeper), and the
+`TypeId` of the input and output gadget types (optional, only defense-in-depth).
+The monomial evaluation of output wires (of a subroutine) already encodes their
+positions relative to the start of the subroutine (thus transitively relative
+to the start of the parent routine). Since the deep fingerprint of the parent
+routine recursively hash in the deep hashes of all child subroutines, the final
+hash binds the entire invocation tree.
+
+
+[^swapped]: As an example, two `RoutineB` nested-call `RoutineA`. The first
+    `RoutineA` invocation: `alloc(w1); alloc(w2); enforce_zero(w1 + w2); return (w1, w2)`;
+    the second invocation: `alloc(w2); alloc(w1); enforce_zero(w1 + w2); return (w1, w2)`.
+    In `BaseFingerprint` computation, the output wires `(w1, w2)` from both
+    invocations are mapped to the same values in their parent `RoutineB` context.
+    Two `RoutineB` invocations gets identical base fingerprints.
+    However, after inlining, the two invocations differ because of swapped
+    allocation of `w1` and `w2`.
 
 ## Pipeline {#pipeline}
 
@@ -457,6 +555,7 @@ fingerprinting model at all, this comparison catches errors in the model
 itself — a routine fingerprint that over-groups, or a memo fingerprint
 that omits a necessary field — not only bugs in the memoization code.
 
+[`WireMap`]: ragu_core::convert::WireMap
 [`RoutineFingerprint`]: ragu_circuits::metrics::RoutineFingerprint
 [`MemoFingerprint`]: ragu_circuits::metrics::MemoFingerprint
 [`TypeId`]: core::any::TypeId

--- a/book/src/implementation/routines.md
+++ b/book/src/implementation/routines.md
@@ -35,7 +35,7 @@ algebraically convenient structure in the resulting wiring polynomial $s(X, Y)$:
 * [`gate`] advances an $i$ counter and returns $(X^{2n - 1 - i}, X^{2n + i}, X^{4n - 1 - i}, X^i)$ wires.
 * `enforce_zero` advances a counter $j$ and adds a fresh linear combination of previous wires multiplied by $Y^j$.
 
-Most of the linear constraints created within a routine consist purely of wires
+Most of the linear constraints created within a routine consist purely of wires also
 created within that routine, meaning that the **internal** contribution of a
 routine can be written as polynomials $g_x, g_{x^{-1}}$ and memoized if the
 routine is invoked multiple times. Given a cache hit, we need only scale $g_x$
@@ -70,11 +70,11 @@ graph LR
         FP[floor plan]
     end
     subgraph tp[trace path]
-        rx --> trace
+        TE[trace eval] --> trace
     end
     C --> MP
-    C --> rx
-    W --> rx
+    C --> TE
+    W --> TE
     metrics --> FP
     FP --> ED
     trace --> TP["r(X)"]
@@ -121,7 +121,7 @@ describes where the $i$-th segment is placed, regardless of whether a
 future floor planner reorders their positions.
 
 The [`Counter`] uses each invocation to build a [`SegmentRecord`] and a
-[`RoutineFingerprint`]. It resets its geometric sequences and Horner
+[`MemoFingerprint`]. It resets its geometric sequences and Horner
 accumulator to a fixed initial state — independent of the caller — so that
 the fingerprint captures only the routine's internal constraint structure.
 Input wires are remapped into the fresh scope without incrementing
@@ -170,7 +170,7 @@ Execution traces are divided into **segments**. All wires allocated outside of
 routine invocations belong to a single **root segment**.[^root-segment] Each
 routine invocation creates a new segment containing only the wires allocated
 directly within it; nested calls produce their own segments in turn. The
-`CircuitExt::rx` method produces a `Trace` that contains these segments in DFS
+`CircuitExt::trace` method produces a `Trace` that contains these segments in DFS
 order, but their actual arrangement in the trace polynomial depends on the floor
 plan's repositioning values.
 
@@ -228,14 +228,14 @@ per-invocation.
 ### Fingerprinting
 
 Two invocations are structurally equivalent when they share a
-[**fingerprint**][`RoutineFingerprint`]: the pair `(TypeId(Input),
-TypeId(Output))`, the Schwartz–Zippel evaluation scalar, and the local gate and
-constraint counts. The [metrics pass](#pipeline) computes a fingerprint for each
-invocation by executing its constraint logic on a lightweight [`Counter`] driver
-that substitutes independent geometric sequences for wire values and
-accumulates constraint contributions via Horner's rule. If the resulting scalar,
-type pairs, and counts all match, the two invocations are structurally
-equivalent with overwhelming probability.
+[**routine fingerprint**][`RoutineFingerprint`]: the Schwartz–Zippel evaluation
+scalar and the local gate and constraint counts. The
+[metrics pass](#pipeline) computes a fingerprint for each invocation by
+executing its constraint logic on a lightweight [`Counter`] driver that
+substitutes independent geometric sequences for wire values and accumulates
+constraint contributions via Horner's rule. If the resulting scalar and counts
+match, the two invocations are structurally equivalent with overwhelming
+probability.
 
 Fingerprints capture only the **local** constraint structure. When entering a
 routine, the `Counter` resets its geometric sequences and Horner accumulator to
@@ -243,7 +243,7 @@ a fixed initial state, and output wires from nested routine calls are remapped
 to fresh positions in the caller's sequence space. This ensures the fingerprint
 is independent of calling context and of any sub-routines the routine invokes.
 
-### Shallow vs. Deep Fingerprints
+### Routine vs. Memo Fingerprints
 
 The [`TypeId`] pairs `(Input, Output)` do not affect what a segment
 contributes to $s(X, Y)$. Two routines with different Rust types but the
@@ -252,28 +252,29 @@ gate and constraint counts — produce identical polynomial contributions.
 This can be verified directly: wrap each routine in a circuit and assert
 that their $s(x, y)$ evaluations agree at random points.
 
-For floor planning, only the polynomial contribution matters. A **shallow
-fingerprint** `(eval, num_gates, num_constraints)` suffices to group
-segments with the same polynomial shape; including [`TypeId`] pairs would
-prevent the floor planner from grouping type-distinct routines that
-contribute identically. For memoization, the constraints are stricter: a
-cached routine must be safely substitutable for a fresh execution, which
-requires matching output wire mappings and recursive subtree structure. A
-**deep fingerprint** extends the shallow fingerprint with `output_eval`
-(a scalar encoding the output wire mapping) and a recursive hash that
-folds in [`TypeId`] pairs, all shallow fields, the child count, and each
-child's deep hash. The floor planner keys on the shallow fingerprint; the
-memo cache keys on the deep fingerprint.
+For floor planning, only the polynomial contribution matters. A
+[`RoutineFingerprint`] `(eval, local_num_gates, local_num_constraints)`
+suffices to group segments with the same polynomial shape; [`TypeId`]
+pairs are deliberately excluded so that the floor planner can group
+type-distinct routines that contribute identically. For memoization, the
+constraints are stricter: a cached routine must be safely substitutable
+for a fresh execution, which requires matching output wire mappings and
+recursive subtree structure. A [`MemoFingerprint`] extends the routine
+fingerprint with `output_eval` (a scalar encoding the output wire
+mapping) and a recursive `deep` hash that folds in [`TypeId`] pairs, all
+routine fingerprint fields, the child count, and each child's deep hash.
+The floor planner keys on the routine fingerprint; the memo cache keys on
+the memo fingerprint.
 
-The distinction is semantic, not just organizational. A shallow
+The distinction is semantic, not just organizational. A routine
 fingerprint captures **segment-level equivalence**: whether two individual
 segments impose the same local constraints and could be aligned in the
 polynomial layout regardless of their subtrees — for instance, padding
-one circuit's segment against another circuit's offset. A deep
+one circuit's segment against another circuit's offset. A memo
 fingerprint captures **subtree-level equivalence**: whether entire routine
 invocations are interchangeable and can be substituted via memoization.
-A segment can be shallow-equivalent to another (same local constraints,
-worth aligning) but deep-inequivalent (different children, so the
+A segment can be routine-equivalent to another (same local constraints,
+worth aligning) but memo-inequivalent (different children, so the
 cached subtree cannot be reused). Consolidating both levels into a single
 identity type loses this distinction and forces the floor planner to
 treat segments as different when only their subtrees differ.
@@ -318,10 +319,11 @@ in a single check. The non-overlapping invariant
 ensures that any disagreement is a real bug rather than a masking
 coincidence. Because the native path does not depend on the
 fingerprinting model at all, this comparison catches errors in the model
-itself — a shallow fingerprint that over-groups, or a deep fingerprint
+itself — a routine fingerprint that over-groups, or a memo fingerprint
 that omits a necessary field — not only bugs in the memoization code.
 
 [`RoutineFingerprint`]: ragu_circuits::metrics::RoutineFingerprint
+[`MemoFingerprint`]: ragu_circuits::metrics::MemoFingerprint
 [`Counter`]: ragu_circuits::metrics::Counter
 [`Trace::assemble`]: ragu_circuits::trace::Trace::assemble
 [`TypeId`]: core::any::TypeId

--- a/book/src/implementation/routines.md
+++ b/book/src/implementation/routines.md
@@ -24,14 +24,6 @@ drivers use manual `mem::replace` on the scoped state instead when they need to
 inspect the child scope's result before restoring.
 We refer our invocation-depth-independent drivers as being _context insensitive_.
 
-```admonish info
-Drivers do not learn the [`TypeId`] of a [`Routine`] they are asked to `execute`,
-since [`Routine`] does not implement [`Any`] / `'static`. Even if they could
-learn this, routines of the same type are allowed to diverge in their actual
-behavior because they can be arbitrarily configured, so long as they remain
-deterministic.
-```
-
 Drivers cannot distinguish routines themselves but merely their **invocations**;
 in each `routine` call, they learn the [`TypeId`] of their [`Input`] and
 [`Output`] gadgets, and thanks to
@@ -83,9 +75,15 @@ The interface contribution cannot be factored (or memoized) the same way:
 the input gadget is allocated by the routine caller at an unknown position, both
 absolute and relative to the start of the routine, so there is no a priori $X^i$
 factors to extract. We must compute interface contributions per-invocation.
-One crucial complication arises from nested routines. Our decision on
+One major complication arises from nested routines. Our decision on
 _context-insensitive_ drivers demands that the output gadgets of nested/child
 routines are also part of the interface contribution of the parent routine.
+It is always safe to categorize them as interface contributions and recompute on
+every invocation of the parent routine.
+However, if we know two routines have identical sub-routines, then these output
+gadgets can be correctively remapped in the parent routine's context such that
+further constraints on them can be memoized as internal contribution again.
+We will elaborate more [later](#fingerprint).
 
 Meanwhile, system contributions are also memoizable:
 
@@ -99,6 +97,98 @@ are referenced, $X^{2n}$ is the monomial for the $b_0 (= 1)$ wire during
 Similarly, we can extract the common factor $X^{2n}Y^j$ for the starting
 constraint index $j$ and the remaining univariate $g_3$ is invariant to the
 routine invocation.
+
+## Example: Synthesis Trace
+
+The following circuit serves as a concrete example for all upcoming discussion:
+
+```
+ Circuit Synthesis Trace
+ ────────────────────────
+ ├─ r0
+ ├─ Routine A
+ │   └─ a0
+ ├─ r1
+ ├─ Routine B
+ │   ├─ b0
+ │   ├─ Routine A
+ │   │   └─ a0
+ │   └─ b1
+ ├─ Routine B
+ │   ├─ b2
+ │   └─ Routine C
+ │       └─ c0
+ └─ r2
+```
+
+All `r0, a0, b0, .., r2` are contiguous sections of synthesized circuit trace
+allocated via [`gate`]. Intermittently, the circuit logic spawns a routine which
+can further spawn nested routines.
+
+## Segments
+
+Given an execution trace, we first need a global indexing of all sub-sections
+so that different drivers can refer to them consistently. Ragu divides the trace
+into **segments** and orders them naturally in a canonical **DFS order** as per
+the routine invocation. Particularly, circuit sections of the same invocation
+depth are merged into a single segment; wires allocated outside of any routine
+belong to a special **root segment**.[^root-segment] Each routine invocation
+creates a new **base segment** containing only the wires allocated directly
+within it; nested calls produce their own segments in turn. The DFS-ordered
+segments are built as [`SegmentRecord`]s during the [metric pass](#pipeline).
+Since circuit synthesis is deterministic, the ordered sequence is stable across
+all drivers of the same circuit code.
+
+[^root-segment]: The root segment is never repositioned. It contains the special
+    `ONE` wire and is where all stage wires of multi-stage circuits are located.
+
+```
+segments[0]: r0 + r1 + r2 (root segment)
+segments[1]: a0           (base segment of Routine A)
+segments[2]: b0 + b1      (base segment of Routine B)
+segments[3]: a0           (in the nested Routine A invoked in Routine B)
+segments[4]: b2           (base segment of the second invocation of Routine B)
+segments[5]: c0           (base segment of Routine C)
+```
+
+
+## Routine Fingerprints {#fingerprint}
+
+A prerequisite of routine memoization is identifying distinct routines.
+Let's start with some naive but incorrect ways to identify a routine:
+
+- by shape (`num_gates` and `num_constraints`):
+  different routines can coincidentally share the same shape.
+- by `(Input, Output)` gadget types:
+  routines executing different operations (e.g. `square` and `double`) can share the
+  same input/output types.
+- by `TypeId::of::<Routine>()`: 
+  routines can be [parameterized](../../guide/routines.md#param) and stateful,
+  even the same `ScaledTxz` routine type (or `RoutineB` in our example)
+  can synthesize to different traces.
+  
+In short, drivers cannot distinguish routines themselves but merely their
+**invocations**. Fingerprinting is the process by which a routine invocation is
+succinctly encapsulated so that _matching fingerprints implies opportunities for
+routine memoization_. There could be multiple fingerprints for one invocation,
+each fingerprint signals a different memoization strategy or aggressive level.
+Ragu produces two fingerprints: a **base fingerprint** that captures _segment-level
+equivalence_ and signals memoization of only the base segment of an invocation;
+and a **deep fingerprint** that captures _subtree-level equivalence_ and signals
+memoization of the entire routine, recursively include all nested sub-routines.
+
+Conceptually, the simplest approach is to pick a random point $(x_r, y_r)$
+and use the internal contribution of each routine invocation to $s(x_r, y_r)$
+as its fingerprint. By Schwartz-Zippel lemma, two different invocations will
+produce different polynomial contribution with overwhelming probability.
+However, such contribution requires tracking monomial evaluations in both
+forward direction ($X^i$ terms) and backward direction ($X^{4n-1-i}$ terms); and
+involves scalar multiplications (for $X^{2n}$ and $X^{4n}$) and expensive
+inversion (for $X^{-1}$) during initialization.
+
+In contrast, Ragu takes a more efficient approach where fingerprints 
+TODO
+
 
 ## Pipeline {#pipeline}
 
@@ -199,16 +289,10 @@ segments back into canonical DFS order.
 
 ## Segments
 
-Execution traces are divided into **segments**. All wires allocated outside of
-routine invocations belong to a single **root segment**.[^root-segment] Each
-routine invocation creates a new segment containing only the wires allocated
-directly within it; nested calls produce their own segments in turn. The
+The
 `CircuitExt::trace` method produces a `Trace` that contains these segments in DFS
 order, but their actual arrangement in the trace polynomial depends on the floor
 plan's repositioning values.
-
-[^root-segment]: The root segment is not repositioned. It contains the special
-    `ONE` wire and is where all stage wires are located.
 
 Each segment has its own [contribution](#algebraic-description) to $s(X, Y)$. A
 leaf routine invocation — one with no nested calls — contributes exactly one

--- a/book/src/implementation/routines.md
+++ b/book/src/implementation/routines.md
@@ -1,0 +1,156 @@
+# Routines
+
+[Routines](../guide/routines.md) are self-contained portions of circuit code
+that satisfy a simple function-like interface: they take a single [`Input`]
+gadget and a [`Driver`] handle, and return a single [`Output`] gadget. They are
+permitted to do anything that normal circuit code can do with a
+[driver](../guide/drivers.md), such as making gates ([`mul`], [`alloc`]) and
+constraining their wires ([`enforce_zero`]).
+
+It is possible to invoke them by manually calling their [`Routine::execute`]
+method, but this almost always defeats the purpose of the abstraction. Instead,
+they are meant to be invoked through the [`Driver::routine`] method, which hands
+control and visibility of its execution to the driver.
+
+```admonish info
+Drivers do not learn the [`TypeId`] of a [`Routine`] they are asked to `execute`,
+since [`Routine`] does not implement [`Any`] / `'static`. Even if they could
+learn this, routines of the same type are allowed to diverge in their actual
+behavior because they can be arbitrarily configured, so long as they remain
+deterministic.
+```
+
+Drivers cannot distinguish routines themselves but merely their **invocations**;
+in each `routine` call, they learn the [`TypeId`] of their [`Input`] and
+[`Output`] gadgets, and thanks to
+[fungibility](../guide/gadgets/index.md#gadget-trait-fungibility) this is very
+useful for their structural analysis (via [conversions]) and induces stable
+algebraic properties at routine boundaries.
+
+### Algebraic Description
+
+Routines exploit the fact that contiguous sections of code tend to have
+algebraically convenient structure in the resulting wiring polynomial $s(X, Y)$:
+
+* `mul` advances an $i$ counter and returns $(X^{2n - 1 - i}, X^{2n + i}, X^{4n - 1 - i})$ wires.
+* `enforce_zero` advances a counter $j$ and adds a fresh linear combination of previous wires multiplied by $Y^j$.
+
+Most of the linear constraints created within a routine consist purely of wires
+created within that routine, meaning that the **internal** contribution of a
+routine can be written as polynomials $g_x, g_{x^{-1}}$ and memoized if the
+routine is invoked multiple times. Given a cache hit, we need only scale $g_x$
+and $g_{x^{-1}}$ by powers of $Y^j X^i$ (or $Y^j X^{-1}$) to obtain the correct
+internal $s(X, Y)$ for an equivalent invocation.
+
+The **interface** contribution to $s(X, Y)$ involves wires created outside the
+routine, such as the input gadget wires or the fixed `ONE` wire. This is less
+amenable to memoization because these wires can vary between invocations; we
+must generally maintain separate polynomials $h_\ell$ for every interface wire.
+
+Taken together, the **contribution** of a routine invocation to $s(X, Y)$ can be
+written as
+
+$$
+Y^j \Big( X^i g_x + X^{-i} g_{x^{-1}} + \sum_\ell h_\ell \Big)
+$$
+
+for some **repositioning** values $i, j$.
+
+## Pipeline
+
+```mermaid
+graph LR
+    subgraph tp[trace path]
+        W[witness] --> rx --> trace
+        TP["r(X)"]
+    end
+    subgraph R[registry]
+        FP[floor plan]
+    end
+    subgraph ep[eval path]
+        C[circuit] --> MP[metrics pass] --> metrics
+        ED[eval drivers] --> SP["s(X,Y)"]
+    end
+    trace --> R
+    metrics --> R
+    FP --> ED
+    FP --> TP
+```
+
+Ragu learns about invocations by executing circuit code in an analysis pass that
+collects metrics about each routine invocation. Because circuit synthesis is
+deterministic, invocations have a canonical order in which they appear during
+synthesis, called their **DFS index**. The metrics can reliably identify each
+invocation by this index for the benefit of future execution of the same circuit
+code.
+
+All of the metrics for every wiring polynomial added to the registry are fed
+into a **floor planner** that is responsible for making scheduling and
+relocation decisions in advance of future circuit operations, such as wiring
+polynomial evaluation or trace polynomial assembly. The floor planner's goal is
+to maximize the optimization opportunities of those operations, usually by
+rearranging the wiring polynomials of the circuits in some way. The result
+is a floor plan, which is maintained by the registry.
+
+The wiring polynomial evaluators use the floor plan to properly align and
+memoize arithmetic to reduce the cost of evaluating the registry polynomial. The
+trace polynomial assembly process produces an unassembled trace of execution for
+a given witness, and the registry uses the floor plan to translate this to the
+actual trace polynomial $r(X)$.
+
+## Segments
+
+Execution traces are divided into **segments**. All wires allocated outside of
+routine invocations belong to a single **root segment**. Each routine invocation
+creates a new segment containing only the wires allocated directly within it;
+nested calls produce their own segments in turn. The `CircuitExt::rx` method
+produces a `Trace` that contains these segments in DFS order, but their actual
+arrangement in the trace polynomial depends on the floor plan's repositioning
+values.
+
+```admonish info
+The root segment is not repositioned. It contains the special `ONE` wire and is
+where all stage wires are located.
+```
+
+Segments have a corresponding [contribution](#algebraic-description) to $s(X, Y)$. For a leaf invocation
+— one with no nested routine calls — the contribution is just its segment's.
+When an invocation nests further calls, its total contribution includes all
+descendant segments, forming a subtree. Whether this subtree behaves as a single
+relocatable unit depends on the floor planner: if descendant segments sit at
+fixed relative offsets from the root, the entire subtree shifts uniformly and can
+be memoized as one piece. If the floor planner positions descendants
+independently, the subtree's contribution acquires multiple independent
+positional degrees of freedom and must be handled per-segment.
+
+### Allocation
+
+Allocation allows gates to be reused as a source of wire values. The allocator
+state (parity and gate index) are stashed whenever a routine is invoked. This
+prevents allocation state from crossing segment boundaries, which would
+contaminate their contributions and interfere with repositioning and
+memoization.
+
+```admonish info
+As an optimization, it is theoretically possible for routine invocations to be
+inlined so that they effectively take place within their parent's segment. This
+decision could be encoded into the floor plan. However, this would require the
+trace computation to be aware of this decision (affecting the pipeline above) or
+would require additional metadata to be stored in the `Trace` for adjustment
+during assembly. **As a simplification, we assume all routine invocations are
+out-of-line.**
+```
+
+[`TypeId`]: core::any::TypeId
+[`Routine`]: ragu_core::routines::Routine
+[`Driver`]: ragu_core::drivers::Driver
+[`Driver::routine`]: ragu_core::drivers::Driver::routine
+[`Input`]: ragu_core::routines::Routine::Input
+[`Output`]: ragu_core::routines::Routine::Output
+[`Routine::execute`]: ragu_core::routines::Routine::execute
+[`enforce_zero`]: ragu_core::drivers::Driver::enforce_zero
+[`mul`]: ragu_core::drivers::Driver::mul
+[`alloc`]: ragu_core::drivers::Driver::alloc
+[`add`]: ragu_core::drivers::Driver::add
+[`Any`]: core::any::Any
+[conversions]: ../guide/gadgets/conversion.md

--- a/book/src/implementation/routines.md
+++ b/book/src/implementation/routines.md
@@ -39,7 +39,7 @@ Most of the linear constraints created within a routine consist purely of wires
 created within that routine, meaning that the **internal** contribution of a
 routine can be written as polynomials $g_x, g_{x^{-1}}$ and memoized if the
 routine is invoked multiple times. Given a cache hit, we need only scale $g_x$
-and $g_{x^{-1}}$ by powers of $Y^j X^i$ (or $Y^j X^{-1}$) to obtain the correct
+and $g_{x^{-1}}$ by powers of $Y^j X^i$ (or $Y^j X^{-i}$) to obtain the correct
 internal $s(X, Y)$ for an equivalent invocation.
 
 The **interface** contribution to $s(X, Y)$ involves wires created outside the
@@ -60,17 +60,19 @@ for some **repositioning** values $i, j$.
 
 ```mermaid
 graph LR
+    C[circuit]
     subgraph tp[trace path]
-        W[witness] --> rx --> trace
-        TP["r(X)"]
+        W[witness] --> rx --> trace --> TP["r(X)"]
     end
     subgraph R[registry]
         FP[floor plan]
     end
     subgraph ep[eval path]
-        C[circuit] --> MP[metrics pass] --> metrics
+        MP[metrics pass] --> metrics
         ED[eval drivers] --> SP["s(X,Y)"]
     end
+    C --> rx
+    C --> MP
     trace --> R
     metrics --> R
     FP --> ED
@@ -79,10 +81,10 @@ graph LR
 
 Ragu learns about invocations by executing circuit code in an analysis pass that
 collects metrics about each routine invocation. Because circuit synthesis is
-deterministic, invocations have a canonical order in which they appear during
-synthesis, called their **DFS index**. The metrics can reliably identify each
-invocation by this index for the benefit of future execution of the same circuit
-code.
+deterministic, invocations appear in a canonical **DFS order** during
+synthesis. Each invocation's position in that order is its **DFS index**. The
+metrics can reliably identify each invocation by this index for the benefit of
+future execution of the same circuit code.
 
 All of the metrics for every wiring polynomial added to the registry are fed
 into a **floor planner** that is responsible for making scheduling and
@@ -151,6 +153,5 @@ out-of-line.**
 [`enforce_zero`]: ragu_core::drivers::Driver::enforce_zero
 [`mul`]: ragu_core::drivers::Driver::mul
 [`alloc`]: ragu_core::drivers::Driver::alloc
-[`add`]: ragu_core::drivers::Driver::add
 [`Any`]: core::any::Any
 [conversions]: ../guide/gadgets/conversion.md

--- a/book/src/implementation/routines.md
+++ b/book/src/implementation/routines.md
@@ -61,21 +61,23 @@ for some **repositioning** values $i, j$.
 ```mermaid
 graph LR
     C[circuit]
-    subgraph tp[trace path]
-        W[witness] --> rx --> trace --> TP["r(X)"]
+    W([witness])
+    subgraph ep[eval path]
+        MP[metrics pass] --> metrics
+        metrics --> ED[eval drivers] --> SP["s(X,Y)"]
     end
     subgraph R[registry]
         FP[floor plan]
     end
-    subgraph ep[eval path]
-        MP[metrics pass] --> metrics
-        ED[eval drivers] --> SP["s(X,Y)"]
+    subgraph tp[trace path]
+        rx --> trace
     end
-    C --> rx
     C --> MP
-    trace --> R
-    metrics --> R
+    C --> rx
+    W --> rx
+    metrics --> FP
     FP --> ED
+    trace --> TP["r(X)"]
     FP --> TP
 ```
 

--- a/book/src/implementation/routines.md
+++ b/book/src/implementation/routines.md
@@ -103,27 +103,34 @@ actual trace polynomial $r(X)$.
 ## Segments
 
 Execution traces are divided into **segments**. All wires allocated outside of
-routine invocations belong to a single **root segment**. Each routine invocation
-creates a new segment containing only the wires allocated directly within it;
-nested calls produce their own segments in turn. The `CircuitExt::rx` method
-produces a `Trace` that contains these segments in DFS order, but their actual
-arrangement in the trace polynomial depends on the floor plan's repositioning
-values.
+routine invocations belong to a single **root segment**.[^root-segment] Each
+routine invocation creates a new segment containing only the wires allocated
+directly within it; nested calls produce their own segments in turn. The
+`CircuitExt::rx` method produces a `Trace` that contains these segments in DFS
+order, but their actual arrangement in the trace polynomial depends on the floor
+plan's repositioning values.
 
-```admonish info
-The root segment is not repositioned. It contains the special `ONE` wire and is
-where all stage wires are located.
-```
+[^root-segment]: The root segment is not repositioned. It contains the special
+    `ONE` wire and is where all stage wires are located.
 
-Segments have a corresponding [contribution](#algebraic-description) to $s(X, Y)$. For a leaf invocation
-— one with no nested routine calls — the contribution is just its segment's.
-When an invocation nests further calls, its total contribution includes all
-descendant segments, forming a subtree. Whether this subtree behaves as a single
-relocatable unit depends on the floor planner: if descendant segments sit at
-fixed relative offsets from the root, the entire subtree shifts uniformly and can
-be memoized as one piece. If the floor planner positions descendants
-independently, the subtree's contribution acquires multiple independent
-positional degrees of freedom and must be handled per-segment.
+Each segment has its own [contribution](#algebraic-description) to $s(X, Y)$. A
+leaf routine invocation — one with no nested calls — contributes exactly one
+segment. When a routine nests further calls, its **total contribution** is the
+sum of its own segment's contribution and every descendant segment's. These
+segments are not independent: routines send and receive wires through [`Input`]
+and [`Output`] gadgets, and those wires are often allocated in different
+segments.
+
+Because each wire's location in $s(X, Y)$ is a monomial in $X$ determined by the
+gate offset of whichever segment allocated it, a constraint referencing a
+foreign wire creates a positional dependency between the two segments. A routine
+invocation and all of its descendants thus form a **subtree** of
+positionally-dependent segments. If every segment in a subtree sits at a fixed
+relative offset from the root, all wire locations shift uniformly — the subtree
+is a single relocatable unit that can be memoized. If the floor planner
+positions descendants independently, cross-segment wire locations introduce
+additional positional degrees of freedom and the subtree must be handled
+per-segment.
 
 ### Allocation
 

--- a/book/src/implementation/routines.md
+++ b/book/src/implementation/routines.md
@@ -109,7 +109,7 @@ scoped state — running wire monomials, constraint counters, Horner
 accumulators, allocation pairing state — and initializes a fresh scope
 for the child routine. On return, the parent scope is restored and the
 child's contribution is folded into the parent's accumulated result. The
-[`DriverScope`] trait provides a `with_scope` helper that automates this
+`DriverScope` trait provides a `with_scope` helper that automates this
 save/restore; some drivers use manual `mem::replace` instead when they
 need to inspect the child scope's result before restoring the parent.
 
@@ -120,7 +120,7 @@ same sequence. The floor plan is indexed by this order: `floor_plan[i]`
 describes where the $i$-th segment is placed, regardless of whether a
 future floor planner reorders their positions.
 
-The [`Counter`] uses each invocation to build a [`SegmentRecord`] and a
+The `Counter` uses each invocation to build a [`SegmentRecord`] and a
 [`MemoFingerprint`]. It resets its geometric sequences and Horner
 accumulator to a fixed initial state — independent of the caller — so that
 the fingerprint captures only the routine's internal constraint structure.
@@ -154,11 +154,9 @@ annotated with their **DFS path** — the sequence of routine-call indices
 from root to the segment — so that the final `finish` step can sort all
 segments back into canonical DFS order.
 
-[`DriverScope`]: ragu_circuits::DriverScope
 [`sxy`]: ragu_circuits::s::sxy
 [`sx`]: ragu_circuits::s::sx
 [`sy`]: ragu_circuits::s::sy
-[`Counter`]: ragu_circuits::metrics::Counter
 [`SegmentRecord`]: ragu_circuits::metrics::SegmentRecord
 [`Prediction`]: ragu_core::routines::Prediction
 [`Known`]: ragu_core::routines::Prediction::Known
@@ -231,7 +229,7 @@ Two invocations are structurally equivalent when they share a
 [**routine fingerprint**][`RoutineFingerprint`]: the Schwartz–Zippel evaluation
 scalar and the local gate and constraint counts. The
 [metrics pass](#pipeline) computes a fingerprint for each invocation by
-executing its constraint logic on a lightweight [`Counter`] driver that
+executing its constraint logic on a lightweight `Counter` driver that
 substitutes independent geometric sequences for wire values and accumulates
 constraint contributions via Horner's rule. If the resulting scalar and counts
 match, the two invocations are structurally equivalent with overwhelming
@@ -294,7 +292,7 @@ no two segments may overlap.
 Because segments are non-overlapping, bugs in the floor planner or
 memoization logic produce observable failures rather than silent
 corruption. If segments were assigned overlapping gate ranges, the
-[`Trace::assemble`] scatter step would overwrite values from one segment
+`Trace::assemble` scatter step would overwrite values from one segment
 with another's, and the post-execution assertions in the wiring polynomial
 evaluators — which verify that each segment consumed exactly the gate and
 constraint counts declared by the floor plan — would fire. A memoization
@@ -324,8 +322,6 @@ that omits a necessary field — not only bugs in the memoization code.
 
 [`RoutineFingerprint`]: ragu_circuits::metrics::RoutineFingerprint
 [`MemoFingerprint`]: ragu_circuits::metrics::MemoFingerprint
-[`Counter`]: ragu_circuits::metrics::Counter
-[`Trace::assemble`]: ragu_circuits::trace::Trace::assemble
 [`TypeId`]: core::any::TypeId
 [`Routine`]: ragu_core::routines::Routine
 [`Driver`]: ragu_core::drivers::Driver

--- a/book/src/implementation/routines.md
+++ b/book/src/implementation/routines.md
@@ -78,7 +78,7 @@ of the parent.
 However, if two parent routines are known to have identical sub-routines, the
 output gadgets can be remapped to matching positions in the parent's context,
 allowing further constraints on them to be memoized as internal contributions.
-We elaborate on this [below](#fingerprint).
+We elaborate on this [below](#memoization).
 
 Meanwhile, system contributions are also memoizable:
 
@@ -336,16 +336,90 @@ downstream drivers: the wiring polynomial evaluators use it to
 in $s(X, Y)$, and the trace polynomial evaluator uses it to scatter each
 segment's gate values to the correct range in $r(X)$.
 
-## Memoization
+## Memoization {#memoization}
 
-The [algebraic description](#algebraic-description) decomposes a routine's
-contribution into **internal** polynomials $g_1(X, Y)$ and $g_2(X^{-1}, Y)$
-that depend only on the routine's constraint structure, and **interface** terms
-that depend on wires crossing the routine boundary. Memoization caches the
-internal part: if two invocations produce the same constraint structure, their
-$g_1$ and $g_2$ are identical and can be reused. The interface terms and
-[repositioning](#algebraic-description) factors $X^i, X^{-i}, Y^j$ must still be
-computed per-invocation.
+The [algebraic description](#algebraic-description) decomposes a routine
+invocation's contribution to $s(X, Y)$ into **internal** polynomials $g_1(X, Y)$
+and $g_2(X^{-1}, Y)$, a **system** polynomial $g_3(Y)$, and **interface** terms
+that cross the routine boundary. The internal and system polynomials depend only
+on the routine's constraint structure and are invariant to invocation context;
+the interface terms depend on externally allocated wires and must be recomputed.
+Memoization caches the invariant parts — $g_1$, $g_2$, and $g_3$ — and replays
+them for subsequent invocations whose [fingerprints](#fingerprint) match, applying
+fresh [repositioning](#algebraic-description) factors $X^i$, $X^{-i}$, $Y^j$ to
+place the cached contribution at the correct offset.
+
+The registry collects fingerprints from the [metric pass](#pipeline) and records
+matches — both within a single circuit and across circuits — so that downstream
+drivers (the wiring polynomial evaluator for $s(X, Y)$ and the trace evaluator
+for $r(X)$) can determine on entry to each routine whether to record a fresh
+contribution or replay a cached one.
+
+How much of a routine can be cached depends on which fingerprint matches.
+
+**Base-fingerprint memoization.** When two invocations share a
+[base fingerprint](#base-fingerprint), only the _base segment_ of the routine is
+known to be equivalent. The driver caches $g_1$, $g_2$, and $g_3$ for that
+segment and repositions them at the new invocation's offset. Contributions from
+nested sub-routines — including any constraints the parent places on their output
+gadgets — remain interface contributions and are recomputed per-invocation.
+
+**Deep-fingerprint memoization.** When two invocations share a
+[deep fingerprint](#deep-fingerprint), the entire invocation tree is equivalent:
+the base segment _and_ all nested sub-routines have matching structure. This
+changes what counts as an interface contribution: output gadgets of child
+routines, which must be treated as interface contributions under base-fingerprint
+memoization, can now be remapped to matching positions within the parent's
+context. Constraints on these output wires become part of the internal
+contribution and are memoizable along with the rest of the subtree.
+
+```admonish important title="Deep memoization redefines the internal contribution"
+Under deep-fingerprint equivalence, the output wires of nested sub-routines are
+no longer interface contributions — the deep fingerprint guarantees that child
+routines produce structurally identical output at identical relative positions.
+The parent can treat these wires as internal, collapsing the entire subtree into
+a single memoizable unit. This is the key advantage of the deep fingerprint: it
+enables full-tree memoization rather than segment-by-segment caching.
+```
+
+When matching fingerprints occur only _within_ a single circuit, memoization
+requires nothing beyond caching and repositioning: the driver records the
+contribution on the first invocation and rescales it for subsequent ones.
+Alignment becomes relevant when matching fingerprints span _multiple_ circuits
+in the registry.
+
+### Inter-Circuit Alignment {#inter-circuit-alignment}
+
+The registry polynomial combines per-circuit wiring polynomials via Lagrange
+interpolation:
+
+$$
+m(w, x, y) = \sum_k \ell_k(w) \cdot s_k(x, y)
+$$
+
+where $\ell_k$ is the Lagrange basis polynomial for circuit $k$. Without
+optimization, each circuit evaluates its routines independently and scales by
+$\ell_k(w)$. If the floor planner places equivalent routines at the _same_
+absolute position across circuits, their invariant contributions coincide and
+can be factored:
+
+$$
+\Big(\sum_{k \in K} \ell_k(w)\Big) \cdot \big(X^i Y^j \cdot g(X, Y)\big)
+$$
+
+where $K$ is the set of circuits sharing the routine at that position. The
+routine's contribution is computed once and multiplied by the sum of the relevant
+Lagrange coefficients, rather than being recomputed per-circuit.
+
+The floor planner prioritizes deep-fingerprint alignment for the largest
+segments, since collapsing an entire subtree yields the greatest savings.
+Alignment introduces implicit padding between segments in the global layout, but
+this padding does not materialize in memory: all downstream drivers process
+segments in a streaming fashion using absolute offsets from the floor plan, so
+padded regions are either skipped or processed at negligible cost. The trace
+polynomial $r(X)$ remains sparse, and padding does not increase the cost of the
+polynomial commitment. Base-fingerprint alignment is also applied when the base
+segment is large enough to justify the padding overhead.
 
 ### Testability
 

--- a/book/src/implementation/routines.md
+++ b/book/src/implementation/routines.md
@@ -12,17 +12,18 @@ method, but this almost always defeats the purpose of the abstraction. Instead,
 they are meant to be invoked through the [`Driver::routine`] method, which
 preserves the context and boundaries of routine invocations for the driver.
 
-Routines can also further invoke other routines, creating **nested routines**.
-To avoid complicated call stack management, our drivers only keep _routine-local_
-states. When circuit code calls [`Driver::routine`], the driver saves its local
+Routines can further invoke other routines, creating **nested routines**.
+To avoid complicated call-stack management, drivers keep only _routine-local_
+state. When circuit code calls [`Driver::routine`], the driver saves its
 scoped state (e.g., running wire monomial evaluations for `sx::Evaluator`,
-constraint counters for `metric::Counter` etc.), and initializes a fresh scope
+constraint counters for `metric::Counter`), and initializes a fresh scope
 for the child routine. On return, the parent scope is restored and the child's
-contribution is rolled up in the parent's accumulated state. The `DriverScope`
-trait provides a `with_scope` helper that automates this save-then-restore; some
-drivers use manual `mem::replace` on the scoped state instead when they need to
-inspect the child scope's result before restoring.
-We refer our invocation-depth-independent drivers as being _context insensitive_.
+contribution is folded into the parent's accumulated result. The `DriverScope`
+trait provides a `with_scope` helper that automates this save-and-restore; some
+drivers use manual `mem::replace` instead when they need to inspect the child
+scope before restoring the parent.
+Because driver behavior does not depend on invocation depth, we call them
+_context insensitive_.
 
 ## Algebraic Description {#algebraic-description}
 
@@ -32,7 +33,7 @@ algebraically convenient structure in the resulting wiring polynomial $s(X, Y)$:
 * [`gate`] advances an $i$ counter and returns $(X^{2n - 1 - i}, X^{2n + i}, X^{4n - 1 - i}, X^i)$ wires.
 * `enforce_zero` advances a counter $j$ and adds a fresh linear combination of previous wires multiplied by $Y^j$.
 
-Most constraints within a routine only involve wires created within the routine.
+Most constraints within a routine involve only wires created within that routine.
 For a routine that starts at gate index $i$ and constraint index $j$, these
 constraints, constituting the **internal contribution** to $s(X, Y)$, can be
 written as:
@@ -46,17 +47,17 @@ where $X^i Y^j$ (and $X^{-i} Y^j$ for wires allocated in reversed segments of a
 factors extracted from all monomial terms in the contribution[^factoring].
 Crucially, $g_1$ and $g_2$ are **invariant to the routine invocation**: they are
 the same regardless of where or how many times the invocation is placed in a
-circuit. This makes _routine memoization_ possible: given a invocation cache hit,
-we only need to apply a **repositioning** by re-scaling them to the starting
-position ($X^i Y^j$ and $X^{-i} Y^j$) of that particular invocation.
+circuit. This makes _routine memoization_ possible: given an invocation cache hit,
+we only need to apply a **repositioning** by re-scaling to the starting position
+($X^i Y^j$ and $X^{-i} Y^j$) of that particular invocation.
 
 [^factoring]: Every wire allocated _after_ entering the routine at gate index $i$
     has a positional monomial $X^{i+k}$ or $X^{-{i+k}}$ (reversed segment) for
     some $k>0$. Each constraint on these internal wires is a linear combination
     of these positional monomials multiplied by $Y^{j+\ell}$ for some $\ell > 0$.
-    Thus, the internal contribution, summing over all $Y$-power-scaled linear
-    combination of $X$ monomials, share a common factor $X^i Y^j$
-    (or $X^{-i}Y^j$). Extracting these factors yield $g_1$ and $g_2$.
+    The internal contribution — the sum of all $Y$-power-scaled linear
+    combinations of $X$ monomials — therefore shares a common factor $X^i Y^j$
+    (or $X^{-i}Y^j$). Extracting these factors yields $g_1$ and $g_2$.
 
 The overall contribution of a routine invocation to $s(X, Y)$ is the sum of this
 internal contribution, an **interface contribution** from constraints that
@@ -64,19 +65,20 @@ reference wires created outside the routine (e.g., input gadget wires), and a
 **system contribution** from constraints that reference system wires (i.e.,
 `ONE`) at fixed locations.
 
-The interface contribution cannot be factored (or memoized) the same way:
-the input gadget is allocated by the routine caller at an unknown position, both
-absolute and relative to the start of the routine, so there is no a priori $X^i$
-factors to extract. We must compute interface contributions per-invocation.
-One major complication arises from nested routines. Our decision on
-_context-insensitive_ drivers demands that the output gadgets of nested/child
-routines are also part of the interface contribution of the parent routine.
-It is always safe to categorize them as interface contributions and recompute on
-every invocation of the parent routine.
-However, if we know two routines have identical sub-routines, then these output
-gadgets can be correctively remapped in the parent routine's context such that
-further constraints on them can be memoized as internal contribution again.
-We will elaborate more [later](#fingerprint).
+The interface contribution cannot be factored or memoized the same way:
+the input gadget is allocated by the caller at an unknown position, both
+absolute and relative to the start of the routine, so there are no a priori
+$X^i$ factors to extract. Interface contributions must be computed
+per-invocation.
+A complication arises from nested routines. The context-insensitive design
+requires that output gadgets of child routines are also treated as interface
+contributions of the parent routine.
+It is always safe to classify them this way and recompute on every invocation
+of the parent.
+However, if two parent routines are known to have identical sub-routines, the
+output gadgets can be remapped to matching positions in the parent's context,
+allowing further constraints on them to be memoized as internal contributions.
+We elaborate on this [below](#fingerprint).
 
 Meanwhile, system contributions are also memoizable:
 
@@ -87,9 +89,9 @@ $$
 where $T$ is the set of constraint indices within the routine where system wires
 are referenced, $X^{2n}$ is the monomial for the $b_0 (= 1)$ wire during
 [wiring checks](../../protocol/local/wiring.md#layout).
-Similarly, we can extract the common factor $X^{2n}Y^j$ for the starting
-constraint index $j$ and the remaining univariate $g_3$ is invariant to the
-routine invocation.
+The common factor $X^{2n}Y^j$ can be extracted for the starting constraint
+index $j$, and the remaining univariate $g_3$ is again invariant to the routine
+invocation.
 
 ## Example: Synthesis Trace {#example}
 
@@ -114,23 +116,23 @@ The following circuit serves as a concrete example for all upcoming discussion:
  └─ r2
 ```
 
-All `r0, a0, b0, .., r2` are contiguous sections of synthesized circuit trace
-allocated via [`gate`]. Intermittently, the circuit logic spawns a routine which
-can further spawn nested routines.
+Each label `r0, a0, b0, …, r2` denotes a contiguous section of circuit trace
+allocated via [`gate`]. At various points the circuit logic invokes a routine,
+which may in turn invoke nested routines.
 
 ## Segments
 
-Given an execution trace, we first need a global indexing of all sub-sections
-so that different drivers can refer to them consistently. Ragu divides the trace
-into **segments** and orders them naturally in a canonical **DFS order** as per
-the routine invocation. Particularly, circuit sections of the same invocation
+Given an execution trace, we need a global indexing of all sub-sections so
+that different drivers can refer to them consistently. Ragu divides the trace
+into **segments** and orders them in a canonical **DFS order** determined by
+routine invocations. In particular, circuit sections at the same invocation
 depth are merged into a single segment; wires allocated outside of any routine
 belong to a special **root segment**.[^root-segment] Each routine invocation
 creates a new **base segment** containing only the wires allocated directly
 within it; nested calls produce their own segments in turn. The DFS-ordered
 segments are built as [`SegmentRecord`]s during the [metric pass](#pipeline).
-Since circuit synthesis is deterministic, the ordered sequence is stable across
-all drivers of the same circuit code.
+Because circuit synthesis is deterministic, the ordered sequence is stable
+across all drivers of the same circuit code.
 
 [^root-segment]: The root segment is never repositioned. It contains the special
     `ONE` wire and is where all stage wires of multi-stage circuits are located.
@@ -148,42 +150,43 @@ segments[5]: c0           (base segment of Routine C)
 ## Routine Fingerprints {#fingerprint}
 
 A prerequisite of routine memoization is identifying distinct routines.
-Let's start with some naive but incorrect ways to identify a routine:
+Consider some naive but incorrect ways to identify one:
 
 - by shape (`num_gates` and `num_constraints`):
   different routines can coincidentally share the same shape.
 - by `(Input, Output)` gadget types:
-  routines executing different operations (e.g. `square` and `double`) can share the
-  same input/output types.
+  routines performing different operations (e.g. `square` and `double`) can share
+  the same input/output types.
 - by `TypeId::of::<Routine>()`: 
-  routines can be [parameterized](../../guide/routines.md#param) and stateful,
+  routines can be [parameterized](../../guide/routines.md#param) and stateful;
   even the same `ScaledTxz` routine type (or `RoutineB` in our example)
-  can synthesize to different traces.
+  can synthesize different traces depending on its configuration.
   
-In short, drivers cannot distinguish routines statically alone, but must also 
-consider their **invocations**. Fingerprinting is the process by which a routine
-invocation is succinctly encapsulated so that _matching fingerprints implies
-opportunities for routine memoization_. There could be multiple fingerprints for
-an invocation, each signals a different memoization strategy or aggressive level.
-Ragu produces two fingerprints: a **base fingerprint** that captures _segment-level
-equivalence_ and signals memoization of only the base segment of an invocation;
-and a **deep fingerprint** that captures _tree-level equivalence_ and signals
-memoization of the entire routine, recursively including all nested sub-routines.
+In short, drivers cannot distinguish routines statically but must also consider
+their **invocations**. Fingerprinting is the process by which a routine
+invocation is succinctly encapsulated so that _matching fingerprints imply
+opportunities for routine memoization_. An invocation can carry multiple
+fingerprints, each indicating a different memoization strategy or level of
+aggressiveness. Ragu produces two: a **base fingerprint** that captures
+_segment-level equivalence_ and enables memoization of only the base segment,
+and a **deep fingerprint** that captures _tree-level equivalence_ and enables
+memoization of the entire routine, recursively including all nested
+sub-routines.
 
 ### Base fingerprint {#base-fingerprint}
 
-Ragu tracks the gates and constraint counts of the local/base segment of a
-routine invocation and its polynomial contribution for `BaseFingerprint`.
-In the [example above](#example), although the two invocations of `RoutineB`
-are obviously different, it's possible that the internal contribution of their
-base segments are identical thus memoizable (i.e., `b0 + b1 = b2`).
+Ragu tracks the gate and constraint counts of a routine invocation's base
+segment, together with its polynomial contribution, as the `BaseFingerprint`.
+In the [example above](#example), the two invocations of `RoutineB` are
+structurally different, but the internal contributions of their base segments
+may still be identical and thus memoizable (i.e., `b0 + b1 = b2`).
 
-Note that the polynomial contribution only include invocation's internal and
-system contributions, those invariant to the invocation's context and location,
-and exclude all interface contributions. Further note that polynomial evaluation
-alone is insufficient because it only captures `enforce_zero` calls, not gate
-count which is crucial for floor planner later. Technically, the constraint
-count, already bounded in the contribution scalar, is purely defense-in-depth.
+The polynomial contribution includes only the invocation's internal and system
+contributions — those invariant to context and location — and excludes all
+interface contributions. Polynomial evaluation alone is insufficient because it
+captures only `enforce_zero` calls, not the gate count, which the floor planner
+requires. The constraint count, already implicit in the contribution scalar, is
+included purely as defense-in-depth.
 
 ```rust
 struct BaseFingerprint {
@@ -198,67 +201,67 @@ struct BaseFingerprint {
 
 Conceptually, the simplest approach to `eval` is to pick a random $(x_r, y_r)$
 and use the internal contribution of each routine invocation to $s(x_r, y_r)$
-as its fingerprint. By Schwartz-Zippel lemma, two different invocations will
-produce different polynomial contribution with overwhelming probability.
-However, such contribution requires tracking monomial evaluations in both
-forward direction ($X^i$ terms) and backward direction ($X^{4n-1-i}$ terms); and
-involves scalar multiplications (for $X^{2n}$ and $X^{4n}$) and expensive
+as its fingerprint. By the Schwartz-Zippel lemma, two different invocations
+produce different polynomial contributions with overwhelming probability.
+However, this requires tracking monomial evaluations in both the forward
+direction ($X^i$ terms) and the backward direction ($X^{4n-1-i}$ terms), and
+involves scalar multiplications (for $X^{2n}$ and $X^{4n}$) and an expensive
 inversion (for $X^{-1}$) during initialization.
 
-Instead, Ragu takes a more efficient approach: use 4 _independent_ geometric
-sequences for wire values (one for each of `a/b/c/d`-wires) and Horner-accumulate
-contribution of `enforce_zero` constraints with $Y$ powers of a random $Y=y_r$.
-Wires from the $i$-th gate corresponds to $(x_0^i, x_1^i, x_2^i, x_3^i)$ monomial
-evaluations for a random $(x_0, x_1, x_2, x_3)$ picked at initialization.
-This simplification is possible thanks to the relaxed requirement on the
-fingerprint: characterize the constraints in any binding way, not necessarily in
-the same way as the wiring polynomial $s(X, Y)$.
+Instead, Ragu uses a more efficient approach: four _independent_ geometric
+sequences for wire values (one for each of the `a/b/c/d`-wires) and
+Horner-accumulated contributions from `enforce_zero` constraints with $Y$ powers
+of a random $Y=y_r$. Wires from the $i$-th gate correspond to
+$(x_0^i, x_1^i, x_2^i, x_3^i)$ monomial evaluations for a random
+$(x_0, x_1, x_2, x_3)$ picked at initialization. This simplification is possible
+because the fingerprint need only characterize constraints in some binding way,
+not necessarily in the same form as the wiring polynomial $s(X, Y)$.
 
-Handling interface contributions is the most subtle logic. In our example, the
-first invocation of `RoutineB` accepts an input gadget from the parent routine
-on enter and receives an output gadget from the child `RoutineA` in the middle.
-Both gadgets are allocated outside the scope of the base segment of `RoutineB`,
-thus any constraint on them belongs to interface contributions and should not
-meaningfully affect the `eval` computation. Concretely, relocating wires in these
-interface gadgets should not affect the `eval` fingerprint.
+Handling interface contributions is the most delicate part. In our example, the
+first invocation of `RoutineB` accepts an input gadget from the parent on entry
+and receives an output gadget from the child `RoutineA` during execution. Both
+gadgets are allocated outside the scope of `RoutineB`'s base segment, so any
+constraint involving them is an interface contribution and must not affect the
+`eval` computation. Concretely, relocating wires in these interface gadgets must
+not change the fingerprint.
 
-There are two approaches to dealing with wires in these interface gadgets:
+There are two approaches to handling wires in interface gadgets:
 
-1. discriminate them as a separate wire type:
+1. Discriminate them as a separate wire type
    (e.g. `enum WireEval { Value, One, Interface }`) so that routines can flag
    them as `WireEval::Interface(F)` and drivers can drop their contribution.
-2. assign context-insensitive values to them so that their contributions are
-   cancelled out among otherwise equivalent invocations, thus cannot impact
-   equivalence meaningfully.
+2. Assign context-insensitive values to them so that their contributions cancel
+   across otherwise-equivalent invocations and thus cannot affect the
+   equivalence test.
 
 Ragu takes the second approach, implemented via a wire remapping [`WireMap`]:
-all wires in interface gadgets are remapped to hold values from an independent
-geometric sequence with another random base.[^x-remap] Importantly, every
-routine, no matter at which invocation depth, starts with the same geometric
-sequence re-initialized so that the input gadget wires holds a positional value
-that is context-insensitive. Furthermore, before exit, every routine remap
-the output gadget and appended to its parent's context.
+all wires in interface gadgets are remapped to values from an independent
+geometric sequence with a separate random base.[^x-remap] Every routine,
+regardless of invocation depth, re-initializes this sequence on entry so that
+input gadget wires hold context-insensitive positional values. Before returning,
+the routine remaps its output gadget wires and appends them to the parent's
+sequence.
 
-[^x-remap]: For code reference, the variable is named `x_remap` and remapped 
-    wires take on values `x_remap^i` which is independent of normal sequences
+[^x-remap]: For code reference, the variable is named `x_remap` and remapped
+    wires take on values `x_remap^i`, independent of the normal sequences
     $(x_0^i, x_1^i, x_2^i, x_3^i)$. Intuitively, every routine starts with a
-    blank page for interface gadget wires written sequentially from the page;
-    and their output gadget wires are appended to the parent's page.
+    blank page for interface gadget wires, written sequentially from the start;
+    output gadget wires are then appended to the parent's page.
 
 ### Deep fingerprint {#deep-fingerprint}
 
-The most aggressive memoization is possible when two routine invocations are
-tree-level equivalent with the structurally identical base and subroutines.
-Intuitively, two invocations with identical deep fingerprints means that their
-shapes (gate and constraint counts) and their polynomial contributions are
-identical if we _flatten and inline all their nested subroutines_.
+The most aggressive memoization applies when two routine invocations are
+tree-level equivalent: structurally identical in both their base segment and all
+nested sub-routines. Two invocations with identical deep fingerprints have
+matching shapes (gate and constraint counts) and matching polynomial
+contributions when all nested sub-routines are _flattened and inlined_.
 
-The main gap from [base fingerprint](#base-fingerprint) is how to handle wires
-of output gadgets from the child subroutines. In base fingerprint, output wires
-are remapped in their parent's context. This remapping erases their positions
-relative to the start of the base/parent routine, which is necessary to test
-equivalence of the inlined routine.[^swapped] Therefore, we must capture the
-positional values of these output wires in the parent's deep fingerprint.
+The gap from the [base fingerprint](#base-fingerprint) lies in how output
+gadgets of child sub-routines are handled. In the base fingerprint, output wires
+are remapped into the parent's context. This remapping erases their positions
+relative to the start of the parent routine, which matters when testing
+equivalence of the inlined routine.[^swapped] The deep fingerprint must
+therefore capture the positional values of these output wires.
 
 ```rust
 struct DeepFingerprint {
@@ -270,23 +273,24 @@ struct DeepFingerprint {
 ```
 
 Ragu augments the base fingerprint with the wire values of the output gadget,
-the deep fingerprint of all its child invocations (one level deeper), and the
-`TypeId` of the input and output gadget types (optional, only defense-in-depth).
-The monomial evaluation of output wires (of a subroutine) already encodes their
-positions relative to the start of the subroutine (thus transitively relative
-to the start of the parent routine). Since the deep fingerprint of the parent
-routine recursively hash in the deep hashes of all child subroutines, the final
-hash binds the entire invocation tree.
+the deep fingerprints of all child invocations (one level deeper), and the
+`TypeId` of the input and output gadget types (optional, defense-in-depth only).
+The monomial evaluation of output wires already encodes their positions relative
+to the start of the sub-routine, and thus transitively relative to the start of
+the parent routine. Because the parent's deep fingerprint recursively folds in
+the deep hashes of all children, the final hash binds the entire invocation
+tree.
 
 
-[^swapped]: As an example, two `RoutineB` nested-call `RoutineA`. The first
-    `RoutineA` invocation: `alloc(w1); alloc(w2); enforce_zero(w1 + w2); return (w1, w2)`;
-    the second invocation: `alloc(w2); alloc(w1); enforce_zero(w1 + w2); return (w1, w2)`.
-    In `BaseFingerprint` computation, the output wires `(w1, w2)` from both
-    invocations are mapped to the same values in their parent `RoutineB` context.
-    Two `RoutineB` invocations gets identical base fingerprints.
-    However, after inlining, the two invocations differ because of swapped
-    allocation of `w1` and `w2`.
+[^swapped]: As an example, suppose two `RoutineB` invocations each nest a call
+    to `RoutineA`. The first `RoutineA` invocation runs
+    `alloc(w1); alloc(w2); enforce_zero(w1 + w2); return (w1, w2)`;
+    the second runs `alloc(w2); alloc(w1); enforce_zero(w1 + w2); return (w1, w2)`.
+    In the `BaseFingerprint` computation, the output wires `(w1, w2)` from both
+    invocations are mapped to the same values in their parent `RoutineB` context,
+    so the two `RoutineB` invocations receive identical base fingerprints.
+    However, after inlining, the invocations differ because of the swapped
+    allocation order of `w1` and `w2`.
 
 ## Pipeline {#pipeline}
 
@@ -294,233 +298,54 @@ hash binds the entire invocation tree.
 graph LR
     C[circuit]
     W([witness])
-    subgraph ep[eval path]
-        MP[metrics pass] --> metrics
-        metrics --> ED[eval drivers] --> SP["s(X,Y)"]
-    end
-    subgraph R[registry]
-        FP[floor plan]
-    end
-    subgraph tp[trace path]
-        TE[trace eval] --> trace
-    end
-    C --> MP
-    C --> TE
-    W --> TE
-    metrics --> FP
-    FP --> ED
-    trace --> TP["r(X)"]
-    FP --> TP
+    M["metrics<br/>(segments, fingerprints)"]
+    FP[floor plan]
+    T[trace]
+    SXY["s(X,Y)"]
+    RX["r(X)"]
+    C -- metric pass --> M
+    M -- planning --> FP
+    C & W --> T
+    FP --> SXY
+    FP --> RX
+    T -- assemble --> RX
 ```
 
-Ragu learns about invocations by executing circuit code in an analysis pass that
-collects metrics about each routine invocation. Because circuit synthesis is
-deterministic, invocations appear in a canonical **DFS order** during
-synthesis. Each invocation's position in that order is its **DFS index**. The
-metrics can reliably identify each invocation by this index for the benefit of
-future execution of the same circuit code.
+A **metric pass** executes the circuit on a lightweight `Counter` driver that
+records the [segment](#segments) decomposition and computes a
+[fingerprint](#fingerprint) for every routine invocation. The output is an
+ordered sequence of [`SegmentRecord`]s — one per segment in DFS order — each
+carrying local gate and constraint counts together with the invocation's base
+and deep fingerprints. Because synthesis is deterministic, the sequence is
+stable across all subsequent driver executions of the same circuit code.
 
-All of the metrics for every wiring polynomial added to the registry are fed
-into a **floor planner** that is responsible for making scheduling and
-relocation decisions in advance of future circuit operations, such as wiring
-polynomial evaluation or trace polynomial assembly. The floor planner's goal is
-to maximize the optimization opportunities of those operations, usually by
-rearranging the wiring polynomials of the circuits in some way. The result
-is a floor plan, which is maintained by the registry.
+The registry collects segment records from every circuit and feeds them into a
+**floor planner** that assigns each segment a non-overlapping absolute position
+`(gate_start, constraint_start)` in the polynomial layout. The floor planner
+aligns segments with matching fingerprints to maximize
+[memoization](#memoization) across the entire registry, both within and between
+circuits: matching base fingerprints enable memoization of the base segment's internal
+contribution, while matching deep fingerprints enable memoization of entire
+routine subtrees. Currently, the floor planner only rearranges segment
+placement; it does not perform circuit-equivalence substitutions that would
+alter the circuit logic itself.
 
-The wiring polynomial evaluators use the floor plan to properly align and
-memoize arithmetic to reduce the cost of evaluating the registry polynomial. The
-trace polynomial assembly process produces an unassembled trace of execution for
-a given witness, and the registry uses the floor plan to translate this to the
-actual trace polynomial $r(X)$.
-
-## Invocations
-
-Because synthesis is deterministic, invocations appear in a canonical **DFS
-order** that is stable across executions of the same circuit code. The
-metrics pass, wiring polynomial evaluators, and trace evaluator all see the
-same sequence. The floor plan is indexed by this order: `floor_plan[i]`
-describes where the $i$-th segment is placed, regardless of whether a
-future floor planner reorders their positions.
-
-The `Counter` uses each invocation to build a [`SegmentRecord`] and a
-[`MemoFingerprint`]. It resets its geometric sequences and Horner
-accumulator to a fixed initial state — independent of the caller — so that
-the fingerprint captures only the routine's internal constraint structure.
-Input wires are remapped into the fresh scope without incrementing
-constraint counts, seeding the sequences for the fingerprint but not
-inflating metrics. After execution, the child's Horner result and
-constraint counts are bundled into the fingerprint. Output wires are then
-remapped back into the parent's sequence space; the `available_d` pairing
-slot is saved and restored around this remap to keep the parent's
-allocation parity aligned with the real evaluation drivers.
-
-The wiring polynomial evaluators ([`sxy`]; [`sx`] and [`sy`] follow the
-same structural protocol with different accumulation targets) use the floor
-plan to jump each routine to its absolute position in the polynomial. The
-child scope's running monomials are initialized at the segment's absolute
-gate offset so that constraints land at the correct position in
-$s(X, Y)$. After execution, assertions verify that the child consumed
-exactly the gate and constraint counts declared by the floor plan. The
-routine's local Horner result is then scaled by the segment's absolute
-$Y$-offset, combined with any nested child contributions, and added to
-the parent's accumulator.
-
-The trace evaluator branches on the [`Prediction`] returned by `predict`.
-[`Unknown`] predictions are executed in-line within the current evaluator
-via `with_scope`. [`Known`] predictions allow the driver to take the
-predicted output and defer actual execution: with multicore enabled, the
-routine is spawned into a parallel task that sends its segments back
-through a channel; without multicore, it is evaluated inline and its
-segments are collected into a deferred buffer. In both cases, segments are
-annotated with their **DFS path** — the sequence of routine-call indices
-from root to the segment — so that the final `finish` step can sort all
-segments back into canonical DFS order.
-
-[`sxy`]: ragu_circuits::s::sxy
-[`sx`]: ragu_circuits::s::sx
-[`sy`]: ragu_circuits::s::sy
-[`SegmentRecord`]: ragu_circuits::metrics::SegmentRecord
-[`Prediction`]: ragu_core::routines::Prediction
-[`Known`]: ragu_core::routines::Prediction::Known
-[`Unknown`]: ragu_core::routines::Prediction::Unknown
-
-## Segments
-
-The
-`CircuitExt::trace` method produces a `Trace` that contains these segments in DFS
-order, but their actual arrangement in the trace polynomial depends on the floor
-plan's repositioning values.
-
-Each segment has its own [contribution](#algebraic-description) to $s(X, Y)$. A
-leaf routine invocation — one with no nested calls — contributes exactly one
-segment. When a routine nests further calls, its **total contribution** is the
-sum of its own segment's contribution and every descendant segment's. These
-segments are not independent: routines send and receive wires through [`Input`]
-and [`Output`] gadgets, and those wires are often allocated in different
-segments.
-
-Because each wire's location in $s(X, Y)$ is a monomial in $X$ determined by the
-gate offset of whichever segment allocated it, a constraint referencing a
-foreign wire creates a positional dependency between the two segments. A routine
-invocation and all of its descendants thus form a **subtree** of
-positionally-dependent segments. If every segment in a subtree sits at a fixed
-relative offset from the root, all wire locations shift uniformly — the subtree
-is a single relocatable unit that can be memoized. If the floor planner
-positions descendants independently, cross-segment wire locations introduce
-additional positional degrees of freedom and the subtree must be handled
-per-segment.
-
-### Allocation
-
-Allocation allows gates to be reused as a source of wire values. The allocator
-state (parity and gate index) are stashed whenever a routine is invoked. This
-prevents allocation state from crossing segment boundaries, which would
-contaminate their contributions and interfere with repositioning and
-memoization.
-
-```admonish info
-As an optimization, it is theoretically possible for routine invocations to be
-inlined so that they effectively take place within their parent's segment. This
-decision could be encoded into the floor plan. However, this would require the
-trace computation to be aware of this decision (affecting the pipeline above) or
-would require additional metadata to be stored in the `Trace` for adjustment
-during assembly. **As a simplification, we assume all routine invocations are
-out-of-line.**
-```
+The floor plan encodes this rearrangement and serves as an auxiliary input to
+downstream drivers: the wiring polynomial evaluators use it to
+[reposition](#algebraic-description) each segment's contribution to its assigned offset
+in $s(X, Y)$, and the trace polynomial evaluator uses it to scatter each
+segment's gate values to the correct range in $r(X)$.
 
 ## Memoization
 
 The [algebraic description](#algebraic-description) decomposes a routine's
-contribution into **internal** polynomials $g_1(X, Y), g_2(X^{-1}, Y)$ that
-depend only on the routine's constraint structure, and **interface** terms that
-depend on wires crossing the routine boundary. Memoization caches the internal
-part: if two invocations produce the same constraint structure, their $g_1$ and
-$g_2$ are identical and can be reused. The interface terms and
-[repositioning](#repositioning) factors $X^i, Y^j$ must still be computed
-per-invocation.
-
-### Fingerprinting
-
-Two invocations are structurally equivalent when they share a
-[**routine fingerprint**][`RoutineFingerprint`]: the Schwartz–Zippel evaluation
-scalar and the local gate and constraint counts. The
-[metrics pass](#pipeline) computes a fingerprint for each invocation by
-executing its constraint logic on a lightweight `Counter` driver that
-substitutes independent geometric sequences for wire values and accumulates
-constraint contributions via Horner's rule. If the resulting scalar and counts
-match, the two invocations are structurally equivalent with overwhelming
-probability.
-
-Fingerprints capture only the **local** constraint structure. When entering a
-routine, the `Counter` resets its geometric sequences and Horner accumulator to
-a fixed initial state, and output wires from nested routine calls are remapped
-to fresh positions in the caller's sequence space. This ensures the fingerprint
-is independent of calling context and of any sub-routines the routine invokes.
-
-### Routine vs. Memo Fingerprints
-
-The [`TypeId`] pairs `(Input, Output)` do not affect what a segment
-contributes to $s(X, Y)$. Two routines with different Rust types but the
-same constraint structure — the same Schwartz–Zippel scalar and the same
-gate and constraint counts — produce identical polynomial contributions.
-This can be verified directly: wrap each routine in a circuit and assert
-that their $s(x, y)$ evaluations agree at random points.
-
-For floor planning, only the polynomial contribution matters. A
-[`RoutineFingerprint`] `(eval, local_num_gates, local_num_constraints)`
-suffices to group segments with the same polynomial shape; [`TypeId`]
-pairs are deliberately excluded so that the floor planner can group
-type-distinct routines that contribute identically. For memoization, the
-constraints are stricter: a cached routine must be safely substitutable
-for a fresh execution, which requires matching output wire mappings and
-recursive subtree structure. A [`MemoFingerprint`] extends the routine
-fingerprint with `output_eval` (a scalar encoding the output wire
-mapping) and a recursive `deep` hash that folds in [`TypeId`] pairs, all
-routine fingerprint fields, the child count, and each child's deep hash.
-The floor planner keys on the routine fingerprint; the memo cache keys on
-the memo fingerprint.
-
-The distinction is semantic, not just organizational. A routine
-fingerprint captures **segment-level equivalence**: whether two individual
-segments impose the same local constraints and could be aligned in the
-polynomial layout regardless of their subtrees — for instance, padding
-one circuit's segment against another circuit's offset. A memo
-fingerprint captures **subtree-level equivalence**: whether entire routine
-invocations are interchangeable and can be substituted via memoization.
-A segment can be routine-equivalent to another (same local constraints,
-worth aligning) but memo-inequivalent (different children, so the
-cached subtree cannot be reused). Consolidating both levels into a single
-identity type loses this distinction and forces the floor planner to
-treat segments as different when only their subtrees differ.
-
-The two-level design avoids four conflation risks that arise when a single
-fingerprint type serves both roles. First, [`TypeId`] pairs do not affect
-what a segment contributes to $s(X, Y)$, so including them in the
-polynomial-equivalence key would prevent the floor planner from grouping
-type-distinct routines that contribute identically. Second, tests that
-assert "different TypeIds ⇒ different fingerprints" are testing memoization
-safety, not polynomial correctness; naming them as if TypeIds were
-necessary for fingerprint correctness obscures which invariant is actually
-being verified. Third, the `Counter` and the wiring polynomial evaluators
-compute fundamentally different things — a context-independent structural
-hash versus an actual polynomial contribution — so bundling both concerns
-into one type hides the boundary between them. Fourth, without an
-independent reference evaluation to compare against, a memoization cache
-that silently returns wrong results could go undetected; the separation
-makes it possible to test polynomial equivalence (via
-[`RoutineFingerprint`]) and memoization substitutability (via
-[`MemoFingerprint`]) with distinct, targeted assertions.
-
-### Repositioning {#repositioning}
-
-Each segment occupies a **non-overlapping** range of gates and constraints in
-the polynomial layout, assigned by the floor planner. Currently, the floor
-planner preserves DFS synthesis order and computes offsets via a simple prefix
-sum, but a future implementation could reorder segments to co-locate equivalent
-routines or improve memory access patterns. The only constraint is that the root
-segment remains pinned at the polynomial origin (both offsets zero), and
-no two segments may overlap.
+contribution into **internal** polynomials $g_1(X, Y)$ and $g_2(X^{-1}, Y)$
+that depend only on the routine's constraint structure, and **interface** terms
+that depend on wires crossing the routine boundary. Memoization caches the
+internal part: if two invocations produce the same constraint structure, their
+$g_1$ and $g_2$ are identical and can be reused. The interface terms and
+[repositioning](#algebraic-description) factors $X^i, X^{-i}, Y^j$ must still be
+computed per-invocation.
 
 ### Testability
 
@@ -569,5 +394,6 @@ that omits a necessary field — not only bugs in the memoization code.
 [`gate`]: ragu_core::drivers::DriverTypes::gate
 [`mul`]: ragu_core::drivers::Driver::mul
 [`alloc`]: ragu_core::drivers::Driver::alloc
+[`SegmentRecord`]: ragu_circuits::metrics::SegmentRecord
 [`Any`]: core::any::Any
 [conversions]: ../guide/gadgets/conversion.md

--- a/book/src/implementation/routines.md
+++ b/book/src/implementation/routines.md
@@ -9,8 +9,20 @@ permitted to do anything that normal circuit code can do with a
 
 It is possible to invoke them by manually calling their [`Routine::execute`]
 method, but this almost always defeats the purpose of the abstraction. Instead,
-they are meant to be invoked through the [`Driver::routine`] method, which hands
-control and visibility of its execution to the driver.
+they are meant to be invoked through the [`Driver::routine`] method, which
+preserves the context and boundaries of routine invocations for the driver.
+
+Routines can also further invoke other routines, creating **nested routines**.
+To avoid complicated call stack management, our drivers only keep _routine-local_
+states. When circuit code calls [`Driver::routine`], the driver saves its local
+scoped state (e.g., running wire monomial evaluations for `sx::Evaluator`,
+constraint counters for `metric::Counter` etc.), and initializes a fresh scope
+for the child routine. On return, the parent scope is restored and the child's
+contribution is rolled up in the parent's accumulated state. The `DriverScope`
+trait provides a `with_scope` helper that automates this save-then-restore; some
+drivers use manual `mem::replace` on the scoped state instead when they need to
+inspect the child scope's result before restoring.
+We refer our invocation-depth-independent drivers as being _context insensitive_.
 
 ```admonish info
 Drivers do not learn the [`TypeId`] of a [`Routine`] they are asked to `execute`,
@@ -35,26 +47,58 @@ algebraically convenient structure in the resulting wiring polynomial $s(X, Y)$:
 * [`gate`] advances an $i$ counter and returns $(X^{2n - 1 - i}, X^{2n + i}, X^{4n - 1 - i}, X^i)$ wires.
 * `enforce_zero` advances a counter $j$ and adds a fresh linear combination of previous wires multiplied by $Y^j$.
 
-Most of the linear constraints created within a routine consist purely of wires also
-created within that routine, meaning that the **internal** contribution of a
-routine can be written as polynomials $g_x, g_{x^{-1}}$ and memoized if the
-routine is invoked multiple times. Given a cache hit, we need only scale $g_x$
-and $g_{x^{-1}}$ by powers of $Y^j X^i$ (or $Y^j X^{-i}$) to obtain the correct
-internal $s(X, Y)$ for an equivalent invocation.
-
-The **interface** contribution to $s(X, Y)$ involves wires created outside the
-routine, such as the input gadget wires or the fixed `ONE` wire. This is less
-amenable to memoization because these wires can vary between invocations; we
-must generally maintain separate polynomials $h_\ell$ for every interface wire.
-
-Taken together, the **contribution** of a routine invocation to $s(X, Y)$ can be
-written as
+Most constraints within a routine only involve wires created within the routine.
+For a routine that starts at gate index $i$ and constraint index $j$, these
+constraints, constituting the **internal contribution** to $s(X, Y)$, can be
+written as:
 
 $$
-Y^j \Big( X^i g_x + X^{-i} g_{x^{-1}} + \sum_\ell h_\ell \Big)
+Y^j \Big( X^i \, g_1(X, Y) + X^{-i} \, g_2(X^{-1}, Y) \Big)
 $$
 
-for some **repositioning** values $i, j$.
+where $X^i Y^j$ (and $X^{-i} Y^j$ for wires allocated in reversed segments of a
+[structured](../../protocol/prelim/structured_vectors.md) trace) are the common
+factors extracted from all monomial terms in the contribution[^factoring].
+Crucially, $g_1$ and $g_2$ are **invariant to the routine invocation**: they are
+the same regardless of where or how many times the invocation is placed in a
+circuit. This makes _routine memoization_ possible: given a invocation cache hit,
+we only need to apply a **repositioning** by re-scaling them to the starting
+position ($X^i Y^j$ and $X^{-i} Y^j$) of that particular invocation.
+
+[^factoring]: Every wire allocated _after_ entering the routine at gate index $i$
+    has a positional monomial $X^{i+k}$ or $X^{-{i+k}}$ (reversed segment) for
+    some $k>0$. Each constraint on these internal wires is a linear combination
+    of these positional monomials multiplied by $Y^{j+\ell}$ for some $\ell > 0$.
+    Thus, the internal contribution, summing over all $Y$-power-scaled linear
+    combination of $X$ monomials, share a common factor $X^i Y^j$
+    (or $X^{-i}Y^j$). Extracting these factors yield $g_1$ and $g_2$.
+
+The overall contribution of a routine invocation to $s(X, Y)$ is the sum of this
+internal contribution, an **interface contribution** from constraints that
+reference wires created outside the routine (e.g., input gadget wires), and a
+**system contribution** from constraints that reference system wires (i.e.,
+`ONE`) at fixed locations.
+
+The interface contribution cannot be factored (or memoized) the same way:
+the input gadget is allocated by the routine caller at an unknown position, both
+absolute and relative to the start of the routine, so there is no a priori $X^i$
+factors to extract. We must compute interface contributions per-invocation.
+One crucial complication arises from nested routines. Our decision on
+_context-insensitive_ drivers demands that the output gadgets of nested/child
+routines are also part of the interface contribution of the parent routine.
+
+Meanwhile, system contributions are also memoizable:
+
+$$
+\sum_{\ell \in T} Y^\ell X^{2n} = X^{2n}Y^j \cdot g_3(Y)
+$$
+
+where $T$ is the set of constraint indices within the routine where system wires
+are referenced, $X^{2n}$ is the monomial for the $b_0 (= 1)$ wire during
+[wiring checks](../../protocol/local/wiring.md#layout).
+Similarly, we can extract the common factor $X^{2n}Y^j$ for the starting
+constraint index $j$ and the remaining univariate $g_3$ is invariant to the
+routine invocation.
 
 ## Pipeline {#pipeline}
 
@@ -103,15 +147,6 @@ a given witness, and the registry uses the floor plan to translate this to the
 actual trace polynomial $r(X)$.
 
 ## Invocations
-
-When circuit code calls [`Driver::routine`], the driver saves its current
-scoped state — running wire monomials, constraint counters, Horner
-accumulators, allocation pairing state — and initializes a fresh scope
-for the child routine. On return, the parent scope is restored and the
-child's contribution is folded into the parent's accumulated result. The
-`DriverScope` trait provides a `with_scope` helper that automates this
-save/restore; some drivers use manual `mem::replace` instead when they
-need to inspect the child scope's result before restoring the parent.
 
 Because synthesis is deterministic, invocations appear in a canonical **DFS
 order** that is stable across executions of the same circuit code. The
@@ -215,11 +250,11 @@ out-of-line.**
 ## Memoization
 
 The [algebraic description](#algebraic-description) decomposes a routine's
-contribution into **internal** polynomials $g_x, g_{x^{-1}}$ that depend only
-on the routine's constraint structure, and **interface** terms $h_\ell$ that
+contribution into **internal** polynomials $g_1(X, Y), g_2(X^{-1}, Y)$ that
+depend only on the routine's constraint structure, and **interface** terms that
 depend on wires crossing the routine boundary. Memoization caches the internal
-part: if two invocations produce the same constraint structure, their $g_x$ and
-$g_{x^{-1}}$ are identical and can be reused. The interface terms and
+part: if two invocations produce the same constraint structure, their $g_1$ and
+$g_2$ are identical and can be reused. The interface terms and
 [repositioning](#repositioning) factors $X^i, Y^j$ must still be computed
 per-invocation.
 

--- a/book/src/implementation/routines.md
+++ b/book/src/implementation/routines.md
@@ -17,14 +17,17 @@ To avoid complicated call-stack management, drivers keep only _routine-local_
 state. When circuit code calls [`Driver::routine`], the driver saves its
 scoped state (e.g., running wire monomial evaluations for `sx::Evaluator`,
 constraint counters for `metrics::Counter`), and initializes a fresh scope
-for the child routine. On return, the parent scope is restored and the child's
-contribution is folded into the parent's accumulated result. The `DriverScope`
-trait provides a `with_scope` helper that automates this save-and-restore; some
-drivers use manual `mem::replace` instead when they need to inspect the child
-scope before restoring the parent.
+for the child routine. The parent and child scopes are isolated from each
+other: a child scope runs against _no_ inherited parent state, so its
+execution depends only on its body and inputs. On return, the parent scope
+is restored unchanged, and the child's contribution is folded into
+driver-level output rather than the parent's scope. The `DriverScope` trait
+provides a `with_scope` helper that automates this save-and-restore; some
+drivers use manual `mem::replace` instead when they need to inspect the
+child scope before restoring the parent.
 
 Because driver behavior does not depend on invocation depth, we call them
-_context insensitive_.
+_depth insensitive_.
 
 ## Algebraic Description {#algebraic-description}
 
@@ -64,19 +67,20 @@ starting position ($X^i Y^j$ and $X^{-i} Y^j$) of that particular invocation.
     combinations of $X$ monomials — therefore shares a common factor $X^i Y^j$
     (or $X^{-i}Y^j$). Extracting these factors yields $g_1$ and $g_2$.
 
-The overall contribution of a routine invocation to $s(X, Y)$ is the sum of this
-internal contribution, an **interface contribution** from constraints that
-reference wires created outside the routine (e.g., input gadget wires), and a
-**system contribution** from constraints that reference system wires (i.e.,
-`ONE`) at fixed locations.
+A routine invocation's overall contribution to $s(X, Y)$ decomposes into
+three buckets: the internal contribution above, an **interface
+contribution** from constraints that reference wires created outside the
+routine (e.g., input gadget wires), and a **system contribution** from
+constraints that reference system wires (i.e., `ONE`) at fixed locations.
+We examine the remaining two next.
 
-The interface contribution cannot be factored or memoized the same way:
-the input gadget is allocated by the caller at an unknown position, both
-absolute and relative to the start of the routine, so there are no a priori
-$X^i$ factors to extract. Interface contributions must be computed
-per-invocation.
+Unlike the internal contribution, the interface contribution cannot be
+factored or memoized the same way: the external wires it references are
+allocated by the caller at positions unknown to the routine, both absolute
+and relative to its start, so there are no a priori $X^i$ factors to
+extract. Interface contributions must be computed per-invocation.
 
-A complication arises from nested routines. The context-insensitive design
+A complication arises from nested routines. The depth-insensitive design
 requires that output gadgets of child routines are also treated as interface
 contributions of the parent routine.
 It is always safe to classify them this way and recompute on every invocation
@@ -86,7 +90,8 @@ output gadgets can be remapped to matching positions in the parent's context,
 allowing further constraints on them to be memoized as internal contributions.
 We elaborate on this [below](#memoization).
 
-System contributions are memoizable by similar reasoning:
+The system contribution is memoizable by similar reasoning to the internal
+contribution:
 
 $$
 \sum_{\ell \in T} Y^\ell X^{2n} = X^{2n}Y^j \cdot g_3(Y)
@@ -136,7 +141,8 @@ routine invocations. In particular, circuit sections at the same invocation
 depth are merged into a single segment; wires allocated outside of any routine
 belong to a special **root segment**.[^root-segment] Each routine invocation
 creates a new **base segment** containing only the wires allocated directly
-within it; nested calls produce their own segments in turn. The DFS-ordered
+within its own body, excluding anything its nested sub-routines allocate;
+nested calls produce their own segments in turn. The DFS-ordered
 segments are built as [`SegmentRecord`]s during the [metric pass](#pipeline).
 Because circuit synthesis is deterministic, the ordered sequence is stable
 across all drivers of the same circuit code.
@@ -174,11 +180,26 @@ their **invocations**. Fingerprinting is the process by which a routine
 invocation is succinctly encapsulated so that _matching fingerprints imply
 opportunities for routine memoization_. An invocation can carry multiple
 fingerprints, each indicating a different memoization strategy or level of
-aggressiveness. Ragu produces two: a **base fingerprint** that captures
-_segment-level equivalence_ and enables memoization of only the base segment,
-and a **deep fingerprint** that captures _tree-level equivalence_ and enables
-memoization of the entire routine, recursively including all nested
-sub-routines.
+aggressiveness. Ragu produces two:
+
+- A **base fingerprint** that captures _segment-level distinction_: whether
+  two individual segments impose the same local constraints and could be
+  aligned in the polynomial layout regardless of their subtrees — for
+  example, padding one circuit's segment against another circuit's offset.
+  Matching base fingerprints signal that the base segment is worth aligning,
+  but do not imply that the nested subtrees match.
+
+- A **deep fingerprint** that captures _subtree-level equivalence_: whether
+  entire routine invocations are interchangeable and can be substituted via
+  memoization. This is strictly stronger — a segment can be base-equivalent
+  (same local constraints, worth aligning) but deep-inequivalent (different
+  children, so the cached subtree cannot be reused).
+
+Keeping these as distinct types preserves the semantic separation: the floor
+planner keys on the base fingerprint for alignment decisions; the memo cache
+keys on the deep fingerprint for substitution safety. Consolidating both
+levels into a single identity type loses this distinction and forces the
+floor planner to treat segments as different when only their subtrees differ.
 
 ### Base fingerprint {#base-fingerprint}
 

--- a/book/src/implementation/routines.md
+++ b/book/src/implementation/routines.md
@@ -4,8 +4,8 @@
 that satisfy a simple function-like interface: they take a single [`Input`]
 gadget and a [`Driver`] handle, and return a single [`Output`] gadget. They are
 permitted to do anything that normal circuit code can do with a
-[driver](../guide/drivers.md), such as making gates ([`gate`], [`mul`], [`alloc`]) and
-constraining their wires ([`enforce_zero`]).
+[driver](../guide/drivers/index.md), such as making gates ([`gate`], [`mul`],
+[`alloc`]) and constraining their wires ([`enforce_zero`]).
 
 It is possible to invoke them by manually calling their [`Routine::execute`]
 method, but this almost always defeats the purpose of the abstraction. Instead,
@@ -23,11 +23,11 @@ deterministic.
 Drivers cannot distinguish routines themselves but merely their **invocations**;
 in each `routine` call, they learn the [`TypeId`] of their [`Input`] and
 [`Output`] gadgets, and thanks to
-[fungibility](../guide/gadgets/index.md#gadget-trait-fungibility) this is very
+[fungibility](../guide/gadgets/index.md#fungibility) this is very
 useful for their structural analysis (via [conversions]) and induces stable
 algebraic properties at routine boundaries.
 
-### Algebraic Description
+## Algebraic Description {#algebraic-description}
 
 Routines exploit the fact that contiguous sections of code tend to have
 algebraically convenient structure in the resulting wiring polynomial $s(X, Y)$:
@@ -56,7 +56,7 @@ $$
 
 for some **repositioning** values $i, j$.
 
-## Pipeline
+## Pipeline {#pipeline}
 
 ```mermaid
 graph LR
@@ -101,6 +101,68 @@ memoize arithmetic to reduce the cost of evaluating the registry polynomial. The
 trace polynomial assembly process produces an unassembled trace of execution for
 a given witness, and the registry uses the floor plan to translate this to the
 actual trace polynomial $r(X)$.
+
+## Invocations
+
+When circuit code calls [`Driver::routine`], the driver saves its current
+scoped state — running wire monomials, constraint counters, Horner
+accumulators, allocation pairing state — and initializes a fresh scope
+for the child routine. On return, the parent scope is restored and the
+child's contribution is folded into the parent's accumulated result. The
+[`DriverScope`] trait provides a `with_scope` helper that automates this
+save/restore; some drivers use manual `mem::replace` instead when they
+need to inspect the child scope's result before restoring the parent.
+
+Because synthesis is deterministic, invocations appear in a canonical **DFS
+order** that is stable across executions of the same circuit code. The
+metrics pass, wiring polynomial evaluators, and trace evaluator all see the
+same sequence. The floor plan is indexed by this order: `floor_plan[i]`
+describes where the $i$-th segment is placed, regardless of whether a
+future floor planner reorders their positions.
+
+The [`Counter`] uses each invocation to build a [`SegmentRecord`] and a
+[`RoutineFingerprint`]. It resets its geometric sequences and Horner
+accumulator to a fixed initial state — independent of the caller — so that
+the fingerprint captures only the routine's internal constraint structure.
+Input wires are remapped into the fresh scope without incrementing
+constraint counts, seeding the sequences for the fingerprint but not
+inflating metrics. After execution, the child's Horner result and
+constraint counts are bundled into the fingerprint. Output wires are then
+remapped back into the parent's sequence space; the `available_d` pairing
+slot is saved and restored around this remap to keep the parent's
+allocation parity aligned with the real evaluation drivers.
+
+The wiring polynomial evaluators ([`sxy`]; [`sx`] and [`sy`] follow the
+same structural protocol with different accumulation targets) use the floor
+plan to jump each routine to its absolute position in the polynomial. The
+child scope's running monomials are initialized at the segment's absolute
+gate offset so that constraints land at the correct position in
+$s(X, Y)$. After execution, assertions verify that the child consumed
+exactly the gate and constraint counts declared by the floor plan. The
+routine's local Horner result is then scaled by the segment's absolute
+$Y$-offset, combined with any nested child contributions, and added to
+the parent's accumulator.
+
+The trace evaluator branches on the [`Prediction`] returned by `predict`.
+[`Unknown`] predictions are executed in-line within the current evaluator
+via `with_scope`. [`Known`] predictions allow the driver to take the
+predicted output and defer actual execution: with multicore enabled, the
+routine is spawned into a parallel task that sends its segments back
+through a channel; without multicore, it is evaluated inline and its
+segments are collected into a deferred buffer. In both cases, segments are
+annotated with their **DFS path** — the sequence of routine-call indices
+from root to the segment — so that the final `finish` step can sort all
+segments back into canonical DFS order.
+
+[`DriverScope`]: ragu_circuits::DriverScope
+[`sxy`]: ragu_circuits::s::sxy
+[`sx`]: ragu_circuits::s::sx
+[`sy`]: ragu_circuits::s::sy
+[`Counter`]: ragu_circuits::metrics::Counter
+[`SegmentRecord`]: ragu_circuits::metrics::SegmentRecord
+[`Prediction`]: ragu_core::routines::Prediction
+[`Known`]: ragu_core::routines::Prediction::Known
+[`Unknown`]: ragu_core::routines::Prediction::Unknown
 
 ## Segments
 
@@ -152,6 +214,116 @@ during assembly. **As a simplification, we assume all routine invocations are
 out-of-line.**
 ```
 
+## Memoization
+
+The [algebraic description](#algebraic-description) decomposes a routine's
+contribution into **internal** polynomials $g_x, g_{x^{-1}}$ that depend only
+on the routine's constraint structure, and **interface** terms $h_\ell$ that
+depend on wires crossing the routine boundary. Memoization caches the internal
+part: if two invocations produce the same constraint structure, their $g_x$ and
+$g_{x^{-1}}$ are identical and can be reused. The interface terms and
+[repositioning](#repositioning) factors $X^i, Y^j$ must still be computed
+per-invocation.
+
+### Fingerprinting
+
+Two invocations are structurally equivalent when they share a
+[**fingerprint**][`RoutineFingerprint`]: the pair `(TypeId(Input),
+TypeId(Output))`, the Schwartz–Zippel evaluation scalar, and the local gate and
+constraint counts. The [metrics pass](#pipeline) computes a fingerprint for each
+invocation by executing its constraint logic on a lightweight [`Counter`] driver
+that substitutes independent geometric sequences for wire values and
+accumulates constraint contributions via Horner's rule. If the resulting scalar,
+type pairs, and counts all match, the two invocations are structurally
+equivalent with overwhelming probability.
+
+Fingerprints capture only the **local** constraint structure. When entering a
+routine, the `Counter` resets its geometric sequences and Horner accumulator to
+a fixed initial state, and output wires from nested routine calls are remapped
+to fresh positions in the caller's sequence space. This ensures the fingerprint
+is independent of calling context and of any sub-routines the routine invokes.
+
+### Shallow vs. Deep Fingerprints
+
+The [`TypeId`] pairs `(Input, Output)` do not affect what a segment
+contributes to $s(X, Y)$. Two routines with different Rust types but the
+same constraint structure — the same Schwartz–Zippel scalar and the same
+gate and constraint counts — produce identical polynomial contributions.
+This can be verified directly: wrap each routine in a circuit and assert
+that their $s(x, y)$ evaluations agree at random points.
+
+For floor planning, only the polynomial contribution matters. A **shallow
+fingerprint** `(eval, num_gates, num_constraints)` suffices to group
+segments with the same polynomial shape; including [`TypeId`] pairs would
+prevent the floor planner from grouping type-distinct routines that
+contribute identically. For memoization, the constraints are stricter: a
+cached routine must be safely substitutable for a fresh execution, which
+requires matching output wire mappings and recursive subtree structure. A
+**deep fingerprint** extends the shallow fingerprint with `output_eval`
+(a scalar encoding the output wire mapping) and a recursive hash that
+folds in [`TypeId`] pairs, all shallow fields, the child count, and each
+child's deep hash. The floor planner keys on the shallow fingerprint; the
+memo cache keys on the deep fingerprint.
+
+The distinction is semantic, not just organizational. A shallow
+fingerprint captures **segment-level equivalence**: whether two individual
+segments impose the same local constraints and could be aligned in the
+polynomial layout regardless of their subtrees — for instance, padding
+one circuit's segment against another circuit's offset. A deep
+fingerprint captures **subtree-level equivalence**: whether entire routine
+invocations are interchangeable and can be substituted via memoization.
+A segment can be shallow-equivalent to another (same local constraints,
+worth aligning) but deep-inequivalent (different children, so the
+cached subtree cannot be reused). Consolidating both levels into a single
+identity type loses this distinction and forces the floor planner to
+treat segments as different when only their subtrees differ.
+
+### Repositioning {#repositioning}
+
+Each segment occupies a **non-overlapping** range of gates and constraints in
+the polynomial layout, assigned by the floor planner. Currently, the floor
+planner preserves DFS synthesis order and computes offsets via a simple prefix
+sum, but a future implementation could reorder segments to co-locate equivalent
+routines or improve memory access patterns. The only constraint is that the root
+segment remains pinned at the polynomial origin (both offsets zero), and
+no two segments may overlap.
+
+### Testability
+
+Because segments are non-overlapping, bugs in the floor planner or
+memoization logic produce observable failures rather than silent
+corruption. If segments were assigned overlapping gate ranges, the
+[`Trace::assemble`] scatter step would overwrite values from one segment
+with another's, and the post-execution assertions in the wiring polynomial
+evaluators — which verify that each segment consumed exactly the gate and
+constraint counts declared by the floor plan — would fire. A memoization
+error manifests differently: a cached internal contribution that disagrees
+with the fresh computation produces a different $s(x, y)$ value, and
+because the final evaluation is a single field element, any discrepancy is
+detectable by comparison. Incorrect repositioning rescaling shifts a
+routine's contribution to the wrong polynomial position, breaking the
+relationship between $s(X, Y)$ and $r(X)$, which verification catches as
+a polynomial identity failure.
+
+These failure modes are all covered by a single reference comparison. The
+native evaluation path computes the registry polynomial $m(w, x, y)$ by
+evaluating each circuit's $s(x, y)$ independently with no caching. The
+memoized path shares a cache across circuits: on the first evaluation of
+a routine at a given canonical position, the contribution and output
+wires are stored; subsequent circuits with the same fingerprint at that
+position reuse the cached contribution, rescaled by the floor plan's
+repositioning factors. Asserting that both paths agree at random
+$(w, x, y)$ points covers floor planning, repositioning, and cache logic
+in a single check. The non-overlapping invariant
+ensures that any disagreement is a real bug rather than a masking
+coincidence. Because the native path does not depend on the
+fingerprinting model at all, this comparison catches errors in the model
+itself — a shallow fingerprint that over-groups, or a deep fingerprint
+that omits a necessary field — not only bugs in the memoization code.
+
+[`RoutineFingerprint`]: ragu_circuits::metrics::RoutineFingerprint
+[`Counter`]: ragu_circuits::metrics::Counter
+[`Trace::assemble`]: ragu_circuits::trace::Trace::assemble
 [`TypeId`]: core::any::TypeId
 [`Routine`]: ragu_core::routines::Routine
 [`Driver`]: ragu_core::drivers::Driver

--- a/book/src/implementation/routines.md
+++ b/book/src/implementation/routines.md
@@ -16,12 +16,13 @@ Routines can further invoke other routines, creating **nested routines**.
 To avoid complicated call-stack management, drivers keep only _routine-local_
 state. When circuit code calls [`Driver::routine`], the driver saves its
 scoped state (e.g., running wire monomial evaluations for `sx::Evaluator`,
-constraint counters for `metric::Counter`), and initializes a fresh scope
+constraint counters for `metrics::Counter`), and initializes a fresh scope
 for the child routine. On return, the parent scope is restored and the child's
 contribution is folded into the parent's accumulated result. The `DriverScope`
 trait provides a `with_scope` helper that automates this save-and-restore; some
 drivers use manual `mem::replace` instead when they need to inspect the child
 scope before restoring the parent.
+
 Because driver behavior does not depend on invocation depth, we call them
 _context insensitive_.
 
@@ -30,10 +31,13 @@ _context insensitive_.
 Routines exploit the fact that contiguous sections of code tend to have
 algebraically convenient structure in the resulting wiring polynomial $s(X, Y)$:
 
-* [`gate`] advances an $i$ counter and returns $(X^{2n - 1 - i}, X^{2n + i}, X^{4n - 1 - i}, X^i)$ wires.
-* `enforce_zero` advances a counter $j$ and adds a fresh linear combination of previous wires multiplied by $Y^j$.
+* [`gate`] advances an $i$ counter and returns
+  $(X^{2n - 1 - i}, X^{2n + i}, X^{4n - 1 - i}, X^i)$ wires.
+* `enforce_zero` advances a counter $j$ and adds a fresh linear
+  combination of previous wires multiplied by $Y^j$.
 
-Most constraints within a routine involve only wires created within that routine.
+Most constraints within a routine involve only wires created within
+that routine.
 For a routine that starts at gate index $i$ and constraint index $j$, these
 constraints, constituting the **internal contribution** to $s(X, Y)$, can be
 written as:
@@ -43,18 +47,19 @@ Y^j \Big( X^i \, g_1(X, Y) + X^{-i} \, g_2(X^{-1}, Y) \Big)
 $$
 
 where $X^i Y^j$ (and $X^{-i} Y^j$ for wires allocated in reversed segments of a
-[structured](../../protocol/prelim/structured_vectors.md) trace) are the common
+[structured](../protocol/prelim/structured_vectors.md) trace) are the common
 factors extracted from all monomial terms in the contribution[^factoring].
 Crucially, $g_1$ and $g_2$ are **invariant to the routine invocation**: they are
 the same regardless of where or how many times the invocation is placed in a
-circuit. This makes _routine memoization_ possible: given an invocation cache hit,
-we only need to apply a **repositioning** by re-scaling to the starting position
-($X^i Y^j$ and $X^{-i} Y^j$) of that particular invocation.
+circuit. This makes _routine memoization_ possible: given an invocation
+cache hit, we only need to apply a **repositioning** by re-scaling to the
+starting position ($X^i Y^j$ and $X^{-i} Y^j$) of that particular invocation.
 
-[^factoring]: Every wire allocated _after_ entering the routine at gate index $i$
-    has a positional monomial $X^{i+k}$ or $X^{-{i+k}}$ (reversed segment) for
-    some $k>0$. Each constraint on these internal wires is a linear combination
-    of these positional monomials multiplied by $Y^{j+\ell}$ for some $\ell > 0$.
+[^factoring]: Every wire allocated within the routine, starting at gate
+    index $i$, has a positional monomial $X^{i+k}$ or $X^{-(i+k)}$
+    (reversed segment) for some $k\geq 0$. Each constraint on these
+    internal wires is a linear combination of these positional monomials
+    multiplied by $Y^{j+\ell}$ for some $\ell \geq 0$.
     The internal contribution — the sum of all $Y$-power-scaled linear
     combinations of $X$ monomials — therefore shares a common factor $X^i Y^j$
     (or $X^{-i}Y^j$). Extracting these factors yields $g_1$ and $g_2$.
@@ -70,6 +75,7 @@ the input gadget is allocated by the caller at an unknown position, both
 absolute and relative to the start of the routine, so there are no a priori
 $X^i$ factors to extract. Interface contributions must be computed
 per-invocation.
+
 A complication arises from nested routines. The context-insensitive design
 requires that output gadgets of child routines are also treated as interface
 contributions of the parent routine.
@@ -80,7 +86,7 @@ output gadgets can be remapped to matching positions in the parent's context,
 allowing further constraints on them to be memoized as internal contributions.
 We elaborate on this [below](#memoization).
 
-Meanwhile, system contributions are also memoizable:
+System contributions are memoizable by similar reasoning:
 
 $$
 \sum_{\ell \in T} Y^\ell X^{2n} = X^{2n}Y^j \cdot g_3(Y)
@@ -88,14 +94,15 @@ $$
 
 where $T$ is the set of constraint indices within the routine where system wires
 are referenced, $X^{2n}$ is the monomial for the $b_0 (= 1)$ wire during
-[wiring checks](../../protocol/local/wiring.md#layout).
+[wiring checks](../protocol/local/wiring.md#layout).
 The common factor $X^{2n}Y^j$ can be extracted for the starting constraint
-index $j$, and the remaining univariate $g_3$ is again invariant to the routine
-invocation.
+index $j$, and the remaining univariate $g_3$ is again invariant to the
+routine invocation: the relative offsets $\ell - j$ within the routine
+depend only on its structure, not on the absolute starting index.
 
 ## Example: Synthesis Trace {#example}
 
-The following circuit serves as a concrete example for all upcoming discussion:
+The following circuit is a concrete example for all upcoming discussion:
 
 ```
  Circuit Synthesis Trace
@@ -120,7 +127,7 @@ Each label `r0, a0, b0, …, r2` denotes a contiguous section of circuit trace
 allocated via [`gate`]. At various points the circuit logic invokes a routine,
 which may in turn invoke nested routines.
 
-## Segments
+## Segments {#segments}
 
 Given an execution trace, we need a global indexing of all sub-sections so
 that different drivers can refer to them consistently. Ragu divides the trace
@@ -155,14 +162,14 @@ Consider some naive but incorrect ways to identify one:
 - by shape (`num_gates` and `num_constraints`):
   different routines can coincidentally share the same shape.
 - by `(Input, Output)` gadget types:
-  routines performing different operations (e.g. `square` and `double`) can share
-  the same input/output types.
+  routines performing different operations (e.g. `square` and `double`)
+  can share the same input/output types.
 - by `TypeId::of::<Routine>()`: 
-  routines can be [parameterized](../../guide/routines.md#param) and stateful;
+  routines can be [parameterized](../guide/routines.md#param) and stateful;
   even the same `ScaledTxz` routine type (or `RoutineB` in our example)
   can synthesize different traces depending on its configuration.
   
-In short, drivers cannot distinguish routines statically but must also consider
+Drivers cannot distinguish routines statically but must also consider
 their **invocations**. Fingerprinting is the process by which a routine
 invocation is succinctly encapsulated so that _matching fingerprints imply
 opportunities for routine memoization_. An invocation can carry multiple
@@ -250,7 +257,7 @@ sequence.
 
 ### Deep fingerprint {#deep-fingerprint}
 
-The most aggressive memoization applies when two routine invocations are
+Deep-fingerprint memoization applies when two routine invocations are
 tree-level equivalent: structurally identical in both their base segment and all
 nested sub-routines. Two invocations with identical deep fingerprints have
 matching shapes (gate and constraint counts) and matching polynomial
@@ -285,10 +292,12 @@ tree.
 [^swapped]: As an example, suppose two `RoutineB` invocations each nest a call
     to `RoutineA`. The first `RoutineA` invocation runs
     `alloc(w1); alloc(w2); enforce_zero(w1 + w2); return (w1, w2)`;
-    the second runs `alloc(w2); alloc(w1); enforce_zero(w1 + w2); return (w1, w2)`.
-    In the `BaseFingerprint` computation, the output wires `(w1, w2)` from both
-    invocations are mapped to the same values in their parent `RoutineB` context,
-    so the two `RoutineB` invocations receive identical base fingerprints.
+    the second runs
+    `alloc(w2); alloc(w1); enforce_zero(w1 + w2); return (w1, w2)`.
+    In the `BaseFingerprint` computation, the output wires `(w1, w2)` from
+    both invocations are mapped to the same values in their parent
+    `RoutineB` context, so the two `RoutineB` invocations receive
+    identical base fingerprints.
     However, after inlining, the invocations differ because of the swapped
     allocation order of `w1` and `w2`.
 
@@ -323,18 +332,20 @@ The registry collects segment records from every circuit and feeds them into a
 **floor planner** that assigns each segment a non-overlapping absolute position
 `(gate_start, constraint_start)` in the polynomial layout. The floor planner
 aligns segments with matching fingerprints to maximize
-[memoization](#memoization) across the entire registry, both within and between
-circuits: matching base fingerprints enable memoization of the base segment's internal
-contribution, while matching deep fingerprints enable memoization of entire
-routine subtrees. Currently, the floor planner only rearranges segment
-placement; it does not perform circuit-equivalence substitutions that would
-alter the circuit logic itself.
+[memoization](#memoization) across the entire registry, both within and
+between circuits: matching base fingerprints enable memoization of the
+base segment's internal contribution, while matching deep fingerprints
+enable memoization of entire routine subtrees. Currently, the floor
+planner only rearranges segment placement; it does not perform
+circuit-equivalence substitutions that would alter the circuit logic
+itself.
 
-The floor plan encodes this rearrangement and serves as an auxiliary input to
+The floor plan encodes this rearrangement and is an auxiliary input to
 downstream drivers: the wiring polynomial evaluators use it to
-[reposition](#algebraic-description) each segment's contribution to its assigned offset
-in $s(X, Y)$, and the trace polynomial evaluator uses it to scatter each
-segment's gate values to the correct range in $r(X)$.
+[reposition](#algebraic-description) each segment's contribution to its
+assigned offset in $s(X, Y)$, and the trace polynomial evaluator uses
+it to scatter each segment's gate values to the correct range in
+$r(X)$.
 
 ## Memoization {#memoization}
 
@@ -344,10 +355,22 @@ and $g_2(X^{-1}, Y)$, a **system** polynomial $g_3(Y)$, and **interface** terms
 that cross the routine boundary. The internal and system polynomials depend only
 on the routine's constraint structure and are invariant to invocation context;
 the interface terms depend on externally allocated wires and must be recomputed.
-Memoization caches the invariant parts — $g_1$, $g_2$, and $g_3$ — and replays
-them for subsequent invocations whose [fingerprints](#fingerprint) match, applying
-fresh [repositioning](#algebraic-description) factors $X^i$, $X^{-i}$, $Y^j$ to
-place the cached contribution at the correct offset.
+Memoization caches the invariant parts — $g_1$, $g_2$, and $g_3$ — and
+replays them for subsequent invocations whose [fingerprints](#fingerprint)
+match, applying fresh [repositioning](#algebraic-description) factors
+$X^i$, $X^{-i}$, $Y^j$ to place the cached contribution at the correct
+offset.
+
+Caching follows $s(X, Y)$'s evaluation logic, not the simplified
+computation used for [fingerprinting](#base-fingerprint). During
+fingerprinting, interface wires receive context-insensitive values so
+their contributions cancel across equivalent invocations (approach 2
+[above](#base-fingerprint)). During memoization, the driver must
+actually _exclude_ interface contributions from the cached result so
+that only the invariant part is stored. This requires approach 1:
+the wire type carries an `Interface` discriminant so that the driver
+can identify interface terms in each constraint and route them to the
+per-invocation computation rather than the cache.
 
 The registry collects fingerprints from the [metric pass](#pipeline) and records
 matches — both within a single circuit and across circuits — so that downstream
@@ -360,18 +383,20 @@ How much of a routine can be cached depends on which fingerprint matches.
 **Base-fingerprint memoization.** When two invocations share a
 [base fingerprint](#base-fingerprint), only the _base segment_ of the routine is
 known to be equivalent. The driver caches $g_1$, $g_2$, and $g_3$ for that
-segment and repositions them at the new invocation's offset. Contributions from
-nested sub-routines — including any constraints the parent places on their output
-gadgets — remain interface contributions and are recomputed per-invocation.
+segment and repositions them at the new invocation's offset.
+Contributions from nested sub-routines — including any constraints the
+parent places on their output gadgets — remain interface contributions
+and are recomputed per-invocation.
 
 **Deep-fingerprint memoization.** When two invocations share a
 [deep fingerprint](#deep-fingerprint), the entire invocation tree is equivalent:
 the base segment _and_ all nested sub-routines have matching structure. This
-changes what counts as an interface contribution: output gadgets of child
-routines, which must be treated as interface contributions under base-fingerprint
-memoization, can now be remapped to matching positions within the parent's
-context. Constraints on these output wires become part of the internal
-contribution and are memoizable along with the rest of the subtree.
+changes what counts as an interface contribution: output gadgets of
+child routines, which must be treated as interface contributions under
+base-fingerprint memoization, can now be remapped to matching positions
+within the parent's context. Constraints on these output wires become
+part of the internal contribution and are memoizable along with the
+rest of the subtree.
 
 ```admonish important title="Deep memoization redefines the internal contribution"
 Under deep-fingerprint equivalence, the output wires of nested sub-routines are
@@ -407,8 +432,9 @@ $$
 \Big(\sum_{k \in K} \ell_k(w)\Big) \cdot \big(X^i Y^j \cdot g(X, Y)\big)
 $$
 
-where $K$ is the set of circuits sharing the routine at that position. The
-routine's contribution is computed once and multiplied by the sum of the relevant
+where $K$ is the set of circuits sharing the routine at that position
+and $g$ denotes the combined invariant contribution. The routine's
+contribution is computed once and multiplied by the sum of the relevant
 Lagrange coefficients, rather than being recomputed per-circuit.
 
 The floor planner prioritizes deep-fingerprint alignment for the largest
@@ -433,10 +459,10 @@ constraint counts declared by the floor plan — would fire. A memoization
 error manifests differently: a cached internal contribution that disagrees
 with the fresh computation produces a different $s(x, y)$ value, and
 because the final evaluation is a single field element, any discrepancy is
-detectable by comparison. Incorrect repositioning rescaling shifts a
-routine's contribution to the wrong polynomial position, breaking the
-relationship between $s(X, Y)$ and $r(X)$, which verification catches as
-a polynomial identity failure.
+detectable by comparison. Incorrect repositioning shifts a routine's
+contribution to the wrong polynomial position, breaking the
+relationship between $s(X, Y)$ and
+$r(X)$, which verification catches as a polynomial identity failure.
 
 These failure modes are all covered by a single reference comparison. The
 native evaluation path computes the registry polynomial $m(w, x, y)$ by
@@ -455,8 +481,6 @@ itself — a routine fingerprint that over-groups, or a memo fingerprint
 that omits a necessary field — not only bugs in the memoization code.
 
 [`WireMap`]: ragu_core::convert::WireMap
-[`RoutineFingerprint`]: ragu_circuits::metrics::RoutineFingerprint
-[`MemoFingerprint`]: ragu_circuits::metrics::MemoFingerprint
 [`TypeId`]: core::any::TypeId
 [`Routine`]: ragu_core::routines::Routine
 [`Driver`]: ragu_core::drivers::Driver

--- a/book/src/implementation/routines.md
+++ b/book/src/implementation/routines.md
@@ -391,28 +391,42 @@ therefore capture the positional values of these output wires.
 struct DeepFingerprint {
     base: BaseFingerprint,
     /// deep hash:
-    /// H(self.base, output_gadget, output_gadget.len(),
-    ///   child_deep_hashes, input_type, output_type)
+    /// H(self.base, output_len, output_gadget,
+    ///   children_len, child_deep_hashes)
     deep: u64,
 }
 ```
 
-Ragu augments the base fingerprint with the wire values of the output gadget,
-the output gadget's length (to prevent length-extension collisions when two
-routines pack different amounts of state into structurally similar output
-shapes), the deep fingerprints of all child invocations (one level deeper),
-and the `TypeId` of the input and output gadget types (optional,
-defense-in-depth only). The monomial evaluation of output wires already
-encodes their positions relative to the start of the sub-routine, and thus
-transitively relative to the start of the parent routine. Because the
-parent's deep fingerprint recursively folds in the deep hashes of all
-children, the final hash binds the entire invocation tree.
+Ragu augments the base fingerprint with the output gadget's length, its wire
+values, the number of child invocations, and the deep fingerprints of all
+child invocations (one level deeper). Both lengths prevent length-extension
+collisions: two routines that pack different amounts of state into
+structurally similar output shapes — or that have differently sized child
+arrays — must produce different deep fingerprints. The monomial
+evaluation of output wires already encodes their positions relative to the
+start of the sub-routine, and thus transitively relative to the start of the
+parent routine. Because the parent's deep fingerprint recursively folds in
+the deep hashes of all children, the final hash binds the entire invocation
+tree.
 
 Composition is via hashing rather than algebraic combination: combining
 fingerprints across tree levels with field arithmetic would risk interference
 between layers and break the linear independence that Schwartz–Zippel relies
 on at the base level. Hashing keeps each level's fingerprint as an opaque
 equality tag while still binding the full tree.
+
+Notably, the input and output [`GadgetKind`][gadgetkind-page] types are
+deliberately _absent_ from the deep hash. From a polynomial perspective the
+contribution to $s(X, Y)$ is type-oblivious, and two invocations whose output
+wires resolve to equivalent streams are interchangeable even when their
+output Rust types differ — for instance, one routine returning `Element` and
+another returning a thin wrapper `MyElement` that encodes a single field
+element identically. Including `TypeId`s would mark such pairs as
+deep-inequivalent and block legitimate memoization without adding any
+soundness margin. The discipline that lets the driver hand back a correctly
+typed output gadget without consulting types in the fingerprint is a
+gadget-layer property, discussed in
+[Output Gadget Reconstruction](#output-reconstruction).
 
 
 [^swapped]: As an example, suppose two `RoutineB` invocations each nest a call
@@ -550,6 +564,48 @@ a single memoizable unit. This is the key advantage of the deep fingerprint: it
 enables full-tree memoization rather than segment-by-segment caching.
 ```
 
+### Output Gadget Reconstruction {#output-reconstruction}
+
+Caching $g_1, g_2, g_3$ makes the contribution to $s(X, Y)$ replayable, but
+the caller still expects a typed output gadget on every invocation —
+including those whose body is skipped on a cache hit. The driver synthesizes
+that gadget by _injecting_ the cached output wires, [shifted](#shifting) to
+the new offset, into a freshly assembled output gadget rather than re-running
+the body to allocate them.
+
+For this injection to be sound, the gadget layer must guarantee that the
+gadget is unambiguously reconstructible from the wire stream alone. We call
+this property **allocation determinism**:
+
+> Given a [`GadgetKind`][gadgetkind-page] and the wire stream produced at the
+> routine boundary, a deterministic algorithm assembles the gadget instance
+> using the stream's length as the only dynamic input, with no out-of-band
+> metadata.
+
+Allocation determinism is strictly weaker than the wire-layout determinism
+that classical [fungibility](../guide/gadgets/index.md#fungibility) implies:
+a gadget kind may own a runtime-sized collection (the stream length resolves
+the count, and any divergence is already caught by the fingerprint), so
+`Vec`-shaped gadgets are admissible. What it rules out are shapes that need
+a side-channel discriminant — most notably enum-shaped gadgets, where
+variant choice cannot in general be recovered from the wire stream (two
+variants may share wire counts, or the variant set may evolve such that
+they collide).
+
+Allocation determinism is the gadget-side counterpart to deep fingerprinting.
+The deep fingerprint guarantees that two invocations contribute identically
+to $s(X, Y)$ and produce equivalent output wire streams; allocation
+determinism guarantees that any gadget reconstructed from such a stream
+agrees with what the body would have produced. Together they make output
+injection safe without consulting gadget types in the fingerprint, which is
+why the deep hash omits `TypeId`s.
+
+Constraint-semantic equivalence — that a `GadgetKind` also pins down the
+constraints applied to its allocated wires — is orthogonal to memoization
+soundness (the constraints live inside the routine body and are already
+captured by the fingerprint scalar) but remains required as an API contract
+so circuit code can reason about a gadget's invariants from its type alone.
+
 When matching fingerprints occur only _within_ a single circuit, memoization
 requires nothing beyond caching and repositioning: the driver records the
 contribution on the first invocation and rescales it for subsequent ones.
@@ -638,3 +694,4 @@ that omits a necessary field — not only bugs in the memoization code.
 [`SegmentRecord`]: ragu_circuits::metrics::SegmentRecord
 [`Any`]: core::any::Any
 [conversions]: ../guide/gadgets/conversion.md
+[gadgetkind-page]: ../guide/gadgets/gadgetkind.md

--- a/book/src/implementation/routines.md
+++ b/book/src/implementation/routines.md
@@ -1,109 +1,62 @@
 # Routines
 
-[Routines](../guide/routines.md) are self-contained portions of circuit code
-that satisfy a simple function-like interface: they take a single [`Input`]
-gadget and a [`Driver`] handle, and return a single [`Output`] gadget. They are
-permitted to do anything that normal circuit code can do with a
-[driver](../guide/drivers/index.md), such as making gates ([`gate`], [`mul`],
+The [overview](../protocol/local/overview.md) presents $s(X, Y)$ as a
+monolithic bivariate polynomial encoding a circuit's linear constraints. In
+practice, circuit code is structured into [routines](../guide/routines.md) —
+self-contained portions of synthesis logic whose invocations occupy
+contiguous blocks of gates and constraints. This page describes how that
+structure decomposes $s(X, Y)$ into relocatable pieces and how the
+decomposition interacts with the [registry](../protocol/extensions/registry.md).
+
+A routine has a function-like interface: it takes a single [`Input`] gadget
+and a [`Driver`] handle, and returns a single [`Output`] gadget. Within its
+body it can do anything normal circuit code does with a
+[driver](../guide/drivers/index.md) — making gates ([`gate`], [`mul`],
 [`alloc`]) and constraining their wires ([`enforce_zero`]).
 
-It is possible to invoke them by manually calling their [`Routine::execute`]
-method, but this almost always defeats the purpose of the abstraction. Instead,
-they are meant to be invoked through the [`Driver::routine`] method, which
-preserves the context and boundaries of routine invocations for the driver.
+Three terms recur throughout this page and refer to distinct things:
+
+- **Routine**: the type and its configuration — a function definition. A
+  routine's Rust type plus any [runtime parameters](../guide/routines.md#param)
+  determines the constraints it produces.
+- **Invocation**: a specific call with specific inputs — a call site. Two
+  invocations of the same routine produce different wire values but the same
+  constraint structure.
+- **Segment**: the polynomial footprint of an invocation — the contiguous
+  range of gate indices and $Y$-power slots it occupies in $s(X, Y)$. Each
+  invocation gets its own segment, and nested calls produce nested segments.
+
+It is possible to invoke a routine by manually calling [`Routine::execute`],
+but this defeats the abstraction. Routines are meant to be invoked through
+[`Driver::routine`], which preserves the call boundaries the driver needs.
 
 Routines can further invoke other routines, creating **nested routines**.
 To avoid complicated call-stack management, drivers keep only _routine-local_
 state. When circuit code calls [`Driver::routine`], the driver saves its
 scoped state (e.g., running wire monomial evaluations for `sx::Evaluator`,
-constraint counters for `metrics::Counter`), and initializes a fresh scope
-for the child routine. The parent and child scopes are isolated from each
-other: a child scope runs against _no_ inherited parent state, so its
-execution depends only on its body and inputs. On return, the parent scope
-is restored unchanged, and the child's contribution is folded into
-driver-level output rather than the parent's scope. The `DriverScope` trait
-provides a `with_scope` helper that automates this save-and-restore; some
-drivers use manual `mem::replace` instead when they need to inspect the
-child scope before restoring the parent.
+constraint counters for `metrics::Counter`, the pending-pair slot used by
+paired allocation) and initializes a fresh scope for the child routine. The
+parent and child scopes are isolated from each other: a child scope runs
+against _no_ inherited parent state, so its execution depends only on its
+body and inputs. On return, the parent scope is restored unchanged, and the
+child's contribution is folded into driver-level output rather than the
+parent's scope. The `DriverScope` trait provides a `with_scope` helper that
+automates this save-and-restore; some drivers use manual `mem::replace`
+instead when they need to inspect the child scope before restoring the
+parent.
 
 Because driver behavior does not depend on invocation depth, we call them
 _depth insensitive_.
 
-## Algebraic Description {#algebraic-description}
-
-Routines exploit the fact that contiguous sections of code tend to have
-algebraically convenient structure in the resulting wiring polynomial $s(X, Y)$:
-
-* [`gate`] advances an $i$ counter and returns
-  $(X^{2n - 1 - i}, X^{2n + i}, X^{4n - 1 - i}, X^i)$ wires.
-* `enforce_zero` advances a counter $j$ and adds a fresh linear
-  combination of previous wires multiplied by $Y^j$.
-
-Most constraints within a routine involve only wires created within
-that routine.
-For a routine that starts at gate index $i$ and constraint index $j$, these
-constraints, constituting the **internal contribution** to $s(X, Y)$, can be
-written as:
-
-$$
-Y^j \Big( X^i \, g_1(X, Y) + X^{-i} \, g_2(X^{-1}, Y) \Big)
-$$
-
-where $X^i Y^j$ (and $X^{-i} Y^j$ for wires allocated in reversed segments of a
-[structured](../protocol/prelim/structured_vectors.md) trace) are the common
-factors extracted from all monomial terms in the contribution[^factoring].
-Crucially, $g_1$ and $g_2$ are **invariant to the routine invocation**: they are
-the same regardless of where or how many times the invocation is placed in a
-circuit. This makes _routine memoization_ possible: given an invocation
-cache hit, we only need to apply a **repositioning** by re-scaling to the
-starting position ($X^i Y^j$ and $X^{-i} Y^j$) of that particular invocation.
-
-[^factoring]: Every wire allocated within the routine, starting at gate
-    index $i$, has a positional monomial $X^{i+k}$ or $X^{-(i+k)}$
-    (reversed segment) for some $k\geq 0$. Each constraint on these
-    internal wires is a linear combination of these positional monomials
-    multiplied by $Y^{j+\ell}$ for some $\ell \geq 0$.
-    The internal contribution — the sum of all $Y$-power-scaled linear
-    combinations of $X$ monomials — therefore shares a common factor $X^i Y^j$
-    (or $X^{-i}Y^j$). Extracting these factors yields $g_1$ and $g_2$.
-
-A routine invocation's overall contribution to $s(X, Y)$ decomposes into
-three buckets: the internal contribution above, an **interface
-contribution** from constraints that reference wires created outside the
-routine (e.g., input gadget wires), and a **system contribution** from
-constraints that reference system wires (i.e., `ONE`) at fixed locations.
-We examine the remaining two next.
-
-Unlike the internal contribution, the interface contribution cannot be
-factored or memoized the same way: the external wires it references are
-allocated by the caller at positions unknown to the routine, both absolute
-and relative to its start, so there are no a priori $X^i$ factors to
-extract. Interface contributions must be computed per-invocation.
-
-A complication arises from nested routines. The depth-insensitive design
-requires that output gadgets of child routines are also treated as interface
-contributions of the parent routine.
-It is always safe to classify them this way and recompute on every invocation
-of the parent.
-However, if two parent routines are known to have identical sub-routines, the
-output gadgets can be remapped to matching positions in the parent's context,
-allowing further constraints on them to be memoized as internal contributions.
-We elaborate on this [below](#memoization).
-
-The system contribution is memoizable by similar reasoning to the internal
-contribution:
-
-$$
-\sum_{\ell \in T} Y^\ell X^{2n} = X^{2n}Y^j \cdot g_3(Y)
-$$
-
-where $T$ is the set of constraint indices within the routine where system wires
-are referenced, $X^{2n}$ is the monomial for the $b_0 (= 1)$ wire during
-[wiring checks](../protocol/local/wiring.md#layout).
-The common factor $X^{2n}Y^j$ can be extracted for the starting constraint
-index $j$, and the remaining univariate $g_3$ is again invariant to the
-routine invocation: the relative offsets $\ell - j$ within the routine
-depend only on its structure, not on the absolute starting index.
+This isolation is hermetic, not conventional: Rust ownership ensures internal
+wires cannot escape the routine's body. A routine's constraints can reference
+exactly _four classes of wires_ — its own internal wires, the input gadget's
+wires, child routines' output gadget wires, and the special ONE wire at the
+[fixed location](../protocol/local/wiring.md#layout).
+No other external wire is reachable. This is what makes the algebraic
+decomposition below structural rather than conventional: the same routine
+instance with type-equivalent inputs produces structurally identical
+constraint patterns, which is what makes memoization possible at all.
 
 ## Example: Synthesis Trace {#example}
 
@@ -137,18 +90,39 @@ which may in turn invoke nested routines.
 Given an execution trace, we need a global indexing of all sub-sections so
 that different drivers can refer to them consistently. Ragu divides the trace
 into **segments** and orders them in a canonical **DFS order** determined by
-routine invocations. In particular, circuit sections at the same invocation
-depth are merged into a single segment; wires allocated outside of any routine
-belong to a special **root segment**.[^root-segment] Each routine invocation
-creates a new **base segment** containing only the wires allocated directly
-within its own body, excluding anything its nested sub-routines allocate;
-nested calls produce their own segments in turn. The DFS-ordered
-segments are built as [`SegmentRecord`]s during the [metric pass](#pipeline).
-Because circuit synthesis is deterministic, the ordered sequence is stable
-across all drivers of the same circuit code.
+routine invocations. Circuit sections at the same invocation depth are merged
+into a single segment; wires allocated outside of any routine belong to a
+special **root segment**.[^root-segment] Each routine invocation creates a new
+**base segment** containing only the wires allocated directly within its own
+body, excluding anything its nested sub-routines allocate; nested calls
+produce their own segments in turn.
 
-[^root-segment]: The root segment is never repositioned. It contains the special
-    `ONE` wire and is where all stage wires of multi-stage circuits are located.
+Each segment carries an absolute position $(m, \ell)$ in the polynomial
+layout — its **gate offset** $m$ (where its multiplication-gate range starts
+in $X$-monomials) and **constraint offset** $\ell$ (where its
+linear-constraint range starts in $Y$-powers). The root segment sits at
+$(0, 0)$ and is never repositioned. Other segments' offsets are assigned by
+the [floor planner](#pipeline) during planning.
+
+[^root-segment]: The root segment is never repositioned. It contains the
+    special `ONE` wire (at $X^0 = 1$) and is where all stage wires of
+    multi-stage circuits are located.
+
+The DFS-ordered segments are built as [`SegmentRecord`]s during the
+[metric pass](#pipeline). During synthesis — which may be parallelized — each
+segment is annotated with its **DFS path**: the sequence of routine-call
+indices from root to that segment (e.g., $[1, 0]$ means "the root's second
+routine call, then its first nested call"). After synthesis completes,
+segments are lexicographically sorted by DFS path to recover canonical
+encounter order.[^dfs-sort] Because synthesis is deterministic, the resulting
+sequence is stable across all drivers of the same circuit code regardless of
+the parallelism strategy used.
+
+[^dfs-sort]: The sort is necessary because parallel synthesis may complete
+    segments out of order. Lexicographic comparison of the path vectors
+    reconstructs the sequential DFS traversal.
+
+For the [example](#example) above, the DFS-ordered segments are:
 
 ```
 segments[0]: r0 + r1 + r2 (root segment)
@@ -159,6 +133,114 @@ segments[4]: b2           (base segment of the second invocation of Routine B)
 segments[5]: c0           (base segment of Routine C)
 ```
 
+
+## Algebraic Description {#algebraic-description}
+
+Routines exploit the fact that contiguous sections of code tend to have
+algebraically convenient structure in the resulting wiring polynomial
+$s(X, Y)$:
+
+* [`gate`] advances a counter $i$ and returns
+  $(X^{2n - 1 - i}, X^{2n + i}, X^{4n - 1 - i}, X^i)$ wires.
+* `enforce_zero` advances a counter $j$ and adds a fresh linear
+  combination of previous wires multiplied by $Y^j$.
+
+Most constraints within a routine involve only wires created within that
+routine. For a routine occupying the segment at position $(m, \ell)$ — gate
+offset $m$ and constraint offset $\ell$ — these constraints, the **internal
+contribution** to $s(X, Y)$, can be written as:
+
+$$
+Y^\ell \Big( X^m \, g_1(X, Y) + X^{-m} \, g_2(X^{-1}, Y) \Big)
+$$
+
+where $X^m Y^\ell$ (and $X^{-m} Y^\ell$ for wires allocated in reversed
+segments of a [structured](../protocol/prelim/structured_vectors.md) trace)
+are the common factors extracted from all monomial terms in the
+contribution[^factoring]. Crucially, $g_1$ and $g_2$ are **invariant to the
+routine invocation**: they are the same regardless of where or how many
+times the invocation is placed in a circuit. This is what makes _routine
+memoization_ possible: given an invocation cache hit, we only need to apply
+the appropriate [shifting](#shifting) factors to reposition the cached
+contribution at the new invocation's $(m, \ell)$.
+
+[^factoring]: Every wire allocated within the routine, starting at gate
+    offset $m$, has a positional monomial $X^{m+k}$ or $X^{-(m+k)}$
+    (reversed segment) for some $k\geq 0$. Each constraint on these
+    internal wires is a linear combination of these positional monomials
+    multiplied by $Y^{\ell+s}$ for some $s \geq 0$. The internal
+    contribution — the sum of all $Y$-power-scaled linear combinations of
+    $X$ monomials — therefore shares a common factor $X^m Y^\ell$
+    (or $X^{-m}Y^\ell$). Extracting these factors yields $g_1$ and $g_2$.
+
+A routine invocation's overall contribution to $s(X, Y)$ decomposes into
+three buckets: the internal contribution above, an **interface contribution**
+from constraints that reference wires created outside the routine (e.g.,
+input gadget wires), and a **system contribution** from constraints that
+reference system wires (i.e., `ONE`) at fixed locations. We examine the
+remaining two next.
+
+Unlike the internal contribution, the interface contribution cannot be
+factored or memoized the same way: the external wires it references are
+allocated by the caller at positions unknown to the routine, both absolute
+and relative to its start, so there are no a priori $X^m$ factors to
+extract. Interface contributions must be computed per-invocation.
+
+A complication arises from nested routines. The depth-insensitive design
+requires that output gadgets of child routines are also treated as interface
+contributions of the parent routine. It is always safe to classify them
+this way and recompute on every invocation of the parent. However, if two
+parent routines are known to have identical sub-routines, the output
+gadgets can be remapped to matching positions in the parent's context,
+allowing further constraints on them to be memoized as internal
+contributions. We elaborate on this [below](#memoization).
+
+The system contribution is memoizable by similar reasoning to the internal
+contribution. The `ONE` wire occupies $d_0$ at $X^0 = 1$, so its $X$-monomial
+is the constant 1, and the system contribution simplifies to:
+
+$$
+\sum_{s \in S} c_s \cdot Y^{\ell + s} = Y^\ell \cdot g_3(Y)
+$$
+
+where $S$ is the set of relative constraint offsets within the routine
+where `ONE` is referenced, $c_s$ is its coefficient at offset $s$, and
+$g_3(Y) = \sum_{s \in S} c_s Y^s$ is again invariant to the routine
+invocation: the relative offsets within the routine depend only on its
+structure, not on the absolute starting index $\ell$.
+
+## Shifting {#shifting}
+
+The internal and system contributions decompose cleanly into three
+position-independent pieces $(g_1, g_2, g_3)$ and the placement factors
+$(X^m, X^{-m}, Y^\ell)$. Repositioning a cached contribution from
+$(m, \ell)$ to $(m', \ell')$ amounts to swapping these factors. The two
+dimensions are orthogonal: changing the gate offset does not affect
+constraint indexing, and vice versa.
+
+- **$Y$-shift** by $\Delta\ell = \ell' - \ell$: multiply the entire
+  contribution by $Y^{\Delta\ell}$. This is a single scalar factor applied
+  uniformly to $g_1$, $g_2$, and $g_3$.
+- **$X$-shift** by $\Delta m = m' - m$: rescale $g_1$ by $X^{\Delta m}$
+  and $g_2$ by $X^{-\Delta m}$. The system polynomial $g_3$ has no
+  $X$-dependence, so $X$-shifting leaves it untouched.
+
+Different drivers specialize $g_1, g_2, g_3$ at different points before
+shifting, and the size of the cached form differs accordingly:
+
+| Driver  | Specialization | Cached form                                  |
+| ------- | -------------- | -------------------------------------------- |
+| `sxy`   | $(x, y)$       | three scalars                                |
+| `sx`    | $x$            | three $Y$-coefficient vectors                |
+| `sy`    | $y$            | two $X$-coefficient vectors and one scalar   |
+
+For `sxy`, replay on cache hit is a few field multiplications — unconditionally
+cheaper than running the routine body. For `sx` and `sy`, the cached form
+has the same order as the routine's contribution, so replay (vector
+scalar-mult plus an offset write) is cheaper than fresh synthesis only when
+synthesis cost (gadget logic, function dispatch, constraint accumulation)
+outweighs the replay cost. See [Memoization](#memoization) for how this
+plays out in practice.
 
 ## Routine Fingerprints {#fingerprint}
 
@@ -238,12 +320,26 @@ inversion (for $X^{-1}$) during initialization.
 
 Instead, Ragu uses a more efficient approach: four _independent_ geometric
 sequences for wire values (one for each of the `a/b/c/d`-wires) and
-Horner-accumulated contributions from `enforce_zero` constraints with $Y$ powers
-of a random $Y=y_r$. Wires from the $i$-th gate correspond to
-$(x_0^i, x_1^i, x_2^i, x_3^i)$ monomial evaluations for a random
-$(x_0, x_1, x_2, x_3)$ picked at initialization. This simplification is possible
-because the fingerprint need only characterize constraints in some binding way,
-not necessarily in the same form as the wiring polynomial $s(X, Y)$.
+Horner-accumulated contributions from `enforce_zero` constraints with $Y$
+powers of a random $Y=y_r$. A wire at local gate index $i \geq 0$ takes value
+$x_t^{i+1}$ for its wire type $t \in \{a, b, c, d\}$, where
+$(x_a, x_b, x_c, x_d)$ are independent random challenges picked at
+initialization.[^onebased] This simplification is possible because the
+fingerprint need only characterize constraints in some binding way, not
+necessarily in the same form as the wiring polynomial $s(X, Y)$.
+
+[^onebased]: Exponents start at 1, not 0, to avoid wire-type collisions at
+    the routine's first gate: under a 0-based scheme,
+    $x_a^0 = x_b^0 = x_c^0 = x_d^0 = 1$, so any constraint involving only
+    the first gate's wires would collapse across types, allowing distinct
+    constraints to receive identical fingerprints.
+
+The `ONE` wire deserves a separate independent challenge $x_{\text{one}}$
+rather than reusing $x_d^0$ (its position-natural value of 1). Without this
+distinction, a constraint that references both `ONE` and a routine's local
+$d$-wire at the first gate — both evaluating to the same scalar under the
+positional scheme — would collide; an independent challenge keeps them
+distinguishable.
 
 Handling interface contributions is the most delicate part. In our example, the
 first invocation of `RoutineB` accepts an input gadget from the parent on entry
@@ -272,7 +368,7 @@ sequence.
 
 [^x-remap]: For code reference, the variable is named `x_remap` and remapped
     wires take on values `x_remap^i`, independent of the normal sequences
-    $(x_0^i, x_1^i, x_2^i, x_3^i)$. Intuitively, every routine starts with a
+    $(x_a, x_b, x_c, x_d)$. Intuitively, every routine starts with a
     blank page for interface gadget wires, written sequentially from the start;
     output gadget wires are then appended to the parent's page.
 
@@ -294,20 +390,29 @@ therefore capture the positional values of these output wires.
 ```rust
 struct DeepFingerprint {
     base: BaseFingerprint,
-    /// deep hash: 
-    /// H(self.base, output_gadget, child_deep_hashes, input_type, output_type)
+    /// deep hash:
+    /// H(self.base, output_gadget, output_gadget.len(),
+    ///   child_deep_hashes, input_type, output_type)
     deep: u64,
 }
 ```
 
 Ragu augments the base fingerprint with the wire values of the output gadget,
-the deep fingerprints of all child invocations (one level deeper), and the
-`TypeId` of the input and output gadget types (optional, defense-in-depth only).
-The monomial evaluation of output wires already encodes their positions relative
-to the start of the sub-routine, and thus transitively relative to the start of
-the parent routine. Because the parent's deep fingerprint recursively folds in
-the deep hashes of all children, the final hash binds the entire invocation
-tree.
+the output gadget's length (to prevent length-extension collisions when two
+routines pack different amounts of state into structurally similar output
+shapes), the deep fingerprints of all child invocations (one level deeper),
+and the `TypeId` of the input and output gadget types (optional,
+defense-in-depth only). The monomial evaluation of output wires already
+encodes their positions relative to the start of the sub-routine, and thus
+transitively relative to the start of the parent routine. Because the
+parent's deep fingerprint recursively folds in the deep hashes of all
+children, the final hash binds the entire invocation tree.
+
+Composition is via hashing rather than algebraic combination: combining
+fingerprints across tree levels with field arithmetic would risk interference
+between layers and break the linear independence that Schwartz–Zippel relies
+on at the base level. Hashing keeps each level's fingerprint as an opaque
+equality tag while still binding the full tree.
 
 
 [^swapped]: As an example, suppose two `RoutineB` invocations each nest a call
@@ -349,75 +454,92 @@ carrying local gate and constraint counts together with the invocation's base
 and deep fingerprints. Because synthesis is deterministic, the sequence is
 stable across all subsequent driver executions of the same circuit code.
 
-The registry collects segment records from every circuit and feeds them into a
-**floor planner** that assigns each segment a non-overlapping absolute position
-`(gate_start, constraint_start)` in the polynomial layout. The floor planner
-aligns segments with matching fingerprints to maximize
-[memoization](#memoization) across the entire registry, both within and
-between circuits: matching base fingerprints enable memoization of the
-base segment's internal contribution, while matching deep fingerprints
-enable memoization of entire routine subtrees. Currently, the floor
-planner only rearranges segment placement; it does not perform
-circuit-equivalence substitutions that would alter the circuit logic
-itself.
+The registry collects segment records from every circuit and feeds them into
+a **floor planner** that assigns each segment a non-overlapping absolute
+position $(m, \ell)$ in the polynomial layout. The floor planner aligns
+segments with matching fingerprints to maximize [memoization](#memoization)
+across the entire registry, both within and between circuits: matching base
+fingerprints enable memoization of the base segment's internal contribution,
+while matching deep fingerprints enable memoization of entire routine
+subtrees. Currently, the floor planner only rearranges segment placement; it
+does not perform circuit-equivalence substitutions that would alter the
+circuit logic itself.
 
 The floor plan encodes this rearrangement and is an auxiliary input to
 downstream drivers: the wiring polynomial evaluators use it to
-[reposition](#algebraic-description) each segment's contribution to its
-assigned offset in $s(X, Y)$, and the trace polynomial evaluator uses
-it to scatter each segment's gate values to the correct range in
-$r(X)$.
+[shift](#shifting) each segment's contribution to its assigned offset in
+$s(X, Y)$, and the trace polynomial evaluator uses it to scatter each
+segment's gate values to the correct range in $r(X)$.
 
 ## Memoization {#memoization}
 
 The [algebraic description](#algebraic-description) decomposes a routine
-invocation's contribution to $s(X, Y)$ into **internal** polynomials $g_1(X, Y)$
-and $g_2(X^{-1}, Y)$, a **system** polynomial $g_3(Y)$, and **interface** terms
-that cross the routine boundary. The internal and system polynomials depend only
-on the routine's constraint structure and are invariant to invocation context;
-the interface terms depend on externally allocated wires and must be recomputed.
-Memoization caches the invariant parts — $g_1$, $g_2$, and $g_3$ — and
-replays them for subsequent invocations whose [fingerprints](#fingerprint)
-match, applying fresh [repositioning](#algebraic-description) factors
-$X^i$, $X^{-i}$, $Y^j$ to place the cached contribution at the correct
-offset.
+invocation's contribution to $s(X, Y)$ into **internal** polynomials
+$g_1(X, Y)$ and $g_2(X^{-1}, Y)$, a **system** polynomial $g_3(Y)$, and
+**interface** terms that cross the routine boundary. The internal and system
+polynomials depend only on the routine's constraint structure and are
+invariant to invocation context; the interface terms depend on externally
+allocated wires and must be recomputed. Memoization caches the invariant
+parts — $g_1$, $g_2$, and $g_3$ — and replays them for subsequent
+invocations whose [fingerprints](#fingerprint) match, applying the
+appropriate [shifting](#shifting) factors to place the cached contribution
+at the new offset.
 
-Caching follows $s(X, Y)$'s evaluation logic, not the simplified
-computation used for [fingerprinting](#base-fingerprint). During
-fingerprinting, interface wires receive context-insensitive values so
-their contributions cancel across equivalent invocations (approach 2
-[above](#base-fingerprint)). During memoization, the driver must
-actually _exclude_ interface contributions from the cached result so
-that only the invariant part is stored. This requires approach 1:
-the wire type carries an `Interface` discriminant so that the driver
-can identify interface terms in each constraint and route them to the
-per-invocation computation rather than the cache.
+The cached form depends on the driver, and so does the size of the win:
 
-The registry collects fingerprints from the [metric pass](#pipeline) and records
-matches — both within a single circuit and across circuits — so that downstream
-drivers (the wiring polynomial evaluator for $s(X, Y)$ and the trace evaluator
-for $r(X)$) can determine on entry to each routine whether to record a fresh
-contribution or replay a cached one.
+- On the scalar `sxy` path, $g_1, g_2, g_3$ collapse to scalars; replay is
+  a few field multiplications, unconditionally cheaper than running the
+  routine body.
+- On the polynomial-valued `sx` and `sy` paths, $g_1, g_2, g_3$ are
+  coefficient vectors of size $O(\text{routine})$; replay is a vector
+  scalar-mult plus an offset write. The win here is conditional on
+  synthesis cost (gadget logic, function dispatch, constraint
+  accumulation) outweighing this cheaper-but-not-trivial replay.
+
+Caching follows $s(X, Y)$'s evaluation logic, not the simplified computation
+used for [fingerprinting](#base-fingerprint). During fingerprinting,
+interface wires receive context-insensitive values so their contributions
+cancel across equivalent invocations (approach 2 [above](#base-fingerprint)).
+During memoization, the driver must actually _exclude_ interface
+contributions from the cached result so that only the invariant part is
+stored. This requires approach 1: the wire type carries an `Interface`
+discriminant so that the driver can identify interface terms in each
+constraint and route them to the per-invocation computation rather than the
+cache.
+
+The registry collects fingerprints from the [metric pass](#pipeline) and
+records matches — both within a single circuit and across circuits — so that
+downstream drivers (the wiring polynomial evaluator for $s(X, Y)$ and the
+trace evaluator for $r(X)$) can determine on entry to each routine whether
+to record a fresh contribution or replay a cached one.
 
 How much of a routine can be cached depends on which fingerprint matches.
 
 **Base-fingerprint memoization.** When two invocations share a
-[base fingerprint](#base-fingerprint), only the _base segment_ of the routine is
-known to be equivalent. The driver caches $g_1$, $g_2$, and $g_3$ for that
-segment and repositions them at the new invocation's offset.
-Contributions from nested sub-routines — including any constraints the
-parent places on their output gadgets — remain interface contributions
-and are recomputed per-invocation.
+[base fingerprint](#base-fingerprint), only the _base segment_ of the
+routine is known to be equivalent. The driver caches $g_1$, $g_2$, and $g_3$
+for that segment and repositions them at the new invocation's offset.
+Contributions from nested sub-routines remain **floating**: their absolute
+positions are independent of the base segment's, and any constraints the
+parent places on their output gadgets stay as interface contributions,
+recomputed per invocation.
 
 **Deep-fingerprint memoization.** When two invocations share a
-[deep fingerprint](#deep-fingerprint), the entire invocation tree is equivalent:
-the base segment _and_ all nested sub-routines have matching structure. This
-changes what counts as an interface contribution: output gadgets of
-child routines, which must be treated as interface contributions under
-base-fingerprint memoization, can now be remapped to matching positions
-within the parent's context. Constraints on these output wires become
-part of the internal contribution and are memoizable along with the
-rest of the subtree.
+[deep fingerprint](#deep-fingerprint), the entire invocation tree is
+equivalent: the base segment _and_ all nested sub-routines have matching
+structure. The previously-floating children are now pinned at fixed relative
+positions, which changes what counts as an interface contribution: output
+gadgets of child routines, treated as interface under base-fingerprint
+memoization, can now be remapped to matching positions within the parent's
+context. Constraints on these output wires become part of the internal
+contribution and are memoizable along with the rest of the subtree. The
+`sxy` driver implementation already exposes the recursive structure this
+needs: each routine scope tracks a `result` (Horner accumulator over its
+own constraints, position-independent in $\ell$) and a `sum` (aggregate of
+positioned child contributions); on exit, the parent absorbs the child as
+$\text{sum}_\text{parent} \mathrel{+}= y^{\ell_\text{child}} \cdot
+\text{result}_\text{child} + \text{sum}_\text{child}$, and a deep-cached
+subtree replays this folding step from the cached value directly.
 
 ```admonish important title="Deep memoization redefines the internal contribution"
 Under deep-fingerprint equivalence, the output wires of nested sub-routines are
@@ -440,17 +562,17 @@ The registry polynomial combines per-circuit wiring polynomials via Lagrange
 interpolation:
 
 $$
-m(w, x, y) = \sum_k \ell_k(w) \cdot s_k(x, y)
+m(w, x, y) = \sum_k L_k(w) \cdot s_k(x, y)
 $$
 
-where $\ell_k$ is the Lagrange basis polynomial for circuit $k$. Without
-optimization, each circuit evaluates its routines independently and scales by
-$\ell_k(w)$. If the floor planner places equivalent routines at the _same_
-absolute position across circuits, their invariant contributions coincide and
-can be factored:
+where $L_k$ is the Lagrange basis polynomial for circuit $k$. Without
+optimization, each circuit evaluates its routines independently and scales
+by $L_k(w)$. If the floor planner places equivalent routines at the _same_
+absolute position across circuits, their invariant contributions coincide
+and can be factored:
 
 $$
-\Big(\sum_{k \in K} \ell_k(w)\Big) \cdot \big(X^i Y^j \cdot g(X, Y)\big)
+\Big(\sum_{k \in K} L_k(w)\Big) \cdot \big(X^m Y^\ell \cdot g(X, Y)\big)
 $$
 
 where $K$ is the set of circuits sharing the routine at that position


### PR DESCRIPTION
rewrite of #599 (imo, supersedes it since we modify on top of that)

There are some key technical differences:

- in algebraic description, I included system contribution $g_3$
- rename shallow fingerprint to "base fingerprint" to signify what it implies, and stick to "deep fingerprint" (rather than `MemoFingerprint` since both fingerprints implies memoization opportunities)
- deep memoization redefines internal contribution (counting the contribution of output wires of child subroutines), which is something we gloss over in previous attempt, i highlight in admonish box. 
- add algebraic description for inter-circuit aligned segment 
- envisioned that for caching polynomial contribution during actual memoization, we need to expand the `enum Wire` type to have an `::Interface()` variant and update all drivers to handle that case, so that we can drop their contribution.