### PR TITLE
feat(fv): extend coverage for existing `element / point` gadgets

### DIFF
--- a/qa/crates/lean_extraction/src/instances/core_alloc_mul.rs
+++ b/qa/crates/lean_extraction/src/instances/core_alloc_mul.rs
@@ -1,0 +1,21 @@
+use ragu_arithmetic::Coeff;
+use ragu_core::drivers::Driver;
+use ragu_pasta::Fp;
+
+use crate::{
+    driver::ExtractionDriver,
+    expr::Expr,
+    instance::CircuitInstance,
+};
+
+pub struct CoreAllocMulInstance;
+
+impl CircuitInstance for CoreAllocMulInstance {
+    type Field = Fp;
+
+    fn circuit(dr: &mut ExtractionDriver<Fp>) -> ragu_core::Result<Vec<Expr<Fp>>> {
+        // MaybeKind = Empty: the closure is never called.
+        let (x, y, z) = dr.mul(|| Ok((Coeff::Zero, Coeff::Zero, Coeff::Zero)))?;
+        Ok(vec![x, y, z])
+    }
+}

--- a/qa/crates/lean_extraction/src/instances/core_alloc_mul.rs
+++ b/qa/crates/lean_extraction/src/instances/core_alloc_mul.rs
@@ -2,11 +2,7 @@ use ragu_arithmetic::Coeff;
 use ragu_core::drivers::Driver;
 use ragu_pasta::Fp;
 
-use crate::{
-    driver::ExtractionDriver,
-    expr::Expr,
-    instance::CircuitInstance,
-};
+use crate::{driver::ExtractionDriver, expr::Expr, instance::CircuitInstance};
 
 pub struct CoreAllocMulInstance;
 

--- a/qa/crates/lean_extraction/src/instances/element_alloc_square.rs
+++ b/qa/crates/lean_extraction/src/instances/element_alloc_square.rs
@@ -1,0 +1,27 @@
+use ff::Field;
+use ragu_core::drivers::Driver;
+use ragu_pasta::Fp;
+use ragu_primitives::Element;
+
+use crate::{
+    driver::ExtractionDriver,
+    expr::Expr,
+    instance::{CircuitInstance, WireCollector},
+};
+
+pub struct ElementAllocSquareInstance;
+
+impl CircuitInstance for ElementAllocSquareInstance {
+    type Field = Fp;
+
+    fn circuit(dr: &mut ExtractionDriver<Fp>) -> ragu_core::Result<Vec<Expr<Fp>>> {
+        // MaybeKind = Empty: the closure is never called.
+        let assignment = ExtractionDriver::<Fp>::just(|| Fp::ZERO);
+        let (a, a_sq) = Element::alloc_square(dr, assignment)?;
+
+        let mut wires = WireCollector::collect_from(&a)?;
+        let mut a_sq_wires = WireCollector::collect_from(&a_sq)?;
+        wires.append(&mut a_sq_wires);
+        Ok(wires)
+    }
+}

--- a/qa/crates/lean_extraction/src/instances/element_div_nonzero.rs
+++ b/qa/crates/lean_extraction/src/instances/element_div_nonzero.rs
@@ -1,0 +1,27 @@
+use ragu_pasta::Fp;
+use ragu_primitives::Element;
+
+use crate::{
+    driver::ExtractionDriver,
+    expr::Expr,
+    instance::{CircuitInstance, WireCollector, WireDeserializer},
+};
+
+pub struct ElementDivNonzeroInstance;
+
+impl CircuitInstance for ElementDivNonzeroInstance {
+    type Field = Fp;
+
+    fn circuit(dr: &mut ExtractionDriver<Fp>) -> ragu_core::Result<Vec<Expr<Fp>>> {
+        let input_wires_x = dr.alloc_input_wires(1);
+        let input_wires_y = dr.alloc_input_wires(1);
+
+        let element_template = Element::constant(dr, Fp::zero());
+        let x = WireDeserializer::new(input_wires_x).into_gadget(&element_template)?;
+        let y = WireDeserializer::new(input_wires_y).into_gadget(&element_template)?;
+
+        let quotient = x.div_nonzero(dr, &y)?;
+
+        WireCollector::collect_from(&quotient)
+    }
+}

--- a/qa/crates/lean_extraction/src/instances/element_mul.rs
+++ b/qa/crates/lean_extraction/src/instances/element_mul.rs
@@ -1,0 +1,29 @@
+use ragu_pasta::Fp;
+use ragu_primitives::Element;
+
+use crate::{
+    driver::ExtractionDriver,
+    expr::Expr,
+    instance::{CircuitInstance, WireCollector, WireDeserializer},
+};
+
+pub struct ElementMulInstance;
+
+impl CircuitInstance for ElementMulInstance {
+    type Field = Fp;
+
+    fn circuit(dr: &mut ExtractionDriver<Fp>) -> ragu_core::Result<Vec<Expr<Fp>>> {
+        let input_wires_x = dr.alloc_input_wires(1);
+        let input_wires_y = dr.alloc_input_wires(1);
+
+        // Reuse a constant element as a structural template, then substitute the
+        // raw input wire into its single-field gadget.
+        let element_template = Element::constant(dr, Fp::zero());
+        let x = WireDeserializer::new(input_wires_x).into_gadget(&element_template)?;
+        let y = WireDeserializer::new(input_wires_y).into_gadget(&element_template)?;
+
+        let z = x.mul(dr, &y)?;
+
+        WireCollector::collect_from(&z)
+    }
+}

--- a/qa/crates/lean_extraction/src/instances/element_square.rs
+++ b/qa/crates/lean_extraction/src/instances/element_square.rs
@@ -1,0 +1,27 @@
+use ragu_pasta::Fp;
+use ragu_primitives::Element;
+
+use crate::{
+    driver::ExtractionDriver,
+    expr::Expr,
+    instance::{CircuitInstance, WireCollector, WireDeserializer},
+};
+
+pub struct ElementSquareInstance;
+
+impl CircuitInstance for ElementSquareInstance {
+    type Field = Fp;
+
+    fn circuit(dr: &mut ExtractionDriver<Fp>) -> ragu_core::Result<Vec<Expr<Fp>>> {
+        let input_wires = dr.alloc_input_wires(1);
+
+        // Reuse a constant element as a structural template, then substitute the
+        // raw input wire into its single-field gadget.
+        let element_template = Element::constant(dr, Fp::zero());
+        let x = WireDeserializer::new(input_wires).into_gadget(&element_template)?;
+
+        let z = x.square(dr)?;
+
+        WireCollector::collect_from(&z)
+    }
+}

--- a/qa/crates/lean_extraction/src/instances/mod.rs
+++ b/qa/crates/lean_extraction/src/instances/mod.rs
@@ -1,3 +1,4 @@
+pub mod core_alloc_mul;
 pub mod element_alloc_square;
 pub mod element_div_nonzero;
 pub mod element_mul;

--- a/qa/crates/lean_extraction/src/instances/mod.rs
+++ b/qa/crates/lean_extraction/src/instances/mod.rs
@@ -1,3 +1,4 @@
+pub mod element_mul;
 pub mod point_add_incomplete;
 pub mod point_alloc;
 pub mod point_double;

--- a/qa/crates/lean_extraction/src/instances/mod.rs
+++ b/qa/crates/lean_extraction/src/instances/mod.rs
@@ -1,4 +1,5 @@
 pub mod element_alloc_square;
+pub mod element_div_nonzero;
 pub mod element_mul;
 pub mod element_square;
 pub mod point_add_incomplete;

--- a/qa/crates/lean_extraction/src/instances/mod.rs
+++ b/qa/crates/lean_extraction/src/instances/mod.rs
@@ -6,4 +6,5 @@ pub mod element_square;
 pub mod point_add_incomplete;
 pub mod point_alloc;
 pub mod point_double;
+pub mod point_endo;
 pub mod point_negate;

--- a/qa/crates/lean_extraction/src/instances/mod.rs
+++ b/qa/crates/lean_extraction/src/instances/mod.rs
@@ -1,4 +1,5 @@
 pub mod element_mul;
+pub mod element_square;
 pub mod point_add_incomplete;
 pub mod point_alloc;
 pub mod point_double;

--- a/qa/crates/lean_extraction/src/instances/mod.rs
+++ b/qa/crates/lean_extraction/src/instances/mod.rs
@@ -1,3 +1,4 @@
+pub mod element_alloc_square;
 pub mod element_mul;
 pub mod element_square;
 pub mod point_add_incomplete;

--- a/qa/crates/lean_extraction/src/instances/point_endo.rs
+++ b/qa/crates/lean_extraction/src/instances/point_endo.rs
@@ -1,0 +1,28 @@
+use group::prime::PrimeCurveAffine;
+use ragu_pasta::{EpAffine, Fp};
+use ragu_primitives::Point;
+
+use crate::{
+    driver::ExtractionDriver,
+    expr::Expr,
+    instance::{CircuitInstance, WireCollector, WireDeserializer},
+};
+
+pub struct PointEndoInstance;
+
+impl CircuitInstance for PointEndoInstance {
+    type Field = Fp;
+
+    fn circuit(dr: &mut ExtractionDriver<Fp>) -> ragu_core::Result<Vec<Expr<Fp>>> {
+        let input_wires = dr.alloc_input_wires(2);
+
+        // Reuse a constant point as a structural template, then substitute the
+        // raw input wires into its `[x, y]` gadget fields.
+        let template = Point::constant(dr, EpAffine::generator())?;
+        let input_point = WireDeserializer::new(input_wires).into_gadget(&template)?;
+
+        let result = input_point.endo(dr);
+
+        WireCollector::collect_from(&result)
+    }
+}

--- a/qa/crates/lean_extraction/src/main.rs
+++ b/qa/crates/lean_extraction/src/main.rs
@@ -15,6 +15,7 @@ use clap::{Parser, Subcommand};
 use instance::CircuitInstance;
 
 use crate::instances::{
+    core_alloc_mul::CoreAllocMulInstance,
     element_alloc_square::ElementAllocSquareInstance,
     element_div_nonzero::ElementDivNonzeroInstance,
     element_mul::ElementMulInstance,
@@ -77,6 +78,11 @@ static EXPORT_TARGETS: &[ExportTarget] = &[
         name: "Ragu.Instances.Autogen.Element.DivNonzero",
         export: export_instance::<ElementDivNonzeroInstance>,
         generated_file: generated_file_instance::<ElementDivNonzeroInstance>,
+    },
+    ExportTarget {
+        name: "Ragu.Instances.Autogen.Core.AllocMul",
+        export: export_instance::<CoreAllocMulInstance>,
+        generated_file: generated_file_instance::<CoreAllocMulInstance>,
     },
 ];
 

--- a/qa/crates/lean_extraction/src/main.rs
+++ b/qa/crates/lean_extraction/src/main.rs
@@ -15,6 +15,7 @@ use clap::{Parser, Subcommand};
 use instance::CircuitInstance;
 
 use crate::instances::{
+    element_alloc_square::ElementAllocSquareInstance,
     element_mul::ElementMulInstance,
     element_square::ElementSquareInstance,
     point_add_incomplete::PointAddIncompleteInstance,
@@ -65,6 +66,11 @@ static EXPORT_TARGETS: &[ExportTarget] = &[
         name: "Ragu.Instances.Autogen.Element.Square",
         export: export_instance::<ElementSquareInstance>,
         generated_file: generated_file_instance::<ElementSquareInstance>,
+    },
+    ExportTarget {
+        name: "Ragu.Instances.Autogen.Element.AllocSquare",
+        export: export_instance::<ElementAllocSquareInstance>,
+        generated_file: generated_file_instance::<ElementAllocSquareInstance>,
     },
 ];
 

--- a/qa/crates/lean_extraction/src/main.rs
+++ b/qa/crates/lean_extraction/src/main.rs
@@ -16,6 +16,7 @@ use instance::CircuitInstance;
 
 use crate::instances::{
     element_mul::ElementMulInstance,
+    element_square::ElementSquareInstance,
     point_add_incomplete::PointAddIncompleteInstance,
     point_alloc::{PointAllocInstanceFp, PointAllocInstanceFq},
     point_double::PointDoubleInstance,
@@ -59,6 +60,11 @@ static EXPORT_TARGETS: &[ExportTarget] = &[
         name: "Ragu.Instances.Autogen.Element.Mul",
         export: export_instance::<ElementMulInstance>,
         generated_file: generated_file_instance::<ElementMulInstance>,
+    },
+    ExportTarget {
+        name: "Ragu.Instances.Autogen.Element.Square",
+        export: export_instance::<ElementSquareInstance>,
+        generated_file: generated_file_instance::<ElementSquareInstance>,
     },
 ];
 

--- a/qa/crates/lean_extraction/src/main.rs
+++ b/qa/crates/lean_extraction/src/main.rs
@@ -23,6 +23,7 @@ use crate::instances::{
     point_add_incomplete::PointAddIncompleteInstance,
     point_alloc::{PointAllocInstanceFp, PointAllocInstanceFq},
     point_double::PointDoubleInstance,
+    point_endo::PointEndoInstance,
     point_negate::PointNegateInstance,
 };
 
@@ -58,6 +59,11 @@ static EXPORT_TARGETS: &[ExportTarget] = &[
         name: "Ragu.Instances.Autogen.Point.Negate",
         export: export_instance::<PointNegateInstance>,
         generated_file: generated_file_instance::<PointNegateInstance>,
+    },
+    ExportTarget {
+        name: "Ragu.Instances.Autogen.Point.Endo",
+        export: export_instance::<PointEndoInstance>,
+        generated_file: generated_file_instance::<PointEndoInstance>,
     },
     ExportTarget {
         name: "Ragu.Instances.Autogen.Element.Mul",

--- a/qa/crates/lean_extraction/src/main.rs
+++ b/qa/crates/lean_extraction/src/main.rs
@@ -15,6 +15,7 @@ use clap::{Parser, Subcommand};
 use instance::CircuitInstance;
 
 use crate::instances::{
+    element_mul::ElementMulInstance,
     point_add_incomplete::PointAddIncompleteInstance,
     point_alloc::{PointAllocInstanceFp, PointAllocInstanceFq},
     point_double::PointDoubleInstance,
@@ -53,6 +54,11 @@ static EXPORT_TARGETS: &[ExportTarget] = &[
         name: "Ragu.Instances.Autogen.Point.Negate",
         export: export_instance::<PointNegateInstance>,
         generated_file: generated_file_instance::<PointNegateInstance>,
+    },
+    ExportTarget {
+        name: "Ragu.Instances.Autogen.Element.Mul",
+        export: export_instance::<ElementMulInstance>,
+        generated_file: generated_file_instance::<ElementMulInstance>,
     },
 ];
 

--- a/qa/crates/lean_extraction/src/main.rs
+++ b/qa/crates/lean_extraction/src/main.rs
@@ -16,6 +16,7 @@ use instance::CircuitInstance;
 
 use crate::instances::{
     element_alloc_square::ElementAllocSquareInstance,
+    element_div_nonzero::ElementDivNonzeroInstance,
     element_mul::ElementMulInstance,
     element_square::ElementSquareInstance,
     point_add_incomplete::PointAddIncompleteInstance,
@@ -71,6 +72,11 @@ static EXPORT_TARGETS: &[ExportTarget] = &[
         name: "Ragu.Instances.Autogen.Element.AllocSquare",
         export: export_instance::<ElementAllocSquareInstance>,
         generated_file: generated_file_instance::<ElementAllocSquareInstance>,
+    },
+    ExportTarget {
+        name: "Ragu.Instances.Autogen.Element.DivNonzero",
+        export: export_instance::<ElementDivNonzeroInstance>,
+        generated_file: generated_file_instance::<ElementDivNonzeroInstance>,
     },
 ];
 

--- a/qa/lean/Ragu.lean
+++ b/qa/lean/Ragu.lean
@@ -7,3 +7,4 @@ import Ragu.Instances.Element.Mul
 import Ragu.Instances.Element.Square
 import Ragu.Instances.Element.AllocSquare
 import Ragu.Instances.Element.DivNonzero
+import Ragu.Instances.Core.AllocMul

--- a/qa/lean/Ragu.lean
+++ b/qa/lean/Ragu.lean
@@ -6,3 +6,4 @@ import Ragu.Instances.Point.Negate
 import Ragu.Instances.Element.Mul
 import Ragu.Instances.Element.Square
 import Ragu.Instances.Element.AllocSquare
+import Ragu.Instances.Element.DivNonzero

--- a/qa/lean/Ragu.lean
+++ b/qa/lean/Ragu.lean
@@ -4,3 +4,4 @@ import Ragu.Instances.Point.Double
 import Ragu.Instances.Point.AddIncomplete
 import Ragu.Instances.Point.Negate
 import Ragu.Instances.Element.Mul
+import Ragu.Instances.Element.Square

--- a/qa/lean/Ragu.lean
+++ b/qa/lean/Ragu.lean
@@ -3,3 +3,4 @@ import Ragu.Instances.Point.AllocFq
 import Ragu.Instances.Point.Double
 import Ragu.Instances.Point.AddIncomplete
 import Ragu.Instances.Point.Negate
+import Ragu.Instances.Element.Mul

--- a/qa/lean/Ragu.lean
+++ b/qa/lean/Ragu.lean
@@ -3,6 +3,7 @@ import Ragu.Instances.Point.AllocFq
 import Ragu.Instances.Point.Double
 import Ragu.Instances.Point.AddIncomplete
 import Ragu.Instances.Point.Negate
+import Ragu.Instances.Point.Endo
 import Ragu.Instances.Element.Mul
 import Ragu.Instances.Element.Square
 import Ragu.Instances.Element.AllocSquare

--- a/qa/lean/Ragu.lean
+++ b/qa/lean/Ragu.lean
@@ -5,3 +5,4 @@ import Ragu.Instances.Point.AddIncomplete
 import Ragu.Instances.Point.Negate
 import Ragu.Instances.Element.Mul
 import Ragu.Instances.Element.Square
+import Ragu.Instances.Element.AllocSquare

--- a/qa/lean/Ragu/Circuits/Element/DivNonzero.lean
+++ b/qa/lean/Ragu/Circuits/Element/DivNonzero.lean
@@ -22,6 +22,15 @@ def GeneralAssumptions (hintReader : ProverHint (F p) → Core.AllocMul.Row (F p
   let r := hintReader hint
   r.y = input.y ∧ r.x * r.y = input.x ∧ (input.y ≠ 0 ∨ input.x = 0)
 
+-- The disjunction `y ≠ 0 ∨ x ≠ 0` (rather than just `y ≠ 0`) reflects what the
+-- circuit actually enforces via `quotient · y = x`:
+--  * `y ≠ 0`: quotient is forced to `x / y`.
+--  * `y = 0 ∧ x ≠ 0`: no valid witness exists; any prover transcript fails.
+--  * `y = 0 ∧ x = 0`: quotient is unconstrained (premise is false, Spec is
+--    vacuously true).
+-- Callers of this gadget must establish `(x, y) ≠ (0, 0)` upstream or accept
+-- the unconstrained-output carve-out. See `element.rs:273-280` for the
+-- corresponding Rust `div_nonzero` doc comment.
 def GeneralSpec (input : Inputs (F p)) (out : field (F p)) (_data : ProverData (F p)) :=
   input.y ≠ 0 ∨ input.x ≠ 0 → out = input.x / input.y
 

--- a/qa/lean/Ragu/Instances/Autogen/Core/AllocMul.lean
+++ b/qa/lean/Ragu/Instances/Autogen/Core/AllocMul.lean
@@ -1,0 +1,29 @@
+import Ragu.Core
+
+namespace Ragu.Instances.Autogen.Core.AllocMul
+open Core.Primes
+
+@[reducible]
+def p := Core.Primes.p
+
+@[reducible]
+def inputLen := 0
+
+@[reducible]
+def outputLen := 3
+
+set_option linter.unusedVariables false in
+def exportedOperations (input_var : Vector (Expression (F p)) inputLen) : Operations (F p) := [
+  Operation.witness 3 (fun _env => default),
+  Operation.assert ((((var ⟨0⟩) * (var ⟨1⟩)) + (((-1 : F p) : Expression (F p)) * (var ⟨2⟩)))),
+]
+
+set_option linter.unusedVariables false in
+@[reducible]
+def exportedOutput (input_var : Vector (Expression (F p)) inputLen) : Vector (Expression (F p)) outputLen := #v[
+  (var ⟨0⟩),
+  (var ⟨1⟩),
+  (var ⟨2⟩)
+]
+
+end Ragu.Instances.Autogen.Core.AllocMul

--- a/qa/lean/Ragu/Instances/Autogen/Element/AllocSquare.lean
+++ b/qa/lean/Ragu/Instances/Autogen/Element/AllocSquare.lean
@@ -1,0 +1,29 @@
+import Ragu.Core
+
+namespace Ragu.Instances.Autogen.Element.AllocSquare
+open Core.Primes
+
+@[reducible]
+def p := Core.Primes.p
+
+@[reducible]
+def inputLen := 0
+
+@[reducible]
+def outputLen := 2
+
+set_option linter.unusedVariables false in
+def exportedOperations (input_var : Vector (Expression (F p)) inputLen) : Operations (F p) := [
+  Operation.witness 3 (fun _env => default),
+  Operation.assert ((((var ⟨0⟩) * (var ⟨1⟩)) + (((-1 : F p) : Expression (F p)) * (var ⟨2⟩)))),
+  Operation.assert (((var ⟨0⟩) + (((-1 : F p) : Expression (F p)) * (var ⟨1⟩)))),
+]
+
+set_option linter.unusedVariables false in
+@[reducible]
+def exportedOutput (input_var : Vector (Expression (F p)) inputLen) : Vector (Expression (F p)) outputLen := #v[
+  (var ⟨0⟩),
+  (var ⟨2⟩)
+]
+
+end Ragu.Instances.Autogen.Element.AllocSquare

--- a/qa/lean/Ragu/Instances/Autogen/Element/DivNonzero.lean
+++ b/qa/lean/Ragu/Instances/Autogen/Element/DivNonzero.lean
@@ -1,0 +1,29 @@
+import Ragu.Core
+
+namespace Ragu.Instances.Autogen.Element.DivNonzero
+open Core.Primes
+
+@[reducible]
+def p := Core.Primes.p
+
+@[reducible]
+def inputLen := 2
+
+@[reducible]
+def outputLen := 1
+
+set_option linter.unusedVariables false in
+def exportedOperations (input_var : Vector (Expression (F p)) inputLen) : Operations (F p) := [
+  Operation.witness 3 (fun _env => default),
+  Operation.assert ((((var ⟨0⟩) * (var ⟨1⟩)) + (((-1 : F p) : Expression (F p)) * (var ⟨2⟩)))),
+  Operation.assert (((input_var[0]) + (((-1 : F p) : Expression (F p)) * (var ⟨2⟩)))),
+  Operation.assert (((input_var[1]) + (((-1 : F p) : Expression (F p)) * (var ⟨1⟩)))),
+]
+
+set_option linter.unusedVariables false in
+@[reducible]
+def exportedOutput (input_var : Vector (Expression (F p)) inputLen) : Vector (Expression (F p)) outputLen := #v[
+  (var ⟨0⟩)
+]
+
+end Ragu.Instances.Autogen.Element.DivNonzero

--- a/qa/lean/Ragu/Instances/Autogen/Element/Mul.lean
+++ b/qa/lean/Ragu/Instances/Autogen/Element/Mul.lean
@@ -1,0 +1,29 @@
+import Ragu.Core
+
+namespace Ragu.Instances.Autogen.Element.Mul
+open Core.Primes
+
+@[reducible]
+def p := Core.Primes.p
+
+@[reducible]
+def inputLen := 2
+
+@[reducible]
+def outputLen := 1
+
+set_option linter.unusedVariables false in
+def exportedOperations (input_var : Vector (Expression (F p)) inputLen) : Operations (F p) := [
+  Operation.witness 3 (fun _env => default),
+  Operation.assert ((((var ⟨0⟩) * (var ⟨1⟩)) + (((-1 : F p) : Expression (F p)) * (var ⟨2⟩)))),
+  Operation.assert (((var ⟨0⟩) + (((-1 : F p) : Expression (F p)) * (input_var[0])))),
+  Operation.assert (((var ⟨1⟩) + (((-1 : F p) : Expression (F p)) * (input_var[1])))),
+]
+
+set_option linter.unusedVariables false in
+@[reducible]
+def exportedOutput (input_var : Vector (Expression (F p)) inputLen) : Vector (Expression (F p)) outputLen := #v[
+  (var ⟨2⟩)
+]
+
+end Ragu.Instances.Autogen.Element.Mul

--- a/qa/lean/Ragu/Instances/Autogen/Element/Square.lean
+++ b/qa/lean/Ragu/Instances/Autogen/Element/Square.lean
@@ -1,0 +1,29 @@
+import Ragu.Core
+
+namespace Ragu.Instances.Autogen.Element.Square
+open Core.Primes
+
+@[reducible]
+def p := Core.Primes.p
+
+@[reducible]
+def inputLen := 1
+
+@[reducible]
+def outputLen := 1
+
+set_option linter.unusedVariables false in
+def exportedOperations (input_var : Vector (Expression (F p)) inputLen) : Operations (F p) := [
+  Operation.witness 3 (fun _env => default),
+  Operation.assert ((((var ⟨0⟩) * (var ⟨1⟩)) + (((-1 : F p) : Expression (F p)) * (var ⟨2⟩)))),
+  Operation.assert (((var ⟨0⟩) + (((-1 : F p) : Expression (F p)) * (input_var[0])))),
+  Operation.assert (((var ⟨1⟩) + (((-1 : F p) : Expression (F p)) * (input_var[0])))),
+]
+
+set_option linter.unusedVariables false in
+@[reducible]
+def exportedOutput (input_var : Vector (Expression (F p)) inputLen) : Vector (Expression (F p)) outputLen := #v[
+  (var ⟨2⟩)
+]
+
+end Ragu.Instances.Autogen.Element.Square

--- a/qa/lean/Ragu/Instances/Autogen/Point/Endo.lean
+++ b/qa/lean/Ragu/Instances/Autogen/Point/Endo.lean
@@ -1,0 +1,26 @@
+import Ragu.Core
+
+namespace Ragu.Instances.Autogen.Point.Endo
+open Core.Primes
+
+@[reducible]
+def p := Core.Primes.p
+
+@[reducible]
+def inputLen := 2
+
+@[reducible]
+def outputLen := 2
+
+set_option linter.unusedVariables false in
+def exportedOperations (input_var : Vector (Expression (F p)) inputLen) : Operations (F p) := [
+]
+
+set_option linter.unusedVariables false in
+@[reducible]
+def exportedOutput (input_var : Vector (Expression (F p)) inputLen) : Vector (Expression (F p)) outputLen := #v[
+  ((0x12ccca834acdba712caad5dc57aab1b01d1f8bd237ad31491dad5ebdfdfe4ab9 : Expression (F p)) * (input_var[0])),
+  (input_var[1])
+]
+
+end Ragu.Instances.Autogen.Point.Endo

--- a/qa/lean/Ragu/Instances/Core/AllocMul.lean
+++ b/qa/lean/Ragu/Instances/Core/AllocMul.lean
@@ -1,0 +1,52 @@
+import Ragu.Circuits.Core.AllocMul
+import Ragu.Instances.Autogen.Core.AllocMul
+import Ragu.Core
+
+namespace Ragu.Instances.Core.AllocMul
+open Ragu.Instances.Autogen.Core.AllocMul
+
+set_option linter.unusedVariables false in
+def deserializeInput (input : Vector (Expression (F p)) inputLen) : Var unit (F p) := ()
+
+def serializeOutput (output : Var Circuits.Core.AllocMul.Row (F p)) : Vector (Expression (F p)) 3 :=
+  #v[output.x, output.y, output.z]
+
+def formal_instance : Core.Statements.GeneralFormalInstance where
+  p
+  inputLen
+  outputLen
+  exportedOperations
+  exportedOutput
+
+  Input := unit
+  Output := Circuits.Core.AllocMul.Row
+
+  deserializeInput
+  serializeOutput
+
+  Spec _input output := output.x * output.y = output.z
+
+  reimplementation := Circuits.Core.AllocMul.circuit (fun _ => ⟨0, 0, 0⟩)
+
+  same_constraints := by
+    intro input
+    simp [Operations.toFlat, circuit_norm, exportedOperations,
+      GeneralFormalCircuit.toSubcircuit,
+      Circuits.Core.AllocMul.circuit,
+      Circuits.Core.AllocMul.elaborated,
+      Circuits.Core.AllocMul.main]
+  same_output := by
+    intro input
+    simp [circuit_norm,
+      GeneralFormalCircuit.toSubcircuit,
+      deserializeInput, serializeOutput,
+      Circuits.Core.AllocMul.circuit,
+      Circuits.Core.AllocMul.elaborated,
+      Circuits.Core.AllocMul.main]
+  same_spec := by
+    intro input output
+    dsimp only [Circuits.Core.AllocMul.circuit,
+      Circuits.Core.AllocMul.Spec]
+    rfl
+
+end Ragu.Instances.Core.AllocMul

--- a/qa/lean/Ragu/Instances/Core/AllocMul.lean
+++ b/qa/lean/Ragu/Instances/Core/AllocMul.lean
@@ -30,11 +30,14 @@ def formal_instance : Core.Statements.GeneralFormalInstance where
 
   same_constraints := by
     intro input
-    simp [Operations.toFlat, circuit_norm, exportedOperations,
+    simp [Core.Statements.FlatOperation.eraseCompute, List.map,
+      Operations.toFlat, circuit_norm,
       GeneralFormalCircuit.toSubcircuit,
+      deserializeInput, exportedOperations,
       Circuits.Core.AllocMul.circuit,
       Circuits.Core.AllocMul.elaborated,
       Circuits.Core.AllocMul.main]
+    rfl
   same_output := by
     intro input
     simp [circuit_norm,
@@ -47,6 +50,6 @@ def formal_instance : Core.Statements.GeneralFormalInstance where
     intro input output
     dsimp only [Circuits.Core.AllocMul.circuit,
       Circuits.Core.AllocMul.Spec]
-    rfl
+    aesop
 
 end Ragu.Instances.Core.AllocMul

--- a/qa/lean/Ragu/Instances/Element/AllocSquare.lean
+++ b/qa/lean/Ragu/Instances/Element/AllocSquare.lean
@@ -1,0 +1,52 @@
+import Ragu.Circuits.Element.AllocSquare
+import Ragu.Instances.Autogen.Element.AllocSquare
+import Ragu.Core
+
+namespace Ragu.Instances.Element.AllocSquare
+open Ragu.Instances.Autogen.Element.AllocSquare
+
+set_option linter.unusedVariables false in
+def deserializeInput (input : Vector (Expression (F p)) inputLen) : Var unit (F p) := ()
+
+def serializeOutput (output : Var Circuits.Element.AllocSquare.Square (F p)) : Vector (Expression (F p)) 2 :=
+  #v[output.a, output.a_sq]
+
+def formal_instance : Core.Statements.GeneralFormalInstance where
+  p
+  inputLen
+  outputLen
+  exportedOperations
+  exportedOutput
+
+  Input := unit
+  Output := Circuits.Element.AllocSquare.Square
+
+  deserializeInput
+  serializeOutput
+
+  Spec _input output := output.a_sq = output.a^2
+
+  reimplementation := Circuits.Element.AllocSquare.generalCircuit (fun _ => 0)
+
+  same_constraints := by
+    intro input
+    simp [Operations.toFlat, circuit_norm, exportedOperations,
+      GeneralFormalCircuit.toSubcircuit,
+      Circuits.Element.AllocSquare.generalCircuit,
+      Circuits.Element.AllocSquare.elaborated,
+      Circuits.Element.AllocSquare.main]
+  same_output := by
+    intro input
+    simp [circuit_norm,
+      GeneralFormalCircuit.toSubcircuit,
+      deserializeInput, serializeOutput,
+      Circuits.Element.AllocSquare.generalCircuit,
+      Circuits.Element.AllocSquare.elaborated,
+      Circuits.Element.AllocSquare.main]
+  same_spec := by
+    intro input output
+    dsimp only [Circuits.Element.AllocSquare.generalCircuit,
+      Circuits.Element.AllocSquare.Spec]
+    rfl
+
+end Ragu.Instances.Element.AllocSquare

--- a/qa/lean/Ragu/Instances/Element/AllocSquare.lean
+++ b/qa/lean/Ragu/Instances/Element/AllocSquare.lean
@@ -30,11 +30,15 @@ def formal_instance : Core.Statements.GeneralFormalInstance where
 
   same_constraints := by
     intro input
-    simp [Operations.toFlat, circuit_norm, exportedOperations,
+    simp [Core.Statements.FlatOperation.eraseCompute, List.map,
+      Operations.toFlat, circuit_norm,
       GeneralFormalCircuit.toSubcircuit,
+      deserializeInput, exportedOperations,
       Circuits.Element.AllocSquare.generalCircuit,
       Circuits.Element.AllocSquare.elaborated,
       Circuits.Element.AllocSquare.main]
+    repeat (constructor; rfl)
+    constructor
   same_output := by
     intro input
     simp [circuit_norm,
@@ -47,6 +51,6 @@ def formal_instance : Core.Statements.GeneralFormalInstance where
     intro input output
     dsimp only [Circuits.Element.AllocSquare.generalCircuit,
       Circuits.Element.AllocSquare.Spec]
-    rfl
+    aesop
 
 end Ragu.Instances.Element.AllocSquare

--- a/qa/lean/Ragu/Instances/Element/DivNonzero.lean
+++ b/qa/lean/Ragu/Instances/Element/DivNonzero.lean
@@ -24,6 +24,8 @@ def formal_instance : Core.Statements.GeneralFormalInstance where
   deserializeInput
   serializeOutput
 
+  -- See `Circuits/Element/DivNonzero.lean` for the rationale behind the
+  -- `y ≠ 0 ∨ x ≠ 0` premise.
   Spec input output :=
     input.y ≠ 0 ∨ input.x ≠ 0 → output = input.x / input.y
 

--- a/qa/lean/Ragu/Instances/Element/DivNonzero.lean
+++ b/qa/lean/Ragu/Instances/Element/DivNonzero.lean
@@ -33,14 +33,17 @@ def formal_instance : Core.Statements.GeneralFormalInstance where
   same_constraints := by
     intro input
     simp [Core.Statements.FlatOperation.eraseCompute, List.map,
-      Operations.toFlat, circuit_norm, exportedOperations,
+      Operations.toFlat, circuit_norm,
       GeneralFormalCircuit.toSubcircuit,
+      deserializeInput, exportedOperations,
       Circuits.Element.DivNonzero.generalCircuit,
       Circuits.Element.DivNonzero.elaborated,
       Circuits.Element.DivNonzero.main,
       Circuits.Core.AllocMul.circuit,
       Circuits.Core.AllocMul.elaborated,
       Circuits.Core.AllocMul.main]
+    repeat (constructor; rfl)
+    constructor
   same_output := by
     intro input
     simp [circuit_norm,
@@ -56,6 +59,6 @@ def formal_instance : Core.Statements.GeneralFormalInstance where
     intro input output
     dsimp only [Circuits.Element.DivNonzero.generalCircuit,
       Circuits.Element.DivNonzero.GeneralSpec]
-    rfl
+    aesop
 
 end Ragu.Instances.Element.DivNonzero

--- a/qa/lean/Ragu/Instances/Element/DivNonzero.lean
+++ b/qa/lean/Ragu/Instances/Element/DivNonzero.lean
@@ -1,0 +1,61 @@
+import Ragu.Circuits.Element.DivNonzero
+import Ragu.Instances.Autogen.Element.DivNonzero
+import Ragu.Core
+
+namespace Ragu.Instances.Element.DivNonzero
+open Ragu.Instances.Autogen.Element.DivNonzero
+
+def deserializeInput (input : Vector (Expression (F p)) inputLen) : Var Circuits.Element.DivNonzero.Inputs (F p) :=
+  { x := input[0], y := input[1] }
+
+def serializeOutput (output : Var field (F p)) : Vector (Expression (F p)) 1 :=
+  #v[output]
+
+def formal_instance : Core.Statements.GeneralFormalInstance where
+  p
+  inputLen
+  outputLen
+  exportedOperations
+  exportedOutput
+
+  Input := Circuits.Element.DivNonzero.Inputs
+  Output := field
+
+  deserializeInput
+  serializeOutput
+
+  Spec input output :=
+    input.y ≠ 0 ∨ input.x ≠ 0 → output = input.x / input.y
+
+  reimplementation :=
+    Circuits.Element.DivNonzero.generalCircuit (fun _ => ⟨0, 0, 0⟩)
+
+  same_constraints := by
+    intro input
+    simp [Core.Statements.FlatOperation.eraseCompute, List.map,
+      Operations.toFlat, circuit_norm, exportedOperations,
+      GeneralFormalCircuit.toSubcircuit,
+      Circuits.Element.DivNonzero.generalCircuit,
+      Circuits.Element.DivNonzero.elaborated,
+      Circuits.Element.DivNonzero.main,
+      Circuits.Core.AllocMul.circuit,
+      Circuits.Core.AllocMul.elaborated,
+      Circuits.Core.AllocMul.main]
+  same_output := by
+    intro input
+    simp [circuit_norm,
+      GeneralFormalCircuit.toSubcircuit,
+      deserializeInput, serializeOutput,
+      Circuits.Element.DivNonzero.generalCircuit,
+      Circuits.Element.DivNonzero.elaborated,
+      Circuits.Element.DivNonzero.main,
+      Circuits.Core.AllocMul.circuit,
+      Circuits.Core.AllocMul.elaborated,
+      Circuits.Core.AllocMul.main]
+  same_spec := by
+    intro input output
+    dsimp only [Circuits.Element.DivNonzero.generalCircuit,
+      Circuits.Element.DivNonzero.GeneralSpec]
+    rfl
+
+end Ragu.Instances.Element.DivNonzero

--- a/qa/lean/Ragu/Instances/Element/Mul.lean
+++ b/qa/lean/Ragu/Instances/Element/Mul.lean
@@ -1,0 +1,53 @@
+import Ragu.Circuits.Element.Mul
+import Ragu.Instances.Autogen.Element.Mul
+import Ragu.Core
+
+namespace Ragu.Instances.Element.Mul
+open Ragu.Instances.Autogen.Element.Mul
+
+def deserializeInput (input : Vector (Expression (F p)) inputLen) : Var Circuits.Element.Mul.Input (F p) :=
+  { x := input[0], y := input[1] }
+
+def serializeOutput (output : Var field (F p)) : Vector (Expression (F p)) 1 :=
+  #v[output]
+
+def formal_instance : Core.Statements.GeneralFormalInstance where
+  p
+  inputLen
+  outputLen
+  exportedOperations
+  exportedOutput
+
+  Input := Circuits.Element.Mul.Input
+  Output := field
+
+  deserializeInput
+  serializeOutput
+
+  Spec input output := output = input.x * input.y
+
+  reimplementation :=
+    FormalCircuit.isGeneralFormalCircuit (F p) Circuits.Element.Mul.Input field
+      Circuits.Element.Mul.circuit
+
+  same_constraints := by
+    intro input
+    simp [Operations.toFlat, circuit_norm, exportedOperations,
+      FormalCircuit.isGeneralFormalCircuit,
+      GeneralFormalCircuit.toSubcircuit,
+      Circuits.Element.Mul.circuit, Circuits.Element.Mul.elaborated, Circuits.Element.Mul.main]
+  same_output := by
+    intro input
+    simp [circuit_norm,
+      FormalCircuit.isGeneralFormalCircuit,
+      GeneralFormalCircuit.toSubcircuit,
+      deserializeInput, serializeOutput,
+      Circuits.Element.Mul.circuit, Circuits.Element.Mul.elaborated, Circuits.Element.Mul.main]
+  same_spec := by
+    intro input output
+    dsimp only [FormalCircuit.isGeneralFormalCircuit,
+      Circuits.Element.Mul.circuit, Circuits.Element.Mul.Assumptions,
+      Circuits.Element.Mul.Spec]
+    rfl
+
+end Ragu.Instances.Element.Mul

--- a/qa/lean/Ragu/Instances/Element/Mul.lean
+++ b/qa/lean/Ragu/Instances/Element/Mul.lean
@@ -32,10 +32,14 @@ def formal_instance : Core.Statements.GeneralFormalInstance where
 
   same_constraints := by
     intro input
-    simp [Operations.toFlat, circuit_norm, exportedOperations,
+    simp [Core.Statements.FlatOperation.eraseCompute, List.map,
+      Operations.toFlat, circuit_norm,
       FormalCircuit.isGeneralFormalCircuit,
       GeneralFormalCircuit.toSubcircuit,
+      deserializeInput, exportedOperations,
       Circuits.Element.Mul.circuit, Circuits.Element.Mul.elaborated, Circuits.Element.Mul.main]
+    repeat (constructor; rfl)
+    constructor
   same_output := by
     intro input
     simp [circuit_norm,
@@ -48,6 +52,6 @@ def formal_instance : Core.Statements.GeneralFormalInstance where
     dsimp only [FormalCircuit.isGeneralFormalCircuit,
       Circuits.Element.Mul.circuit, Circuits.Element.Mul.Assumptions,
       Circuits.Element.Mul.Spec]
-    rfl
+    aesop
 
 end Ragu.Instances.Element.Mul

--- a/qa/lean/Ragu/Instances/Element/Square.lean
+++ b/qa/lean/Ragu/Instances/Element/Square.lean
@@ -24,7 +24,7 @@ def formal_instance : Core.Statements.GeneralFormalInstance where
   deserializeInput
   serializeOutput
 
-  Spec (input : F p) (output : F p) := output = input * input
+  Spec (input : F p) (output : F p) := output = input^2
 
   reimplementation :=
     FormalCircuit.isGeneralFormalCircuit (F p) field field

--- a/qa/lean/Ragu/Instances/Element/Square.lean
+++ b/qa/lean/Ragu/Instances/Element/Square.lean
@@ -24,7 +24,7 @@ def formal_instance : Core.Statements.GeneralFormalInstance where
   deserializeInput
   serializeOutput
 
-  Spec input output := output = input^2
+  Spec (input : F p) (output : F p) := output = input * input
 
   reimplementation :=
     FormalCircuit.isGeneralFormalCircuit (F p) field field
@@ -32,11 +32,15 @@ def formal_instance : Core.Statements.GeneralFormalInstance where
 
   same_constraints := by
     intro input
-    simp [Operations.toFlat, circuit_norm, exportedOperations,
+    simp [Core.Statements.FlatOperation.eraseCompute, List.map,
+      Operations.toFlat, circuit_norm,
       FormalCircuit.isGeneralFormalCircuit,
       GeneralFormalCircuit.toSubcircuit, FormalCircuit.toSubcircuit,
+      deserializeInput, exportedOperations,
       Circuits.Element.Square.circuit, Circuits.Element.Square.elaborated, Circuits.Element.Square.main,
       Circuits.Element.Mul.circuit, Circuits.Element.Mul.elaborated, Circuits.Element.Mul.main]
+    repeat (constructor; rfl)
+    constructor
   same_output := by
     intro input
     simp [circuit_norm,
@@ -50,6 +54,6 @@ def formal_instance : Core.Statements.GeneralFormalInstance where
     dsimp only [FormalCircuit.isGeneralFormalCircuit,
       Circuits.Element.Square.circuit, Circuits.Element.Square.Assumptions,
       Circuits.Element.Square.Spec]
-    rfl
+    simp [sq]
 
 end Ragu.Instances.Element.Square

--- a/qa/lean/Ragu/Instances/Element/Square.lean
+++ b/qa/lean/Ragu/Instances/Element/Square.lean
@@ -1,0 +1,55 @@
+import Ragu.Circuits.Element.Square
+import Ragu.Instances.Autogen.Element.Square
+import Ragu.Core
+
+namespace Ragu.Instances.Element.Square
+open Ragu.Instances.Autogen.Element.Square
+
+def deserializeInput (input : Vector (Expression (F p)) inputLen) : Var field (F p) :=
+  input[0]
+
+def serializeOutput (output : Var field (F p)) : Vector (Expression (F p)) 1 :=
+  #v[output]
+
+def formal_instance : Core.Statements.GeneralFormalInstance where
+  p
+  inputLen
+  outputLen
+  exportedOperations
+  exportedOutput
+
+  Input := field
+  Output := field
+
+  deserializeInput
+  serializeOutput
+
+  Spec input output := output = input^2
+
+  reimplementation :=
+    FormalCircuit.isGeneralFormalCircuit (F p) field field
+      Circuits.Element.Square.circuit
+
+  same_constraints := by
+    intro input
+    simp [Operations.toFlat, circuit_norm, exportedOperations,
+      FormalCircuit.isGeneralFormalCircuit,
+      GeneralFormalCircuit.toSubcircuit, FormalCircuit.toSubcircuit,
+      Circuits.Element.Square.circuit, Circuits.Element.Square.elaborated, Circuits.Element.Square.main,
+      Circuits.Element.Mul.circuit, Circuits.Element.Mul.elaborated, Circuits.Element.Mul.main]
+  same_output := by
+    intro input
+    simp [circuit_norm,
+      FormalCircuit.isGeneralFormalCircuit,
+      GeneralFormalCircuit.toSubcircuit, FormalCircuit.toSubcircuit,
+      deserializeInput, serializeOutput,
+      Circuits.Element.Square.circuit, Circuits.Element.Square.elaborated, Circuits.Element.Square.main,
+      Circuits.Element.Mul.circuit, Circuits.Element.Mul.elaborated, Circuits.Element.Mul.main]
+  same_spec := by
+    intro input output
+    dsimp only [FormalCircuit.isGeneralFormalCircuit,
+      Circuits.Element.Square.circuit, Circuits.Element.Square.Assumptions,
+      Circuits.Element.Square.Spec]
+    rfl
+
+end Ragu.Instances.Element.Square

--- a/qa/lean/Ragu/Instances/Point/Endo.lean
+++ b/qa/lean/Ragu/Instances/Point/Endo.lean
@@ -1,0 +1,58 @@
+import Ragu.Circuits.Point.Endo
+import Ragu.Instances.Autogen.Point.Endo
+import Ragu.Core
+
+namespace Ragu.Instances.Point.Endo
+open Ragu.Instances.Autogen.Point.Endo
+
+def deserializeInput (input : Vector (Expression (F p)) inputLen) : Var Circuits.Point.Spec.Point (F p) :=
+  { x := input[0], y := input[1] }
+
+def serializeOutput (output : Var Circuits.Point.Spec.Point (F p)) : Vector (Expression (F p)) 2 :=
+  #v[output.x, output.y]
+
+def formal_instance : Core.Statements.GeneralFormalInstance where
+  p
+  inputLen
+  outputLen
+  exportedOperations
+  exportedOutput
+
+  Input := Circuits.Point.Spec.Point
+  Output := Circuits.Point.Spec.Point
+
+  deserializeInput
+  serializeOutput
+
+  Spec input output :=
+    input.isOnCurve Circuits.Point.Spec.EpAffineParams →
+    (output = Circuits.Point.Spec.Point.endo input Circuits.Point.Spec.EpAffineParams
+      ∧ output.isOnCurve Circuits.Point.Spec.EpAffineParams)
+
+  reimplementation :=
+    FormalCircuit.isGeneralFormalCircuit (F p) Circuits.Point.Spec.Point Circuits.Point.Spec.Point
+      (Circuits.Point.Endo.circuit Circuits.Point.Spec.EpAffineParams)
+
+  same_constraints := by
+    intro input
+    simp [Operations.toFlat, circuit_norm, exportedOperations,
+      FormalCircuit.isGeneralFormalCircuit,
+      GeneralFormalCircuit.toSubcircuit,
+      Circuits.Point.Endo.circuit, Circuits.Point.Endo.elaborated, Circuits.Point.Endo.main]
+  same_output := by
+    intro input
+    simp [circuit_norm,
+      FormalCircuit.isGeneralFormalCircuit,
+      GeneralFormalCircuit.toSubcircuit,
+      deserializeInput, serializeOutput,
+      Circuits.Point.Endo.circuit, Circuits.Point.Endo.elaborated, Circuits.Point.Endo.main]
+    show Expression.mul _ _ = Expression.mul _ _
+    congr 1
+  same_spec := by
+    intro input output
+    dsimp only [FormalCircuit.isGeneralFormalCircuit,
+      Circuits.Point.Endo.circuit, Circuits.Point.Endo.Assumptions,
+      Circuits.Point.Endo.Spec]
+    rfl
+
+end Ragu.Instances.Point.Endo


### PR DESCRIPTION
Builds on https://github.com/tachyon-zcash/ragu/pull/642 and references https://github.com/tachyon-zcash/ragu/pull/642#pullrequestreview-4140712859. The `Point` gadget implemented the [full stack of artifacts](https://github.com/tachyon-zcash/ragu/pull/642#discussion_r3102920311) for formal verification (rust instance / autogen / clean reimplementation / formal instance), but the field arithmetic primitives for `Element` only had the reimplementation (no standalone extraction). They were transitively verified through the `Point` gadget (ie. `Element`'s reimpl was composed as a subcircuit inside `Point`'s reimpl). This PR extends the FV surface area to _also_ cover that coverage gap (`Core::AllocMul, Element::Mul, Element::Square, Element::AllocSquare, Element::DivNonzero, Point::Endo`). cc @mitschabaude @gio54321.

I ran `lake build` locally to verify the extracted autogen matches the reimplementation at the lean kernel level. The extractor is trusted and  reimplementation is untrusted, and if the reimplementation is buggy, the equivalence theorem / proof will fail, which it doesn't. After the reimpl was verified (soundness / completeness closed), it was checked against the autogen with `~/.elan/bin/lake build -- --wfail`.

Follow-up PRs can cover the rest of `Point` / `Element` gadget components and other gadgets (`Boolean` / `Poseidon` / `Endoscalar`, etc.) that aren't yet implemented in _any_ capacity. 

cc @ebfull for visibility.