### PR TITLE
ci: avoid jq panic when no PR_NUMBER

### DIFF
--- a/.github/workflows/bench-alert.yml
+++ b/.github/workflows/bench-alert.yml
@@ -26,14 +26,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          PR_NUMBER=$(gh pr list \
-              --repo ${{ github.repository }} \
-              --state open \
-              --json number,headRefName,headRefOid,headRepositoryOwner \
+          PR_NUMBER=$(
+            (
+              gh pr list \
+                --repo ${{ github.repository }} \
+                --state open \
+                --json number,headRefName,headRefOid,headRepositoryOwner \
+              || echo '[]'
+            ) \
             | jq --raw-output --from-file .github/scripts/find-pr.jq \
               --arg pr_owner '${{ github.event.workflow_run.head_repository.owner.login }}' \
               --arg pr_branch '${{ github.event.workflow_run.head_branch }}' \
-              --arg pr_sha '${{ github.event.workflow_run.head_sha }}')
+              --arg pr_sha '${{ github.event.workflow_run.head_sha }}'
+          )
           echo "pr_number=${PR_NUMBER}" | tee $GITHUB_OUTPUT
 
       - name: Download benchmark results artifact


### PR DESCRIPTION
fixing a CI failure notification: https://github.com/tachyon-zcash/ragu/actions/runs/24870248395/job/72814994477

So return a fallback `[]` which is a valid json. our `scripts/find-pr` already assign `pr_number = ""` empty string if not found, and rest of the workflow will cancel -- this is the correct behavior.