### PR TITLE
feat(circuits): group stage masks

### DIFF
--- a/crates/ragu_circuits/src/polynomials/sparse/mod.rs
+++ b/crates/ragu_circuits/src/polynomials/sparse/mod.rs
@@ -214,6 +214,21 @@ impl<F: Field, R: Rank> Polynomial<F, R> {
         }
     }
 
+    /// Returns an iterator over `(degree, &coefficient)` pairs for every
+    /// stored nonzero coefficient, in ascending degree order. Skips both
+    /// structural gaps between blocks and inline zeros within blocks.
+    pub fn iter_nonzero(&self) -> impl Iterator<Item = (usize, &F)> + '_ {
+        self.blocks.iter().flat_map(|(start, data)| {
+            data.iter().enumerate().filter_map(move |(i, c)| {
+                if bool::from(c.is_zero()) {
+                    None
+                } else {
+                    Some((start + i, c))
+                }
+            })
+        })
+    }
+
     /// Merges another polynomial into this one using the given binary
     /// operation, pruning all-zero blocks from the result.
     fn combine_assign(&mut self, other: &Self, mut op: impl FnMut(&mut F, &F)) {

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -1,3 +1,5 @@
+use alloc::{vec, vec::Vec};
+
 use ff::Field;
 use ragu_arithmetic::geosum;
 use ragu_core::Result;
@@ -85,10 +87,14 @@ pub(crate) fn global_project<F: Field, R: Rank>(p: F) -> sparse::Polynomial<F, R
     view.build()
 }
 
+/// Bonding polynomial that masks the data wires outside one or more
+/// stage windows. A single-stage mask is constructed via [`new`](Self::new);
+/// multiple stages can be bundled into one registry slot by chaining
+/// [`with_notch`](Self::with_notch).
 #[derive(Clone)]
 pub struct StageMask<R: Rank> {
-    skip_gates: usize,
-    num_gates: usize,
+    /// One `(skip_gates, num_gates)` per masked stage window.
+    notches: Vec<(usize, usize)>,
     _marker: core::marker::PhantomData<R>,
 }
 
@@ -102,13 +108,9 @@ impl<R: Rank> StageMask<R> {
     /// `d[0]` may or may not be set to 1; `b[0]` and `c[0]` are
     /// zero in all cases.
     pub fn new(skip_gates: usize, num_gates: usize) -> Result<Self> {
-        assert!(skip_gates > 0, "skip_gates must include the SYSTEM gate");
-        if skip_gates + num_gates > R::n() {
-            return Err(ragu_core::Error::GateBoundExceeded { limit: R::n() });
-        }
+        Self::check_notch(skip_gates, num_gates)?;
         Ok(Self {
-            skip_gates,
-            num_gates,
+            notches: vec![(skip_gates, num_gates)],
             _marker: core::marker::PhantomData,
         })
     }
@@ -123,50 +125,77 @@ impl<R: Rank> StageMask<R> {
         if skip_gates > R::n() {
             return Err(ragu_core::Error::GateBoundExceeded { limit: R::n() });
         }
-
         let num_gates = R::n() - skip_gates;
-
         Ok(Self {
-            skip_gates,
-            num_gates,
+            notches: vec![(skip_gates, num_gates)],
             _marker: core::marker::PhantomData,
         })
     }
 
+    /// Bundles an additional stage window into this mask, occupying the
+    /// same registry slot as the original. Caller must ensure the
+    /// bundled stages occupy disjoint gate windows.
+    #[allow(dead_code, reason = "exposed for future stage-grouping migrations")]
+    pub fn with_notch(mut self, skip_gates: usize, num_gates: usize) -> Result<Self> {
+        Self::check_notch(skip_gates, num_gates)?;
+        self.notches.push((skip_gates, num_gates));
+        Ok(self)
+    }
+
+    fn check_notch(skip_gates: usize, num_gates: usize) -> Result<()> {
+        assert!(skip_gates > 0, "skip_gates must include the SYSTEM gate");
+        if skip_gates + num_gates > R::n() {
+            return Err(ragu_core::Error::GateBoundExceeded { limit: R::n() });
+        }
+        Ok(())
+    }
+
     /// Returns a sparse polynomial containing the negated notch entries for
-    /// the active-stage gate wires at positions `skip_gates..skip_gates + num_gates`.
-    /// The SYSTEM gate is excluded (it is already zero in the global mask).
+    /// the active-stage gate wires at positions `skip_gates..skip_gates + num_gates`,
+    /// summed across every notch in the mask. The SYSTEM gate is excluded
+    /// (it is already zero in the global mask).
     ///
-    /// The result has `4 × num_gates` non-zero entries
-    /// (vs `4(n - 1)` for the full mask projection).
+    /// For a single-stage mask the result has `4 × num_gates` non-zero
+    /// entries; bundled masks accumulate per-notch contributions into the
+    /// same view (notches are expected to occupy disjoint windows, so no
+    /// real accumulation occurs in well-formed cases).
     fn notch_project<F: Field>(&self, p: F) -> sparse::Polynomial<F, R> {
-        if self.num_gates == 0 || p == F::ZERO {
+        if p == F::ZERO {
             return sparse::Polynomial::default();
         }
+
+        let max_extent = self.notches.iter().map(|(g, m)| g + m).max().unwrap_or(0);
+        if max_extent == 0 {
+            return sparse::Polynomial::default();
+        }
+
         let n = R::n();
-        let g = self.skip_gates;
-        let m = self.num_gates;
         let mut view = sparse::View::<F, R, _>::wiring();
-        view.d.resize(g + m, F::ZERO);
-        view.a.resize(g + m, F::ZERO);
-        view.b.resize(g + m, F::ZERO);
-        view.c.resize(g + m, F::ZERO);
+        view.d.resize(max_extent, F::ZERO);
+        view.a.resize(max_extent, F::ZERO);
+        view.b.resize(max_extent, F::ZERO);
+        view.c.resize(max_extent, F::ZERO);
 
         let p_inv = p.invert().expect("p is not zero");
-        let mut d = -p.pow_vartime([g as u64]);
-        let mut a = -p.pow_vartime([(2 * n + g) as u64]);
-        let mut b = -p.pow_vartime([(2 * n - 1 - g) as u64]);
-        let mut c = -p.pow_vartime([(4 * n - 1 - g) as u64]);
+        for &(g, m) in &self.notches {
+            if m == 0 {
+                continue;
+            }
+            let mut d = -p.pow_vartime([g as u64]);
+            let mut a = -p.pow_vartime([(2 * n + g) as u64]);
+            let mut b = -p.pow_vartime([(2 * n - 1 - g) as u64]);
+            let mut c = -p.pow_vartime([(4 * n - 1 - g) as u64]);
 
-        for j in g..g + m {
-            view.d[j] = d;
-            view.a[j] = a;
-            view.b[j] = b;
-            view.c[j] = c;
-            d *= p;
-            a *= p;
-            b *= p_inv;
-            c *= p_inv;
+            for j in g..g + m {
+                view.d[j] += d;
+                view.a[j] += a;
+                view.b[j] += b;
+                view.c[j] += c;
+                d *= p;
+                a *= p;
+                b *= p_inv;
+                c *= p_inv;
+            }
         }
 
         view.build()
@@ -174,17 +203,19 @@ impl<R: Rank> StageMask<R> {
 }
 
 impl<F: Field, R: Rank> WiringObject<F, R> for StageMask<R> {
-    /// Evaluates the per-instance notch term $-\text{notch}(x, y)$.
+    /// Evaluates the per-instance notch term $-\text{notch}(x, y)$,
+    /// summed across every notch in the mask.
     ///
     /// The full stage mask is $S\_{\text{global}} - \text{notch}$, but
     /// the invariant $S\_{\text{global}}$ term is factored out and applied
-    /// once by the [`Registry`](crate::registry::Registry). This method
-    /// returns only $-\text{notch}$, where
+    /// once by the [`Registry`](crate::registry::Registry). For each
+    /// `(skip_gates, num_gates)` pair this method contributes
     ///
     /// $$\text{notch}(x, y) = (1 + (xy)^{2n})\bigl((xy)^g + (xy)^{2n-g-m}\bigr)
     ///     \cdot \sum_{i=0}^{m-1} (xy)^i$$
     ///
-    /// with $g = \text{skip\_gates}$ and $m = \text{num\_gates}$.
+    /// with $g = \text{skip\_gates}$ and $m = \text{num\_gates}$. The
+    /// $(1 + (xy)^{2n})$ factor is shared across notches and applied once.
     fn sxy(&self, x: F, y: F, _floor_plan: &[crate::floor_planner::ConstraintSegment]) -> F {
         if x == F::ZERO || y == F::ZERO {
             return F::ZERO;
@@ -193,11 +224,18 @@ impl<F: Field, R: Rank> WiringObject<F, R> for StageMask<R> {
         let xy = x * y;
         let xy_2n = xy.pow_vartime([2 * R::n() as u64]);
 
-        let gsum = geosum(xy, self.num_gates);
-        let skip = xy.pow_vartime([self.skip_gates as u64]);
-        let tail = xy.pow_vartime([(2 * R::n() - self.skip_gates - self.num_gates) as u64]);
+        let mut inner = F::ZERO;
+        for &(skip_gates, num_gates) in &self.notches {
+            if num_gates == 0 {
+                continue;
+            }
+            let gsum = geosum(xy, num_gates);
+            let skip = xy.pow_vartime([skip_gates as u64]);
+            let tail = xy.pow_vartime([(2 * R::n() - skip_gates - num_gates) as u64]);
+            inner += (skip + tail) * gsum;
+        }
 
-        -((F::ONE + xy_2n) * (skip + tail) * gsum)
+        -(F::ONE + xy_2n) * inner
     }
 
     fn sx(
@@ -286,7 +324,13 @@ mod tests {
         where
             Self: 'dr,
         {
-            assert!(self.skip_gates + self.num_gates <= R::n());
+            assert_eq!(
+                self.notches.len(),
+                1,
+                "RawCircuit impl is single-notch only"
+            );
+            let (skip_gates, num_gates) = self.notches[0];
+            assert!(skip_gates + num_gates <= R::n());
 
             // Allocate gates 1..n locally; gate 0 (the SYSTEM gate) is
             // allocated by `orchestrate` and is not referenced here. Vec
@@ -299,8 +343,7 @@ mod tests {
                 gates.push(Gate { a, b, c, d });
             }
 
-            let is_active =
-                |j: usize| j == 0 || (j >= self.skip_gates && j < self.skip_gates + self.num_gates);
+            let is_active = |j: usize| j == 0 || (j >= skip_gates && j < skip_gates + num_gates);
 
             // Issue 4n-2 enforce_zero in decreasing degree order so that the
             // driver assigns y^k to the constraint at degree k. Dummy (empty
@@ -377,14 +420,20 @@ mod tests {
             generators: &impl FixedGenerators<C>,
             coefficient_index: usize,
         ) -> C {
+            assert_eq!(
+                self.notches.len(),
+                1,
+                "generator_for_a_coefficient is single-notch only"
+            );
+            let (skip_gates, num_gates) = self.notches[0];
             assert!(
-                coefficient_index < self.num_gates,
+                coefficient_index < num_gates,
                 "coefficient_index {} exceeds num_gates {}",
                 coefficient_index,
-                self.num_gates
+                num_gates
             );
 
-            let idx = 2 * R::n() - 1 - self.skip_gates - coefficient_index;
+            let idx = 2 * R::n() - 1 - skip_gates - coefficient_index;
             generators.g()[idx]
         }
     }
@@ -664,6 +713,33 @@ mod tests {
             let sxy_b = mask_b.sxy(x, y, &[]);
             let global_xy = super::global_mask::<Fp, R>(x, y);
             prop_assert_eq!(sxy_a + sxy_b, -global_xy);
+        }
+
+        /// A multi-notch `StageMask` (built via `with_notch`) produces
+        /// the same notch projection and `sxy` value as summing two
+        /// single-notch masks over the same windows.
+        #[test]
+        fn test_with_notch_matches_sum(split in 1..R::n()) {
+            let mask_a = StageMask::<R>::new(1, split - 1).unwrap();
+            let mask_b = StageMask::<R>::new(split, R::n() - split).unwrap();
+            let combined = StageMask::<R>::new(1, split - 1)
+                .unwrap()
+                .with_notch(split, R::n() - split)
+                .unwrap();
+
+            let p = Fp::random(&mut rand::rng());
+            let x = Fp::random(&mut rand::rng());
+            let y = Fp::random(&mut rand::rng());
+            let q = Fp::random(&mut rand::rng());
+
+            let mut sum_poly = mask_a.notch_project(p);
+            sum_poly += &mask_b.notch_project(p);
+            prop_assert_eq!(sum_poly.eval(q), combined.notch_project(p).eval(q));
+
+            prop_assert_eq!(
+                mask_a.sxy(x, y, &[]) + mask_b.sxy(x, y, &[]),
+                combined.sxy(x, y, &[]),
+            );
         }
     }
 

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -622,6 +622,33 @@ mod tests {
             .unwrap();
     }
 
+    /// A bundled mask must reject an rx with a nonzero entry outside the
+    /// union of its notch windows. Verifies the bundled bonding check is
+    /// actively soundness-enforcing, not vacuous.
+    #[test]
+    fn test_with_notch_catches_planted_rx_outside_union() {
+        let mask = StageMask::<R>::new(1, 100)
+            .unwrap()
+            .with_notch(200, 100)
+            .unwrap();
+
+        let y = Fp::random(&mut rand::rng());
+
+        let n = R::n();
+        let mut coeffs = alloc::vec![Fp::ZERO; R::num_coeffs()];
+        coeffs[2 * n - 1 - 150] = Fp::from(42u64);
+        let rx = sparse::Polynomial::<Fp, R>::from_coeffs(coeffs);
+
+        let mut full_sy = super::global_project::<Fp, R>(y);
+        full_sy += &mask.notch_project(y);
+
+        assert_ne!(
+            rx.revdot(&full_sy),
+            Fp::ZERO,
+            "bundled mask should reject rx with planted entry outside notch union",
+        );
+    }
+
     #[test]
     fn test_stage_mask_exact_boundary() {
         let result = StageMask::<R>::new(R::n() - 1, 1);

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -140,10 +140,7 @@ impl<R: Rank> StageMask<R> {
         Self::check_notch(skip_gates, num_gates)?;
         if num_gates > 0 {
             let new_end = skip_gates + num_gates;
-            for &(s, n) in &self.notches {
-                if n == 0 {
-                    continue;
-                }
+            for (s, n) in self.active_notches() {
                 let existing_end = s + n;
                 let disjoint = new_end <= s || existing_end <= skip_gates;
                 assert!(
@@ -164,6 +161,13 @@ impl<R: Rank> StageMask<R> {
         Ok(())
     }
 
+    /// Iterates over notches that contribute to the mask. Notches with
+    /// `num_gates == 0` are absorbing identities for the bonding sum and
+    /// are skipped.
+    fn active_notches(&self) -> impl Iterator<Item = (usize, usize)> + '_ {
+        self.notches.iter().copied().filter(|&(_, m)| m != 0)
+    }
+
     /// Returns a sparse polynomial containing the negated notch entries for
     /// the active-stage gate wires at positions `skip_gates..skip_gates + num_gates`,
     /// summed across every notch in the mask. The SYSTEM gate is excluded
@@ -178,7 +182,7 @@ impl<R: Rank> StageMask<R> {
             return sparse::Polynomial::default();
         }
 
-        let max_extent = self.notches.iter().map(|(g, m)| g + m).max().unwrap_or(0);
+        let max_extent = self.active_notches().map(|(g, m)| g + m).max().unwrap_or(0);
         if max_extent == 0 {
             return sparse::Polynomial::default();
         }
@@ -191,10 +195,7 @@ impl<R: Rank> StageMask<R> {
         view.c.resize(max_extent, F::ZERO);
 
         let p_inv = p.invert().expect("p is not zero");
-        for &(g, m) in &self.notches {
-            if m == 0 {
-                continue;
-            }
+        for (g, m) in self.active_notches() {
             let mut d = -p.pow_vartime([g as u64]);
             let mut a = -p.pow_vartime([(2 * n + g) as u64]);
             let mut b = -p.pow_vartime([(2 * n - 1 - g) as u64]);
@@ -239,10 +240,7 @@ impl<F: Field, R: Rank> WiringObject<F, R> for StageMask<R> {
         let xy_2n = xy.pow_vartime([2 * R::n() as u64]);
 
         let mut inner = F::ZERO;
-        for &(skip_gates, num_gates) in &self.notches {
-            if num_gates == 0 {
-                continue;
-            }
+        for (skip_gates, num_gates) in self.active_notches() {
             let gsum = geosum(xy, num_gates);
             let skip = xy.pow_vartime([skip_gates as u64]);
             let tail = xy.pow_vartime([(2 * R::n() - skip_gates - num_gates) as u64]);

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -135,7 +135,6 @@ impl<R: Rank> StageMask<R> {
     /// Bundles an additional stage window into this mask, occupying the
     /// same registry slot as the original. Caller must ensure the
     /// bundled stages occupy disjoint gate windows.
-    #[allow(dead_code, reason = "exposed for future stage-grouping migrations")]
     pub fn with_notch(mut self, skip_gates: usize, num_gates: usize) -> Result<Self> {
         Self::check_notch(skip_gates, num_gates)?;
         self.notches.push((skip_gates, num_gates));

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -133,10 +133,25 @@ impl<R: Rank> StageMask<R> {
     }
 
     /// Bundles an additional stage window into this mask, occupying the
-    /// same registry slot as the original. Caller must ensure the
-    /// bundled stages occupy disjoint gate windows.
+    /// same registry slot as the original. Panics if the new window
+    /// overlaps any existing notch — disjointness is required for the
+    /// bundled bonding identity to remain sound.
     pub fn with_notch(mut self, skip_gates: usize, num_gates: usize) -> Result<Self> {
         Self::check_notch(skip_gates, num_gates)?;
+        if num_gates > 0 {
+            let new_end = skip_gates + num_gates;
+            for &(s, n) in &self.notches {
+                if n == 0 {
+                    continue;
+                }
+                let existing_end = s + n;
+                let disjoint = new_end <= s || existing_end <= skip_gates;
+                assert!(
+                    disjoint,
+                    "notch ({skip_gates}, {num_gates}) overlaps existing notch ({s}, {n})",
+                );
+            }
+        }
         self.notches.push((skip_gates, num_gates));
         Ok(self)
     }
@@ -595,6 +610,16 @@ mod tests {
             "root segment must have at least 1 constraint (ONE), got {}",
             floor_plan[0].num_constraints,
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "overlaps existing notch")]
+    fn test_with_notch_rejects_overlap() {
+        // Two notches sharing gate 10 must panic.
+        let _ = StageMask::<R>::new(1, 15)
+            .unwrap()
+            .with_notch(10, 5)
+            .unwrap();
     }
 
     #[test]

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -283,6 +283,58 @@ impl<F: Field, R: Rank> WiringObject<F, R> for StageMask<R> {
     }
 }
 
+/// Structural well-formedness check for a stage rx: every nonzero
+/// coefficient must live on the `a` or `d` wires at gate `0` (SYSTEM)
+/// or within `[skip_gates, skip_gates + num_gates)`.
+///
+/// The bundled bonding identity `revdot(rx_i, s_bundle) = 0` no longer
+/// enforces this locally — `s_bundle` is zero on the union of all
+/// bundled stages' windows, so a coefficient planted inside another
+/// stage's window slips through. Called per rx with its own window,
+/// this primitive rejects such plants structurally.
+///
+/// Wire/gate map (trace perspective, `n = R::n()`):
+///
+/// - `c[g]` -> degree `g`           (range `[0, n)`)
+/// - `a[g]` -> degree `2n - 1 - g`  (range `[n, 2n)`)
+/// - `b[g]` -> degree `2n + g`      (range `[2n, 3n)`)
+/// - `d[g]` -> degree `4n - 1 - g`  (range `[3n, 4n)`)
+///
+/// `b` and `c` are rejected wholesale (the honest Standard-allocator
+/// layout is `(a, 0, 0, d)` per gate).
+pub fn verify_stage_support<F: Field, R: Rank>(
+    rx: &sparse::Polynomial<F, R>,
+    skip_gates: usize,
+    num_gates: usize,
+) -> bool {
+    let n = R::n();
+    let stage_end = skip_gates + num_gates;
+    let gate_allowed =
+        |gate: usize| gate == 0 || (gate >= skip_gates && gate < stage_end);
+
+    for (degree, _coeff) in rx.iter_nonzero() {
+        let wire_ok = if degree < n {
+            // c-wire: must be zero everywhere under Standard layout.
+            false
+        } else if degree < 2 * n {
+            // a-wire: gate = 2n - 1 - degree.
+            gate_allowed(2 * n - 1 - degree)
+        } else if degree < 3 * n {
+            // b-wire: must be zero everywhere under Standard layout.
+            false
+        } else {
+            // d-wire: gate = 4n - 1 - degree.
+            gate_allowed(4 * n - 1 - degree)
+        };
+
+        if !wire_ok {
+            return false;
+        }
+    }
+
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use core::marker::PhantomData;
@@ -644,6 +696,168 @@ mod tests {
             rx.revdot(&full_sy),
             Fp::ZERO,
             "bundled mask should reject rx with planted entry outside notch union",
+        );
+    }
+
+    /// Demonstrates the soundness gap flagged in PR #688 review (alxiong):
+    /// the bundled mask `s_global - notch_1 - notch_2` zeros out **both**
+    /// stage windows, so a malformed `rx_1` carrying a nonzero coefficient
+    /// inside stage 2's notch slips through `revdot(rx_1, bundled_sy) = 0`.
+    /// The original per-stage check `revdot(rx_1, stage1_sy) = 0` catches
+    /// the same entry because `s_1 = s_global - notch_1` is nonzero on
+    /// stage 2's region.
+    ///
+    /// This test asserts the failure mode is real: the bundled check
+    /// accepts a malformed rx that the per-stage check would reject. It
+    /// passes only as long as the gap exists.
+    #[test]
+    fn test_bundled_mask_misses_cross_stage_planted_rx() {
+        // Stage 1: gates 1..101. Stage 2: gates 200..300. Disjoint.
+        const STAGE1_SKIP: usize = 1;
+        const STAGE1_NUM: usize = 100;
+        const STAGE2_SKIP: usize = 200;
+        const STAGE2_NUM: usize = 100;
+
+        let stage1_mask = StageMask::<R>::new(STAGE1_SKIP, STAGE1_NUM).unwrap();
+        let bundled_mask = StageMask::<R>::new(STAGE1_SKIP, STAGE1_NUM)
+            .unwrap()
+            .with_notch(STAGE2_SKIP, STAGE2_NUM)
+            .unwrap();
+
+        let y = Fp::random(&mut rand::rng());
+
+        // Plant a nonzero on the a-wire of gate 250 — INSIDE stage 2's
+        // notch [200, 300) and OUTSIDE stage 1's notch [1, 101).
+        const PLANTED_GATE: usize = 250;
+        assert!(PLANTED_GATE >= STAGE2_SKIP && PLANTED_GATE < STAGE2_SKIP + STAGE2_NUM);
+        assert!(PLANTED_GATE < STAGE1_SKIP || PLANTED_GATE >= STAGE1_SKIP + STAGE1_NUM);
+
+        let n = R::n();
+        let mut coeffs = alloc::vec![Fp::ZERO; R::num_coeffs()];
+        // Trace perspective: a-wire at gate j is at coefficient index 2n - 1 - j.
+        coeffs[2 * n - 1 - PLANTED_GATE] = Fp::from(0xDEADBEEFu64);
+        let malicious_rx_1 = sparse::Polynomial::<Fp, R>::from_coeffs(coeffs);
+
+        // Bundled bonding check: notch_2 zeros s_global on gate 250, so the
+        // planted entry contributes nothing. The malformed rx_1 passes.
+        let mut bundled_sy = super::global_project::<Fp, R>(y);
+        bundled_sy += &bundled_mask.notch_project(y);
+        let bundled_check = malicious_rx_1.revdot(&bundled_sy);
+        assert_eq!(
+            bundled_check,
+            Fp::ZERO,
+            "soundness gap: bundled mask is zero on stage 2's region, so a planted \
+             entry of rx_1 inside stage 2 is invisible to the bundled bonding check",
+        );
+
+        // Per-stage bonding check: stage 1's mask is nonzero on stage 2's
+        // region (notch_1 doesn't reach there), so the same entry is visible
+        // and the check rejects.
+        let mut stage1_sy = super::global_project::<Fp, R>(y);
+        stage1_sy += &stage1_mask.notch_project(y);
+        let stage1_check = malicious_rx_1.revdot(&stage1_sy);
+        assert_ne!(
+            stage1_check,
+            Fp::ZERO,
+            "the original per-stage check rejects the malformed rx_1 — bundling lost \
+             a constraint that the separate-mask protocol enforced",
+        );
+    }
+
+    /// `verify_stage_support` closes the gap from
+    /// [`test_bundled_mask_misses_cross_stage_planted_rx`]: the same
+    /// planted rx that slips past the bundled bonding revdot is rejected
+    /// structurally because gate 250 lies outside stage 1's own window
+    /// `[1, 101)`.
+    #[test]
+    fn test_verify_stage_support_rejects_cross_stage_plant() {
+        const STAGE1_SKIP: usize = 1;
+        const STAGE1_NUM: usize = 100;
+        const PLANTED_GATE: usize = 250;
+
+        let n = R::n();
+        let mut coeffs = alloc::vec![Fp::ZERO; R::num_coeffs()];
+        coeffs[2 * n - 1 - PLANTED_GATE] = Fp::from(0xDEADBEEFu64);
+        let malicious_rx = sparse::Polynomial::<Fp, R>::from_coeffs(coeffs);
+
+        assert!(
+            !super::verify_stage_support(&malicious_rx, STAGE1_SKIP, STAGE1_NUM),
+            "support check must reject a planted entry outside stage 1's own window",
+        );
+    }
+
+    /// An honest rx that places witnesses only on `a`/`d` wires at
+    /// gate `0` and within `[skip, skip + num)` must be accepted.
+    #[test]
+    fn test_verify_stage_support_accepts_honest_layout() {
+        const SKIP: usize = 10;
+        const NUM: usize = 50;
+
+        let n = R::n();
+        let mut coeffs = alloc::vec![Fp::ZERO; R::num_coeffs()];
+
+        // SYSTEM gate: a[0] = alpha (nonzero), d[0] = 1.
+        coeffs[2 * n - 1 - 0] = Fp::from(7u64); // a[0]
+        coeffs[4 * n - 1 - 0] = Fp::ONE; // d[0]
+
+        // Active window: a[g] and d[g] for g in [10, 60).
+        for g in SKIP..SKIP + NUM {
+            coeffs[2 * n - 1 - g] = Fp::from(g as u64 + 1);
+            coeffs[4 * n - 1 - g] = Fp::from(g as u64 + 100);
+        }
+
+        let honest_rx = sparse::Polynomial::<Fp, R>::from_coeffs(coeffs);
+
+        assert!(
+            super::verify_stage_support(&honest_rx, SKIP, NUM),
+            "support check must accept an honest (a, 0, 0, d) layout",
+        );
+    }
+
+    /// Stress all four wire / window-position combinations.
+    #[test]
+    fn test_verify_stage_support_rejects_b_and_c_wires() {
+        const SKIP: usize = 5;
+        const NUM: usize = 20;
+        const G_INSIDE: usize = 10;
+        const G_OUTSIDE: usize = 100;
+
+        let n = R::n();
+
+        // c-wire inside window — still rejected (Standard layout forbids c).
+        let mut coeffs = alloc::vec![Fp::ZERO; R::num_coeffs()];
+        coeffs[G_INSIDE] = Fp::ONE;
+        let rx = sparse::Polynomial::<Fp, R>::from_coeffs(coeffs);
+        assert!(
+            !super::verify_stage_support(&rx, SKIP, NUM),
+            "c-wire (inside window) must be rejected",
+        );
+
+        // b-wire inside window — still rejected.
+        let mut coeffs = alloc::vec![Fp::ZERO; R::num_coeffs()];
+        coeffs[2 * n + G_INSIDE] = Fp::ONE;
+        let rx = sparse::Polynomial::<Fp, R>::from_coeffs(coeffs);
+        assert!(
+            !super::verify_stage_support(&rx, SKIP, NUM),
+            "b-wire (inside window) must be rejected",
+        );
+
+        // a-wire outside window — rejected.
+        let mut coeffs = alloc::vec![Fp::ZERO; R::num_coeffs()];
+        coeffs[2 * n - 1 - G_OUTSIDE] = Fp::ONE;
+        let rx = sparse::Polynomial::<Fp, R>::from_coeffs(coeffs);
+        assert!(
+            !super::verify_stage_support(&rx, SKIP, NUM),
+            "a-wire (outside window) must be rejected",
+        );
+
+        // d-wire outside window — rejected.
+        let mut coeffs = alloc::vec![Fp::ZERO; R::num_coeffs()];
+        coeffs[4 * n - 1 - G_OUTSIDE] = Fp::ONE;
+        let rx = sparse::Polynomial::<Fp, R>::from_coeffs(coeffs);
+        assert!(
+            !super::verify_stage_support(&rx, SKIP, NUM),
+            "d-wire (outside window) must be rejected",
         );
     }
 

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -309,8 +309,7 @@ pub fn verify_stage_support<F: Field, R: Rank>(
 ) -> bool {
     let n = R::n();
     let stage_end = skip_gates + num_gates;
-    let gate_allowed =
-        |gate: usize| gate == 0 || (gate >= skip_gates && gate < stage_end);
+    let gate_allowed = |gate: usize| gate == 0 || (gate >= skip_gates && gate < stage_end);
 
     for (degree, _coeff) in rx.iter_nonzero() {
         let wire_ok = if degree < n {
@@ -729,8 +728,10 @@ mod tests {
         // Plant a nonzero on the a-wire of gate 250 — INSIDE stage 2's
         // notch [200, 300) and OUTSIDE stage 1's notch [1, 101).
         const PLANTED_GATE: usize = 250;
-        assert!(PLANTED_GATE >= STAGE2_SKIP && PLANTED_GATE < STAGE2_SKIP + STAGE2_NUM);
-        assert!(PLANTED_GATE < STAGE1_SKIP || PLANTED_GATE >= STAGE1_SKIP + STAGE1_NUM);
+        const _: () =
+            assert!(PLANTED_GATE >= STAGE2_SKIP && PLANTED_GATE < STAGE2_SKIP + STAGE2_NUM);
+        const _: () =
+            assert!(PLANTED_GATE < STAGE1_SKIP || PLANTED_GATE >= STAGE1_SKIP + STAGE1_NUM);
 
         let n = R::n();
         let mut coeffs = alloc::vec![Fp::ZERO; R::num_coeffs()];
@@ -797,8 +798,8 @@ mod tests {
         let mut coeffs = alloc::vec![Fp::ZERO; R::num_coeffs()];
 
         // SYSTEM gate: a[0] = alpha (nonzero), d[0] = 1.
-        coeffs[2 * n - 1 - 0] = Fp::from(7u64); // a[0]
-        coeffs[4 * n - 1 - 0] = Fp::ONE; // d[0]
+        coeffs[2 * n - 1] = Fp::from(7u64); // a[0]
+        coeffs[4 * n - 1] = Fp::ONE; // d[0]
 
         // Active window: a[g] and d[g] for g in [10, 60).
         for g in SKIP..SKIP + NUM {

--- a/crates/ragu_circuits/src/staging/mod.rs
+++ b/crates/ragu_circuits/src/staging/mod.rs
@@ -440,6 +440,13 @@ impl<F: Field, R: Rank, S: Stage<F, R>> StageExt<F, R> for S {}
 /// corresponds to one bundled stage; the resulting polynomial is the sum
 /// of the per-stage notches plus the shared global term added once by the
 /// [`Registry`](crate::registry::Registry).
+///
+/// Soundness depends on stage rxs living only in the `(a, 0, 0, d)` wire
+/// pattern — currently provided by
+/// [`Standard`](ragu_primitives::allocator::Standard). Cross-stage
+/// `revdot(rx_i, mask_j)` terms vanish for `i != j` only when rxs are
+/// zero in the `b` and `c` blocks; an allocator that placed data there
+/// would silently break this bundling identity.
 pub fn bundle_stage_masks<'a, F: Field, R: Rank>(
     notches: impl IntoIterator<Item = (usize, usize)>,
 ) -> Result<BondingObject<'a, F, R>> {

--- a/crates/ragu_circuits/src/staging/mod.rs
+++ b/crates/ragu_circuits/src/staging/mod.rs
@@ -443,7 +443,7 @@ impl<F: Field, R: Rank, S: Stage<F, R>> StageExt<F, R> for S {}
 ///
 /// Soundness depends on stage rxs living only in the `(a, 0, 0, d)` wire
 /// pattern — currently provided by
-/// [`Standard`](ragu_primitives::allocator::Standard). Cross-stage
+/// [`ragu_primitives::allocator::Standard`]. Cross-stage
 /// `revdot(rx_i, mask_j)` terms vanish for `i != j` only when rxs are
 /// zero in the `b` and `c` blocks; an allocator that placed data there
 /// would silently break this bundling identity.

--- a/crates/ragu_circuits/src/staging/mod.rs
+++ b/crates/ragu_circuits/src/staging/mod.rs
@@ -447,11 +447,12 @@ impl<F: Field, R: Rank, S: Stage<F, R>> StageExt<F, R> for S {}
 /// `revdot(rx_i, mask_j)` terms vanish for `i != j` only when rxs are
 /// zero in the `b` and `c` blocks; an allocator that placed data there
 /// would silently break this bundling identity.
-pub fn bundle_stage_masks<'a, F: Field, R: Rank>(
-    notches: impl IntoIterator<Item = (usize, usize)>,
+pub fn bundle_stage_masks<'a, F: Field, R: Rank, const N: usize>(
+    notches: [(usize, usize); N],
 ) -> Result<BondingObject<'a, F, R>> {
+    const { assert!(N > 0, "bundle_stage_masks requires at least one notch") };
     let mut iter = notches.into_iter();
-    let (skip, num) = iter.next().expect("at least one notch is required");
+    let (skip, num) = iter.next().expect("N > 0 by const assertion");
     let mut mask = mask::StageMask::<R>::new(skip, num)?;
     for (skip, num) in iter {
         mask = mask.with_notch(skip, num)?;

--- a/crates/ragu_circuits/src/staging/mod.rs
+++ b/crates/ragu_circuits/src/staging/mod.rs
@@ -434,3 +434,20 @@ pub trait StageExt<F: Field, R: Rank>: Stage<F, R> {
 }
 
 impl<F: Field, R: Rank, S: Stage<F, R>> StageExt<F, R> for S {}
+
+/// Bundles multiple stage windows into a single bonding polynomial that
+/// occupies one registry slot. Each `(skip_gates, num_gates)` entry
+/// corresponds to one bundled stage; the resulting polynomial is the sum
+/// of the per-stage notches plus the shared global term added once by the
+/// [`Registry`](crate::registry::Registry).
+pub fn bundle_stage_masks<'a, F: Field, R: Rank>(
+    notches: impl IntoIterator<Item = (usize, usize)>,
+) -> Result<BondingObject<'a, F, R>> {
+    let mut iter = notches.into_iter();
+    let (skip, num) = iter.next().expect("at least one notch is required");
+    let mut mask = mask::StageMask::<R>::new(skip, num)?;
+    for (skip, num) in iter {
+        mask = mask.with_notch(skip, num)?;
+    }
+    Ok(BondingObject::new(Box::new(mask)))
+}

--- a/crates/ragu_circuits/src/staging/mod.rs
+++ b/crates/ragu_circuits/src/staging/mod.rs
@@ -123,8 +123,8 @@ mod rx_driver;
 use alloc::boxed::Box;
 
 pub use builder::{StageBuilder, StageGuard};
-pub use mask::verify_stage_support;
 use ff::Field;
+pub use mask::verify_stage_support;
 use ragu_arithmetic::Coeff;
 use ragu_core::{
     Result,

--- a/crates/ragu_circuits/src/staging/mod.rs
+++ b/crates/ragu_circuits/src/staging/mod.rs
@@ -123,6 +123,7 @@ mod rx_driver;
 use alloc::boxed::Box;
 
 pub use builder::{StageBuilder, StageGuard};
+pub use mask::verify_stage_support;
 use ff::Field;
 use ragu_arithmetic::Coeff;
 use ragu_core::{

--- a/crates/ragu_pcd/src/internal/native/claims.rs
+++ b/crates/ragu_pcd/src/internal/native/claims.rs
@@ -221,17 +221,19 @@ where
             PreambleStage => {
                 processor.bonding_claim(id, source.rx(Rx(Preamble)))?;
             }
-            InnerErrorStage => {
-                processor.bonding_claim(id, source.rx(Rx(InnerError)))?;
+            OuterInnerErrorGroup => {
+                let groups = source
+                    .rx(Rx(OuterError))
+                    .zip(source.rx(Rx(InnerError)))
+                    .map(|(oe, ie)| [oe, ie].into_iter());
+                processor.grouped_bonding_claim(id, groups)?;
             }
-            OuterErrorStage => {
-                processor.bonding_claim(id, source.rx(Rx(OuterError)))?;
-            }
-            QueryStage => {
-                processor.bonding_claim(id, source.rx(Rx(Query)))?;
-            }
-            EvalStage => {
-                processor.bonding_claim(id, source.rx(Rx(Eval)))?;
+            QueryEvalGroup => {
+                let groups = source
+                    .rx(Rx(Query))
+                    .zip(source.rx(Rx(Eval)))
+                    .map(|(q, e)| [q, e].into_iter());
+                processor.grouped_bonding_claim(id, groups)?;
             }
 
             // Final stage bonding claims

--- a/crates/ragu_pcd/src/internal/native/mod.rs
+++ b/crates/ragu_pcd/src/internal/native/mod.rs
@@ -4,7 +4,7 @@ use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::Rank,
     registry::{CircuitIndex, RegistryBuilder},
-    staging::StageExt,
+    staging::{Stage, StageExt, bundle_stage_masks},
 };
 use ragu_core::Result;
 use ragu_primitives::vec::ConstLen;
@@ -16,7 +16,7 @@ use crate::{internal::fold_revdot::Parameters, step};
 pub struct RevdotParameters;
 
 impl Parameters for RevdotParameters {
-    type NumGroups = ConstLen<19>;
+    type NumGroups = ConstLen<16>;
     type GroupSize = ConstLen<7>;
 }
 
@@ -49,10 +49,8 @@ pub enum InternalCircuitIndex {
     ComputeVCircuit,
     // Native stages
     PreambleStage,
-    InnerErrorStage,
-    OuterErrorStage,
-    QueryStage,
-    EvalStage,
+    OuterInnerErrorGroup,
+    QueryEvalGroup,
     // Final stage masks
     InnerErrorFinalStaged,
     OuterErrorFinalStaged,
@@ -71,7 +69,7 @@ pub const fn total_circuit_counts(num_application_steps: usize) -> (usize, u32) 
 impl InternalCircuitIndex {
     /// The number of internal circuits registered by [`register_all`],
     /// equal to the number of variants in [`InternalCircuitIndex`].
-    pub const NUM: usize = 13;
+    pub const NUM: usize = 11;
 
     /// All variants in canonical iteration order.
     ///
@@ -92,10 +90,8 @@ impl InternalCircuitIndex {
         push(&mut slots, &mut c, Self::OuterCollapseCircuit);
         push(&mut slots, &mut c, Self::ComputeVCircuit);
         push(&mut slots, &mut c, Self::PreambleStage);
-        push(&mut slots, &mut c, Self::InnerErrorStage);
-        push(&mut slots, &mut c, Self::OuterErrorStage);
-        push(&mut slots, &mut c, Self::QueryStage);
-        push(&mut slots, &mut c, Self::EvalStage);
+        push(&mut slots, &mut c, Self::OuterInnerErrorGroup);
+        push(&mut slots, &mut c, Self::QueryEvalGroup);
         push(&mut slots, &mut c, Self::InnerErrorFinalStaged);
         push(&mut slots, &mut c, Self::OuterErrorFinalStaged);
         push(&mut slots, &mut c, Self::EvalFinalStaged);
@@ -126,10 +122,8 @@ pub struct InternalCircuitValues<T> {
     pub outer_collapse_circuit: T,
     pub compute_v_circuit: T,
     pub preamble_stage: T,
-    pub inner_error_stage: T,
-    pub outer_error_stage: T,
-    pub query_stage: T,
-    pub eval_stage: T,
+    pub outer_inner_error_group: T,
+    pub query_eval_group: T,
     pub inner_error_final_staged: T,
     pub outer_error_final_staged: T,
     pub eval_final_staged: T,
@@ -146,10 +140,8 @@ impl<T> InternalCircuitValues<T> {
             OuterCollapseCircuit => &self.outer_collapse_circuit,
             ComputeVCircuit => &self.compute_v_circuit,
             PreambleStage => &self.preamble_stage,
-            InnerErrorStage => &self.inner_error_stage,
-            OuterErrorStage => &self.outer_error_stage,
-            QueryStage => &self.query_stage,
-            EvalStage => &self.eval_stage,
+            OuterInnerErrorGroup => &self.outer_inner_error_group,
+            QueryEvalGroup => &self.query_eval_group,
             InnerErrorFinalStaged => &self.inner_error_final_staged,
             OuterErrorFinalStaged => &self.outer_error_final_staged,
             EvalFinalStaged => &self.eval_final_staged,
@@ -179,10 +171,8 @@ impl<T> InternalCircuitValues<T> {
             outer_collapse_circuit: f(OuterCollapseCircuit)?,
             compute_v_circuit: f(ComputeVCircuit)?,
             preamble_stage: f(PreambleStage)?,
-            inner_error_stage: f(InnerErrorStage)?,
-            outer_error_stage: f(OuterErrorStage)?,
-            query_stage: f(QueryStage)?,
-            eval_stage: f(EvalStage)?,
+            outer_inner_error_group: f(OuterInnerErrorGroup)?,
+            query_eval_group: f(QueryEvalGroup)?,
             inner_error_final_staged: f(InnerErrorFinalStaged)?,
             outer_error_final_staged: f(OuterErrorFinalStaged)?,
             eval_final_staged: f(EvalFinalStaged)?,
@@ -339,23 +329,35 @@ pub fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>(
             PreambleStage => {
                 registry.register_bonding(stages::preamble::Stage::<C, R, HEADER_SIZE>::mask()?)
             }
-            InnerErrorStage => registry.register_bonding(stages::inner_error::Stage::<
-                C,
-                R,
-                HEADER_SIZE,
-                RevdotParameters,
-            >::mask()?),
-            OuterErrorStage => registry.register_bonding(stages::outer_error::Stage::<
-                C,
-                R,
-                HEADER_SIZE,
-                RevdotParameters,
-            >::mask()?),
-            QueryStage => {
-                registry.register_bonding(stages::query::Stage::<C, R, HEADER_SIZE>::mask()?)
+            OuterInnerErrorGroup => {
+                type OE<C, R, const H: usize> = stages::outer_error::Stage<C, R, H, RevdotParameters>;
+                type IE<C, R, const H: usize> = stages::inner_error::Stage<C, R, H, RevdotParameters>;
+                let notches = [
+                    (
+                        <OE<C, R, HEADER_SIZE>>::skip_gates(),
+                        <OE<C, R, HEADER_SIZE> as StageExt<_, _>>::num_gates(),
+                    ),
+                    (
+                        <IE<C, R, HEADER_SIZE>>::skip_gates(),
+                        <IE<C, R, HEADER_SIZE> as StageExt<_, _>>::num_gates(),
+                    ),
+                ];
+                registry.register_bonding(bundle_stage_masks::<C::CircuitField, R>(notches)?)
             }
-            EvalStage => {
-                registry.register_bonding(stages::eval::Stage::<C, R, HEADER_SIZE>::mask()?)
+            QueryEvalGroup => {
+                type Q<C, R, const H: usize> = stages::query::Stage<C, R, H>;
+                type Ev<C, R, const H: usize> = stages::eval::Stage<C, R, H>;
+                let notches = [
+                    (
+                        <Q<C, R, HEADER_SIZE>>::skip_gates(),
+                        <Q<C, R, HEADER_SIZE> as StageExt<_, _>>::num_gates(),
+                    ),
+                    (
+                        <Ev<C, R, HEADER_SIZE>>::skip_gates(),
+                        <Ev<C, R, HEADER_SIZE> as StageExt<_, _>>::num_gates(),
+                    ),
+                ];
+                registry.register_bonding(bundle_stage_masks::<C::CircuitField, R>(notches)?)
             }
             InnerErrorFinalStaged => registry.register_bonding(stages::inner_error::Stage::<
                 C,

--- a/crates/ragu_pcd/src/internal/native/mod.rs
+++ b/crates/ragu_pcd/src/internal/native/mod.rs
@@ -330,8 +330,10 @@ pub fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>(
                 registry.register_bonding(stages::preamble::Stage::<C, R, HEADER_SIZE>::mask()?)
             }
             OuterInnerErrorGroup => {
-                type OE<C, R, const H: usize> = stages::outer_error::Stage<C, R, H, RevdotParameters>;
-                type IE<C, R, const H: usize> = stages::inner_error::Stage<C, R, H, RevdotParameters>;
+                type OE<C, R, const H: usize> =
+                    stages::outer_error::Stage<C, R, H, RevdotParameters>;
+                type IE<C, R, const H: usize> =
+                    stages::inner_error::Stage<C, R, H, RevdotParameters>;
                 let notches = [
                     (
                         <OE<C, R, HEADER_SIZE>>::skip_gates(),

--- a/crates/ragu_pcd/src/internal/native/mod.rs
+++ b/crates/ragu_pcd/src/internal/native/mod.rs
@@ -344,7 +344,7 @@ pub fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>(
                         <IE<C, R, HEADER_SIZE> as StageExt<_, _>>::num_gates(),
                     ),
                 ];
-                registry.register_bonding(bundle_stage_masks::<C::CircuitField, R>(notches)?)
+                registry.register_bonding(bundle_stage_masks::<C::CircuitField, R, _>(notches)?)
             }
             QueryEvalGroup => {
                 type Q<C, R, const H: usize> = stages::query::Stage<C, R, H>;
@@ -359,7 +359,7 @@ pub fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>(
                         <Ev<C, R, HEADER_SIZE> as StageExt<_, _>>::num_gates(),
                     ),
                 ];
-                registry.register_bonding(bundle_stage_masks::<C::CircuitField, R>(notches)?)
+                registry.register_bonding(bundle_stage_masks::<C::CircuitField, R, _>(notches)?)
             }
             InnerErrorFinalStaged => registry.register_bonding(stages::inner_error::Stage::<
                 C,

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -88,11 +88,11 @@ fn test_internal_circuit_constraint_counts() {
         }};
     }
 
-    check_constraints!(Hashes1Circuit,         mul = 2045, lin = 3422);
-    check_constraints!(Hashes2Circuit,         mul = 1879, lin = 2951);
-    check_constraints!(InnerCollapseCircuit,  mul = 1756, lin = 1918);
-    check_constraints!(OuterCollapseCircuit,  mul = 809 , lin = 808);
-    check_constraints!(ComputeVCircuit,        mul = 1135, lin = 1773);
+    check_constraints!(Hashes1Circuit,         mul = 1993, lin = 3422);
+    check_constraints!(Hashes2Circuit,         mul = 1827, lin = 2951);
+    check_constraints!(InnerCollapseCircuit,  mul = 1497, lin = 1627);
+    check_constraints!(OuterCollapseCircuit,  mul = 652 , lin = 598);
+    check_constraints!(ComputeVCircuit,        mul = 1108, lin = 1721);
 }
 
 #[rustfmt::skip]
@@ -106,10 +106,10 @@ fn test_internal_stage_parameters() {
     }
 
     check_stage!(Preamble, skip =   1, num = 225);
-    check_stage!(OuterError,  skip = 226, num = 186);
-    check_stage!(InnerError,  skip = 412, num = 399);
-    check_stage!(Query,   skip = 226, num =  23);
-    check_stage!(Eval,    skip = 249, num =  18);
+    check_stage!(OuterError,  skip = 226, num = 134);
+    check_stage!(InnerError,  skip = 360, num = 336);
+    check_stage!(Query,   skip = 226, num =  22);
+    check_stage!(Eval,    skip = 248, num =  18);
 }
 
 /// Helper test to print current constraint counts in copy-pasteable format.
@@ -197,7 +197,7 @@ fn test_native_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fp!(0x39bb8de1c0aac1d53ccb0895096a7b18c10b2cc248123289edab8ec76a74c05d);
+    let expected = fp!(0x14a321b5bbea68b1062d3aeb87d8ab32a494312b254b34fd7123e80e8578734c);
 
     assert_eq!(
         app.native_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -95,6 +95,45 @@ fn test_internal_circuit_constraint_counts() {
     check_constraints!(ComputeVCircuit,        mul = 1108, lin = 1721);
 }
 
+#[test]
+fn test_nested_internal_circuit_constraint_counts() {
+    use crate::internal::{Side, nested::InternalCircuitIndex as NestedIdx};
+
+    let pasta = Pasta::baked();
+
+    let app = ApplicationBuilder::<Pasta, R, HEADER_SIZE>::new()
+        .register_dummy_circuits(NUM_APP_STEPS)
+        .unwrap()
+        .finalize(pasta)
+        .unwrap();
+
+    let check = |variant: NestedIdx, mul: usize, lin: usize| {
+        let circuit_index = variant.circuit_index();
+        let (actual_gates, actual_constraints) =
+            app.nested_registry.constraint_counts(circuit_index);
+        assert_eq!(actual_gates, mul, "{:?}: gates", variant);
+        assert_eq!(actual_constraints, lin, "{:?}: constraints", variant);
+    };
+
+    // All endoscaling steps share the same shape.
+    for variant in NestedIdx::ALL {
+        if let NestedIdx::EndoscalingStep(_) = variant {
+            check(variant, 1948, 3677);
+        }
+    }
+
+    // Stage masks are capped by the StageMask formula (4n-1 constraints, n gates).
+    // BridgeGroup bundles 8 stages into one slot — this is the headline change in PR #688.
+    check(NestedIdx::EndoscalarStage, 2048, 8191);
+    check(NestedIdx::PointsStage, 2048, 8191);
+    check(NestedIdx::PointsFinalStaged, 2048, 8191);
+    check(NestedIdx::BridgeGroup, 2048, 8191);
+
+    check(NestedIdx::Loading, 154, 76);
+    check(NestedIdx::Copying(Side::Left), 154, 18);
+    check(NestedIdx::Copying(Side::Right), 154, 18);
+}
+
 #[rustfmt::skip]
 #[test]
 fn test_internal_stage_parameters() {
@@ -150,6 +189,35 @@ fn print_internal_circuit_constraint_counts() {
             format!("{},", name),
             mul,
             lin
+        );
+    }
+}
+
+/// Helper test to print current nested constraint counts in copy-pasteable format.
+/// Run with: `cargo test -p ragu_pcd --release print_nested_internal_circuit -- --nocapture`
+#[test]
+fn print_nested_internal_circuit_constraint_counts() {
+    use alloc::format;
+    use std::println;
+
+    use crate::internal::nested::InternalCircuitIndex as NestedIdx;
+
+    let pasta = Pasta::baked();
+
+    let app = ApplicationBuilder::<Pasta, R, HEADER_SIZE>::new()
+        .register_dummy_circuits(NUM_APP_STEPS)
+        .unwrap()
+        .finalize(pasta)
+        .unwrap();
+
+    println!("\n// Copy-paste the following into test_nested_internal_circuit_constraint_counts:");
+    for variant in NestedIdx::ALL {
+        let circuit_index = variant.circuit_index();
+        let (mul, lin) = app.nested_registry.constraint_counts(circuit_index);
+        let label = format!("NestedIdx::{:?},", variant);
+        println!(
+            "    check_constraints!({:<36} mul = {:<5}, lin = {});",
+            label, mul, lin
         );
     }
 }

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -123,11 +123,17 @@ fn test_nested_internal_circuit_constraint_counts() {
     }
 
     // Stage masks are capped by the StageMask formula (4n-1 constraints, n gates).
-    // BridgeGroup bundles 8 stages into one slot — this is the headline change in PR #688.
     check(NestedIdx::EndoscalarStage, 2048, 8191);
     check(NestedIdx::PointsStage, 2048, 8191);
     check(NestedIdx::PointsFinalStaged, 2048, 8191);
-    check(NestedIdx::BridgeGroup, 2048, 8191);
+    check(NestedIdx::BridgePreamble, 2048, 8191);
+    check(NestedIdx::BridgeSPrime, 2048, 8191);
+    check(NestedIdx::BridgeInnerError, 2048, 8191);
+    check(NestedIdx::BridgeOuterError, 2048, 8191);
+    check(NestedIdx::BridgeAB, 2048, 8191);
+    check(NestedIdx::BridgeQuery, 2048, 8191);
+    check(NestedIdx::BridgeF, 2048, 8191);
+    check(NestedIdx::BridgeEval, 2048, 8191);
 
     check(NestedIdx::Loading, 154, 76);
     check(NestedIdx::Copying(Side::Left), 154, 18);

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -64,6 +64,13 @@ impl<C: Cycle, R: Rank, H: Header<C::CircuitField>> Pcd<C, R, H> {
         &self.proof
     }
 
+    /// Returns a mutable reference to the recursive proof. Used by tests
+    /// that tamper with proof fields to exercise verifier-side fences.
+    #[cfg(test)]
+    pub(crate) fn proof_mut(&mut self) -> &mut Proof<C, R> {
+        &mut self.proof
+    }
+
     /// Consumes the proof-carrying data and returns the proof and data
     /// separately.
     pub(crate) fn into_parts(self) -> (Proof<C, R>, H::Data) {

--- a/crates/ragu_pcd/src/verify.rs
+++ b/crates/ragu_pcd/src/verify.rs
@@ -37,39 +37,40 @@ use crate::{
 fn verify_native_stage_supports<C: Cycle, R: Rank, const HEADER_SIZE: usize>(
     proof: &Proof<C, R>,
 ) -> bool {
-    let stage_windows: [(RxIndex, usize, usize); 5] = [
-        (
-            RxIndex::Preamble,
-            <stages::preamble::Stage<C, R, HEADER_SIZE>>::skip_gates(),
-            <stages::preamble::Stage<C, R, HEADER_SIZE> as StageExt<_, _>>::num_gates(),
-        ),
-        (
-            RxIndex::OuterError,
-            <stages::outer_error::Stage<C, R, HEADER_SIZE, RevdotParameters>>::skip_gates(),
-            <stages::outer_error::Stage<C, R, HEADER_SIZE, RevdotParameters> as StageExt<
-                _,
-                _,
-            >>::num_gates(),
-        ),
-        (
-            RxIndex::InnerError,
-            <stages::inner_error::Stage<C, R, HEADER_SIZE, RevdotParameters>>::skip_gates(),
-            <stages::inner_error::Stage<C, R, HEADER_SIZE, RevdotParameters> as StageExt<
-                _,
-                _,
-            >>::num_gates(),
-        ),
-        (
-            RxIndex::Query,
-            <stages::query::Stage<C, R, HEADER_SIZE>>::skip_gates(),
-            <stages::query::Stage<C, R, HEADER_SIZE> as StageExt<_, _>>::num_gates(),
-        ),
-        (
-            RxIndex::Eval,
-            <stages::eval::Stage<C, R, HEADER_SIZE>>::skip_gates(),
-            <stages::eval::Stage<C, R, HEADER_SIZE> as StageExt<_, _>>::num_gates(),
-        ),
-    ];
+    let stage_windows: [(RxIndex, usize, usize); 5] =
+        [
+            (
+                RxIndex::Preamble,
+                <stages::preamble::Stage<C, R, HEADER_SIZE>>::skip_gates(),
+                <stages::preamble::Stage<C, R, HEADER_SIZE> as StageExt<_, _>>::num_gates(),
+            ),
+            (
+                RxIndex::OuterError,
+                <stages::outer_error::Stage<C, R, HEADER_SIZE, RevdotParameters>>::skip_gates(),
+                <stages::outer_error::Stage<C, R, HEADER_SIZE, RevdotParameters> as StageExt<
+                    _,
+                    _,
+                >>::num_gates(),
+            ),
+            (
+                RxIndex::InnerError,
+                <stages::inner_error::Stage<C, R, HEADER_SIZE, RevdotParameters>>::skip_gates(),
+                <stages::inner_error::Stage<C, R, HEADER_SIZE, RevdotParameters> as StageExt<
+                    _,
+                    _,
+                >>::num_gates(),
+            ),
+            (
+                RxIndex::Query,
+                <stages::query::Stage<C, R, HEADER_SIZE>>::skip_gates(),
+                <stages::query::Stage<C, R, HEADER_SIZE> as StageExt<_, _>>::num_gates(),
+            ),
+            (
+                RxIndex::Eval,
+                <stages::eval::Stage<C, R, HEADER_SIZE>>::skip_gates(),
+                <stages::eval::Stage<C, R, HEADER_SIZE> as StageExt<_, _>>::num_gates(),
+            ),
+        ];
 
     stage_windows
         .into_iter()
@@ -389,7 +390,7 @@ mod tests {
         // Baseline: an honestly-seeded leaf (trivial step) verifies.
         let (leaf, _) = app.seed(&mut rng, Trivial::new(), ()).unwrap();
         assert!(
-            app.verify(&leaf, &mut StdRng::seed_from_u64(5678)).unwrap(),
+            app.verify(&leaf, StdRng::seed_from_u64(5678)).unwrap(),
             "honestly-seeded trivial leaf must verify",
         );
 
@@ -405,7 +406,7 @@ mod tests {
             sparse::Polynomial::<Fp, TestR>::from_coeffs(coeffs);
 
         let result = app
-            .verify(&tampered, &mut StdRng::seed_from_u64(5678))
+            .verify(&tampered, StdRng::seed_from_u64(5678))
             .expect("verify should not error");
         assert!(
             !result,

--- a/crates/ragu_pcd/src/verify.rs
+++ b/crates/ragu_pcd/src/verify.rs
@@ -7,6 +7,7 @@ use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::{Rank, sparse},
     registry::CircuitIndex,
+    staging::{Stage, StageExt, verify_stage_support},
 };
 use ragu_core::{Result, drivers::emulator::Emulator, maybe::Maybe};
 use ragu_primitives::Element;
@@ -17,10 +18,63 @@ use crate::{
     header::Header,
     internal::{
         claims,
-        native::{claims as native_claims, stages::preamble::ProofInputs},
+        native::{
+            RevdotParameters, RxIndex, claims as native_claims, stages,
+            stages::preamble::ProofInputs,
+        },
         nested::claims as nested_claims,
     },
 };
+
+/// Per-rx structural well-formedness check for every native stage in the proof.
+///
+/// Each stage rx is pinned to its own gate window: nonzero coefficients must
+/// live on the `(a, d)` wires at gate `0` (SYSTEM) or within
+/// `[skip, skip + num)` for that stage. Rxs that place coefficients outside
+/// their stage's own window are rejected.
+///
+/// Returns `true` if every native stage rx is admissible.
+fn verify_native_stage_supports<C: Cycle, R: Rank, const HEADER_SIZE: usize>(
+    proof: &Proof<C, R>,
+) -> bool {
+    let stage_windows: [(RxIndex, usize, usize); 5] = [
+        (
+            RxIndex::Preamble,
+            <stages::preamble::Stage<C, R, HEADER_SIZE>>::skip_gates(),
+            <stages::preamble::Stage<C, R, HEADER_SIZE> as StageExt<_, _>>::num_gates(),
+        ),
+        (
+            RxIndex::OuterError,
+            <stages::outer_error::Stage<C, R, HEADER_SIZE, RevdotParameters>>::skip_gates(),
+            <stages::outer_error::Stage<C, R, HEADER_SIZE, RevdotParameters> as StageExt<
+                _,
+                _,
+            >>::num_gates(),
+        ),
+        (
+            RxIndex::InnerError,
+            <stages::inner_error::Stage<C, R, HEADER_SIZE, RevdotParameters>>::skip_gates(),
+            <stages::inner_error::Stage<C, R, HEADER_SIZE, RevdotParameters> as StageExt<
+                _,
+                _,
+            >>::num_gates(),
+        ),
+        (
+            RxIndex::Query,
+            <stages::query::Stage<C, R, HEADER_SIZE>>::skip_gates(),
+            <stages::query::Stage<C, R, HEADER_SIZE> as StageExt<_, _>>::num_gates(),
+        ),
+        (
+            RxIndex::Eval,
+            <stages::eval::Stage<C, R, HEADER_SIZE>>::skip_gates(),
+            <stages::eval::Stage<C, R, HEADER_SIZE> as StageExt<_, _>>::num_gates(),
+        ),
+    ];
+
+    stage_windows
+        .into_iter()
+        .all(|(idx, skip, num)| verify_stage_support(&proof[idx], skip, num))
+}
 
 impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
     /// Verifies some [`Pcd`] for the provided [`Header`].
@@ -54,6 +108,14 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         if pcd.proof().left_header().len() != HEADER_SIZE
             || pcd.proof().right_header().len() != HEADER_SIZE
         {
+            return Ok(false);
+        }
+
+        // Validate per-stage rx well-formedness. The bundled bonding identity
+        // only catches plants outside the union of all bundled stages' windows;
+        // this structural check rejects plants inside another bundled stage's
+        // window that the bundled revdot would miss.
+        if !verify_native_stage_supports::<C, R, HEADER_SIZE>(pcd.proof()) {
             return Ok(false);
         }
 

--- a/crates/ragu_pcd/src/verify.rs
+++ b/crates/ragu_pcd/src/verify.rs
@@ -366,4 +366,50 @@ mod tests {
         let result = app.verify(&pcd, &mut rng).expect("verify should not error");
         assert!(!result, "verify should reject wrong right_header size");
     }
+
+    /// End-to-end check that the per-stage support fence catches a
+    /// malformed stage rx that the bundled bonding revdot would miss.
+    ///
+    /// Plant a nonzero coefficient on `native_outer_error_rx`'s a-wire at
+    /// gate 500. Stage `OuterError`'s own window is `[226, 360)`; stage
+    /// `InnerError`'s window is `[360, 696)`. Gate 500 lies inside
+    /// `InnerError`'s window — i.e. inside the bundled `OuterInnerError`
+    /// union — so the bundled mask is zero there and the bundled revdot
+    /// would not detect the planted entry. The support fence rejects it
+    /// because gate 500 lies outside `OuterError`'s own window.
+    #[test]
+    fn verify_rejects_native_stage_rx_planted_outside_its_window() {
+        use ragu_pasta::Fp;
+
+        use crate::step::internal::trivial::Trivial;
+
+        let app = create_test_app();
+        let mut rng = StdRng::seed_from_u64(1234);
+
+        // Baseline: an honestly-seeded leaf (trivial step) verifies.
+        let (leaf, _) = app.seed(&mut rng, Trivial::new(), ()).unwrap();
+        assert!(
+            app.verify(&leaf, &mut StdRng::seed_from_u64(5678)).unwrap(),
+            "honestly-seeded trivial leaf must verify",
+        );
+
+        // Plant a `0xDEADBEEF` on `native_outer_error_rx`'s a-wire at gate 500.
+        // Gate 500 is inside InnerError's window [360, 696) (the OuterInnerError
+        // bundle's union) and outside OuterError's own window [226, 360).
+        let mut tampered = leaf;
+        let n = <TestR as Rank>::n();
+        const PLANTED_GATE: usize = 500;
+        let mut coeffs = alloc::vec![Fp::ZERO; <TestR as Rank>::num_coeffs()];
+        coeffs[2 * n - 1 - PLANTED_GATE] = Fp::from(0xDEADBEEFu64);
+        tampered.proof_mut().native_outer_error_rx =
+            sparse::Polynomial::<Fp, TestR>::from_coeffs(coeffs);
+
+        let result = app
+            .verify(&tampered, &mut StdRng::seed_from_u64(5678))
+            .expect("verify should not error");
+        assert!(
+            !result,
+            "tampered leaf must be rejected by the per-stage support fence",
+        );
+    }
 }

--- a/crates/ragu_primitives/src/allocator.rs
+++ b/crates/ragu_primitives/src/allocator.rs
@@ -83,6 +83,11 @@ impl<'dr, D: Driver<'dr>> Allocator<'dr, D> for () {
 ///
 /// Dropping a `Standard` with tokens still in the pool is safe:
 /// the driver already assigned $D = 0$ for those gates.
+///
+/// Per-gate this produces the `(a, 0, 0, d)` trace pattern. This
+/// pattern is load-bearing for stage-mask grouping in `ragu_circuits`:
+/// changing it (e.g., placing data in `b` or `c`) would silently
+/// break the bundled bonding-claim identity.
 pub struct Standard<E> {
     pool: Vec<E>,
 }


### PR DESCRIPTION
Closes https://github.com/tachyon-zcash/ragu/issues/185 (the issue was opened prematurely and actual impl diverges, see design decisions in https://github.com/tachyon-zcash/ragu/issues/185#issuecomment-4380341389).

The precondition for this kind of stage mask grouping optimization was "same-direction allocation" [support](https://github.com/tachyon-zcash/ragu/issues/678), which enables an implicit shifting property (a-block and d-block shift in lockstep). We can now group `OuterError / InnerError` and `Query / Eval` stage mask registrations into a single slot separately, along with their associated bonding claims. The side-effect of this slot reshuffling is (1) registry digest changes, and (2) constraint reduction (proportional to the quadratic asymptotics from the `NumGroups` parameter). This only touches the native-side. Fuse savings here are ~5%, with verifier savings ~10%.
