### PR TITLE
chore(circuits): remove ambiguous constraint_counts in favor of metrics

### DIFF
--- a/crates/ragu_circuits/Cargo.toml
+++ b/crates/ragu_circuits/Cargo.toml
@@ -35,6 +35,7 @@ modern-deps = [
 ]
 multicore = ["maybe-rayon/threads", "ragu_arithmetic/multicore", "std"]
 std = []
+test-utils = []
 
 [lib]
 bench = false
@@ -60,6 +61,7 @@ ragu_testing = { path = "../ragu_testing", version = "0.0.0" }
 [[bench]]
 name = "circuits"
 harness = false
+required-features = ["test-utils"]
 
 [[bench]]
 name = "trace_criterion"

--- a/crates/ragu_circuits/benches/circuits.rs
+++ b/crates/ragu_circuits/benches/circuits.rs
@@ -9,7 +9,7 @@ use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     Circuit, CircuitExt,
     polynomials::{ProductionRank, TestRank, sparse},
-    registry::{CircuitIndex, Registry, RegistryBuilder},
+    registry::{Registry, RegistryBuilder},
 };
 use ragu_pasta::{Fp, Pasta};
 use ragu_testing::circuits::{MySimpleCircuit, SquareCircuit};
@@ -77,24 +77,14 @@ fn eval_ky((a, b, y): (Fp, Fp, Fp)) {
 
 #[library_benchmark]
 #[bench::simple(MySimpleCircuit)]
-fn constraint_counts_simple(circuit: impl Circuit<Fp> + 'static) {
-    let registry = RegistryBuilder::<Fp, TestRank>::new()
-        .register_internal_circuit(circuit)
-        .unwrap()
-        .finalize()
-        .unwrap();
-    black_box(registry.constraint_counts(CircuitIndex::new(0)));
+fn metrics_simple(circuit: impl Circuit<Fp> + 'static) {
+    black_box(circuit.metrics()).unwrap();
 }
 
 #[library_benchmark]
 #[benches::multiple( SquareCircuit { times: 2 }, SquareCircuit { times: 10 },)]
-fn constraint_counts_square(circuit: impl Circuit<Fp> + 'static) {
-    let registry = RegistryBuilder::<Fp, TestRank>::new()
-        .register_internal_circuit(circuit)
-        .unwrap()
-        .finalize()
-        .unwrap();
-    black_box(registry.constraint_counts(CircuitIndex::new(0)));
+fn metrics_square(circuit: impl Circuit<Fp> + 'static) {
+    black_box(circuit.metrics()).unwrap();
 }
 
 #[library_benchmark(setup = setup_rng)]
@@ -114,7 +104,7 @@ fn trace_production_rank((circuit, (witness,)): (SquareCircuit, (Fp,))) {
 
 library_benchmark_group!(
     name = circuit_synthesis;
-    benchmarks = constraint_counts_simple, constraint_counts_square, eval_ky, trace_test_rank, trace_production_rank,
+    benchmarks = metrics_simple, metrics_square, eval_ky, trace_test_rank, trace_production_rank,
 );
 
 #[library_benchmark]

--- a/crates/ragu_circuits/benches/circuits.rs
+++ b/crates/ragu_circuits/benches/circuits.rs
@@ -10,6 +10,7 @@ use ragu_circuits::{
     Circuit, CircuitExt,
     polynomials::{ProductionRank, TestRank, sparse},
     registry::{Registry, RegistryBuilder},
+    testing::synthesis_counts,
 };
 use ragu_pasta::{Fp, Pasta};
 use ragu_testing::circuits::{MySimpleCircuit, SquareCircuit};
@@ -78,13 +79,13 @@ fn eval_ky((a, b, y): (Fp, Fp, Fp)) {
 #[library_benchmark]
 #[bench::simple(MySimpleCircuit)]
 fn metrics_simple(circuit: impl Circuit<Fp> + 'static) {
-    black_box(circuit.metrics()).unwrap();
+    black_box(synthesis_counts(&circuit)).unwrap();
 }
 
 #[library_benchmark]
 #[benches::multiple( SquareCircuit { times: 2 }, SquareCircuit { times: 10 },)]
 fn metrics_square(circuit: impl Circuit<Fp> + 'static) {
-    black_box(circuit.metrics()).unwrap();
+    black_box(synthesis_counts(&circuit)).unwrap();
 }
 
 #[library_benchmark(setup = setup_rng)]

--- a/crates/ragu_circuits/src/lib.rs
+++ b/crates/ragu_circuits/src/lib.rs
@@ -32,7 +32,7 @@ mod trace;
 mod trivial;
 mod wiring;
 
-pub use metrics::{RoutineFingerprint, RoutineIdentity, SegmentRecord};
+pub use metrics::{CircuitMetrics, RoutineFingerprint, RoutineIdentity, SegmentRecord};
 pub use trace::Trace;
 
 #[cfg(test)]
@@ -173,6 +173,18 @@ pub trait CircuitExt<F: Field>: Circuit<F> {
     fn ky(&self, instance: Self::Instance<'_>, y: F) -> Result<F> {
         ky::eval(self, instance, y)
     }
+
+    /// Computes synthesis metrics for this circuit using the same analysis
+    /// driver used during registry compilation.
+    ///
+    /// The returned counts describe raw circuit synthesis, including system
+    /// constraints such as the root `enforce_one` call.
+    fn metrics(&self) -> Result<CircuitMetrics>
+    where
+        F: FromUniformBytes<64>,
+    {
+        metrics::eval(self)
+    }
 }
 
 impl<F: Field, C: Circuit<F>> CircuitExt<F> for C {}
@@ -196,11 +208,6 @@ pub(crate) trait WiringObject<F: Field, R: Rank>: Send + Sync {
     /// Computes the polynomial restriction $s(X, y)$ for some $y \in \mathbb{F}$.
     fn sy(&self, y: F, floor_plan: &[floor_planner::ConstraintSegment])
     -> sparse::Polynomial<F, R>;
-
-    /// Returns constraint counts as `(gates, constraints)`, where gates is
-    /// the number of multiplication gates and constraints is the number of
-    /// [`enforce_zero`](ragu_core::drivers::Driver::enforce_zero) calls.
-    fn constraint_counts(&self) -> (usize, usize);
 
     /// Returns per-segment constraint records in DFS synthesis order.
     ///
@@ -281,9 +288,6 @@ where
         ) -> sparse::Polynomial<F, R> {
             wiring::sy::eval(&self.circuit, y, floor_plan)
                 .expect("should succeed if metrics succeeded")
-        }
-        fn constraint_counts(&self) -> (usize, usize) {
-            (self.metrics.num_gates, self.metrics.num_constraints)
         }
         fn segment_records(&self) -> &[SegmentRecord] {
             &self.metrics.segments

--- a/crates/ragu_circuits/src/lib.rs
+++ b/crates/ragu_circuits/src/lib.rs
@@ -28,11 +28,14 @@ pub mod polynomials;
 mod raw;
 pub mod registry;
 pub mod staging;
+/// Test-only circuit analysis utilities.
+#[cfg(feature = "test-utils")]
+pub mod testing;
 mod trace;
 mod trivial;
 mod wiring;
 
-pub use metrics::{CircuitMetrics, RoutineFingerprint, RoutineIdentity, SegmentRecord};
+pub use metrics::{RoutineFingerprint, RoutineIdentity, SegmentRecord};
 pub use trace::Trace;
 
 #[cfg(test)]
@@ -172,18 +175,6 @@ pub trait CircuitExt<F: Field>: Circuit<F> {
     /// a point $y \in \mathbb{F}$.
     fn ky(&self, instance: Self::Instance<'_>, y: F) -> Result<F> {
         ky::eval(self, instance, y)
-    }
-
-    /// Computes synthesis metrics for this circuit using the same analysis
-    /// driver used during registry compilation.
-    ///
-    /// The returned counts describe raw circuit synthesis, including system
-    /// constraints such as the root `enforce_one` call.
-    fn metrics(&self) -> Result<CircuitMetrics>
-    where
-        F: FromUniformBytes<64>,
-    {
-        metrics::eval(self)
     }
 }
 

--- a/crates/ragu_circuits/src/metrics.rs
+++ b/crates/ragu_circuits/src/metrics.rs
@@ -206,6 +206,26 @@ pub struct CircuitMetrics {
     pub(crate) segments: Vec<SegmentRecord>,
 }
 
+impl CircuitMetrics {
+    /// Returns the total number of multiplication gates synthesized by the
+    /// circuit.
+    pub fn num_gates(&self) -> usize {
+        self.num_gates
+    }
+
+    /// Returns the total number of `enforce_zero` constraints synthesized by
+    /// the circuit, including system constraints such as the root
+    /// `enforce_one` call.
+    pub fn num_constraints(&self) -> usize {
+        self.num_constraints
+    }
+
+    /// Returns per-segment constraint records in DFS synthesis order.
+    pub fn segment_records(&self) -> &[SegmentRecord] {
+        &self.segments
+    }
+}
+
 /// Per-routine state that is saved and restored across routine boundaries.
 ///
 /// Contains both the constraint counting record index and the identity

--- a/crates/ragu_circuits/src/metrics.rs
+++ b/crates/ragu_circuits/src/metrics.rs
@@ -206,26 +206,6 @@ pub struct CircuitMetrics {
     pub(crate) segments: Vec<SegmentRecord>,
 }
 
-impl CircuitMetrics {
-    /// Returns the total number of multiplication gates synthesized by the
-    /// circuit.
-    pub fn num_gates(&self) -> usize {
-        self.num_gates
-    }
-
-    /// Returns the total number of `enforce_zero` constraints synthesized by
-    /// the circuit, including system constraints such as the root
-    /// `enforce_one` call.
-    pub fn num_constraints(&self) -> usize {
-        self.num_constraints
-    }
-
-    /// Returns per-segment constraint records in DFS synthesis order.
-    pub fn segment_records(&self) -> &[SegmentRecord] {
-        &self.segments
-    }
-}
-
 /// Per-routine state that is saved and restored across routine boundaries.
 ///
 /// Contains both the constraint counting record index and the identity

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -394,11 +394,6 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
         self.circuits.len()
     }
 
-    /// Returns the constraint counts for the given circuit.
-    pub fn constraint_counts(&self, circuit: CircuitIndex) -> (usize, usize) {
-        self.circuits[usize::from(circuit)].constraint_counts()
-    }
-
     /// Evaluates the registry key contribution $k \cdot (XY)^{4n-1}$
     /// at $(x, y)$, returning a scalar.
     fn key_sxy(&self, x: F, y: F) -> F {

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -396,11 +396,6 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
         self.circuits.len()
     }
 
-    /// Returns the constraint counts for the given circuit.
-    pub fn constraint_counts(&self, circuit: CircuitIndex) -> (usize, usize) {
-        self.circuits[usize::from(circuit)].constraint_counts()
-    }
-
     /// Evaluates the registry key contribution $k \cdot (XY)^{4n-1}$
     /// at $(x, y)$, returning a scalar.
     fn key_sxy(&self, x: F, y: F) -> F {

--- a/crates/ragu_circuits/src/staging/bonding.rs
+++ b/crates/ragu_circuits/src/staging/bonding.rs
@@ -237,14 +237,6 @@ impl<F: Field, R: Rank> WiringObject<F, R> for Stripped<'_, F, R> {
         poly
     }
 
-    // TODO(#614): revisit constraint_counts semantics — ambiguous with
-    // system constraints (enforce_one, registry key, SYSTEM gate).
-    fn constraint_counts(&self) -> (usize, usize) {
-        let (mul, lin) = self.0.constraint_counts();
-        // The inner object includes the `enforce_one` constraint that we strip.
-        (mul, lin - 1)
-    }
-
     fn segment_records(&self) -> &[SegmentRecord] {
         self.0.segment_records()
     }

--- a/crates/ragu_circuits/src/staging/bonding.rs
+++ b/crates/ragu_circuits/src/staging/bonding.rs
@@ -254,14 +254,6 @@ impl<F: Field, R: Rank> WiringObject<F, R> for Stripped<'_, F, R> {
         poly
     }
 
-    // TODO(#614): revisit constraint_counts semantics — ambiguous with
-    // system constraints (enforce_one, registry key, SYSTEM gate).
-    fn constraint_counts(&self) -> (usize, usize) {
-        let (mul, lin) = self.0.constraint_counts();
-        // The inner object includes the `enforce_one` constraint that we strip.
-        (mul, lin - 1)
-    }
-
     fn segment_records(&self) -> &[SegmentRecord] {
         self.0.segment_records()
     }

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -216,14 +216,6 @@ impl<F: Field, R: Rank> WiringObject<F, R> for StageMask<R> {
         self.notch_project(y)
     }
 
-    fn constraint_counts(&self) -> (usize, usize) {
-        let num_gates = R::n();
-        // 4n-2 enforce_zero (all degrees from 4n-2 to 1, with dummies for
-        // active gates and the SYSTEM gate's inaccessible wires) + 1 enforce_one.
-        let num_constraints = 4 * R::n() - 1;
-        (num_gates, num_constraints)
-    }
-
     fn segment_records(&self) -> &[crate::SegmentRecord] {
         &[]
     }
@@ -740,30 +732,6 @@ mod tests {
             Fp::ZERO,
             "valid witness should produce well-formed stage polynomial"
         );
-    }
-
-    #[test]
-    fn test_constraint_counts_matches_metrics() {
-        for skip in 1..10 {
-            for num in 0..(R::n() - skip) {
-                let stage_mask = StageMask::<R>::new(skip, num).unwrap();
-                let (mul_from_method, linear_from_method) =
-                    <StageMask<R> as WiringObject<Fp, R>>::constraint_counts(&stage_mask);
-
-                let metrics = metrics::eval_raw::<Fp, _>(&stage_mask).unwrap();
-
-                assert_eq!(
-                    mul_from_method, metrics.num_gates,
-                    "gate count mismatch for skip={}, num={}",
-                    skip, num
-                );
-                assert_eq!(
-                    linear_from_method, metrics.num_constraints,
-                    "constraint count mismatch for skip={}, num={}",
-                    skip, num
-                );
-            }
-        }
     }
 
     #[test]

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -215,14 +215,6 @@ impl<F: Field, R: Rank> WiringObject<F, R> for StageMask<R> {
         self.notch_project(y)
     }
 
-    fn constraint_counts(&self) -> (usize, usize) {
-        let num_gates = R::n();
-        // 4n-2 enforce_zero (all degrees from 4n-2 to 1, with dummies for
-        // active gates and the SYSTEM gate's inaccessible wires) + 1 enforce_one.
-        let num_constraints = 4 * R::n() - 1;
-        (num_gates, num_constraints)
-    }
-
     fn segment_records(&self) -> &[crate::SegmentRecord] {
         &[]
     }
@@ -753,30 +745,6 @@ mod tests {
             Fp::ZERO,
             "valid witness should produce well-formed stage polynomial"
         );
-    }
-
-    #[test]
-    fn test_constraint_counts_matches_metrics() {
-        for skip in 1..10 {
-            for num in 0..(R::n() - skip) {
-                let stage_mask = StageMask::<R>::new(skip, num).unwrap();
-                let (mul_from_method, linear_from_method) =
-                    <StageMask<R> as WiringObject<Fp, R>>::constraint_counts(&stage_mask);
-
-                let metrics = metrics::eval_raw::<Fp, _>(&stage_mask).unwrap();
-
-                assert_eq!(
-                    mul_from_method, metrics.num_gates,
-                    "gate count mismatch for skip={}, num={}",
-                    skip, num
-                );
-                assert_eq!(
-                    linear_from_method, metrics.num_constraints,
-                    "constraint count mismatch for skip={}, num={}",
-                    skip, num
-                );
-            }
-        }
     }
 
     #[test]

--- a/crates/ragu_circuits/src/testing.rs
+++ b/crates/ragu_circuits/src/testing.rs
@@ -1,0 +1,28 @@
+//! Test-only circuit analysis utilities.
+
+use ragu_core::Result;
+
+use crate::{Circuit, FromUniformBytes};
+
+/// Raw counts collected by a circuit synthesis analysis pass.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SynthesisCounts {
+    /// The total number of gates, including the reserved SYSTEM gate.
+    pub num_gates: usize,
+    /// The total number of constraints, including public-output constraints
+    /// and the final ONE constraint.
+    pub num_constraints: usize,
+}
+
+/// Runs the production synthesis analysis pass and returns its raw counts.
+pub fn synthesis_counts<F, C>(circuit: &C) -> Result<SynthesisCounts>
+where
+    F: FromUniformBytes<64>,
+    C: Circuit<F>,
+{
+    let metrics = crate::metrics::eval(circuit)?;
+    Ok(SynthesisCounts {
+        num_gates: metrics.num_gates,
+        num_constraints: metrics.num_constraints,
+    })
+}

--- a/crates/ragu_circuits/src/tests/error_swallowing.rs
+++ b/crates/ragu_circuits/src/tests/error_swallowing.rs
@@ -354,11 +354,11 @@ fn test_error_swallowing_is_invisible_to_trace() {
 fn test_error_swallowing_desyncs_trace_and_metrics() {
     let witness = (Fp::from(3u64), Fp::from(7u64));
 
-    let good_obj = into_wiring_object::<_, _, TestRank>(WellBehavedCircuit).unwrap();
-    let bad_obj = into_wiring_object::<_, _, TestRank>(ErrorSwallowingCircuit).unwrap();
+    let good_metrics = crate::metrics::eval(&WellBehavedCircuit).unwrap();
+    let bad_metrics = crate::metrics::eval(&ErrorSwallowingCircuit).unwrap();
 
-    let (good_gates, good_constraints) = good_obj.constraint_counts();
-    let (bad_gates, bad_constraints) = bad_obj.constraint_counts();
+    let (good_gates, good_constraints) = (good_metrics.num_gates, good_metrics.num_constraints);
+    let (bad_gates, bad_constraints) = (bad_metrics.num_gates, bad_metrics.num_constraints);
 
     assert_eq!(
         good_gates + 1,

--- a/crates/ragu_pcd/Cargo.toml
+++ b/crates/ragu_pcd/Cargo.toml
@@ -62,6 +62,7 @@ ff = { workspace = true }
 pasta_curves = { workspace = true }
 rand = { workspace = true }
 criterion = { workspace = true }
+ragu_circuits = { path = "../ragu_circuits", version = "0.0.0", default-features = false, features = ["alloc", "test-utils"] }
 ragu_pasta = { path = "../ragu_pasta", version = "0.0.0", features = ["baked"] }
 gungraun = { workspace = true }
 ragu_testing = { path = "../ragu_testing", version = "0.0.0" }

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -2,7 +2,10 @@ use native::{
     InternalCircuitIndex, InternalCircuitValues, RevdotParameters, RxIndex, RxValues,
     stages::{eval, inner_error, outer_error, preamble, query},
 };
-use ragu_circuits::staging::{Stage, StageExt};
+use ragu_circuits::{
+    CircuitExt,
+    staging::{Stage, StageExt},
+};
 use ragu_pasta::{Pasta, fp, fq};
 
 use super::*;
@@ -43,8 +46,9 @@ where
 pub const HEADER_SIZE: usize = 65;
 
 // Number of dummy application circuits to register before testing internal
-// circuits. This ensures the tests work correctly even when application
-// steps are present.
+// circuits. Internal circuit construction depends on the resulting registry
+// domain size, and other tests still build an application with this many
+// placeholder steps.
 const NUM_APP_STEPS: usize = 6000;
 
 type Preamble = preamble::Stage<Pasta, R, HEADER_SIZE>;
@@ -53,22 +57,60 @@ type InnerError = inner_error::Stage<Pasta, R, HEADER_SIZE, RevdotParameters>;
 type Query = query::Stage<Pasta, R, HEADER_SIZE>;
 type Eval = eval::Stage<Pasta, R, HEADER_SIZE>;
 
+fn internal_circuit_counts(variant: InternalCircuitIndex) -> (usize, usize) {
+    let pasta = Pasta::baked();
+    let (_, log2_circuits) = native::total_circuit_counts(NUM_APP_STEPS);
+
+    let metrics = match variant {
+        InternalCircuitIndex::Hashes1Circuit => {
+            native::circuits::hashes_1::Circuit::<Pasta, R, HEADER_SIZE, RevdotParameters>::new(
+                pasta,
+                log2_circuits,
+            )
+            .metrics()
+            .unwrap()
+        }
+        InternalCircuitIndex::Hashes2Circuit => {
+            native::circuits::hashes_2::Circuit::<Pasta, R, HEADER_SIZE, RevdotParameters>::new(
+                pasta,
+            )
+            .metrics()
+            .unwrap()
+        }
+        InternalCircuitIndex::InnerCollapseCircuit => native::circuits::inner_collapse::Circuit::<
+            Pasta,
+            R,
+            HEADER_SIZE,
+            RevdotParameters,
+        >::new()
+        .metrics()
+        .unwrap(),
+        InternalCircuitIndex::OuterCollapseCircuit => native::circuits::outer_collapse::Circuit::<
+            Pasta,
+            R,
+            HEADER_SIZE,
+            RevdotParameters,
+        >::new()
+        .metrics()
+        .unwrap(),
+        InternalCircuitIndex::ComputeVCircuit => {
+            native::circuits::compute_v::Circuit::<Pasta, R, HEADER_SIZE>::new()
+                .metrics()
+                .unwrap()
+        }
+        _ => panic!("constraint counts only apply to internal circuits"),
+    };
+
+    (metrics.num_gates(), metrics.num_constraints())
+}
+
 #[rustfmt::skip]
 #[test]
 fn test_internal_circuit_constraint_counts() {
-    let pasta = Pasta::baked();
-
-    let app = ApplicationBuilder::<Pasta, R, HEADER_SIZE>::new()
-        .register_dummy_circuits(NUM_APP_STEPS)
-        .unwrap()
-        .finalize(pasta)
-        .unwrap();
-
     macro_rules! check_constraints {
         ($variant:ident, mul = $mul:expr, lin = $lin:expr) => {{
-            let circuit_index = InternalCircuitIndex::$variant.circuit_index();
             let (actual_gates, actual_constraints) =
-                app.native_registry.constraint_counts(circuit_index);
+                internal_circuit_counts(InternalCircuitIndex::$variant);
             assert_eq!(
                 actual_gates,
                 $mul,
@@ -119,14 +161,6 @@ fn print_internal_circuit_constraint_counts() {
     use alloc::format;
     use std::println;
 
-    let pasta = Pasta::baked();
-
-    let app = ApplicationBuilder::<Pasta, R, HEADER_SIZE>::new()
-        .register_dummy_circuits(NUM_APP_STEPS)
-        .unwrap()
-        .finalize(pasta)
-        .unwrap();
-
     let variants = [
         ("Hashes1Circuit", InternalCircuitIndex::Hashes1Circuit),
         ("Hashes2Circuit", InternalCircuitIndex::Hashes2Circuit),
@@ -143,8 +177,7 @@ fn print_internal_circuit_constraint_counts() {
 
     println!("\n// Copy-paste the following into test_internal_circuit_constraint_counts:");
     for (name, variant) in variants {
-        let circuit_index = variant.circuit_index();
-        let (mul, lin) = app.native_registry.constraint_counts(circuit_index);
+        let (mul, lin) = internal_circuit_counts(variant);
         println!(
             "        check_constraints!({:<24} mul = {:<4}, lin = {});",
             format!("{},", name),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -3,10 +3,10 @@ use native::{
     stages::{eval, inner_error, outer_error, preamble, query},
 };
 use ragu_circuits::{
-    CircuitExt,
+    Circuit,
     staging::{Stage, StageExt},
 };
-use ragu_pasta::{Pasta, fp, fq};
+use ragu_pasta::{Fp, Pasta, fp, fq};
 
 use super::*;
 use crate::*;
@@ -57,51 +57,53 @@ type InnerError = inner_error::Stage<Pasta, R, HEADER_SIZE, RevdotParameters>;
 type Query = query::Stage<Pasta, R, HEADER_SIZE>;
 type Eval = eval::Stage<Pasta, R, HEADER_SIZE>;
 
+fn synthesis_counts(circuit: impl Circuit<Fp>) -> (usize, usize) {
+    let counts = ragu_circuits::testing::synthesis_counts(&circuit).unwrap();
+    (counts.num_gates, counts.num_constraints)
+}
+
 fn internal_circuit_counts(variant: InternalCircuitIndex) -> (usize, usize) {
     let pasta = Pasta::baked();
     let (_, log2_circuits) = native::total_circuit_counts(NUM_APP_STEPS);
 
-    let metrics = match variant {
+    match variant {
         InternalCircuitIndex::Hashes1Circuit => {
-            native::circuits::hashes_1::Circuit::<Pasta, R, HEADER_SIZE, RevdotParameters>::new(
-                pasta,
-                log2_circuits,
-            )
-            .metrics()
-            .unwrap()
+            synthesis_counts(native::circuits::hashes_1::Circuit::<
+                Pasta,
+                R,
+                HEADER_SIZE,
+                RevdotParameters,
+            >::new(pasta, log2_circuits))
         }
         InternalCircuitIndex::Hashes2Circuit => {
-            native::circuits::hashes_2::Circuit::<Pasta, R, HEADER_SIZE, RevdotParameters>::new(
-                pasta,
-            )
-            .metrics()
-            .unwrap()
+            synthesis_counts(native::circuits::hashes_2::Circuit::<
+                Pasta,
+                R,
+                HEADER_SIZE,
+                RevdotParameters,
+            >::new(pasta))
         }
-        InternalCircuitIndex::InnerCollapseCircuit => native::circuits::inner_collapse::Circuit::<
-            Pasta,
-            R,
-            HEADER_SIZE,
-            RevdotParameters,
-        >::new()
-        .metrics()
-        .unwrap(),
-        InternalCircuitIndex::OuterCollapseCircuit => native::circuits::outer_collapse::Circuit::<
-            Pasta,
-            R,
-            HEADER_SIZE,
-            RevdotParameters,
-        >::new()
-        .metrics()
-        .unwrap(),
+        InternalCircuitIndex::InnerCollapseCircuit => {
+            synthesis_counts(native::circuits::inner_collapse::Circuit::<
+                Pasta,
+                R,
+                HEADER_SIZE,
+                RevdotParameters,
+            >::new())
+        }
+        InternalCircuitIndex::OuterCollapseCircuit => {
+            synthesis_counts(native::circuits::outer_collapse::Circuit::<
+                Pasta,
+                R,
+                HEADER_SIZE,
+                RevdotParameters,
+            >::new())
+        }
         InternalCircuitIndex::ComputeVCircuit => {
-            native::circuits::compute_v::Circuit::<Pasta, R, HEADER_SIZE>::new()
-                .metrics()
-                .unwrap()
+            synthesis_counts(native::circuits::compute_v::Circuit::<Pasta, R, HEADER_SIZE>::new())
         }
         _ => panic!("constraint counts only apply to internal circuits"),
-    };
-
-    (metrics.num_gates(), metrics.num_constraints())
+    }
 }
 
 #[rustfmt::skip]

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -2,7 +2,10 @@ use native::{
     InternalCircuitIndex, InternalCircuitValues, RevdotParameters, RxIndex, RxValues,
     stages::{eval, inner_error, outer_error, preamble, query},
 };
-use ragu_circuits::staging::{Stage, StageExt};
+use ragu_circuits::{
+    CircuitExt,
+    staging::{Stage, StageExt},
+};
 use ragu_pasta::{Pasta, fp, fq};
 
 use super::*;
@@ -43,8 +46,9 @@ where
 pub const HEADER_SIZE: usize = 105;
 
 // Number of dummy application circuits to register before testing internal
-// circuits. This ensures the tests work correctly even when application
-// steps are present.
+// circuits. Internal circuit construction depends on the resulting registry
+// domain size, and other tests still build an application with this many
+// placeholder steps.
 const NUM_APP_STEPS: usize = 6000;
 
 type Preamble = preamble::Stage<Pasta, R, HEADER_SIZE>;
@@ -53,22 +57,60 @@ type InnerError = inner_error::Stage<Pasta, R, HEADER_SIZE, RevdotParameters>;
 type Query = query::Stage<Pasta, R, HEADER_SIZE>;
 type Eval = eval::Stage<Pasta, R, HEADER_SIZE>;
 
+fn internal_circuit_counts(variant: InternalCircuitIndex) -> (usize, usize) {
+    let pasta = Pasta::baked();
+    let (_, log2_circuits) = native::total_circuit_counts(NUM_APP_STEPS);
+
+    let metrics = match variant {
+        InternalCircuitIndex::Hashes1Circuit => {
+            native::circuits::hashes_1::Circuit::<Pasta, R, HEADER_SIZE, RevdotParameters>::new(
+                pasta,
+                log2_circuits,
+            )
+            .metrics()
+            .unwrap()
+        }
+        InternalCircuitIndex::Hashes2Circuit => {
+            native::circuits::hashes_2::Circuit::<Pasta, R, HEADER_SIZE, RevdotParameters>::new(
+                pasta,
+            )
+            .metrics()
+            .unwrap()
+        }
+        InternalCircuitIndex::InnerCollapseCircuit => native::circuits::inner_collapse::Circuit::<
+            Pasta,
+            R,
+            HEADER_SIZE,
+            RevdotParameters,
+        >::new()
+        .metrics()
+        .unwrap(),
+        InternalCircuitIndex::OuterCollapseCircuit => native::circuits::outer_collapse::Circuit::<
+            Pasta,
+            R,
+            HEADER_SIZE,
+            RevdotParameters,
+        >::new()
+        .metrics()
+        .unwrap(),
+        InternalCircuitIndex::ComputeVCircuit => {
+            native::circuits::compute_v::Circuit::<Pasta, R, HEADER_SIZE>::new()
+                .metrics()
+                .unwrap()
+        }
+        _ => panic!("constraint counts only apply to internal circuits"),
+    };
+
+    (metrics.num_gates(), metrics.num_constraints())
+}
+
 #[rustfmt::skip]
 #[test]
 fn test_internal_circuit_constraint_counts() {
-    let pasta = Pasta::baked();
-
-    let app = ApplicationBuilder::<Pasta, R, HEADER_SIZE>::new()
-        .register_dummy_circuits(NUM_APP_STEPS)
-        .unwrap()
-        .finalize(pasta)
-        .unwrap();
-
     macro_rules! check_constraints {
         ($variant:ident, mul = $mul:expr, lin = $lin:expr) => {{
-            let circuit_index = InternalCircuitIndex::$variant.circuit_index();
             let (actual_gates, actual_constraints) =
-                app.native_registry.constraint_counts(circuit_index);
+                internal_circuit_counts(InternalCircuitIndex::$variant);
             assert_eq!(
                 actual_gates,
                 $mul,
@@ -119,14 +161,6 @@ fn print_internal_circuit_constraint_counts() {
     use alloc::format;
     use std::println;
 
-    let pasta = Pasta::baked();
-
-    let app = ApplicationBuilder::<Pasta, R, HEADER_SIZE>::new()
-        .register_dummy_circuits(NUM_APP_STEPS)
-        .unwrap()
-        .finalize(pasta)
-        .unwrap();
-
     let variants = [
         ("Hashes1Circuit", InternalCircuitIndex::Hashes1Circuit),
         ("Hashes2Circuit", InternalCircuitIndex::Hashes2Circuit),
@@ -143,8 +177,7 @@ fn print_internal_circuit_constraint_counts() {
 
     println!("\n// Copy-paste the following into test_internal_circuit_constraint_counts:");
     for (name, variant) in variants {
-        let circuit_index = variant.circuit_index();
-        let (mul, lin) = app.native_registry.constraint_counts(circuit_index);
+        let (mul, lin) = internal_circuit_counts(variant);
         println!(
             "        check_constraints!({:<24} mul = {:<4}, lin = {});",
             format!("{},", name),


### PR DESCRIPTION
Went with removal over redefinition. `constraint_counts` was only load-bearing for the PCD regression tests and metrics benchmarks. Both now use the feature-gated `ragu_circuits::testing::synthesis_counts()` helper, which runs the same synthesis analysis as registry compilation.

The returned raw counts have explicit semantics: they include the reserved SYSTEM gate, public-output constraints, and final ONE constraint. Normal builds do not enable `test-utils`.

Refs #614.