### PR TITLE
chore(fv): gate ci on filter list

### DIFF
--- a/.github/workflows/fv.yml
+++ b/.github/workflows/fv.yml
@@ -6,8 +6,35 @@ on:
   pull_request:
 
 jobs:
+  changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      fv: ${{ steps.filter.outputs.fv }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            fv:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - '**/Cargo.lock'
+              - 'rust-toolchain.toml'
+              - 'qa/lean/**'
+              - '.github/workflows/fv.yml'
+              - '.github/actions/**'
+
   lean:
     name: exporter + lean
+    needs: changes
+    if: needs.changes.outputs.fv == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/fv.yml
+++ b/.github/workflows/fv.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+# Cancel in-progress runs when a new commit is pushed to the same branch/PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     name: detect changes


### PR DESCRIPTION
CI action for [FV workloads](https://github.com/tachyon-zcash/ragu/blob/main/.github/workflows/fv.yml) runs two things: a check (verifies extracted lean files are up to date) and full build `lake build` (of `qa/lean`). Mean runtime was measured at ~4min with a SD of ~2min, so it's an amenable target for skipping things like book updates.