### PR TITLE
feat: add merkle path verification gadget

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -22,6 +22,7 @@
   - [Primitives](guide/primitives/index.md) <!-- todo -->
     - [Allocation](guide/primitives/allocation.md) <!-- todo -->
     - [Simulator](guide/primitives/simulator.md) <!-- todo -->
+    - [Merkle Path](guide/primitives/merkle.md)
   - [Writing Circuits](guide/writing_circuits.md) <!-- todo -->
   - [Configuration](guide/configuration.md) <!-- todo -->
 - [Part II: Protocol Design]()

--- a/book/src/guide/getting_started.md
+++ b/book/src/guide/getting_started.md
@@ -2,7 +2,8 @@
 
 This guide demonstrates a complete proof-carrying data (PCD) application
 built with Ragu. The example constructs a simple Merkle tree where each node
-carries a proof of correctness.
+carries a proof of correctness. For the in-circuit Merkle path verification
+primitive, see [Merkle Path Verification](primitives/merkle.md).
 
 ## What This Example Demonstrates
 

--- a/book/src/guide/primitives/merkle.md
+++ b/book/src/guide/primitives/merkle.md
@@ -1,0 +1,82 @@
+# Merkle Path Verification
+
+Merkle trees authenticate set membership by reducing a global root
+commitment to a short sequence of sibling hashes along a path from a leaf
+to the root. Verifying membership inside an arithmetic circuit follows the
+same structure: at each level, the verifier conditionally reorders the
+current node and its sibling, hashes them together, and repeats until it
+reaches the root.
+
+The [`merkle`][merkle-mod] module provides this verification as a pair of
+functions, [`compute_root`] and [`enforce_inclusion`] operating over a
+const-generic [`MerklePath`].
+
+## [`MerklePath`]
+
+A [`MerklePath`] holds `DEPTH` pairs of `(sibling, direction_bit)`,
+ordered from the leaf level upward. The depth is a const generic, so the
+number of wires is type-determined, satisfying
+[fungibility](../gadgets/index.md#fungibility). Callers construct a path
+from pre-allocated [`Element`]s and [`Boolean`]s:
+
+```rust
+let path = MerklePath::new([
+    (sib0, dir0),
+    (sib1, dir1),
+    (sib2, dir2),
+]);
+```
+
+Each direction bit describes which side of the hash the current node
+occupies. A value of `false` places the current node on the left; `true`
+places it on the right.
+
+## [`compute_root`] and [`enforce_inclusion`]
+
+[`compute_root`] hashes a leaf up a [`MerklePath`] and returns the
+computed root as an [`Element`]. At each level it calls
+[`Boolean::conditional_swap`] to reorder the current node and sibling,
+absorbs both into a fresh Poseidon sponge, and squeezes the result:
+
+```rust
+let root = compute_root(dr, params, &leaf, &path)?;
+```
+
+[`enforce_inclusion`] does the same, then constrains the computed root to
+equal an expected value:
+
+```rust
+enforce_inclusion(dr, params, &leaf, &path, &expected_root)?;
+```
+
+Both functions are generic over [`PoseidonPermutation`], so the hash
+parameters are not fixed by the module.
+
+## [`Boolean::conditional_swap`] {#conditional-swap}
+
+Merkle path verification needs to reorder two elements based on a
+direction bit. Two separate [`conditional_select`] calls would cost two
+multiplication gates. [`Boolean::conditional_swap`] achieves the same
+result with a single gate: it computes the difference of the two inputs
+(free), multiplies by the bit (one gate), and derives both outputs from
+the product (free).
+
+## Cost
+
+Each level of the path contributes one [`conditional_swap`] gate and one
+Poseidon permutation, so a depth `DEPTH` verification costs
+
+$$\text{DEPTH} \times (1 + \text{permutation gates})$$
+
+Allocation of the leaf, siblings, and direction bits is the caller's
+responsibility and is not included in this count.
+
+[merkle-mod]: ragu_primitives::merkle
+[`MerklePath`]: ragu_primitives::merkle::MerklePath
+[`compute_root`]: ragu_primitives::merkle::compute_root
+[`enforce_inclusion`]: ragu_primitives::merkle::enforce_inclusion
+[`Boolean::conditional_swap`]: ragu_primitives::Boolean::conditional_swap
+[`conditional_select`]: ragu_primitives::Boolean::conditional_select
+[`Element`]: ragu_primitives::Element
+[`Boolean`]: ragu_primitives::Boolean
+[`PoseidonPermutation`]: ragu_arithmetic::PoseidonPermutation

--- a/book/src/guide/writing_circuits.md
+++ b/book/src/guide/writing_circuits.md
@@ -241,6 +241,8 @@ For details on parameter selection (`Pasta`, `R<13>`, `4`), see
 
 - [Getting Started](getting_started.md) provides a complete walkthrough with
   a working Merkle tree example
+- [Merkle Path](primitives/merkle.md) documents the in-circuit path
+  verification primitive
 - [Configuration](configuration.md) explains the ApplicationBuilder
   parameter choices
 - [Gadgets](gadgets/index.md) documents the available building block operations

--- a/crates/ragu_primitives/src/boolean.rs
+++ b/crates/ragu_primitives/src/boolean.rs
@@ -108,6 +108,24 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
         Ok(a.add(dr, &cond_times_diff))
     }
 
+    /// Swaps two elements based on this boolean's value.
+    /// When false, returns `(a, b)` unchanged.
+    /// When true, returns `(b, a)`.
+    ///
+    /// This costs one gate and two constraints.
+    pub fn conditional_swap(
+        &self,
+        dr: &mut D,
+        a: &Element<'dr, D>,
+        b: &Element<'dr, D>,
+    ) -> Result<(Element<'dr, D>, Element<'dr, D>)> {
+        let diff = b.sub(dr, a);
+        let cond_diff = self.element().mul(dr, &diff)?;
+        let left = a.add(dr, &cond_diff);
+        let right = b.sub(dr, &cond_diff);
+        Ok((left, right))
+    }
+
     /// Conditionally enforces that two elements are equal.
     /// When this boolean is true, enforces `a == b`; when false, no constraint.
     ///
@@ -422,6 +440,45 @@ fn test_conditional_enforce_equal() -> Result<()> {
         let b = Element::alloc(dr, allocator, b)?;
 
         cond.conditional_enforce_equal(dr, allocator, &a, &b)?;
+        Ok(())
+    })?;
+
+    Ok(())
+}
+
+#[test]
+fn test_conditional_swap() -> Result<()> {
+    type F = ragu_pasta::Fp;
+    type Simulator = crate::Simulator<F>;
+
+    // swap = false: (a, b) unchanged
+    let sim = Simulator::simulate((false, F::from(10u64), F::from(20u64)), |dr, witness| {
+        let (cond, a, b) = witness.cast();
+        let allocator = &mut Standard::new();
+        let cond = Boolean::alloc(dr, &mut (), cond)?;
+        let a = Element::alloc(dr, allocator, a)?;
+        let b = Element::alloc(dr, allocator, b)?;
+
+        dr.reset();
+        let (left, right) = cond.conditional_swap(dr, &a, &b)?;
+        assert_eq!(*left.value().take(), F::from(10u64));
+        assert_eq!(*right.value().take(), F::from(20u64));
+        Ok(())
+    })?;
+    assert_eq!(sim.num_gates(), 1);
+    assert_eq!(sim.num_constraints(), 2);
+
+    // swap = true: (a, b) becomes (b, a)
+    Simulator::simulate((true, F::from(10u64), F::from(20u64)), |dr, witness| {
+        let (cond, a, b) = witness.cast();
+        let allocator = &mut Standard::new();
+        let cond = Boolean::alloc(dr, &mut (), cond)?;
+        let a = Element::alloc(dr, allocator, a)?;
+        let b = Element::alloc(dr, allocator, b)?;
+
+        let (left, right) = cond.conditional_swap(dr, &a, &b)?;
+        assert_eq!(*left.value().take(), F::from(20u64));
+        assert_eq!(*right.value().take(), F::from(10u64));
         Ok(())
     })?;
 

--- a/crates/ragu_primitives/src/lib.rs
+++ b/crates/ragu_primitives/src/lib.rs
@@ -24,6 +24,7 @@ mod element;
 mod endoscalar;
 mod foreign;
 pub mod io;
+pub mod merkle;
 mod point;
 pub mod poseidon;
 pub mod promotion;

--- a/crates/ragu_primitives/src/merkle.rs
+++ b/crates/ragu_primitives/src/merkle.rs
@@ -22,11 +22,7 @@
 //! giving **289 gates per level**.
 
 use ragu_arithmetic::PoseidonPermutation;
-use ragu_core::{
-    Result,
-    drivers::Driver,
-    gadgets::Gadget,
-};
+use ragu_core::{Result, drivers::Driver, gadgets::Gadget};
 
 use crate::{Boolean, Element, poseidon::Sponge};
 
@@ -226,11 +222,7 @@ mod tests {
             let dir1 = Boolean::alloc(dr, allocator, Sim::just(|| true))?;
             let dir2 = Boolean::alloc(dr, allocator, Sim::just(|| false))?;
 
-            let path = MerklePath::new([
-                (sibling0, dir0),
-                (sibling1, dir1),
-                (sibling2, dir2),
-            ]);
+            let path = MerklePath::new([(sibling0, dir0), (sibling1, dir1), (sibling2, dir2)]);
             let root = compute_root(dr, params, &leaf, &path)?;
 
             assert_eq!(*root.value().take(), expected_root);
@@ -298,9 +290,7 @@ mod tests {
     // ---------------------------------------------------------------
 
     /// Build a valid depth-2 proof and return the components.
-    fn valid_depth_2(
-        params: &PoseidonParams,
-    ) -> (Fp, Fp, Fp, bool, bool, Fp) {
+    fn valid_depth_2(params: &PoseidonParams) -> (Fp, Fp, Fp, bool, bool, Fp) {
         let leaf = Fp::from(10u64);
         let sib0 = Fp::from(20u64);
         let sib1 = Fp::from(30u64);
@@ -354,7 +344,9 @@ mod tests {
 
         // Mutated leaf fails.
         let bad_leaf = leaf + Fp::ONE;
-        assert!(!try_inclusion(params, bad_leaf, sib0, sib1, dir0, dir1, root));
+        assert!(!try_inclusion(
+            params, bad_leaf, sib0, sib1, dir0, dir1, root
+        ));
     }
 
     #[test]
@@ -365,11 +357,15 @@ mod tests {
 
         // Corrupt sibling at level 0.
         let bad_sib0 = sib0 + Fp::ONE;
-        assert!(!try_inclusion(params, leaf, bad_sib0, sib1, dir0, dir1, root));
+        assert!(!try_inclusion(
+            params, leaf, bad_sib0, sib1, dir0, dir1, root
+        ));
 
         // Corrupt sibling at level 1.
         let bad_sib1 = sib1 + Fp::ONE;
-        assert!(!try_inclusion(params, leaf, sib0, bad_sib1, dir0, dir1, root));
+        assert!(!try_inclusion(
+            params, leaf, sib0, bad_sib1, dir0, dir1, root
+        ));
     }
 
     #[test]
@@ -392,6 +388,8 @@ mod tests {
         let (leaf, sib0, sib1, dir0, dir1, root) = valid_depth_2(params);
 
         let wrong_root = root + Fp::ONE;
-        assert!(!try_inclusion(params, leaf, sib0, sib1, dir0, dir1, wrong_root));
+        assert!(!try_inclusion(
+            params, leaf, sib0, sib1, dir0, dir1, wrong_root
+        ));
     }
 }

--- a/crates/ragu_primitives/src/merkle.rs
+++ b/crates/ragu_primitives/src/merkle.rs
@@ -1,0 +1,397 @@
+//! Merkle tree path verification gadget.
+//!
+//! Provides [`compute_root`] and [`enforce_inclusion`] for verifying Merkle
+//! authentication paths inside arithmetic circuits. Callers allocate the leaf,
+//! siblings, and direction bits; this module only performs the hash-chain
+//! computation.
+//!
+//! The path depth `DEPTH` is a const generic, enforcing compile-time
+//! fixed-depth synthesis as required by Ragu's
+//! [fungibility invariant](ragu_core::gadgets).
+//!
+//! # Cost
+//!
+//! A depth-`DEPTH` verification performs `DEPTH` iterations, each consisting
+//! of one [`conditional_swap`](crate::Boolean::conditional_swap) multiplication
+//! (1 gate) and a sponge round whose cost depends on the selected
+//! [`PoseidonPermutation`]. When `P::RATE >= 2`, each level absorbs both inputs
+//! before the first squeeze-triggered permutation, so the total gate cost is
+//! `DEPTH × (1 + permutation_gates)`.
+//!
+//! With the default Pasta Poseidon parameters, one permutation costs 288 gates,
+//! giving **289 gates per level**.
+
+use ragu_arithmetic::PoseidonPermutation;
+use ragu_core::{
+    Result,
+    drivers::Driver,
+    gadgets::Gadget,
+};
+
+use crate::{Boolean, Element, poseidon::Sponge};
+
+/// A Merkle authentication path of compile-time depth `DEPTH`.
+///
+/// Each entry is a `(sibling, direction_bit)` pair, ordered from the leaf
+/// level upward. The direction bit convention:
+/// - `false` (0): current node is on the **left**, sibling is on the right.
+/// - `true` (1): current node is on the **right**, sibling is on the left.
+#[derive(Gadget)]
+pub struct MerklePath<'dr, D: Driver<'dr>, const DEPTH: usize> {
+    #[ragu(gadget)]
+    entries: [(Element<'dr, D>, Boolean<'dr, D>); DEPTH],
+}
+
+impl<'dr, D: Driver<'dr>, const DEPTH: usize> MerklePath<'dr, D, DEPTH> {
+    /// Creates a path from an array of `(sibling, direction)` pairs.
+    pub fn new(entries: [(Element<'dr, D>, Boolean<'dr, D>); DEPTH]) -> Self {
+        Self { entries }
+    }
+
+    /// Returns a reference to the path entries.
+    pub fn entries(&self) -> &[(Element<'dr, D>, Boolean<'dr, D>); DEPTH] {
+        &self.entries
+    }
+}
+
+/// Computes the Merkle root by hashing a leaf up a [`MerklePath`].
+///
+/// At each level, the current node and sibling are conditionally swapped
+/// according to the direction bit, then hashed with Poseidon to produce the
+/// next level's node.
+///
+/// # Errors
+///
+/// Returns an error if any constraint operation fails (e.g., gate bound
+/// exceeded).
+pub fn compute_root<'dr, D, P, const DEPTH: usize>(
+    dr: &mut D,
+    params: &'dr P,
+    leaf: &Element<'dr, D>,
+    path: &MerklePath<'dr, D, DEPTH>,
+) -> Result<Element<'dr, D>>
+where
+    D: Driver<'dr>,
+    P: PoseidonPermutation<D::F>,
+{
+    let mut current = leaf.clone();
+
+    for (sibling, direction) in path.entries() {
+        let (left, right) = direction.conditional_swap(dr, &current, sibling)?;
+
+        let mut sponge = Sponge::<'_, D, P>::new(dr, params);
+        sponge.absorb(dr, &left)?;
+        sponge.absorb(dr, &right)?;
+        current = sponge.squeeze(dr)?;
+    }
+
+    Ok(current)
+}
+
+/// Enforces that a leaf is included in a Merkle tree with the given root.
+///
+/// This is equivalent to [`compute_root`] followed by an equality constraint
+/// between the computed and expected roots.
+///
+/// # Errors
+///
+/// Returns an error if any constraint operation fails or if the computed root
+/// does not match `expected_root` (i.e., the witness is inconsistent).
+pub fn enforce_inclusion<'dr, D, P, const DEPTH: usize>(
+    dr: &mut D,
+    params: &'dr P,
+    leaf: &Element<'dr, D>,
+    path: &MerklePath<'dr, D, DEPTH>,
+    expected_root: &Element<'dr, D>,
+) -> Result<()>
+where
+    D: Driver<'dr>,
+    P: PoseidonPermutation<D::F>,
+{
+    let computed = compute_root(dr, params, leaf, path)?;
+    dr.enforce_equal(computed.wire(), expected_root.wire())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use ff::Field;
+    use ragu_arithmetic::Cycle;
+    use ragu_core::maybe::Maybe;
+    use ragu_pasta::{Fp, Pasta};
+
+    use super::*;
+    use crate::{Simulator, allocator::Standard};
+
+    type Sim = Simulator<Fp>;
+    type PoseidonParams = <Pasta as Cycle>::CircuitPoseidon;
+
+    /// Compute a Poseidon hash of two field elements outside the circuit
+    /// (using the simulator) for test oracle construction.
+    fn hash_pair(params: &PoseidonParams, a: Fp, b: Fp) -> Fp {
+        let mut dr = Sim::new();
+        let allocator = &mut Standard::new();
+        let a = Element::alloc(&mut dr, allocator, Sim::just(|| a)).unwrap();
+        let b = Element::alloc(&mut dr, allocator, Sim::just(|| b)).unwrap();
+        let mut sponge = Sponge::<'_, Sim, PoseidonParams>::new(&mut dr, params);
+        sponge.absorb(&mut dr, &a).unwrap();
+        sponge.absorb(&mut dr, &b).unwrap();
+        let out = sponge.squeeze(&mut dr).unwrap();
+        *out.value().take()
+    }
+
+    // ---------------------------------------------------------------
+    // Positive tests (tier 1): verify correct inputs produce correct roots
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn compute_root_depth_1() -> Result<()> {
+        let baked = Pasta::baked();
+        let params = Pasta::circuit_poseidon(baked);
+
+        let leaf = Fp::from(42u64);
+        let sibling = Fp::from(99u64);
+        let expected_root = hash_pair(params, leaf, sibling);
+
+        Sim::simulate((leaf, sibling, false), |dr, witness| {
+            let (leaf_val, sib_val, dir_val) = witness.cast();
+            let allocator = &mut Standard::new();
+
+            let leaf = Element::alloc(dr, allocator, leaf_val)?;
+            let sibling = Element::alloc(dr, allocator, sib_val)?;
+            let direction = Boolean::alloc(dr, allocator, dir_val)?;
+
+            let path = MerklePath::new([(sibling, direction)]);
+            let root = compute_root(dr, params, &leaf, &path)?;
+
+            assert_eq!(*root.value().take(), expected_root);
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn compute_root_depth_1_swapped() -> Result<()> {
+        let baked = Pasta::baked();
+        let params = Pasta::circuit_poseidon(baked);
+
+        let leaf = Fp::from(42u64);
+        let sibling = Fp::from(99u64);
+        let expected_root = hash_pair(params, sibling, leaf);
+
+        Sim::simulate((leaf, sibling, true), |dr, witness| {
+            let (leaf_val, sib_val, dir_val) = witness.cast();
+            let allocator = &mut Standard::new();
+
+            let leaf = Element::alloc(dr, allocator, leaf_val)?;
+            let sibling = Element::alloc(dr, allocator, sib_val)?;
+            let direction = Boolean::alloc(dr, allocator, dir_val)?;
+
+            let path = MerklePath::new([(sibling, direction)]);
+            let root = compute_root(dr, params, &leaf, &path)?;
+
+            assert_eq!(*root.value().take(), expected_root);
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn compute_root_depth_3() -> Result<()> {
+        let baked = Pasta::baked();
+        let params = Pasta::circuit_poseidon(baked);
+
+        let leaf = Fp::from(1u64);
+        let sib0 = Fp::from(2u64);
+        let sib1 = Fp::from(3u64);
+        let sib2 = Fp::from(4u64);
+
+        let h0 = hash_pair(params, leaf, sib0);
+        let h1 = hash_pair(params, sib1, h0);
+        let expected_root = hash_pair(params, h1, sib2);
+
+        let witness = (leaf, sib0, sib1, sib2);
+        Sim::simulate(witness, |dr, w| {
+            let (leaf_val, s0, s1, s2) = w.cast();
+            let allocator = &mut Standard::new();
+
+            let leaf = Element::alloc(dr, allocator, leaf_val)?;
+            let sibling0 = Element::alloc(dr, allocator, s0)?;
+            let sibling1 = Element::alloc(dr, allocator, s1)?;
+            let sibling2 = Element::alloc(dr, allocator, s2)?;
+
+            let dir0 = Boolean::alloc(dr, allocator, Sim::just(|| false))?;
+            let dir1 = Boolean::alloc(dr, allocator, Sim::just(|| true))?;
+            let dir2 = Boolean::alloc(dr, allocator, Sim::just(|| false))?;
+
+            let path = MerklePath::new([
+                (sibling0, dir0),
+                (sibling1, dir1),
+                (sibling2, dir2),
+            ]);
+            let root = compute_root(dr, params, &leaf, &path)?;
+
+            assert_eq!(*root.value().take(), expected_root);
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn enforce_inclusion_valid() -> Result<()> {
+        let baked = Pasta::baked();
+        let params = Pasta::circuit_poseidon(baked);
+
+        let leaf = Fp::from(7u64);
+        let sibling = Fp::from(13u64);
+        let expected_root = hash_pair(params, leaf, sibling);
+
+        Sim::simulate((leaf, sibling, expected_root), |dr, witness| {
+            let (leaf_val, sib_val, root_val) = witness.cast();
+            let allocator = &mut Standard::new();
+
+            let leaf = Element::alloc(dr, allocator, leaf_val)?;
+            let sibling = Element::alloc(dr, allocator, sib_val)?;
+            let direction = Boolean::alloc(dr, allocator, Sim::just(|| false))?;
+            let root = Element::alloc(dr, allocator, root_val)?;
+
+            let path = MerklePath::new([(sibling, direction)]);
+            enforce_inclusion(dr, params, &leaf, &path, &root)?;
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn gate_cost_per_level() -> Result<()> {
+        let baked = Pasta::baked();
+        let params = Pasta::circuit_poseidon(baked);
+
+        let leaf = Fp::from(1u64);
+        let sibling = Fp::from(2u64);
+
+        let sim = Sim::simulate((leaf, sibling, false), |dr, witness| {
+            let (leaf_val, sib_val, dir_val) = witness.cast();
+            let allocator = &mut Standard::new();
+
+            let leaf = Element::alloc(dr, allocator, leaf_val)?;
+            let sibling = Element::alloc(dr, allocator, sib_val)?;
+            let direction = Boolean::alloc(dr, allocator, dir_val)?;
+
+            dr.reset();
+            let path = MerklePath::new([(sibling, direction)]);
+            compute_root(dr, params, &leaf, &path)?;
+            Ok(())
+        })?;
+
+        // 1 gate (conditional_swap) + 288 gates (Poseidon permutation)
+        assert_eq!(sim.num_gates(), 289);
+        Ok(())
+    }
+
+    // ---------------------------------------------------------------
+    // Negative tests (tier 2): verify invalid inputs cause constraint failure
+    // ---------------------------------------------------------------
+
+    /// Build a valid depth-2 proof and return the components.
+    fn valid_depth_2(
+        params: &PoseidonParams,
+    ) -> (Fp, Fp, Fp, bool, bool, Fp) {
+        let leaf = Fp::from(10u64);
+        let sib0 = Fp::from(20u64);
+        let sib1 = Fp::from(30u64);
+        let dir0 = false;
+        let dir1 = true;
+
+        let h0 = hash_pair(params, leaf, sib0);
+        let root = hash_pair(params, sib1, h0);
+
+        (leaf, sib0, sib1, dir0, dir1, root)
+    }
+
+    /// Helper: run enforce_inclusion with depth-2 parameters and return
+    /// whether it succeeds.
+    fn try_inclusion(
+        params: &PoseidonParams,
+        leaf: Fp,
+        sib0: Fp,
+        sib1: Fp,
+        dir0: bool,
+        dir1: bool,
+        root: Fp,
+    ) -> bool {
+        Sim::simulate((leaf, sib0, sib1, root), |dr, w| {
+            let (leaf_val, s0, s1, root_val) = w.cast();
+            let allocator = &mut Standard::new();
+
+            let leaf = Element::alloc(dr, allocator, leaf_val)?;
+            let sibling0 = Element::alloc(dr, allocator, s0)?;
+            let sibling1 = Element::alloc(dr, allocator, s1)?;
+            let root = Element::alloc(dr, allocator, root_val)?;
+
+            let d0 = Boolean::alloc(dr, allocator, Sim::just(|| dir0))?;
+            let d1 = Boolean::alloc(dr, allocator, Sim::just(|| dir1))?;
+
+            let path = MerklePath::new([(sibling0, d0), (sibling1, d1)]);
+            enforce_inclusion(dr, params, &leaf, &path, &root)?;
+            Ok(())
+        })
+        .is_ok()
+    }
+
+    #[test]
+    fn rejects_mutated_leaf() {
+        let baked = Pasta::baked();
+        let params = Pasta::circuit_poseidon(baked);
+        let (leaf, sib0, sib1, dir0, dir1, root) = valid_depth_2(params);
+
+        // Valid proof passes.
+        assert!(try_inclusion(params, leaf, sib0, sib1, dir0, dir1, root));
+
+        // Mutated leaf fails.
+        let bad_leaf = leaf + Fp::ONE;
+        assert!(!try_inclusion(params, bad_leaf, sib0, sib1, dir0, dir1, root));
+    }
+
+    #[test]
+    fn rejects_corrupted_sibling() {
+        let baked = Pasta::baked();
+        let params = Pasta::circuit_poseidon(baked);
+        let (leaf, sib0, sib1, dir0, dir1, root) = valid_depth_2(params);
+
+        // Corrupt sibling at level 0.
+        let bad_sib0 = sib0 + Fp::ONE;
+        assert!(!try_inclusion(params, leaf, bad_sib0, sib1, dir0, dir1, root));
+
+        // Corrupt sibling at level 1.
+        let bad_sib1 = sib1 + Fp::ONE;
+        assert!(!try_inclusion(params, leaf, sib0, bad_sib1, dir0, dir1, root));
+    }
+
+    #[test]
+    fn rejects_flipped_direction_bit() {
+        let baked = Pasta::baked();
+        let params = Pasta::circuit_poseidon(baked);
+        let (leaf, sib0, sib1, dir0, dir1, root) = valid_depth_2(params);
+
+        // Flip direction bit at level 0.
+        assert!(!try_inclusion(params, leaf, sib0, sib1, !dir0, dir1, root));
+
+        // Flip direction bit at level 1.
+        assert!(!try_inclusion(params, leaf, sib0, sib1, dir0, !dir1, root));
+    }
+
+    #[test]
+    fn rejects_wrong_expected_root() {
+        let baked = Pasta::baked();
+        let params = Pasta::circuit_poseidon(baked);
+        let (leaf, sib0, sib1, dir0, dir1, root) = valid_depth_2(params);
+
+        let wrong_root = root + Fp::ONE;
+        assert!(!try_inclusion(params, leaf, sib0, sib1, dir0, dir1, wrong_root));
+    }
+}


### PR DESCRIPTION
Book page under `guide/primitives/merkle.md` with cross-links from `getting_started.md `and `writing_circuits.md`.