### PR TITLE
docs: expand # errors coverage across public result APIs

### DIFF
--- a/crates/ragu_circuits/src/horner.rs
+++ b/crates/ragu_circuits/src/horner.rs
@@ -45,6 +45,11 @@ impl<'a, 'dr, D: Driver<'dr>> Horner<'a, 'dr, D> {
 
     /// Finishes the evaluation with a trailing constant $1$ term appended,
     /// following the $k(Y)$ polynomial convention.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from writing the trailing constant term into this
+    /// buffer.
     pub fn finish_ky(mut self, dr: &mut D) -> Result<Element<'dr, D>> {
         Element::one().write(dr, &mut self)?;
         Ok(self.finish(dr))

--- a/crates/ragu_circuits/src/ky.rs
+++ b/crates/ragu_circuits/src/ky.rs
@@ -16,6 +16,12 @@ use super::Circuit;
 
 /// Evaluates $k(y)$ for the given circuit and instance at a point $y$, without
 /// collecting intermediate coefficients.
+///
+/// # Errors
+///
+/// Propagates any error from allocating the evaluation point, synthesizing the
+/// instance gadget, streaming it into Horner form, or finalizing the
+/// evaluation.
 pub fn eval<F: Field, C: Circuit<F>>(circuit: &C, instance: C::Instance<'_>, y: F) -> Result<F> {
     let mut dr = Emulator::extractor();
     let y_elem = Element::alloc(&mut dr, &mut (), Always::<F>::just(|| y))?;

--- a/crates/ragu_circuits/src/lib.rs
+++ b/crates/ragu_circuits/src/lib.rs
@@ -161,6 +161,10 @@ pub trait CircuitExt<F: Field>: Circuit<F> {
     ///
     /// The returned [`Trace`] can be assembled into a polynomial
     /// via [`Registry::assemble`](registry::Registry::assemble).
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from evaluating the circuit trace.
     fn trace<'witness>(
         &self,
         witness: Self::Witness<'witness>,
@@ -170,6 +174,10 @@ pub trait CircuitExt<F: Field>: Circuit<F> {
 
     /// Evaluates the instance polynomial $k(y)$ for the given instance at
     /// a point $y \in \mathbb{F}$.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from evaluating the instance polynomial.
     fn ky(&self, instance: Self::Instance<'_>, y: F) -> Result<F> {
         ky::eval(self, instance, y)
     }

--- a/crates/ragu_circuits/src/metrics.rs
+++ b/crates/ragu_circuits/src/metrics.rs
@@ -478,6 +478,11 @@ impl<F: FromUniformBytes<64>> WireMap<F> for Counter<F> {
 }
 
 /// Evaluates the constraint topology of a circuit.
+///
+/// # Errors
+///
+/// Propagates any error from the raw orchestration pass used to analyze the
+/// circuit.
 pub fn eval<F: FromUniformBytes<64>, C: Circuit<F>>(circuit: &C) -> Result<CircuitMetrics> {
     eval_raw(&super::raw::CircuitAdapterRef(circuit))
 }

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -118,6 +118,11 @@ impl<'params, F: FromUniformBytes<64>, R: Rank> RegistryBuilder<'params, F, R> {
     }
 
     /// Registers an application step circuit.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from converting `circuit` into the registry's
+    /// internal wiring representation.
     pub fn register_circuit<C>(mut self, circuit: C) -> Result<Self>
     where
         C: Circuit<F> + 'params,
@@ -128,6 +133,11 @@ impl<'params, F: FromUniformBytes<64>, R: Rank> RegistryBuilder<'params, F, R> {
     }
 
     /// Registers an internal circuit.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from converting `circuit` into the registry's
+    /// internal wiring representation.
     pub fn register_internal_circuit<C>(mut self, circuit: C) -> Result<Self>
     where
         C: Circuit<F> + 'params,
@@ -138,6 +148,11 @@ impl<'params, F: FromUniformBytes<64>, R: Rank> RegistryBuilder<'params, F, R> {
     }
 
     /// Registers an internal step circuit.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from converting `circuit` into the registry's
+    /// internal wiring representation.
     pub fn register_internal_step<C>(mut self, circuit: C) -> Result<Self>
     where
         C: Circuit<F> + 'params,
@@ -163,6 +178,11 @@ impl<'params, F: FromUniformBytes<64>, R: Rank> RegistryBuilder<'params, F, R> {
     ///
     /// This concatenation order must match `InternalCircuitIndex::ALL` in
     /// `ragu_pcd`, which derives [`CircuitIndex`] from position in the array.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::CircuitBoundExceeded`] if the total number of
+    /// registered circuits exceeds the rank capacity.
     pub fn finalize(self) -> Result<Registry<'params, F, R>>
     where
         F: FromUniformBytes<64>,
@@ -354,6 +374,10 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     ///
     /// Calls [`assemble_with_alpha`](Self::assemble_with_alpha) with a
     /// random value sampled from `rng`.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from [`Registry::assemble_with_alpha`].
     pub fn assemble(
         &self,
         trace: &crate::trace::Trace<F>,
@@ -371,6 +395,11 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     /// all-zero (the ONE wire at `d[0] = 1` ensures this), but the
     /// predictable ONE slot can cancel in linear combinations of traces;
     /// a random `alpha` at `a[0]` keeps derived polynomials non-zero.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from assembling the trace against the stored
+    /// floor plan.
     pub fn assemble_with_alpha(
         &self,
         trace: &crate::trace::Trace<F>,

--- a/crates/ragu_circuits/src/staging/bonding.rs
+++ b/crates/ragu_circuits/src/staging/bonding.rs
@@ -60,6 +60,12 @@ where
     /// [`Driver::constant`]: ragu_core::drivers::Driver::constant
     /// [`Driver::enforce_zero`]: ragu_core::drivers::Driver::enforce_zero
     /// [`Driver::ONE`]: ragu_core::drivers::Driver::ONE
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ragu_core::Error::InvalidWitness`] if the circuit violates
+    /// the bonding restrictions, or propagates any error from the standard
+    /// wiring-object construction pipeline.
     pub fn into_bonding_object<'a>(self) -> Result<BondingObject<'a, F, R>>
     where
         Self: 'a,

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -101,6 +101,11 @@ impl<R: Rank> StageMask<R> {
     /// here because `a[0]` carries the alpha blinding factor and
     /// `d[0]` may or may not be set to 1; `b[0]` and `c[0]` are
     /// zero in all cases.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ragu_core::Error::GateBoundExceeded`] if
+    /// `skip_gates + num_gates` exceeds the rank capacity.
     pub fn new(skip_gates: usize, num_gates: usize) -> Result<Self> {
         assert!(skip_gates > 0, "skip_gates must include the SYSTEM gate");
         if skip_gates + num_gates > R::n() {
@@ -118,6 +123,11 @@ impl<R: Rank> StageMask<R> {
     /// be at least 1 (it includes the SYSTEM gate). The number
     /// of gates will be `R::n() - skip_gates`, which is the maximum
     /// before bounds are reached.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ragu_core::Error::GateBoundExceeded`] if `skip_gates`
+    /// exceeds the rank capacity.
     pub fn new_final(skip_gates: usize) -> Result<Self> {
         assert!(skip_gates > 0, "skip_gates must include the SYSTEM gate");
         if skip_gates > R::n() {

--- a/crates/ragu_circuits/src/staging/mod.rs
+++ b/crates/ragu_circuits/src/staging/mod.rs
@@ -291,6 +291,10 @@ impl<F: Field, R: Rank, S: MultiStageCircuit<F, R>> MultiStage<F, R, S> {
     }
 
     /// Proxy for [`S::Last::final_mask`](StageExt::final_mask).
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from [`StageExt::final_mask`].
     pub fn final_mask<'a>(&self) -> Result<BondingObject<'a, F, R>> {
         S::Last::final_mask()
     }

--- a/crates/ragu_core/src/drivers.rs
+++ b/crates/ragu_core/src/drivers.rs
@@ -150,6 +150,11 @@ pub trait DriverTypes {
     /// [`Maybe`]/[`DriverValue`] system provides a
     /// stronger guarantee—those drivers never call this closure, and its body
     /// is dead-code-eliminated after monomorphization.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error produced by `values`, or any error from the driver
+    /// while allocating the gate.
     fn gate(
         &mut self,
         values: impl Fn() -> Result<(
@@ -166,6 +171,11 @@ pub trait DriverTypes {
     /// The provided closure follows the same purity contract as [`gate`](Self::gate):
     /// it may be called zero or more times, should be side-effect-free, and
     /// errors propagate to the caller.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error produced by `value`, or any error from the driver
+    /// while assigning the auxiliary wire.
     fn assign_extra(
         &mut self,
         extra: Self::Extra,
@@ -264,6 +274,11 @@ pub trait Driver<'dr>: DriverTypes<ImplWire = Self::Wire, ImplField = Self::F> +
     /// [`Maybe`]/[`DriverValue`] system provides a stronger guarantee—those
     /// drivers never call this closure, and its body is dead-code-eliminated
     /// after monomorphization.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error produced by `values`, or any error from the
+    /// underlying [`DriverTypes::gate`] call.
     fn mul(
         &mut self,
         values: impl Fn() -> Result<(Coeff<Self::F>, Coeff<Self::F>, Coeff<Self::F>)>,
@@ -302,9 +317,17 @@ pub trait Driver<'dr>: DriverTypes<ImplWire = Self::Wire, ImplField = Self::F> +
     /// [`LCenforce`](DriverTypes::LCenforce) argument may itself carry
     /// interior-mutable state (as a driver implementation detail), but circuit
     /// code should not introduce its own observable side effects.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the driver cannot record the constraint.
     fn enforce_zero(&mut self, lc: impl Fn(Self::LCenforce) -> Self::LCenforce) -> Result<()>;
 
     /// Enforces that two wires are equal.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from [`Driver::enforce_zero`].
     fn enforce_equal(&mut self, a: &Self::Wire, b: &Self::Wire) -> Result<()> {
         self.enforce_zero(|lc| lc.add(a).sub(b))
     }
@@ -315,6 +338,10 @@ pub trait Driver<'dr>: DriverTypes<ImplWire = Self::Wire, ImplField = Self::F> +
     }
 
     /// Proxy for the `Witness::try_just` method for this driver.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error produced by `f`.
     fn try_just<R: Send>(f: impl FnOnce() -> Result<R>) -> Result<DriverValue<Self, R>> {
         <DriverValue<Self, R> as Maybe<R>>::try_just(f)
     }
@@ -326,6 +353,10 @@ pub trait Driver<'dr>: DriverTypes<ImplWire = Self::Wire, ImplField = Self::F> +
     }
 
     /// Executes a routine with this driver.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from routine prediction or execution.
     fn routine<R: Routine<Self::F> + 'dr>(
         &mut self,
         routine: R,

--- a/crates/ragu_core/src/drivers/emulator.rs
+++ b/crates/ragu_core/src/drivers/emulator.rs
@@ -181,6 +181,11 @@ pub struct Emulator<M: Mode>(PhantomData<M>);
 impl<F: Field> Emulator<Wired<F>> {
     /// Extract the wires from a gadget produced using a wired [`Emulator`].
     /// This method returns the actual wire assignments if successful.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from remapping the gadget's wires into the output
+    /// vector.
     pub fn wires<'dr, G: Gadget<'dr, Self>>(&self, gadget: &G) -> Result<Vec<F>> {
         /// A conversion utility for extracting wire values.
         struct WireExtractor<F: Field> {

--- a/crates/ragu_core/src/gadgets.rs
+++ b/crates/ragu_core/src/gadgets.rs
@@ -122,6 +122,10 @@ pub trait Gadget<'dr, D: Driver<'dr>>: Clone {
     type Kind: GadgetKind<D::F, Rebind<'dr, D> = Self>;
 
     /// Proxy for [`GadgetKind::map_gadget`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from [`GadgetKind::map_gadget`].
     fn map<'dst, WM: WireMap<D::F, Src = D, Dst: Driver<'dst, F = D::F>>>(
         &self,
         wm: &mut WM,
@@ -130,6 +134,10 @@ pub trait Gadget<'dr, D: Driver<'dr>>: Clone {
     }
 
     /// Proxy for [`GadgetKind::enforce_equal_gadget`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from [`GadgetKind::enforce_equal_gadget`].
     fn enforce_equal<D2: Driver<'dr, F = D::F, Wire = D::Wire>>(
         &self,
         dr: &mut D2,

--- a/crates/ragu_core/src/maybe/mod.rs
+++ b/crates/ragu_core/src/maybe/mod.rs
@@ -98,6 +98,11 @@ pub trait Maybe<T: Send>: sealed::Sealed + Send {
     /// Creates a new value of this `Maybe<T>` given a fallible closure. Similar
     /// to `just` the provided closure is not called if the concrete type does
     /// not represent an existing value.
+    ///
+    /// # Errors
+    ///
+    /// If this `Maybe<T>` kind represents existing values, returns any error
+    /// produced by `f`.
     fn try_just<R: Send, E>(f: impl FnOnce() -> Result<R, E>) -> Result<Perhaps<Self::Kind, R>, E>;
 
     /// In contexts where the `Maybe<T>` is known or guaranteed to be an
@@ -170,6 +175,11 @@ pub trait MaybeKind: sealed::Sealed {
     }
 
     /// Proxy for the associated [`Maybe<T>::try_just`] method.
+    ///
+    /// # Errors
+    ///
+    /// If this kind represents existing values, returns any error produced by
+    /// `f`.
     fn maybe_try_just<R: Send, E>(f: impl FnOnce() -> Result<R, E>) -> Result<Self::Rebind<R>, E> {
         Self::Rebind::<R>::try_just(f)
     }

--- a/crates/ragu_pcd/src/header.rs
+++ b/crates/ragu_pcd/src/header.rs
@@ -96,6 +96,11 @@ pub trait Header<F: Field>: Send + Sync + Any {
     ///
     /// Implementations should pass `allocator` through to all allocation
     /// calls rather than substituting a different allocator.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error encountered while allocating or constraining the
+    /// encoded header gadget.
     fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
         dr: &mut D,
         allocator: &mut A,

--- a/crates/ragu_primitives/src/allocator.rs
+++ b/crates/ragu_primitives/src/allocator.rs
@@ -44,6 +44,11 @@ pub trait Allocator<'dr, D: Driver<'dr>> {
     /// The closure follows the same purity contract as [`Driver::mul`]:
     /// it may be called zero or more times, it must be side-effect-free,
     /// and errors returned from it propagate to the caller.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error produced by `value`, or any error from the driver
+    /// while allocating the wire.
     fn alloc(&mut self, dr: &mut D, value: impl Fn() -> Result<Coeff<D::F>>) -> Result<D::Wire>;
 
     /// Accepts a spare [`Extra`](ragu_core::drivers::DriverTypes::Extra)

--- a/crates/ragu_primitives/src/boolean.rs
+++ b/crates/ragu_primitives/src/boolean.rs
@@ -42,6 +42,11 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
     /// Allocates a boolean with the provided witness value.
     ///
     /// This costs one gate and two constraints.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the underlying gate allocation or from the
+    /// boolean constraints enforced afterward.
     pub fn alloc<A: crate::allocator::Allocator<'dr, D>>(
         dr: &mut D,
         allocator: &mut A,
@@ -74,6 +79,11 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
 
     /// Computes the AND of two booleans. This costs one gate and two
     /// constraints.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the multiplication gate or equality
+    /// constraints used to bind the operands.
     pub fn and(&self, dr: &mut D, other: &Self) -> Result<Self> {
         let result = D::just(|| self.value.snag() & other.value.snag());
         let (a, b, c) = dr.mul(|| {
@@ -96,6 +106,11 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
     /// Returns `a` when false, `b` when true.
     ///
     /// This costs one gate and two constraints.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the intermediate multiplication used to
+    /// apply the conditional difference.
     pub fn conditional_select(
         &self,
         dr: &mut D,
@@ -112,6 +127,11 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
     /// When this boolean is true, enforces `a == b`; when false, no constraint.
     ///
     /// This costs one gate and three constraints.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the gate allocation or equality and zero
+    /// constraints used to encode the conditional check.
     pub fn conditional_enforce_equal(
         &self,
         dr: &mut D,
@@ -242,6 +262,10 @@ impl<F: Field> Promotion<F> for Kind![F; @Boolean<'_, _>] {
 /// Packs boolean slices into field elements using little-endian bit order.
 ///
 /// The first bit in each chunk is the least significant bit.
+///
+/// # Errors
+///
+/// This function does not currently return an error.
 pub fn multipack<'dr, D: Driver<'dr, F: ff::PrimeField>>(
     dr: &mut D,
     bits: &[Boolean<'dr, D>],

--- a/crates/ragu_primitives/src/consistent.rs
+++ b/crates/ragu_primitives/src/consistent.rs
@@ -20,6 +20,11 @@ use ragu_core::{Result, drivers::Driver, gadgets::Gadget};
 /// [`Element`]: crate::Element
 pub trait Consistent<'dr, D: Driver<'dr>>: Gadget<'dr, D> {
     /// Enforce internal consistency constraints on this gadget's wires.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error encountered while enforcing the gadget's internal
+    /// constraints.
     fn enforce_consistent(&self, dr: &mut D) -> Result<()>;
 }
 

--- a/crates/ragu_primitives/src/element.rs
+++ b/crates/ragu_primitives/src/element.rs
@@ -65,6 +65,10 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
     /// supplied [`Allocator`] to create the underlying wire.
     ///
     /// This costs one allocation.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the provided [`Allocator`].
     pub fn alloc<A: Allocator<'dr, D>>(
         dr: &mut D,
         allocator: &mut A,
@@ -82,6 +86,11 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
     /// squares it in a single step. Returns $(a, a^2)$.
     ///
     /// This costs one gate.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the multiplication gate or the equality
+    /// constraint that ties its inputs together.
     pub fn alloc_square(dr: &mut D, assignment: DriverValue<D, D::F>) -> Result<(Self, Self)> {
         let square = D::just(|| assignment.snag().square());
         let (a, b, c) = dr.mul(|| {
@@ -150,6 +159,11 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
     }
 
     /// Multiply two elements together.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the multiplication gate or the equality
+    /// constraints that bind its inputs.
     pub fn mul(&self, dr: &mut D, other: &Self) -> Result<Self> {
         let product = D::just(|| {
             let a = *self.value.snag();
@@ -174,11 +188,19 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
     }
 
     /// Squares an element.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from [`Element::mul`].
     pub fn square(&self, dr: &mut D) -> Result<Self> {
         self.mul(dr, self)
     }
 
     /// Enforces that this element equals zero.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from [`Driver::enforce_zero`].
     pub fn enforce_zero(&self, dr: &mut D) -> Result<()> {
         dr.enforce_zero(|lc| lc.add(&self.wire))
     }
@@ -238,6 +260,11 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
     /// Invert this element if it is nonzero.
     ///
     /// This will fail to synthesize if the element is zero.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidWitness`] if the element is zero, or
+    /// propagates any error from [`Element::invert_with`].
     pub fn invert(&self, dr: &mut D) -> Result<Self> {
         let inverse = D::try_just(|| {
             self.value
@@ -252,6 +279,11 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
 
     /// Enforce that this element times the provided `inverse` (unallocated value) equals one.
     /// Returns the allocated `inverse` element.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the multiplication gate or the equality
+    /// constraints that bind the numerator and unit output.
     pub fn invert_with(&self, dr: &mut D, inverse: DriverValue<D, D::F>) -> Result<Self> {
         let (a, b, c) = dr.mul(|| {
             Ok((
@@ -278,6 +310,12 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
     ///
     /// which enforces that `quotient` is equal to `self / by` if and only if
     /// `by` is nonzero.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidWitness`] if `by` is zero, or propagates any
+    /// error from the multiplication gate or equality constraints used to bind
+    /// the quotient.
     pub fn div_nonzero(&self, dr: &mut D, by: &Self) -> Result<Self> {
         let quotient_value = D::try_just(|| {
             Ok(*self.value().take()
@@ -309,6 +347,10 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
     }
 
     /// Returns a boolean indicating whether this element is zero.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the underlying zero-check gadget.
     pub fn is_zero(
         &self,
         dr: &mut D,
@@ -318,6 +360,10 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
     }
 
     /// Returns a boolean indicating whether this element equals another.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from [`Element::is_zero`].
     pub fn is_equal(
         &self,
         dr: &mut D,
@@ -334,6 +380,11 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
     /// Horner's method is used to evaluate the weighted sum, effectively
     /// scaling the first element by the highest power of `scale_factor` and the
     /// last element by nothing at all.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the intermediate multiplications performed
+    /// while folding the iterator.
     pub fn fold<E: Borrow<Element<'dr, D>>>(
         dr: &mut D,
         elements: impl IntoIterator<Item = E>,
@@ -350,6 +401,11 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
     }
 
     /// Constrains that `self` is a $2^k$-th root of unity, i.e., $\mathtt{self}^{2^k} = 1$.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the repeated squaring steps or the final
+    /// zero constraint.
     pub fn enforce_root_of_unity(&self, dr: &mut D, k: u32) -> Result<()> {
         let mut value = self.clone();
         for _ in 0..k {

--- a/crates/ragu_primitives/src/endoscalar.rs
+++ b/crates/ragu_primitives/src/endoscalar.rs
@@ -44,6 +44,11 @@ pub struct Endoscalar<'dr, D: Driver<'dr>> {
 
 impl<'dr, D: Driver<'dr>> Endoscalar<'dr, D> {
     /// Allocate an endoscalar with the provided `Uendo` value.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from allocating or demoting the constituent
+    /// boolean bits.
     pub fn alloc(dr: &mut D, value: DriverValue<D, Uendo>) -> Result<Self> {
         // Convert the provided Uendo into a little-endian representation of its
         // bits.
@@ -76,6 +81,11 @@ impl<'dr, D: Driver<'dr>> Endoscalar<'dr, D> {
     }
 
     /// Extracts an endoscalar from a random element in the field.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from witness extraction, bit allocation,
+    /// intermediate field operations, or the final fixed-length collection.
     pub fn extract<A: crate::allocator::Allocator<'dr, D>>(
         dr: &mut D,
         allocator: &mut A,
@@ -152,6 +162,11 @@ impl<'dr, D: Driver<'dr>> Endoscalar<'dr, D> {
     }
 
     /// Scale a point by the endoscalar.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the intermediate point additions, doublings,
+    /// or conditional transformations.
     pub fn group_scale<C: CurveAffine<Base = D::F>>(
         &self,
         dr: &mut D,
@@ -175,6 +190,11 @@ impl<'dr, D: Driver<'dr>> Endoscalar<'dr, D> {
     }
 
     /// Lifts this endoscalar to a field element (scales $1$ by the endoscalar).
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the intermediate boolean and field-element
+    /// operations used during the lift.
     pub fn lift(&self, dr: &mut D) -> Result<Element<'dr, D>>
     where
         D::F: WithSmallOrderMulGroup<3>,

--- a/crates/ragu_primitives/src/io.rs
+++ b/crates/ragu_primitives/src/io.rs
@@ -39,6 +39,10 @@ use crate::Element;
 pub trait Write<F: Field>: GadgetKind<F> {
     /// Write this gadget into wires that are written the provided buffer,
     /// using the driver to synthesize the elements if needed.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error encountered while writing this gadget into `buf`.
     fn write_gadget<'dr, D: Driver<'dr, F = F>, B: Buffer<'dr, D>>(
         this: &Bound<'dr, D, Self>,
         dr: &mut D,
@@ -50,6 +54,11 @@ pub trait Write<F: Field>: GadgetKind<F> {
 /// provided driver context.
 pub trait Buffer<'dr, D: Driver<'dr>> {
     /// Push an `Element` into this buffer using the provided driver `D`.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error encountered while accepting `value` into this
+    /// buffer.
     fn write(&mut self, dr: &mut D, value: &Element<'dr, D>) -> Result<()>;
 }
 

--- a/crates/ragu_primitives/src/lib.rs
+++ b/crates/ragu_primitives/src/lib.rs
@@ -49,6 +49,10 @@ pub use suffix::WithSuffix;
 pub trait GadgetExt<'dr, D: Driver<'dr>>: Gadget<'dr, D> {
     /// Write this gadget into a buffer, assuming the gadget's
     /// [`Kind`](Gadget::Kind) implements [`Write`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from [`Write::write_gadget`].
     fn write<B: Buffer<'dr, D>>(&self, dr: &mut D, buf: &mut B) -> Result<()>
     where
         Self::Kind: Write<D::F>,
@@ -57,6 +61,10 @@ pub trait GadgetExt<'dr, D: Driver<'dr>>: Gadget<'dr, D> {
     }
 
     /// Demote this gadget by stripping its witness data.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from [`Demoted::new`].
     fn demote(&self) -> Result<Demoted<'dr, D, Self>> {
         Demoted::new(self)
     }

--- a/crates/ragu_primitives/src/point.rs
+++ b/crates/ragu_primitives/src/point.rs
@@ -46,6 +46,12 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
     ///
     /// This method uses [`Element::alloc_square`] to allocate coordinates and
     /// then enforces the curve equation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidWitness`] if `p` is the point at infinity, or
+    /// any synthesis error encountered while allocating coordinates and
+    /// enforcing the curve equation.
     pub fn alloc(dr: &mut D, p: DriverValue<D, C>) -> Result<Self> {
         let coordinates = D::try_just(|| {
             let coordinates = p.take().coordinates().into_option();
@@ -70,6 +76,10 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
 
     /// Obtain a constant point in the circuit. Fails if the point is the
     /// identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidWitness`] if `p` is the identity.
     pub fn constant(dr: &mut D, p: C) -> Result<Self> {
         if let Some(coordinates) = p.coordinates().into_option() {
             let x = Element::constant(dr, *coordinates.x());
@@ -108,6 +118,10 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
     }
 
     /// Apply the endomorphism iff the provided condition is true.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the conditional element selection.
     pub fn conditional_endo(&self, dr: &mut D, condition: &Boolean<'dr, D>) -> Result<Self> {
         let endo_x = self.x.scale(dr, Coeff::Arbitrary(D::F::ZETA));
         let x = condition.conditional_select(dr, &self.x, &endo_x)?;
@@ -115,6 +129,10 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
     }
 
     /// Apply the negation map iff the provided condition is true.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the conditional element selection.
     pub fn conditional_negate(&self, dr: &mut D, condition: &Boolean<'dr, D>) -> Result<Self> {
         let neg_y = self.y.negate(dr);
         let y = condition.conditional_select(dr, &self.y, &neg_y)?;
@@ -123,6 +141,12 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
 
     /// Doubles this point. Ragu does not support curves with points of order
     /// two, and thus all affine points have affine doubles.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any synthesis error from the intermediate field operations,
+    /// including division-by-zero witness failures if the doubling formula's
+    /// denominator is witnessed as zero.
     pub fn double(&self, dr: &mut D) -> Result<Self> {
         // delta = 3x^2 / 2y
         let double_y = self.y.double(dr);
@@ -150,6 +174,12 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
     /// processing a batch of additions, [invert](Element::invert) `*acc` once;
     /// inversion succeeds iff every `x_1 - x_0 != 0`, thereby certifying that
     /// all pairs had distinct x-coordinates.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any synthesis error from the intermediate field operations,
+    /// including division-by-zero witness failures if the points do not have
+    /// distinct x-coordinates.
     pub fn add_incomplete(
         &self,
         dr: &mut D,
@@ -179,6 +209,12 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
 
     /// Computes $\[2\] Q + P$. **The caller must ensure that $P$ and $Q$ do not
     /// have the same x-coordinate and that the result is not the identity.**
+    ///
+    /// # Errors
+    ///
+    /// Propagates any synthesis error from the intermediate field operations,
+    /// including division-by-zero witness failures if the caller's
+    /// preconditions are violated.
     pub fn double_and_add_incomplete(&self, dr: &mut D, other: &Self) -> Result<Self> {
         // See <https://github.com/zcash/zcash/issues/3924> for an explanation.
 

--- a/crates/ragu_primitives/src/poseidon.rs
+++ b/crates/ragu_primitives/src/poseidon.rs
@@ -154,6 +154,11 @@ impl<'dr, D: Driver<'dr>, P: ragu_arithmetic::PoseidonPermutation<D::F>> Sponge<
     }
 
     /// Squeeze a value from the sponge.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ragu_core::Error::Initialization`] if no values have been
+    /// absorbed yet, or any synthesis error from the internal permutation.
     pub fn squeeze(&mut self, dr: &mut D) -> Result<Element<'dr, D>> {
         match &mut self.mode {
             Mode::Squeeze { values, .. } => {
@@ -192,6 +197,11 @@ impl<'dr, D: Driver<'dr>, P: ragu_arithmetic::PoseidonPermutation<D::F>> Sponge<
     }
 
     /// Absorb a value into the sponge.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any synthesis error from the internal permutation needed
+    /// when the absorb buffer is full or when switching out of squeeze mode.
     pub fn absorb(&mut self, dr: &mut D, value: &Element<'dr, D>) -> Result<()> {
         match &mut self.mode {
             Mode::Squeeze { state, .. } => {

--- a/crates/ragu_primitives/src/promotion.rs
+++ b/crates/ragu_primitives/src/promotion.rs
@@ -126,6 +126,10 @@ impl<'dr, D: Driver<'dr>, G: Gadget<'dr, D>> Deref for Demoted<'dr, D, G> {
 
 impl<'dr, D: Driver<'dr>, G: Gadget<'dr, D>> Demoted<'dr, D, G> {
     /// Strips a gadget of its witness data and returns a demoted version of it.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the underlying wire remapping operation.
     pub fn new(gadget: &G) -> Result<Self> {
         Ok(Demoted {
             gadget: CloneWires::<_, DemotedDriver<D>>::remap(gadget)?,

--- a/crates/ragu_primitives/src/vec.rs
+++ b/crates/ragu_primitives/src/vec.rs
@@ -101,6 +101,11 @@ impl<T, L: Len> TryFrom<Vec<T>> for FixedVec<T, L> {
 pub trait CollectFixed: Iterator + Sized {
     /// Collect this iterator into a [`FixedVec`], returning an error if the
     /// length does not match [`L::len()`](Len::len).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::VectorLengthMismatch`] if the collected iterator length
+    /// does not match [`L::len()`](Len::len).
     fn collect_fixed<L: Len>(self) -> Result<FixedVec<Self::Item, L>> {
         FixedVec::try_from(self.collect::<Vec<_>>())
     }
@@ -108,6 +113,12 @@ pub trait CollectFixed: Iterator + Sized {
     /// Collect this iterator of [`ragu_core::Result`]s into a [`FixedVec`],
     /// short-circuiting on the first error, then returning an error if the
     /// length does not match [`L::len()`](Len::len).
+    ///
+    /// # Errors
+    ///
+    /// Returns the first error produced by the iterator, or
+    /// [`Error::VectorLengthMismatch`] if the collected length does not match
+    /// [`L::len()`](Len::len).
     fn try_collect_fixed<T, L: Len>(self) -> Result<FixedVec<T, L>>
     where
         Self: Iterator<Item = Result<T>>,
@@ -122,6 +133,11 @@ impl<I: Iterator> CollectFixed for I {}
 impl<T, L: Len> FixedVec<T, L> {
     /// Creates a new [`FixedVec`] from a vector, returning an error if the
     /// length does not match [`L::len()`](Len::len).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::VectorLengthMismatch`] if `v.len()` does not match
+    /// [`L::len()`](Len::len).
     pub fn new(v: Vec<T>) -> Result<Self> {
         Self::try_from(v)
     }
@@ -142,6 +158,12 @@ impl<T, L: Len> FixedVec<T, L> {
     /// Initialize a [`FixedVec`] using a closure that initializes each element
     /// based on its index, returning an error instead if the closure ever
     /// returns an error.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first error produced by `f`, or
+    /// [`Error::VectorLengthMismatch`] if the constructed vector length does
+    /// not match [`L::len()`](Len::len).
     pub fn try_from_fn<F>(f: F) -> Result<Self>
     where
         F: FnMut(usize) -> Result<T>,


### PR DESCRIPTION
Adds missing rustdoc `# Errors` sections across the main public `Result`-returning API surface in `ragu_core`, `ragu_primitives`, `ragu_circuits`, and `ragu_pcd`.