### PR TITLE
perf: share child proof rx polynomials

### DIFF
--- a/crates/ragu_pcd/src/proof/builder.rs
+++ b/crates/ragu_pcd/src/proof/builder.rs
@@ -17,7 +17,7 @@ use ragu_circuits::{
 };
 use ragu_core::Result;
 
-use super::{Cached, Proof, SharedPolynomial};
+use super::{Cached, Proof};
 use crate::internal::nested;
 
 /// Produces `pub(crate) fn $name(&mut self, v: $ty)` that sets an `Option`
@@ -112,7 +112,7 @@ macro_rules! bridge_pair {
             commitment: C::NestedCurve,
         ) {
             assert!(self.$rx.is_none(), concat!("double-set: ", stringify!($rx)));
-            self.$rx = Some(rx);
+            self.$rx = Some(Arc::new(rx));
             self.$commitment = Some(commitment);
         }
 
@@ -163,7 +163,7 @@ macro_rules! explicit_commitment_getter {
     };
 }
 
-/// Produces `pub(crate) fn $rx(&self) -> Result<&sparse::Polynomial<...>>`
+/// Produces `pub(crate) fn $rx(&self) -> Result<&Arc<sparse::Polynomial<...>>>`
 /// and `pub(crate) fn $commitment(&self) -> Result<C::NestedCurve>` that
 /// lazily derive a cached bridge. On first call, `$rx` builds a
 /// `nested::stages::$stage::Witness` from the given getter methods, derives
@@ -177,9 +177,9 @@ macro_rules! explicit_commitment_getter {
 macro_rules! cached_bridge {
     ($rx:ident, $commitment:ident,
      $idx:expr, $stage:ident, { $($wit_field:ident : $getter:ident()),* }) => {
-        pub(crate) fn $rx(&self) -> Result<&sparse::Polynomial<C::ScalarField, R>> {
+        pub(crate) fn $rx(&self) -> Result<&Arc<sparse::Polynomial<C::ScalarField, R>>> {
             if let Some(rx) = self.$rx.get() {
-                return Ok(rx.as_ref());
+                return Ok(rx);
             }
             let rx = nested::stages::$stage::Stage::<C::HostCurve, R>::rx(
                 self.bridge_alpha_power($idx),
@@ -189,7 +189,7 @@ macro_rules! cached_bridge {
             )?;
             // The early return above guarantees the cell is empty, so
             // `get_or_init` will always run the closure and store `rx`.
-            Ok(self.$rx.get_or_init(|| Arc::new(rx)).as_ref())
+            Ok(self.$rx.get_or_init(|| Arc::new(rx)))
         }
 
         pub(crate) fn $commitment(&self) -> Result<C::NestedCurve> {
@@ -235,28 +235,28 @@ pub(crate) struct ProofBuilder<'params, C: Cycle, R: Rank> {
     native_compute_v_rx: Option<sparse::Polynomial<C::CircuitField, R>>,
 
     // Bridge rx polynomials + commitments (set together by caller)
-    bridge_preamble_rx: Option<sparse::Polynomial<C::ScalarField, R>>,
+    bridge_preamble_rx: Option<Arc<sparse::Polynomial<C::ScalarField, R>>>,
     bridge_preamble_commitment: Option<C::NestedCurve>,
-    bridge_s_prime_rx: Option<SharedPolynomial<C::ScalarField, R>>,
+    bridge_s_prime_rx: Option<Arc<sparse::Polynomial<C::ScalarField, R>>>,
     bridge_s_prime_commitment: Option<C::NestedCurve>,
-    bridge_inner_error_rx: Option<SharedPolynomial<C::ScalarField, R>>,
+    bridge_inner_error_rx: Option<Arc<sparse::Polynomial<C::ScalarField, R>>>,
     bridge_inner_error_commitment: Option<C::NestedCurve>,
-    bridge_f_rx: Option<sparse::Polynomial<C::ScalarField, R>>,
+    bridge_f_rx: Option<Arc<sparse::Polynomial<C::ScalarField, R>>>,
     bridge_f_commitment: Option<C::NestedCurve>,
 
     // Cached bridge rx polynomials (lazily derived from `bridge_alpha` +
     // native commitments). Parallels the native rx/commitment split: the rx
     // slot is populated on first access, and the commitment slot is derived
     // lazily from it.
-    bridge_outer_error_rx: OnceCell<SharedPolynomial<C::ScalarField, R>>,
-    bridge_ab_rx: OnceCell<SharedPolynomial<C::ScalarField, R>>,
-    bridge_query_rx: OnceCell<SharedPolynomial<C::ScalarField, R>>,
-    bridge_eval_rx: OnceCell<SharedPolynomial<C::ScalarField, R>>,
+    bridge_outer_error_rx: OnceCell<Arc<sparse::Polynomial<C::ScalarField, R>>>,
+    bridge_ab_rx: OnceCell<Arc<sparse::Polynomial<C::ScalarField, R>>>,
+    bridge_query_rx: OnceCell<Arc<sparse::Polynomial<C::ScalarField, R>>>,
+    bridge_eval_rx: OnceCell<Arc<sparse::Polynomial<C::ScalarField, R>>>,
 
     // Nested endoscaling data
     nested_endoscaling_step_rxs: Option<Vec<sparse::Polynomial<C::ScalarField, R>>>,
     nested_endoscalar_rx: Option<sparse::Polynomial<C::ScalarField, R>>,
-    nested_points_rx: Option<SharedPolynomial<C::ScalarField, R>>,
+    nested_points_rx: Option<Arc<sparse::Polynomial<C::ScalarField, R>>>,
 
     // Nested endoscaling commitment caches (lazily computed from polynomials)
     nested_endoscaling_step_commitments: OnceCell<Vec<C::NestedCurve>>,
@@ -416,47 +416,21 @@ impl<'params, C: Cycle, R: Rank> ProofBuilder<'params, C, R> {
     ref_getter!(native_registry_xy_poly, native_registry_xy_poly, sparse::Polynomial<C::CircuitField, R>);
     ref_getter!(native_p_poly, native_p_poly, sparse::Polynomial<C::CircuitField, R>);
 
-    pub(crate) fn nested_points_rx(&self) -> &sparse::Polynomial<C::ScalarField, R> {
-        self.nested_points_rx
-            .as_deref()
-            .expect("nested_points_rx not set")
-    }
-
-    pub(crate) fn shared_nested_points_rx(&self) -> SharedPolynomial<C::ScalarField, R> {
-        Arc::clone(
-            self.nested_points_rx
-                .as_ref()
-                .expect("nested_points_rx not set"),
-        )
-    }
-
-    pub(crate) fn bridge_s_prime_rx(&self) -> &sparse::Polynomial<C::ScalarField, R> {
-        self.bridge_s_prime_rx
-            .as_deref()
-            .expect("bridge_s_prime_rx not set")
-    }
-
-    pub(crate) fn shared_bridge_s_prime_rx(&self) -> SharedPolynomial<C::ScalarField, R> {
-        Arc::clone(
-            self.bridge_s_prime_rx
-                .as_ref()
-                .expect("bridge_s_prime_rx not set"),
-        )
-    }
-
-    pub(crate) fn bridge_inner_error_rx(&self) -> &sparse::Polynomial<C::ScalarField, R> {
-        self.bridge_inner_error_rx
-            .as_deref()
-            .expect("bridge_inner_error_rx not set")
-    }
-
-    pub(crate) fn shared_bridge_inner_error_rx(&self) -> SharedPolynomial<C::ScalarField, R> {
-        Arc::clone(
-            self.bridge_inner_error_rx
-                .as_ref()
-                .expect("bridge_inner_error_rx not set"),
-        )
-    }
+    ref_getter!(
+        nested_points_rx,
+        nested_points_rx,
+        Arc<sparse::Polynomial<C::ScalarField, R>>
+    );
+    ref_getter!(
+        bridge_s_prime_rx,
+        bridge_s_prime_rx,
+        Arc<sparse::Polynomial<C::ScalarField, R>>
+    );
+    ref_getter!(
+        bridge_inner_error_rx,
+        bridge_inner_error_rx,
+        Arc<sparse::Polynomial<C::ScalarField, R>>
+    );
 
     lazy_commitment!(
         native,
@@ -542,47 +516,23 @@ impl<'params, C: Cycle, R: Rank> ProofBuilder<'params, C, R> {
         bridge_preamble_commitment
     );
     bridge_pair!(
+        set_bridge_s_prime_rx,
+        bridge_s_prime_commitment,
+        bridge_s_prime_rx,
+        bridge_s_prime_commitment
+    );
+    bridge_pair!(
+        set_bridge_inner_error_rx,
+        bridge_inner_error_commitment,
+        bridge_inner_error_rx,
+        bridge_inner_error_commitment
+    );
+    bridge_pair!(
         set_bridge_f_rx,
         bridge_f_commitment,
         bridge_f_rx,
         bridge_f_commitment
     );
-
-    pub(crate) fn set_bridge_s_prime_rx(
-        &mut self,
-        rx: sparse::Polynomial<C::ScalarField, R>,
-        commitment: C::NestedCurve,
-    ) {
-        assert!(
-            self.bridge_s_prime_rx.is_none(),
-            "double-set: bridge_s_prime_rx"
-        );
-        self.bridge_s_prime_rx = Some(Arc::new(rx));
-        self.bridge_s_prime_commitment = Some(commitment);
-    }
-
-    pub(crate) fn bridge_s_prime_commitment(&self) -> C::NestedCurve {
-        self.bridge_s_prime_commitment
-            .expect("bridge_s_prime_commitment not set")
-    }
-
-    pub(crate) fn set_bridge_inner_error_rx(
-        &mut self,
-        rx: sparse::Polynomial<C::ScalarField, R>,
-        commitment: C::NestedCurve,
-    ) {
-        assert!(
-            self.bridge_inner_error_rx.is_none(),
-            "double-set: bridge_inner_error_rx"
-        );
-        self.bridge_inner_error_rx = Some(Arc::new(rx));
-        self.bridge_inner_error_commitment = Some(commitment);
-    }
-
-    pub(crate) fn bridge_inner_error_commitment(&self) -> C::NestedCurve {
-        self.bridge_inner_error_commitment
-            .expect("bridge_inner_error_commitment not set")
-    }
 
     /// Returns the derived alpha for a cached bridge, as a distinct power of
     /// `bridge_alpha`.
@@ -641,38 +591,6 @@ impl<'params, C: Cycle, R: Rank> ProofBuilder<'params, C, R> {
             "double-set: nested_points_rx"
         );
         self.nested_points_rx = Some(Arc::new(v));
-    }
-
-    pub(crate) fn shared_bridge_outer_error_rx(
-        &self,
-    ) -> Result<SharedPolynomial<C::ScalarField, R>> {
-        self.bridge_outer_error_rx()?;
-        Ok(Arc::clone(
-            self.bridge_outer_error_rx
-                .get()
-                .expect("bridge_outer_error_rx not set"),
-        ))
-    }
-
-    pub(crate) fn shared_bridge_ab_rx(&self) -> Result<SharedPolynomial<C::ScalarField, R>> {
-        self.bridge_ab_rx()?;
-        Ok(Arc::clone(
-            self.bridge_ab_rx.get().expect("bridge_ab_rx not set"),
-        ))
-    }
-
-    pub(crate) fn shared_bridge_query_rx(&self) -> Result<SharedPolynomial<C::ScalarField, R>> {
-        self.bridge_query_rx()?;
-        Ok(Arc::clone(
-            self.bridge_query_rx.get().expect("bridge_query_rx not set"),
-        ))
-    }
-
-    pub(crate) fn shared_bridge_eval_rx(&self) -> Result<SharedPolynomial<C::ScalarField, R>> {
-        self.bridge_eval_rx()?;
-        Ok(Arc::clone(
-            self.bridge_eval_rx.get().expect("bridge_eval_rx not set"),
-        ))
     }
 
     /// Lazily computes and caches commitments for all endoscaling step rx

--- a/crates/ragu_pcd/src/proof/builder.rs
+++ b/crates/ragu_pcd/src/proof/builder.rs
@@ -6,7 +6,7 @@
 //! lazily computed from [`bridge_alpha`](ProofBuilder::bridge_alpha) and the
 //! native commitments already on the builder.
 
-use alloc::vec::Vec;
+use alloc::{sync::Arc, vec::Vec};
 use core::cell::OnceCell;
 
 use ragu_arithmetic::{Cycle, ff::Field};
@@ -17,7 +17,7 @@ use ragu_circuits::{
 };
 use ragu_core::Result;
 
-use super::{Cached, Proof};
+use super::{Cached, Proof, SharedPolynomial};
 use crate::internal::nested;
 
 /// Produces `pub(crate) fn $name(&mut self, v: $ty)` that sets an `Option`
@@ -179,7 +179,7 @@ macro_rules! cached_bridge {
      $idx:expr, $stage:ident, { $($wit_field:ident : $getter:ident()),* }) => {
         pub(crate) fn $rx(&self) -> Result<&sparse::Polynomial<C::ScalarField, R>> {
             if let Some(rx) = self.$rx.get() {
-                return Ok(rx);
+                return Ok(rx.as_ref());
             }
             let rx = nested::stages::$stage::Stage::<C::HostCurve, R>::rx(
                 self.bridge_alpha_power($idx),
@@ -189,7 +189,7 @@ macro_rules! cached_bridge {
             )?;
             // The early return above guarantees the cell is empty, so
             // `get_or_init` will always run the closure and store `rx`.
-            Ok(self.$rx.get_or_init(|| rx))
+            Ok(self.$rx.get_or_init(|| Arc::new(rx)).as_ref())
         }
 
         pub(crate) fn $commitment(&self) -> Result<C::NestedCurve> {
@@ -237,9 +237,9 @@ pub(crate) struct ProofBuilder<'params, C: Cycle, R: Rank> {
     // Bridge rx polynomials + commitments (set together by caller)
     bridge_preamble_rx: Option<sparse::Polynomial<C::ScalarField, R>>,
     bridge_preamble_commitment: Option<C::NestedCurve>,
-    bridge_s_prime_rx: Option<sparse::Polynomial<C::ScalarField, R>>,
+    bridge_s_prime_rx: Option<SharedPolynomial<C::ScalarField, R>>,
     bridge_s_prime_commitment: Option<C::NestedCurve>,
-    bridge_inner_error_rx: Option<sparse::Polynomial<C::ScalarField, R>>,
+    bridge_inner_error_rx: Option<SharedPolynomial<C::ScalarField, R>>,
     bridge_inner_error_commitment: Option<C::NestedCurve>,
     bridge_f_rx: Option<sparse::Polynomial<C::ScalarField, R>>,
     bridge_f_commitment: Option<C::NestedCurve>,
@@ -248,15 +248,15 @@ pub(crate) struct ProofBuilder<'params, C: Cycle, R: Rank> {
     // native commitments). Parallels the native rx/commitment split: the rx
     // slot is populated on first access, and the commitment slot is derived
     // lazily from it.
-    bridge_outer_error_rx: OnceCell<sparse::Polynomial<C::ScalarField, R>>,
-    bridge_ab_rx: OnceCell<sparse::Polynomial<C::ScalarField, R>>,
-    bridge_query_rx: OnceCell<sparse::Polynomial<C::ScalarField, R>>,
-    bridge_eval_rx: OnceCell<sparse::Polynomial<C::ScalarField, R>>,
+    bridge_outer_error_rx: OnceCell<SharedPolynomial<C::ScalarField, R>>,
+    bridge_ab_rx: OnceCell<SharedPolynomial<C::ScalarField, R>>,
+    bridge_query_rx: OnceCell<SharedPolynomial<C::ScalarField, R>>,
+    bridge_eval_rx: OnceCell<SharedPolynomial<C::ScalarField, R>>,
 
     // Nested endoscaling data
     nested_endoscaling_step_rxs: Option<Vec<sparse::Polynomial<C::ScalarField, R>>>,
     nested_endoscalar_rx: Option<sparse::Polynomial<C::ScalarField, R>>,
-    nested_points_rx: Option<sparse::Polynomial<C::ScalarField, R>>,
+    nested_points_rx: Option<SharedPolynomial<C::ScalarField, R>>,
 
     // Nested endoscaling commitment caches (lazily computed from polynomials)
     nested_endoscaling_step_commitments: OnceCell<Vec<C::NestedCurve>>,
@@ -415,9 +415,48 @@ impl<'params, C: Cycle, R: Rank> ProofBuilder<'params, C, R> {
     ref_getter!(native_b_poly, native_b_poly, sparse::Polynomial<C::CircuitField, R>);
     ref_getter!(native_registry_xy_poly, native_registry_xy_poly, sparse::Polynomial<C::CircuitField, R>);
     ref_getter!(native_p_poly, native_p_poly, sparse::Polynomial<C::CircuitField, R>);
-    ref_getter!(nested_points_rx, nested_points_rx, sparse::Polynomial<C::ScalarField, R>);
-    ref_getter!(bridge_s_prime_rx, bridge_s_prime_rx, sparse::Polynomial<C::ScalarField, R>);
-    ref_getter!(bridge_inner_error_rx, bridge_inner_error_rx, sparse::Polynomial<C::ScalarField, R>);
+
+    pub(crate) fn nested_points_rx(&self) -> &sparse::Polynomial<C::ScalarField, R> {
+        self.nested_points_rx
+            .as_deref()
+            .expect("nested_points_rx not set")
+    }
+
+    pub(crate) fn shared_nested_points_rx(&self) -> SharedPolynomial<C::ScalarField, R> {
+        Arc::clone(
+            self.nested_points_rx
+                .as_ref()
+                .expect("nested_points_rx not set"),
+        )
+    }
+
+    pub(crate) fn bridge_s_prime_rx(&self) -> &sparse::Polynomial<C::ScalarField, R> {
+        self.bridge_s_prime_rx
+            .as_deref()
+            .expect("bridge_s_prime_rx not set")
+    }
+
+    pub(crate) fn shared_bridge_s_prime_rx(&self) -> SharedPolynomial<C::ScalarField, R> {
+        Arc::clone(
+            self.bridge_s_prime_rx
+                .as_ref()
+                .expect("bridge_s_prime_rx not set"),
+        )
+    }
+
+    pub(crate) fn bridge_inner_error_rx(&self) -> &sparse::Polynomial<C::ScalarField, R> {
+        self.bridge_inner_error_rx
+            .as_deref()
+            .expect("bridge_inner_error_rx not set")
+    }
+
+    pub(crate) fn shared_bridge_inner_error_rx(&self) -> SharedPolynomial<C::ScalarField, R> {
+        Arc::clone(
+            self.bridge_inner_error_rx
+                .as_ref()
+                .expect("bridge_inner_error_rx not set"),
+        )
+    }
 
     lazy_commitment!(
         native,
@@ -503,23 +542,47 @@ impl<'params, C: Cycle, R: Rank> ProofBuilder<'params, C, R> {
         bridge_preamble_commitment
     );
     bridge_pair!(
-        set_bridge_s_prime_rx,
-        bridge_s_prime_commitment,
-        bridge_s_prime_rx,
-        bridge_s_prime_commitment
-    );
-    bridge_pair!(
-        set_bridge_inner_error_rx,
-        bridge_inner_error_commitment,
-        bridge_inner_error_rx,
-        bridge_inner_error_commitment
-    );
-    bridge_pair!(
         set_bridge_f_rx,
         bridge_f_commitment,
         bridge_f_rx,
         bridge_f_commitment
     );
+
+    pub(crate) fn set_bridge_s_prime_rx(
+        &mut self,
+        rx: sparse::Polynomial<C::ScalarField, R>,
+        commitment: C::NestedCurve,
+    ) {
+        assert!(
+            self.bridge_s_prime_rx.is_none(),
+            "double-set: bridge_s_prime_rx"
+        );
+        self.bridge_s_prime_rx = Some(Arc::new(rx));
+        self.bridge_s_prime_commitment = Some(commitment);
+    }
+
+    pub(crate) fn bridge_s_prime_commitment(&self) -> C::NestedCurve {
+        self.bridge_s_prime_commitment
+            .expect("bridge_s_prime_commitment not set")
+    }
+
+    pub(crate) fn set_bridge_inner_error_rx(
+        &mut self,
+        rx: sparse::Polynomial<C::ScalarField, R>,
+        commitment: C::NestedCurve,
+    ) {
+        assert!(
+            self.bridge_inner_error_rx.is_none(),
+            "double-set: bridge_inner_error_rx"
+        );
+        self.bridge_inner_error_rx = Some(Arc::new(rx));
+        self.bridge_inner_error_commitment = Some(commitment);
+    }
+
+    pub(crate) fn bridge_inner_error_commitment(&self) -> C::NestedCurve {
+        self.bridge_inner_error_commitment
+            .expect("bridge_inner_error_commitment not set")
+    }
 
     /// Returns the derived alpha for a cached bridge, as a distinct power of
     /// `bridge_alpha`.
@@ -572,7 +635,45 @@ impl<'params, C: Cycle, R: Rank> ProofBuilder<'params, C, R> {
         Vec<sparse::Polynomial<C::ScalarField, R>>
     );
     setter!(set_nested_endoscalar_rx, nested_endoscalar_rx, sparse::Polynomial<C::ScalarField, R>);
-    setter!(set_nested_points_rx, nested_points_rx, sparse::Polynomial<C::ScalarField, R>);
+    pub(crate) fn set_nested_points_rx(&mut self, v: sparse::Polynomial<C::ScalarField, R>) {
+        assert!(
+            self.nested_points_rx.is_none(),
+            "double-set: nested_points_rx"
+        );
+        self.nested_points_rx = Some(Arc::new(v));
+    }
+
+    pub(crate) fn shared_bridge_outer_error_rx(
+        &self,
+    ) -> Result<SharedPolynomial<C::ScalarField, R>> {
+        self.bridge_outer_error_rx()?;
+        Ok(Arc::clone(
+            self.bridge_outer_error_rx
+                .get()
+                .expect("bridge_outer_error_rx not set"),
+        ))
+    }
+
+    pub(crate) fn shared_bridge_ab_rx(&self) -> Result<SharedPolynomial<C::ScalarField, R>> {
+        self.bridge_ab_rx()?;
+        Ok(Arc::clone(
+            self.bridge_ab_rx.get().expect("bridge_ab_rx not set"),
+        ))
+    }
+
+    pub(crate) fn shared_bridge_query_rx(&self) -> Result<SharedPolynomial<C::ScalarField, R>> {
+        self.bridge_query_rx()?;
+        Ok(Arc::clone(
+            self.bridge_query_rx.get().expect("bridge_query_rx not set"),
+        ))
+    }
+
+    pub(crate) fn shared_bridge_eval_rx(&self) -> Result<SharedPolynomial<C::ScalarField, R>> {
+        self.bridge_eval_rx()?;
+        Ok(Arc::clone(
+            self.bridge_eval_rx.get().expect("bridge_eval_rx not set"),
+        ))
+    }
 
     /// Lazily computes and caches commitments for all endoscaling step rx
     /// polynomials. Returns the cached slice.

--- a/crates/ragu_pcd/src/proof/builder.rs
+++ b/crates/ragu_pcd/src/proof/builder.rs
@@ -125,7 +125,7 @@ macro_rules! bridge_pair {
 
 /// Produces `pub(crate) fn $name(&mut self, poly, commitment)` that stores a
 /// native polynomial in an `Option` field and its pre-computed commitment in a
-/// `Cell` cache. Used for a/b/p whose commitments are computed via non-standard
+/// `OnceCell` cache. Used for a/b/p whose commitments are computed via non-standard
 /// techniques rather than lazy evaluation.
 macro_rules! native_poly_with_commitment_setter {
     ($name:ident, $poly:ident, $cache:ident) => {
@@ -148,7 +148,7 @@ macro_rules! native_poly_with_commitment_setter {
 }
 
 /// Produces `pub(crate) fn $getter(&self) -> C::HostCurve` that reads a
-/// pre-computed native commitment from a `Cell`. Used for a/b/p whose
+/// pre-computed native commitment from a `OnceCell`. Used for a/b/p whose
 /// commitments are set explicitly via a special setter rather than lazily.
 macro_rules! explicit_commitment_getter {
     ($getter:ident, $cache:ident, $setter:ident) => {

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -45,8 +45,6 @@ use crate::{
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct Cached<T>(T);
 
-type SharedPolynomial<F, R> = Arc<sparse::Polynomial<F, R>>;
-
 /// Represents proof-carrying data, a recursive proof for the correctness of
 /// some accompanying data.
 pub struct Pcd<C: Cycle, R: Rank, H: Header<C::CircuitField>> {
@@ -85,13 +83,13 @@ impl<C: Cycle, R: Rank, H: Header<C::CircuitField>> Clone for Pcd<C, R, H> {
 /// check copying circuit claims.
 #[derive(Clone)]
 pub(crate) struct ChildStageRx<F: ragu_arithmetic::ff::PrimeField, R: Rank> {
-    pub points_stage: SharedPolynomial<F, R>,
-    pub bridge_s_prime: SharedPolynomial<F, R>,
-    pub bridge_inner_error: SharedPolynomial<F, R>,
-    pub bridge_outer_error: SharedPolynomial<F, R>,
-    pub bridge_ab: SharedPolynomial<F, R>,
-    pub bridge_query: SharedPolynomial<F, R>,
-    pub bridge_eval: SharedPolynomial<F, R>,
+    pub points_stage: Arc<sparse::Polynomial<F, R>>,
+    pub bridge_s_prime: Arc<sparse::Polynomial<F, R>>,
+    pub bridge_inner_error: Arc<sparse::Polynomial<F, R>>,
+    pub bridge_outer_error: Arc<sparse::Polynomial<F, R>>,
+    pub bridge_ab: Arc<sparse::Polynomial<F, R>>,
+    pub bridge_query: Arc<sparse::Polynomial<F, R>>,
+    pub bridge_eval: Arc<sparse::Polynomial<F, R>>,
 }
 
 impl<F: ragu_arithmetic::ff::PrimeField, R: Rank> ChildStageRx<F, R> {
@@ -158,21 +156,21 @@ pub struct Proof<C: Cycle, R: Rank> {
     pub(crate) native_compute_v_rx: sparse::Polynomial<C::CircuitField, R>,
 
     // Bridge rx polynomials (non-cached, set by caller)
-    pub(crate) bridge_preamble_rx: sparse::Polynomial<C::ScalarField, R>,
-    pub(crate) bridge_s_prime_rx: SharedPolynomial<C::ScalarField, R>,
-    pub(crate) bridge_inner_error_rx: SharedPolynomial<C::ScalarField, R>,
-    pub(crate) bridge_f_rx: sparse::Polynomial<C::ScalarField, R>,
+    pub(crate) bridge_preamble_rx: Arc<sparse::Polynomial<C::ScalarField, R>>,
+    pub(crate) bridge_s_prime_rx: Arc<sparse::Polynomial<C::ScalarField, R>>,
+    pub(crate) bridge_inner_error_rx: Arc<sparse::Polynomial<C::ScalarField, R>>,
+    pub(crate) bridge_f_rx: Arc<sparse::Polynomial<C::ScalarField, R>>,
 
     // Bridge rx polynomials (cached, derived from bridge_alpha + native commitments)
-    bridge_outer_error_rx: Cached<SharedPolynomial<C::ScalarField, R>>,
-    bridge_ab_rx: Cached<SharedPolynomial<C::ScalarField, R>>,
-    bridge_query_rx: Cached<SharedPolynomial<C::ScalarField, R>>,
-    bridge_eval_rx: Cached<SharedPolynomial<C::ScalarField, R>>,
+    bridge_outer_error_rx: Cached<Arc<sparse::Polynomial<C::ScalarField, R>>>,
+    bridge_ab_rx: Cached<Arc<sparse::Polynomial<C::ScalarField, R>>>,
+    bridge_query_rx: Cached<Arc<sparse::Polynomial<C::ScalarField, R>>>,
+    bridge_eval_rx: Cached<Arc<sparse::Polynomial<C::ScalarField, R>>>,
 
     // Nested endoscaling data (ScalarField, NestedCurve commitment)
     pub(crate) nested_endoscaling_step_rxs: Vec<sparse::Polynomial<C::ScalarField, R>>,
     pub(crate) nested_endoscalar_rx: sparse::Polynomial<C::ScalarField, R>,
-    pub(crate) nested_points_rx: SharedPolynomial<C::ScalarField, R>,
+    pub(crate) nested_points_rx: Arc<sparse::Polynomial<C::ScalarField, R>>,
 
     // Nested endoscaling commitment caches
     nested_endoscaling_step_commitments: Vec<Cached<C::NestedCurve>>,
@@ -265,13 +263,13 @@ impl<C: Cycle, R: Rank> core::ops::Index<nested::RxIndex> for Proof<C, R> {
             EndoscalingStep(step) => &self.nested_endoscaling_step_rxs[step as usize],
             EndoscalarStage => &self.nested_endoscalar_rx,
             PointsStage => self.nested_points_rx.as_ref(),
-            BridgePreamble => &self.bridge_preamble_rx,
+            BridgePreamble => self.bridge_preamble_rx.as_ref(),
             BridgeSPrime => self.bridge_s_prime_rx.as_ref(),
             BridgeInnerError => self.bridge_inner_error_rx.as_ref(),
             BridgeOuterError => self.bridge_outer_error_rx.0.as_ref(),
             BridgeAB => self.bridge_ab_rx.0.as_ref(),
             BridgeQuery => self.bridge_query_rx.0.as_ref(),
-            BridgeF => &self.bridge_f_rx,
+            BridgeF => self.bridge_f_rx.as_ref(),
             BridgeEval => self.bridge_eval_rx.0.as_ref(),
             ChildPointsStage(side) => self.child_stage_rx(side).points_stage.as_ref(),
             ChildBridge(kind, side) => self.child_stage_rx(side).bridge_at(kind),
@@ -683,19 +681,17 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
         // child rx must match the proof's own rx. Force lazy evaluation of
         // cached bridges first so we can clone them.
         let trivial_child = ChildStageRx {
-            points_stage: builder.shared_nested_points_rx(),
-            bridge_s_prime: builder.shared_bridge_s_prime_rx(),
-            bridge_inner_error: builder.shared_bridge_inner_error_rx(),
-            bridge_outer_error: builder
-                .shared_bridge_outer_error_rx()
-                .expect("trivial bridge_outer_error_rx"),
-            bridge_ab: builder.shared_bridge_ab_rx().expect("trivial bridge_ab_rx"),
-            bridge_query: builder
-                .shared_bridge_query_rx()
-                .expect("trivial bridge_query_rx"),
-            bridge_eval: builder
-                .shared_bridge_eval_rx()
-                .expect("trivial bridge_eval_rx"),
+            points_stage: Arc::clone(builder.nested_points_rx()),
+            bridge_s_prime: Arc::clone(builder.bridge_s_prime_rx()),
+            bridge_inner_error: Arc::clone(builder.bridge_inner_error_rx()),
+            bridge_outer_error: Arc::clone(
+                builder
+                    .bridge_outer_error_rx()
+                    .expect("trivial bridge_outer_error_rx"),
+            ),
+            bridge_ab: Arc::clone(builder.bridge_ab_rx().expect("trivial bridge_ab_rx")),
+            bridge_query: Arc::clone(builder.bridge_query_rx().expect("trivial bridge_query_rx")),
+            bridge_eval: Arc::clone(builder.bridge_eval_rx().expect("trivial bridge_eval_rx")),
         };
         builder.set_child_left_stage_rx(trivial_child.clone());
         builder.set_child_right_stage_rx(trivial_child);

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -11,7 +11,7 @@
 
 pub(crate) mod builder;
 
-use alloc::{vec, vec::Vec};
+use alloc::{sync::Arc, vec, vec::Vec};
 
 pub(crate) use builder::ProofBuilder;
 use ragu_arithmetic::{Cycle, ff::Field};
@@ -42,8 +42,10 @@ use crate::{
 /// Wraps a value that can be recomputed from primary proof data. Used to
 /// distinguish commitment caches from primary polynomial fields at the type
 /// level. Immutable once constructed.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct Cached<T>(T);
+
+type SharedPolynomial<F, R> = Arc<sparse::Polynomial<F, R>>;
 
 /// Represents proof-carrying data, a recursive proof for the correctness of
 /// some accompanying data.
@@ -83,25 +85,25 @@ impl<C: Cycle, R: Rank, H: Header<C::CircuitField>> Clone for Pcd<C, R, H> {
 /// check copying circuit claims.
 #[derive(Clone)]
 pub(crate) struct ChildStageRx<F: ragu_arithmetic::ff::PrimeField, R: Rank> {
-    pub points_stage: sparse::Polynomial<F, R>,
-    pub bridge_s_prime: sparse::Polynomial<F, R>,
-    pub bridge_inner_error: sparse::Polynomial<F, R>,
-    pub bridge_outer_error: sparse::Polynomial<F, R>,
-    pub bridge_ab: sparse::Polynomial<F, R>,
-    pub bridge_query: sparse::Polynomial<F, R>,
-    pub bridge_eval: sparse::Polynomial<F, R>,
+    pub points_stage: SharedPolynomial<F, R>,
+    pub bridge_s_prime: SharedPolynomial<F, R>,
+    pub bridge_inner_error: SharedPolynomial<F, R>,
+    pub bridge_outer_error: SharedPolynomial<F, R>,
+    pub bridge_ab: SharedPolynomial<F, R>,
+    pub bridge_query: SharedPolynomial<F, R>,
+    pub bridge_eval: SharedPolynomial<F, R>,
 }
 
 impl<F: ragu_arithmetic::ff::PrimeField, R: Rank> ChildStageRx<F, R> {
     /// Dispatch to the bridge-stage rx polynomial named by `kind`.
     pub(crate) fn bridge_at(&self, kind: ChildBridgeKind) -> &sparse::Polynomial<F, R> {
         match kind {
-            ChildBridgeKind::SPrime => &self.bridge_s_prime,
-            ChildBridgeKind::InnerError => &self.bridge_inner_error,
-            ChildBridgeKind::OuterError => &self.bridge_outer_error,
-            ChildBridgeKind::AB => &self.bridge_ab,
-            ChildBridgeKind::Query => &self.bridge_query,
-            ChildBridgeKind::Eval => &self.bridge_eval,
+            ChildBridgeKind::SPrime => self.bridge_s_prime.as_ref(),
+            ChildBridgeKind::InnerError => self.bridge_inner_error.as_ref(),
+            ChildBridgeKind::OuterError => self.bridge_outer_error.as_ref(),
+            ChildBridgeKind::AB => self.bridge_ab.as_ref(),
+            ChildBridgeKind::Query => self.bridge_query.as_ref(),
+            ChildBridgeKind::Eval => self.bridge_eval.as_ref(),
         }
     }
 }
@@ -110,18 +112,15 @@ impl<C: Cycle, R: Rank> Proof<C, R> {
     /// Extract stage rx polynomials from this proof for storage as child
     /// data in a parent proof.
     //
-    // TODO: wrap each child polynomial in `Arc` so this extraction can
-    // share ownership instead of cloning every rx polynomial.
     pub(crate) fn as_child_stage_rx(&self) -> ChildStageRx<C::ScalarField, R> {
         ChildStageRx {
-            points_stage: self.nested_points_rx.clone(),
-            bridge_s_prime: self.bridge_s_prime_rx.clone(),
-            bridge_inner_error: self.bridge_inner_error_rx.clone(),
-            // .0 = polynomial (these are (poly, commitment) tuples from cached_bridge!)
-            bridge_outer_error: self.bridge_outer_error_rx.0.clone(),
-            bridge_ab: self.bridge_ab_rx.0.clone(),
-            bridge_query: self.bridge_query_rx.0.clone(),
-            bridge_eval: self.bridge_eval_rx.0.clone(),
+            points_stage: Arc::clone(&self.nested_points_rx),
+            bridge_s_prime: Arc::clone(&self.bridge_s_prime_rx),
+            bridge_inner_error: Arc::clone(&self.bridge_inner_error_rx),
+            bridge_outer_error: Arc::clone(&self.bridge_outer_error_rx.0),
+            bridge_ab: Arc::clone(&self.bridge_ab_rx.0),
+            bridge_query: Arc::clone(&self.bridge_query_rx.0),
+            bridge_eval: Arc::clone(&self.bridge_eval_rx.0),
         }
     }
 }
@@ -161,20 +160,20 @@ pub struct Proof<C: Cycle, R: Rank> {
 
     // Bridge rx polynomials (non-cached, set by caller)
     pub(crate) bridge_preamble_rx: sparse::Polynomial<C::ScalarField, R>,
-    pub(crate) bridge_s_prime_rx: sparse::Polynomial<C::ScalarField, R>,
-    pub(crate) bridge_inner_error_rx: sparse::Polynomial<C::ScalarField, R>,
+    pub(crate) bridge_s_prime_rx: SharedPolynomial<C::ScalarField, R>,
+    pub(crate) bridge_inner_error_rx: SharedPolynomial<C::ScalarField, R>,
     pub(crate) bridge_f_rx: sparse::Polynomial<C::ScalarField, R>,
 
     // Bridge rx polynomials (cached, derived from bridge_alpha + native commitments)
-    bridge_outer_error_rx: Cached<sparse::Polynomial<C::ScalarField, R>>,
-    bridge_ab_rx: Cached<sparse::Polynomial<C::ScalarField, R>>,
-    bridge_query_rx: Cached<sparse::Polynomial<C::ScalarField, R>>,
-    bridge_eval_rx: Cached<sparse::Polynomial<C::ScalarField, R>>,
+    bridge_outer_error_rx: Cached<SharedPolynomial<C::ScalarField, R>>,
+    bridge_ab_rx: Cached<SharedPolynomial<C::ScalarField, R>>,
+    bridge_query_rx: Cached<SharedPolynomial<C::ScalarField, R>>,
+    bridge_eval_rx: Cached<SharedPolynomial<C::ScalarField, R>>,
 
     // Nested endoscaling data (ScalarField, NestedCurve commitment)
     pub(crate) nested_endoscaling_step_rxs: Vec<sparse::Polynomial<C::ScalarField, R>>,
     pub(crate) nested_endoscalar_rx: sparse::Polynomial<C::ScalarField, R>,
-    pub(crate) nested_points_rx: sparse::Polynomial<C::ScalarField, R>,
+    pub(crate) nested_points_rx: SharedPolynomial<C::ScalarField, R>,
 
     // Nested endoscaling commitment caches
     nested_endoscaling_step_commitments: Vec<Cached<C::NestedCurve>>,
@@ -266,16 +265,16 @@ impl<C: Cycle, R: Rank> core::ops::Index<nested::RxIndex> for Proof<C, R> {
         match idx {
             EndoscalingStep(step) => &self.nested_endoscaling_step_rxs[step as usize],
             EndoscalarStage => &self.nested_endoscalar_rx,
-            PointsStage => &self.nested_points_rx,
+            PointsStage => self.nested_points_rx.as_ref(),
             BridgePreamble => &self.bridge_preamble_rx,
-            BridgeSPrime => &self.bridge_s_prime_rx,
-            BridgeInnerError => &self.bridge_inner_error_rx,
-            BridgeOuterError => &self.bridge_outer_error_rx.0,
-            BridgeAB => &self.bridge_ab_rx.0,
-            BridgeQuery => &self.bridge_query_rx.0,
+            BridgeSPrime => self.bridge_s_prime_rx.as_ref(),
+            BridgeInnerError => self.bridge_inner_error_rx.as_ref(),
+            BridgeOuterError => self.bridge_outer_error_rx.0.as_ref(),
+            BridgeAB => self.bridge_ab_rx.0.as_ref(),
+            BridgeQuery => self.bridge_query_rx.0.as_ref(),
             BridgeF => &self.bridge_f_rx,
-            BridgeEval => &self.bridge_eval_rx.0,
-            ChildPointsStage(side) => &self.child_stage_rx(side).points_stage,
+            BridgeEval => self.bridge_eval_rx.0.as_ref(),
+            ChildPointsStage(side) => self.child_stage_rx(side).points_stage.as_ref(),
             ChildBridge(kind, side) => self.child_stage_rx(side).bridge_at(kind),
         }
     }
@@ -685,25 +684,19 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
         // child rx must match the proof's own rx. Force lazy evaluation of
         // cached bridges first so we can clone them.
         let trivial_child = ChildStageRx {
-            points_stage: builder.nested_points_rx().clone(),
-            bridge_s_prime: builder.bridge_s_prime_rx().clone(),
-            bridge_inner_error: builder.bridge_inner_error_rx().clone(),
+            points_stage: builder.shared_nested_points_rx(),
+            bridge_s_prime: builder.shared_bridge_s_prime_rx(),
+            bridge_inner_error: builder.shared_bridge_inner_error_rx(),
             bridge_outer_error: builder
-                .bridge_outer_error_rx()
-                .expect("trivial bridge_outer_error_rx")
-                .clone(),
-            bridge_ab: builder
-                .bridge_ab_rx()
-                .expect("trivial bridge_ab_rx")
-                .clone(),
+                .shared_bridge_outer_error_rx()
+                .expect("trivial bridge_outer_error_rx"),
+            bridge_ab: builder.shared_bridge_ab_rx().expect("trivial bridge_ab_rx"),
             bridge_query: builder
-                .bridge_query_rx()
-                .expect("trivial bridge_query_rx")
-                .clone(),
+                .shared_bridge_query_rx()
+                .expect("trivial bridge_query_rx"),
             bridge_eval: builder
-                .bridge_eval_rx()
-                .expect("trivial bridge_eval_rx")
-                .clone(),
+                .shared_bridge_eval_rx()
+                .expect("trivial bridge_eval_rx"),
         };
         builder.set_child_left_stage_rx(trivial_child.clone());
         builder.set_child_right_stage_rx(trivial_child);

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -111,7 +111,6 @@ impl<F: ragu_arithmetic::ff::PrimeField, R: Rank> ChildStageRx<F, R> {
 impl<C: Cycle, R: Rank> Proof<C, R> {
     /// Extract stage rx polynomials from this proof for storage as child
     /// data in a parent proof.
-    //
     pub(crate) fn as_child_stage_rx(&self) -> ChildStageRx<C::ScalarField, R> {
         ChildStageRx {
             points_stage: Arc::clone(&self.nested_points_rx),


### PR DESCRIPTION
## Summary

Resolves the TODO at `proof/mod.rs:114` `Proof::as_child_stage_rx()` now clones `Arc` handles instead of deep-cloning 7 sparse polynomials per child (14 total per fuse call).

- `ChildStageRx` fields and bridge rx fields on `Proof`/`ProofBuilder` store `Arc<sparse::Polynomial<F, R>>` — `Clone` is a refcount bump
- `ProofBuilder` wraps polynomials in `Arc` at set time; bridge accessors return `&Arc<...>` so callers can `Arc::clone` for shared ownership
- Internal `Index` impls still return `&sparse::Polynomial` via `.as_ref()`
    — no API churn outside `ragu_pcd::proof`

also simplifies the trivial-proof self-child construction in `mod.rs:685`, which was deep-cloning the same  polynomials twice for left and right children.