### PR TITLE
perf: benchmark registry eval restrictions

### DIFF
--- a/crates/ragu_pcd/benches/criterion/registry.rs
+++ b/crates/ragu_pcd/benches/criterion/registry.rs
@@ -1,4 +1,4 @@
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use ff::Field;
 use ragu_arithmetic::Cycle;
 use ragu_circuits::polynomials::ProductionRank;
@@ -37,6 +37,9 @@ fn registry_bench(c: &mut Criterion) {
     let w = Fp::random(&mut rng);
     let x = Fp::random(&mut rng);
     let y = Fp::random(&mut rng);
+    let x0 = Fp::random(&mut rng);
+    let x1 = Fp::random(&mut rng);
+    let u = Fp::random(&mut rng);
 
     c.bench_function("registry::wx", |b| {
         b.iter(|| registry.wx(w, x));
@@ -48,6 +51,30 @@ fn registry_bench(c: &mut Criterion) {
 
     c.bench_function("registry::wxy", |b| {
         b.iter(|| registry.wxy(w, x, y));
+    });
+
+    let registry_at_w = registry.at(w);
+    c.bench_function("registry::wxy_separate3", |b| {
+        b.iter(|| {
+            black_box([
+                registry_at_w.xy(x0, u),
+                registry_at_w.xy(x1, u),
+                registry_at_w.xy(u, y),
+            ])
+        });
+    });
+
+    let registry_wx0_poly = registry_at_w.x(x0);
+    let registry_wx1_poly = registry_at_w.x(x1);
+    let registry_wy_poly = registry_at_w.y(y);
+    c.bench_function("registry::restriction_eval3", |b| {
+        b.iter(|| {
+            black_box([
+                registry_wx0_poly.eval(u),
+                registry_wx1_poly.eval(u),
+                registry_wy_poly.eval(u),
+            ])
+        });
     });
 }
 

--- a/crates/ragu_pcd/src/fuse/_09_eval.rs
+++ b/crates/ragu_pcd/src/fuse/_09_eval.rs
@@ -34,10 +34,10 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             left: native::stages::eval::ChildEvaluationsWitness::from_proof(left, u),
             right: native::stages::eval::ChildEvaluationsWitness::from_proof(right, u),
             current: native::stages::eval::CurrentStepWitness {
-                // TODO: the registry evaluations here could _theoretically_ be more
-                // efficient if they're computed simultaneously with assistance
-                // from the registry itself, rather than individually evaluated for
-                // each of these restrictions.
+                // These restriction polynomials already exist for commitments and
+                // later accumulation. Evaluating them directly is faster than
+                // recomputing the same values through the registry here; see the
+                // `registry::restriction_eval3` criterion benchmark.
                 registry_wx0: s_prime.registry_wx0_poly.eval(u),
                 registry_wx1: s_prime.registry_wx1_poly.eval(u),
                 registry_wy: registry_wy.poly.eval(u),


### PR DESCRIPTION
Resolves the `_09_eval.rs` TODO by measuring the proposed registry-evaluation optimization instead of changing the fuse hot path speculatively.

The TODO suggested that registry evaluations in `_09_eval` could theoretically be more efficient if computed with registry
assistance. but those restriction polynomials already exist because they are committed earlier and used later for accumulation.

Measured locally:

- `registry::wxy_separate3`: ~5.16-5.34 ms
- `registry::restriction_eval3`: ~690-716 us

so changing `_09_eval` to recompute through the registry would regress performance rather than improve it.