### PR TITLE
refactor: share fuse query ordering

### DIFF
--- a/crates/ragu_pcd/src/fuse/_08_f.rs
+++ b/crates/ragu_pcd/src/fuse/_08_f.rs
@@ -116,51 +116,59 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             idx.circuit_index().omega_j()
         };
 
-        let static_query_iter = |query| match query {
-            StaticFQuery::LeftP => factor_iter(left.native_p_poly().iter_coeffs(), left.u()),
-            StaticFQuery::RightP => factor_iter(right.native_p_poly().iter_coeffs(), right.u()),
-            StaticFQuery::LeftRegistryXyAtW => {
-                factor_iter(left.native_registry_xy_poly().iter_coeffs(), w)
-            }
-            StaticFQuery::RightRegistryXyAtW => {
-                factor_iter(right.native_registry_xy_poly().iter_coeffs(), w)
-            }
-            StaticFQuery::RegistryWx0AtLeftY => {
-                factor_iter(s_prime.registry_wx0_poly.iter_coeffs(), left.y())
-            }
-            StaticFQuery::RegistryWx1AtRightY => {
-                factor_iter(s_prime.registry_wx1_poly.iter_coeffs(), right.y())
-            }
-            StaticFQuery::RegistryWx0AtY => factor_iter(s_prime.registry_wx0_poly.iter_coeffs(), y),
-            StaticFQuery::RegistryWx1AtY => factor_iter(s_prime.registry_wx1_poly.iter_coeffs(), y),
-            StaticFQuery::RegistryWyAtLeftX => {
-                factor_iter(registry_wy.poly.iter_coeffs(), left.x())
-            }
-            StaticFQuery::RegistryWyAtRightX => {
-                factor_iter(registry_wy.poly.iter_coeffs(), right.x())
-            }
-            StaticFQuery::RegistryWyAtX => factor_iter(registry_wy.poly.iter_coeffs(), x),
-            StaticFQuery::RegistryXyAtW => {
-                factor_iter(builder.native_registry_xy_poly().iter_coeffs(), w)
-            }
-            StaticFQuery::RegistryXyAtLeftCircuitId => factor_iter(
-                builder.native_registry_xy_poly().iter_coeffs(),
-                left.circuit_id().omega_j(),
-            ),
-            StaticFQuery::RegistryXyAtRightCircuitId => factor_iter(
-                builder.native_registry_xy_poly().iter_coeffs(),
-                right.circuit_id().omega_j(),
-            ),
-            StaticFQuery::LeftAbAAtXz => factor_iter(left[RxComponent::AbA].iter_coeffs(), xz),
-            StaticFQuery::LeftAbBAtX => factor_iter(left[RxComponent::AbB].iter_coeffs(), x),
-            StaticFQuery::RightAbAAtXz => factor_iter(right[RxComponent::AbA].iter_coeffs(), xz),
-            StaticFQuery::RightAbBAtX => factor_iter(right[RxComponent::AbB].iter_coeffs(), x),
-            StaticFQuery::CurrentAAtXz => factor_iter(builder.native_a_poly().iter_coeffs(), xz),
-            StaticFQuery::CurrentBAtX => factor_iter(builder.native_b_poly().iter_coeffs(), x),
-        };
-
-        let mut iters: Vec<_> = Vec::with_capacity(native::NUM_F_QUERIES);
-        iters.extend(STATIC_F_QUERIES.into_iter().map(static_query_iter));
+        let mut iters: Vec<_> = STATIC_F_QUERIES
+            .into_iter()
+            .map(|query| match query {
+                StaticFQuery::LeftP => factor_iter(left.native_p_poly().iter_coeffs(), left.u()),
+                StaticFQuery::RightP => factor_iter(right.native_p_poly().iter_coeffs(), right.u()),
+                StaticFQuery::LeftRegistryXyAtW => {
+                    factor_iter(left.native_registry_xy_poly().iter_coeffs(), w)
+                }
+                StaticFQuery::RightRegistryXyAtW => {
+                    factor_iter(right.native_registry_xy_poly().iter_coeffs(), w)
+                }
+                StaticFQuery::RegistryWx0AtLeftY => {
+                    factor_iter(s_prime.registry_wx0_poly.iter_coeffs(), left.y())
+                }
+                StaticFQuery::RegistryWx1AtRightY => {
+                    factor_iter(s_prime.registry_wx1_poly.iter_coeffs(), right.y())
+                }
+                StaticFQuery::RegistryWx0AtY => {
+                    factor_iter(s_prime.registry_wx0_poly.iter_coeffs(), y)
+                }
+                StaticFQuery::RegistryWx1AtY => {
+                    factor_iter(s_prime.registry_wx1_poly.iter_coeffs(), y)
+                }
+                StaticFQuery::RegistryWyAtLeftX => {
+                    factor_iter(registry_wy.poly.iter_coeffs(), left.x())
+                }
+                StaticFQuery::RegistryWyAtRightX => {
+                    factor_iter(registry_wy.poly.iter_coeffs(), right.x())
+                }
+                StaticFQuery::RegistryWyAtX => factor_iter(registry_wy.poly.iter_coeffs(), x),
+                StaticFQuery::RegistryXyAtW => {
+                    factor_iter(builder.native_registry_xy_poly().iter_coeffs(), w)
+                }
+                StaticFQuery::RegistryXyAtLeftCircuitId => factor_iter(
+                    builder.native_registry_xy_poly().iter_coeffs(),
+                    left.circuit_id().omega_j(),
+                ),
+                StaticFQuery::RegistryXyAtRightCircuitId => factor_iter(
+                    builder.native_registry_xy_poly().iter_coeffs(),
+                    right.circuit_id().omega_j(),
+                ),
+                StaticFQuery::LeftAbAAtXz => factor_iter(left[RxComponent::AbA].iter_coeffs(), xz),
+                StaticFQuery::LeftAbBAtX => factor_iter(left[RxComponent::AbB].iter_coeffs(), x),
+                StaticFQuery::RightAbAAtXz => {
+                    factor_iter(right[RxComponent::AbA].iter_coeffs(), xz)
+                }
+                StaticFQuery::RightAbBAtX => factor_iter(right[RxComponent::AbB].iter_coeffs(), x),
+                StaticFQuery::CurrentAAtXz => {
+                    factor_iter(builder.native_a_poly().iter_coeffs(), xz)
+                }
+                StaticFQuery::CurrentBAtX => factor_iter(builder.native_b_poly().iter_coeffs(), x),
+            })
+            .collect();
         // Per-rx evaluations at xz only. The same r_i(xz) values feed
         // into both A(xz) (undilated) and B(x) (Z-dilated).
         for proof in [left, right] {

--- a/crates/ragu_pcd/src/fuse/_08_f.rs
+++ b/crates/ragu_pcd/src/fuse/_08_f.rs
@@ -5,10 +5,11 @@
 //! bridge for committing to the polynomial.
 //!
 //! Each `factor_iter` call below produces the coefficients of $(p\_i(X) - v\_i)
-//! / (X - x\_i)$ for a single query. The terms must match `poly_queries` in the
-//! `compute_v` circuit exactly.
+//! / (X - x\_i)$ for a single query. The static query prefix is defined by
+//! [`STATIC_F_QUERIES`] and consumed by both this prover path and the
+//! `compute_v` circuit.
 
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 
 use ff::Field;
 use ragu_arithmetic::Cycle;
@@ -25,7 +26,7 @@ use crate::{
     Application, Proof,
     internal::{
         native,
-        native::{RxComponent, RxIndex},
+        native::{RxComponent, RxIndex, STATIC_F_QUERIES, StaticFQuery},
         nested,
     },
     proof::ProofBuilder,
@@ -115,41 +116,51 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             idx.circuit_index().omega_j()
         };
 
-        // This must exactly match the ordering of the `poly_queries` function
-        // in the `compute_v` circuit.
-        let mut iters: Vec<_> = vec![
-            // Child proof p(u)=v checks
-            factor_iter(left.native_p_poly().iter_coeffs(), left.u()),
-            factor_iter(right.native_p_poly().iter_coeffs(), right.u()),
-            // Registry transitions
-            factor_iter(left.native_registry_xy_poly().iter_coeffs(), w),
-            factor_iter(right.native_registry_xy_poly().iter_coeffs(), w),
-            factor_iter(s_prime.registry_wx0_poly.iter_coeffs(), left.y()),
-            factor_iter(s_prime.registry_wx1_poly.iter_coeffs(), right.y()),
-            factor_iter(s_prime.registry_wx0_poly.iter_coeffs(), y),
-            factor_iter(s_prime.registry_wx1_poly.iter_coeffs(), y),
-            factor_iter(registry_wy.poly.iter_coeffs(), left.x()),
-            factor_iter(registry_wy.poly.iter_coeffs(), right.x()),
-            factor_iter(registry_wy.poly.iter_coeffs(), x),
-            factor_iter(builder.native_registry_xy_poly().iter_coeffs(), w),
-            // App circuit registry evals
-            factor_iter(
+        let static_query_iter = |query| match query {
+            StaticFQuery::LeftP => factor_iter(left.native_p_poly().iter_coeffs(), left.u()),
+            StaticFQuery::RightP => factor_iter(right.native_p_poly().iter_coeffs(), right.u()),
+            StaticFQuery::LeftRegistryXyAtW => {
+                factor_iter(left.native_registry_xy_poly().iter_coeffs(), w)
+            }
+            StaticFQuery::RightRegistryXyAtW => {
+                factor_iter(right.native_registry_xy_poly().iter_coeffs(), w)
+            }
+            StaticFQuery::RegistryWx0AtLeftY => {
+                factor_iter(s_prime.registry_wx0_poly.iter_coeffs(), left.y())
+            }
+            StaticFQuery::RegistryWx1AtRightY => {
+                factor_iter(s_prime.registry_wx1_poly.iter_coeffs(), right.y())
+            }
+            StaticFQuery::RegistryWx0AtY => factor_iter(s_prime.registry_wx0_poly.iter_coeffs(), y),
+            StaticFQuery::RegistryWx1AtY => factor_iter(s_prime.registry_wx1_poly.iter_coeffs(), y),
+            StaticFQuery::RegistryWyAtLeftX => {
+                factor_iter(registry_wy.poly.iter_coeffs(), left.x())
+            }
+            StaticFQuery::RegistryWyAtRightX => {
+                factor_iter(registry_wy.poly.iter_coeffs(), right.x())
+            }
+            StaticFQuery::RegistryWyAtX => factor_iter(registry_wy.poly.iter_coeffs(), x),
+            StaticFQuery::RegistryXyAtW => {
+                factor_iter(builder.native_registry_xy_poly().iter_coeffs(), w)
+            }
+            StaticFQuery::RegistryXyAtLeftCircuitId => factor_iter(
                 builder.native_registry_xy_poly().iter_coeffs(),
                 left.circuit_id().omega_j(),
             ),
-            factor_iter(
+            StaticFQuery::RegistryXyAtRightCircuitId => factor_iter(
                 builder.native_registry_xy_poly().iter_coeffs(),
                 right.circuit_id().omega_j(),
             ),
-            // A/B polynomial queries:
-            // a_poly at xz, b_poly at x for left child, right child, current
-            factor_iter(left[RxComponent::AbA].iter_coeffs(), xz),
-            factor_iter(left[RxComponent::AbB].iter_coeffs(), x),
-            factor_iter(right[RxComponent::AbA].iter_coeffs(), xz),
-            factor_iter(right[RxComponent::AbB].iter_coeffs(), x),
-            factor_iter(builder.native_a_poly().iter_coeffs(), xz),
-            factor_iter(builder.native_b_poly().iter_coeffs(), x),
-        ];
+            StaticFQuery::LeftAbAAtXz => factor_iter(left[RxComponent::AbA].iter_coeffs(), xz),
+            StaticFQuery::LeftAbBAtX => factor_iter(left[RxComponent::AbB].iter_coeffs(), x),
+            StaticFQuery::RightAbAAtXz => factor_iter(right[RxComponent::AbA].iter_coeffs(), xz),
+            StaticFQuery::RightAbBAtX => factor_iter(right[RxComponent::AbB].iter_coeffs(), x),
+            StaticFQuery::CurrentAAtXz => factor_iter(builder.native_a_poly().iter_coeffs(), xz),
+            StaticFQuery::CurrentBAtX => factor_iter(builder.native_b_poly().iter_coeffs(), x),
+        };
+
+        let mut iters: Vec<_> = Vec::with_capacity(native::NUM_F_QUERIES);
+        iters.extend(STATIC_F_QUERIES.into_iter().map(static_query_iter));
         // Per-rx evaluations at xz only. The same r_i(xz) values feed
         // into both A(xz) (undilated) and B(x) (Z-dilated).
         for proof in [left, right] {

--- a/crates/ragu_pcd/src/internal/native/circuits/compute_v.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/compute_v.rs
@@ -63,7 +63,8 @@ use ragu_core::{
 use ragu_primitives::{Element, Endoscalar, GadgetExt, allocator::Standard};
 
 use super::super::{
-    InternalCircuitIndex, InternalCircuitValues, RxComponent, RxIndex,
+    InternalCircuitIndex, InternalCircuitValues, RxComponent, RxIndex, STATIC_F_QUERIES,
+    StaticFQuery,
     claims::{self, Processor},
     stages::{
         eval as native_eval, preamble as native_preamble,
@@ -554,9 +555,9 @@ fn compute_axbx<'dr, D: Driver<'dr>, P: Parameters>(
 /// 6. **Internal circuit registry evaluations** - $m(\omega^j, x, y)$ for each
 ///    internal index
 ///
-/// The queries must be ordered exactly as in the prover's computation of $f(X)$
-/// in [`compute_f`], since the ordering affects the weight (with respect to
-/// [$\alpha$]) of each quotient polynomial.
+/// The static query prefix is defined by [`STATIC_F_QUERIES`] and consumed by
+/// both this circuit and the prover's [`compute_f`] path. The ordering affects
+/// the weight (with respect to [$\alpha$]) of each quotient polynomial.
 ///
 /// [`compute_f`]: crate::Application::compute_f
 /// [$\alpha$]: unified::Output::alpha
@@ -569,37 +570,80 @@ fn poly_queries<'a, 'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HE
     computed_ax: &'a Element<'dr, D>,
     computed_bx: &'a Element<'dr, D>,
 ) -> impl Iterator<Item = (&'a Element<'dr, D>, &'a Element<'dr, D>, &'a Element<'dr, D>)> {
-    [
-        // Check p(u) = v for each child proof.
-        (&eval.left.p_poly,        &preamble.left.unified.v,                     &d.left.u),
-        (&eval.right.p_poly,       &preamble.right.unified.v,                    &d.right.u),
-        // m(W, x_i, y_i) -> m(w, x_i, Y)
-        (&eval.left.registry_xy_poly,  &query.left.child_registry_xy_at_current_w,       &d.challenges.w),
-        (&eval.right.registry_xy_poly, &query.right.child_registry_xy_at_current_w,      &d.challenges.w),
-        (&eval.registry_wx0,           &query.left.child_registry_xy_at_current_w,       &d.left.y),
-        (&eval.registry_wx1,           &query.right.child_registry_xy_at_current_w,      &d.right.y),
-        // m(w, x_i, Y) -> m(w, X, y)
-        (&eval.registry_wx0,           &query.left.current_registry_wy_at_child_x,       &d.challenges.y),
-        (&eval.registry_wx1,           &query.right.current_registry_wy_at_child_x,      &d.challenges.y),
-        (&eval.registry_wy,            &query.left.current_registry_wy_at_child_x,       &d.left.x),
-        (&eval.registry_wy,            &query.right.current_registry_wy_at_child_x,      &d.right.x),
-        // m(w, X, y) -> s(W, x, y)
-        (&eval.registry_wy,            &query.registry_wxy,                              &d.challenges.x),
-        (&eval.registry_xy,            &query.registry_wxy,                              &d.challenges.w),
-        // m(circuit_id_i, x, y) evaluations for the ith child proof
-        (&eval.registry_xy,            &query.left.current_registry_xy_at_child_circuit_id,  &d.left.circuit_id),
-        (&eval.registry_xy,            &query.right.current_registry_xy_at_child_circuit_id, &d.right.circuit_id),
-        // a_i(xz), b_i(x) polynomial queries for each child proof
-        (&eval.left.a_poly,        &query.left.a_poly_at_xz,                         &d.challenges.xz),
-        (&eval.left.b_poly,        &query.left.b_poly_at_x,                          &d.challenges.x),
-        (&eval.right.a_poly,       &query.right.a_poly_at_xz,                        &d.challenges.xz),
-        (&eval.right.b_poly,       &query.right.b_poly_at_x,                         &d.challenges.x),
-        // a(xz), b(x) polynomial queries for the new accumulator; crucially, these evaluations
-        // are computed by the verifier based on the other evaluations, NOT witnessed by the
-        // prover.
-        (&eval.a_poly,             computed_ax,                                      &d.challenges.xz),
-        (&eval.b_poly,             computed_bx,                                      &d.challenges.x),
-    ].into_iter()
+    STATIC_F_QUERIES.into_iter().map(move |query_id| match query_id {
+        StaticFQuery::LeftP => (&eval.left.p_poly, &preamble.left.unified.v, &d.left.u),
+        StaticFQuery::RightP => (&eval.right.p_poly, &preamble.right.unified.v, &d.right.u),
+        StaticFQuery::LeftRegistryXyAtW => (
+            &eval.left.registry_xy_poly,
+            &query.left.child_registry_xy_at_current_w,
+            &d.challenges.w,
+        ),
+        StaticFQuery::RightRegistryXyAtW => (
+            &eval.right.registry_xy_poly,
+            &query.right.child_registry_xy_at_current_w,
+            &d.challenges.w,
+        ),
+        StaticFQuery::RegistryWx0AtLeftY => (
+            &eval.registry_wx0,
+            &query.left.child_registry_xy_at_current_w,
+            &d.left.y,
+        ),
+        StaticFQuery::RegistryWx1AtRightY => (
+            &eval.registry_wx1,
+            &query.right.child_registry_xy_at_current_w,
+            &d.right.y,
+        ),
+        StaticFQuery::RegistryWx0AtY => (
+            &eval.registry_wx0,
+            &query.left.current_registry_wy_at_child_x,
+            &d.challenges.y,
+        ),
+        StaticFQuery::RegistryWx1AtY => (
+            &eval.registry_wx1,
+            &query.right.current_registry_wy_at_child_x,
+            &d.challenges.y,
+        ),
+        StaticFQuery::RegistryWyAtLeftX => (
+            &eval.registry_wy,
+            &query.left.current_registry_wy_at_child_x,
+            &d.left.x,
+        ),
+        StaticFQuery::RegistryWyAtRightX => (
+            &eval.registry_wy,
+            &query.right.current_registry_wy_at_child_x,
+            &d.right.x,
+        ),
+        StaticFQuery::RegistryWyAtX => (&eval.registry_wy, &query.registry_wxy, &d.challenges.x),
+        StaticFQuery::RegistryXyAtW => (&eval.registry_xy, &query.registry_wxy, &d.challenges.w),
+        StaticFQuery::RegistryXyAtLeftCircuitId => (
+            &eval.registry_xy,
+            &query.left.current_registry_xy_at_child_circuit_id,
+            &d.left.circuit_id,
+        ),
+        StaticFQuery::RegistryXyAtRightCircuitId => (
+            &eval.registry_xy,
+            &query.right.current_registry_xy_at_child_circuit_id,
+            &d.right.circuit_id,
+        ),
+        StaticFQuery::LeftAbAAtXz => (
+            &eval.left.a_poly,
+            &query.left.a_poly_at_xz,
+            &d.challenges.xz,
+        ),
+        StaticFQuery::LeftAbBAtX => (&eval.left.b_poly, &query.left.b_poly_at_x, &d.challenges.x),
+        StaticFQuery::RightAbAAtXz => (
+            &eval.right.a_poly,
+            &query.right.a_poly_at_xz,
+            &d.challenges.xz,
+        ),
+        StaticFQuery::RightAbBAtX => (
+            &eval.right.b_poly,
+            &query.right.b_poly_at_x,
+            &d.challenges.x,
+        ),
+        StaticFQuery::CurrentAAtXz => (&eval.a_poly, computed_ax, &d.challenges.xz),
+        StaticFQuery::CurrentBAtX => (&eval.b_poly, computed_bx, &d.challenges.x),
+    })
     // Stage and circuit rx evaluations at xz for each child proof.
     // The same r_i(xz) values feed into both A(xz) (undilated) and
     // B(x) (Z-dilated) recomputations.

--- a/crates/ragu_pcd/src/internal/native/mod.rs
+++ b/crates/ragu_pcd/src/internal/native/mod.rs
@@ -322,6 +322,85 @@ pub enum RxComponent {
     Rx(RxIndex),
 }
 
+/// Static prefix of the polynomial-query order used to construct and verify
+/// the fuse quotient polynomial $f(X)$.
+///
+/// These queries are consumed by both the prover-side `compute_f` path and the
+/// `compute_v` circuit. Keeping this prefix in one ordered list prevents the
+/// two implementations from drifting independently; the dynamic suffixes are
+/// still driven by [`RxIndex::ALL`] and [`InternalCircuitIndex::ALL`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum StaticFQuery {
+    /// Left child proof $p(u)=v$ check.
+    LeftP,
+    /// Right child proof $p(u)=v$ check.
+    RightP,
+    /// Left child registry-xy polynomial queried at the current `w`.
+    LeftRegistryXyAtW,
+    /// Right child registry-xy polynomial queried at the current `w`.
+    RightRegistryXyAtW,
+    /// Current `m(w, x_0, Y)` queried at the left child's `y`.
+    RegistryWx0AtLeftY,
+    /// Current `m(w, x_1, Y)` queried at the right child's `y`.
+    RegistryWx1AtRightY,
+    /// Current `m(w, x_0, Y)` queried at the current `y`.
+    RegistryWx0AtY,
+    /// Current `m(w, x_1, Y)` queried at the current `y`.
+    RegistryWx1AtY,
+    /// Current `m(w, X, y)` queried at the left child's `x`.
+    RegistryWyAtLeftX,
+    /// Current `m(w, X, y)` queried at the right child's `x`.
+    RegistryWyAtRightX,
+    /// Current `m(w, X, y)` queried at the current `x`.
+    RegistryWyAtX,
+    /// Current registry-xy polynomial queried at the current `w`.
+    RegistryXyAtW,
+    /// Current registry-xy polynomial queried at the left child's circuit id.
+    RegistryXyAtLeftCircuitId,
+    /// Current registry-xy polynomial queried at the right child's circuit id.
+    RegistryXyAtRightCircuitId,
+    /// Left child `a` polynomial queried at `xz`.
+    LeftAbAAtXz,
+    /// Left child `b` polynomial queried at `x`.
+    LeftAbBAtX,
+    /// Right child `a` polynomial queried at `xz`.
+    RightAbAAtXz,
+    /// Right child `b` polynomial queried at `x`.
+    RightAbBAtX,
+    /// Current accumulator `a` polynomial queried at `xz`.
+    CurrentAAtXz,
+    /// Current accumulator `b` polynomial queried at `x`.
+    CurrentBAtX,
+}
+
+/// Ordered static prefix for fuse quotient polynomial queries.
+pub(crate) const STATIC_F_QUERIES: [StaticFQuery; 20] = [
+    StaticFQuery::LeftP,
+    StaticFQuery::RightP,
+    StaticFQuery::LeftRegistryXyAtW,
+    StaticFQuery::RightRegistryXyAtW,
+    StaticFQuery::RegistryWx0AtLeftY,
+    StaticFQuery::RegistryWx1AtRightY,
+    StaticFQuery::RegistryWx0AtY,
+    StaticFQuery::RegistryWx1AtY,
+    StaticFQuery::RegistryWyAtLeftX,
+    StaticFQuery::RegistryWyAtRightX,
+    StaticFQuery::RegistryWyAtX,
+    StaticFQuery::RegistryXyAtW,
+    StaticFQuery::RegistryXyAtLeftCircuitId,
+    StaticFQuery::RegistryXyAtRightCircuitId,
+    StaticFQuery::LeftAbAAtXz,
+    StaticFQuery::LeftAbBAtX,
+    StaticFQuery::RightAbAAtXz,
+    StaticFQuery::RightAbBAtX,
+    StaticFQuery::CurrentAAtXz,
+    StaticFQuery::CurrentBAtX,
+];
+
+/// Total number of polynomial queries used to construct and verify $f(X)$.
+pub(crate) const NUM_F_QUERIES: usize =
+    STATIC_F_QUERIES.len() + 2 * RxIndex::NUM + InternalCircuitIndex::NUM;
+
 /// Registers internal native circuits and masks into the provided registry.
 ///
 /// Does not register internal steps (rerandomize, trivial); those are
@@ -419,4 +498,28 @@ pub fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>(
     );
 
     Ok(registry)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{InternalCircuitIndex, NUM_F_QUERIES, RxIndex, STATIC_F_QUERIES};
+
+    #[test]
+    fn f_query_count_matches_static_and_dynamic_sections() {
+        assert_eq!(STATIC_F_QUERIES.len(), 20);
+        assert_eq!(
+            NUM_F_QUERIES,
+            STATIC_F_QUERIES.len() + 2 * RxIndex::NUM + InternalCircuitIndex::NUM
+        );
+    }
+
+    #[test]
+    fn static_f_queries_are_unique() {
+        for (i, query) in STATIC_F_QUERIES.iter().enumerate() {
+            assert!(
+                !STATIC_F_QUERIES[..i].contains(query),
+                "duplicate static f query: {query:?}"
+            );
+        }
+    }
 }

--- a/crates/ragu_pcd/src/internal/native/mod.rs
+++ b/crates/ragu_pcd/src/internal/native/mod.rs
@@ -397,10 +397,6 @@ pub(crate) const STATIC_F_QUERIES: [StaticFQuery; 20] = [
     StaticFQuery::CurrentBAtX,
 ];
 
-/// Total number of polynomial queries used to construct and verify $f(X)$.
-pub(crate) const NUM_F_QUERIES: usize =
-    STATIC_F_QUERIES.len() + 2 * RxIndex::NUM + InternalCircuitIndex::NUM;
-
 /// Registers internal native circuits and masks into the provided registry.
 ///
 /// Does not register internal steps (rerandomize, trivial); those are
@@ -498,28 +494,4 @@ pub fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>(
     );
 
     Ok(registry)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{InternalCircuitIndex, NUM_F_QUERIES, RxIndex, STATIC_F_QUERIES};
-
-    #[test]
-    fn f_query_count_matches_static_and_dynamic_sections() {
-        assert_eq!(STATIC_F_QUERIES.len(), 20);
-        assert_eq!(
-            NUM_F_QUERIES,
-            STATIC_F_QUERIES.len() + 2 * RxIndex::NUM + InternalCircuitIndex::NUM
-        );
-    }
-
-    #[test]
-    fn static_f_queries_are_unique() {
-        for (i, query) in STATIC_F_QUERIES.iter().enumerate() {
-            assert!(
-                !STATIC_F_QUERIES[..i].contains(query),
-                "duplicate static f query: {query:?}"
-            );
-        }
-    }
 }

--- a/crates/ragu_pcd/src/internal/native/mod.rs
+++ b/crates/ragu_pcd/src/internal/native/mod.rs
@@ -329,47 +329,46 @@ pub enum RxComponent {
 /// `compute_v` circuit. Keeping this prefix in one ordered list prevents the
 /// two implementations from drifting independently; the dynamic suffixes are
 /// still driven by [`RxIndex::ALL`] and [`InternalCircuitIndex::ALL`].
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum StaticFQuery {
     /// Left child proof $p(u)=v$ check.
     LeftP,
     /// Right child proof $p(u)=v$ check.
     RightP,
-    /// Left child registry-xy polynomial queried at the current `w`.
+    /// Left child registry-xy polynomial queried at the current $w$.
     LeftRegistryXyAtW,
-    /// Right child registry-xy polynomial queried at the current `w`.
+    /// Right child registry-xy polynomial queried at the current $w$.
     RightRegistryXyAtW,
-    /// Current `m(w, x_0, Y)` queried at the left child's `y`.
+    /// Current $m(w, x_0, Y)$ queried at the left child's $y$.
     RegistryWx0AtLeftY,
-    /// Current `m(w, x_1, Y)` queried at the right child's `y`.
+    /// Current $m(w, x_1, Y)$ queried at the right child's $y$.
     RegistryWx1AtRightY,
-    /// Current `m(w, x_0, Y)` queried at the current `y`.
+    /// Current $m(w, x_0, Y)$ queried at the current $y$.
     RegistryWx0AtY,
-    /// Current `m(w, x_1, Y)` queried at the current `y`.
+    /// Current $m(w, x_1, Y)$ queried at the current $y$.
     RegistryWx1AtY,
-    /// Current `m(w, X, y)` queried at the left child's `x`.
+    /// Current $m(w, X, y)$ queried at the left child's $x$.
     RegistryWyAtLeftX,
-    /// Current `m(w, X, y)` queried at the right child's `x`.
+    /// Current $m(w, X, y)$ queried at the right child's $x$.
     RegistryWyAtRightX,
-    /// Current `m(w, X, y)` queried at the current `x`.
+    /// Current $m(w, X, y)$ queried at the current $x$.
     RegistryWyAtX,
-    /// Current registry-xy polynomial queried at the current `w`.
+    /// Current registry-xy polynomial queried at the current $w$.
     RegistryXyAtW,
     /// Current registry-xy polynomial queried at the left child's circuit id.
     RegistryXyAtLeftCircuitId,
     /// Current registry-xy polynomial queried at the right child's circuit id.
     RegistryXyAtRightCircuitId,
-    /// Left child `a` polynomial queried at `xz`.
+    /// Left child $a$ polynomial queried at $xz$.
     LeftAbAAtXz,
-    /// Left child `b` polynomial queried at `x`.
+    /// Left child $b$ polynomial queried at $x$.
     LeftAbBAtX,
-    /// Right child `a` polynomial queried at `xz`.
+    /// Right child $a$ polynomial queried at $xz$.
     RightAbAAtXz,
-    /// Right child `b` polynomial queried at `x`.
+    /// Right child $b$ polynomial queried at $x$.
     RightAbBAtX,
-    /// Current accumulator `a` polynomial queried at `xz`.
+    /// Current accumulator $a$ polynomial queried at $xz$.
     CurrentAAtXz,
-    /// Current accumulator `b` polynomial queried at `x`.
+    /// Current accumulator $b$ polynomial queried at $x$.
     CurrentBAtX,
 }
 


### PR DESCRIPTION
makes the static fuse query prefix a shared internal descriptor list instead of manually duplicating the order in two places.

this adds:
  - `StaticFQuery`
  - `STATIC_F_QUERIES`

both sides now consume that same static descriptor list:
- prover-side `compute_f` maps each `StaticFQuery` to its `factor_iter(...)`
- circuit-side `poly_queries` maps each `StaticFQuery` to `(p(u), v, denominator)`

the dynamic suffixes remain driven by the existing canonical lists:
  - `RxIndex::ALL`
  - `InternalCircuitIndex::ALL`
  
fixes #603 
