### PR TITLE
chore(fv): make lean reimpls polymorphic

### DIFF
--- a/.claude/skills/clean-circuits/SKILL.md
+++ b/.claude/skills/clean-circuits/SKILL.md
@@ -113,6 +113,32 @@ def main (input : Var Inputs F) : Circuit F (Var Outputs F) := do
   ...
 ```
 
+### Loop combinators (`Clean/Circuit/Loops.lean`)
+
+Clean ships five loop combinators with `circuit_norm`-tagged simp lemmas. **Use these for any iteration**; don't write recursive helper functions (`fooStep` / `barIter` patterns) — they require manual induction proofs and bypass the auto-simp path that `circuit_proof_start` is designed around.
+
+| Combinator | Signature (sketch) | Use when |
+|---|---|---|
+| `Circuit.forEach xs body` | `Vector α m → (α → Circuit F Unit)` | Constraint-only iteration; body emits constraints, no accumulator. |
+| `Circuit.map xs body` | `Vector α m → (α → Circuit F β) → Circuit F (Vector β m)` | Element-wise transform; per-iter output collected into a Vector. |
+| `Circuit.mapFinRange m body` | `(Fin m → Circuit F β) → Circuit F (Vector β m)` | Like `map` but iterates over `Fin m` indices directly. |
+| `Circuit.foldl xs init body` | `Vector α m → β → (β → α → Circuit F β) → Circuit F β` | Accumulating fold; threads `β` through iterations. |
+| `Circuit.foldlRange m init body` | `(Fin m → ...)` | Like `foldl` but iterates over `Fin m` instead of an element vector. |
+
+**Typeclass requirements.** All of `foldl`, `foldlRange`, `mapFinRange` require `[Inhabited β]`; `foldl` additionally requires `[Inhabited α]` for the element type. `Fin k` has no `Inhabited` instance when `k = 0` — so a polymorphic gadget using `Circuit.foldl (.finRange k)` typically rcases `k` to handle the `k = 0` case separately, then invokes the foldl in the `k+1` branch where `Fin (k+1)` IS `Inhabited`.
+
+**`ConstantOutput` requirement (foldl only).** `Circuit.foldl` carries a default-tactic argument
+```lean
+(_const_out : ConstantOutput (fun (s, a) => body s a) := by simp only [circuit_norm]; intros; rfl)
+```
+which asserts the body's *symbolic output* is invariant under (acc, element). This is what unlocks `foldl.output_eq` in `circuit_norm` — the foldl collapses to a single body application at the last index, cleanly threadable through `circuit_proof_start`. If your body returns a fresh wire (`Mul.circuit` output is `var ⟨offset + 2⟩`), `ConstantOutput` holds trivially. If it returns `wire + xs[i+1]` (index-dependent), `ConstantOutput` fails and `Circuit.foldl` won't elaborate.
+
+**`foldlRange` lacks `ConstantOutput`.** Its corresponding `foldlRange.output_eq` leaves `Circuit.FoldlM.foldlAcc` unexpanded — proofs work but require manual induction over the foldl. Prefer `foldl` when the body's output happens to be acc/index-independent (often achievable by restructuring: pull the index-dependent addition *outside* the loop, or push it into the *input* of a subcircuit so its output is just a fresh wire).
+
+### Auto-simp philosophy
+
+The intended UX (per mitschabaude): `circuit_proof_start` yields a goal that looks like *normal Lean/Mathlib math* — the circuit-specific machinery (loop combinators, subcircuit calls, witness/assert offsets) has already been collapsed by `circuit_norm`. Users then reason with `induction`, `ring`, `simp`, mathlib lemmas, etc. If you find yourself invoking circuit-specific simp lemmas explicitly (e.g., `simp [foldlRange.output_eq, Circuit.FoldlM.foldlAcc]`), you're off the happy path — either pick a different combinator (one whose lemmas already fire under `circuit_norm`) or restructure the gadget so the auto-simp path applies.
+
 ## Proof Patterns
 
 ### Starting a Proof

--- a/.claude/skills/fv-review/SKILL.md
+++ b/.claude/skills/fv-review/SKILL.md
@@ -216,6 +216,102 @@ Clean has plenty of length-polymorphic circuits. Don't claim "Clean can't expres
 
 The Lean formalization should represent the Rust circuit in its **full generality**, regardless of extraction limits.
 
+## Use Clean's loop combinators, not recursive helpers
+
+The single repeated review note across PR #710: **never** write a recursive helper function (`squareIter`, `hornerStep`, `for_step`, …) to express an iteration. Clean ships five loop combinators with `circuit_norm`-tagged simp lemmas (`Circuit.forEach`, `Circuit.map`, `Circuit.mapFinRange`, `Circuit.foldl`, `Circuit.foldlRange`); use those. See [Clean's loop combinators reference](https://deepwiki.com/Verified-zkEVM/clean/2.5-circuit-loops-and-iteration) for the full menu.
+
+**Why this matters.** Recursive helpers force you to write your own length / consistency / soundness / completeness lemmas by induction. The combinators bring those lemmas with them, tagged into `circuit_norm`, so `circuit_proof_start` collapses the loop machinery automatically and leaves you with a goal that looks like plain Lean math (a `Fin.foldl` equation, a per-iteration recurrence on `env.get` values).
+
+**The reviewer principle (Gregor, PR #710 Slack thread):** *"clean users are not supposed to have to call simplification lemmas explicitly. `circuit_proof_start` is supposed to yield a nice simplified version of the statement, after which your agent can just reason about normal lean/mathlib instead of our library."* If you find yourself manually invoking `simp [foldlRange.output_eq, Circuit.FoldlM.foldlAcc, …]` to make progress, that's a smell — either pick a different combinator or restructure the gadget so the auto-simp path applies.
+
+### Pick `foldl` over `foldlRange` when both work
+
+`Circuit.foldl xs init body` requires `ConstantOutput` on the body — the body's *symbolic* output must be invariant under (acc, element). When this holds, `foldl.output_eq` fires under `circuit_norm` and the proof environment is clean. `Circuit.foldlRange` doesn't require `ConstantOutput`, but its corresponding lemma leaves `Circuit.FoldlM.foldlAcc` unexpanded, forcing manual induction.
+
+**Default to `foldl`.** Reach for `foldlRange` only when the body genuinely produces an index-dependent output that can't be restructured.
+
+### Handle `Inhabited (Fin 0)` with an outer rcases
+
+`Circuit.foldl (.finRange k)` requires `[Inhabited (Fin k)]`, which fails when `k = 0`. The fix is the same shape every time: split the polymorphic parameter at the boundary and handle the empty case structurally.
+
+```lean
+def main : (k : ℕ) → Var Inputs (F p) → Circuit (F p) (...)
+  | 0, input => /- structural empty case, no loop -/
+  | k + 1, input => do
+    let result ← Circuit.foldl (.finRange (k + 1)) init body
+    /- continue -/
+```
+
+`EnforceRootOfUnity` in `qa/lean/Ragu/Circuits/Element/EnforceRootOfUnity.lean` is the canonical worked example (k=0 → `assertZero (input - 1)`, k+1 → `Circuit.foldl (.finRange (k+1)) input fun x _ => Mul.circuit ⟨x, x⟩`).
+
+### Restructure the body to make `ConstantOutput` hold
+
+If a naïve translation produces a body like
+```lean
+fun acc i => do
+  let scaled ← Mul.circuit ⟨acc, s⟩
+  pure (scaled + xs[i + 1])   -- output depends on i → ConstantOutput FAILS
+```
+the post-Mul addition makes the body output index-dependent and `Circuit.foldl`'s `_const_out` autotactic fails to synthesize. **Don't fall back to `foldlRange`** — restructure.
+
+The trick is to make the body's *last action* a subcircuit call whose output is a fresh wire (constant). For an `acc * s + xs[i+1]` Horner step:
+
+1. Do the first Horner step (`xs[0] * s`) as an *explicit* `Mul.circuit ⟨xs[0], s⟩` **outside** the foldl. Its output wire becomes the foldl's `init`.
+2. The foldl body is `fun acc i => Mul.circuit ⟨acc + xs[i+1], s⟩` — the index-dependent addition is now *inside* the Mul's input expression, and the body's output is just the fresh Mul wire (`var ⟨offset + 2⟩`), trivially `ConstantOutput`.
+3. After the foldl, add the trailing `xs[n]` via a free expression.
+
+`Fold` in `qa/lean/Ragu/Circuits/Element/Fold.lean` is the worked example (4-way rcases: 0, 1, 2, n+3 — the extra cases handle `Fin 0`/`Fin 1` boundaries cleanly). The autogen extractor sees the same `Mul`-per-Horner-step structure as a recursive-helper translation, so this restructure remains byte-for-byte compatible with the autogen instance proofs.
+
+### Sidestep `field (F p)` HPow synthesis in helper lemmas
+
+After `circuit_proof_start`, the loop's per-iteration witness is typed as `input : field (F p)` (where `field := id`). Lean's typeclass elaborator doesn't always unfold the `field` abbrev when synthesizing instances like `HPow (field (F p)) ℕ (F p)`, so writing `have wire_eq : ... = input ^ (2 ^ (i + 1)) := …` directly inside the proof fails with a typeclass synthesis error.
+
+**Workaround:** extract the inductive lemma as a `private` declaration parameterized over an explicit `env : Environment (F p)` and `x_val : F p`:
+
+```lean
+private lemma wire_value_eq_pow (k : ℕ) (env : Environment (F p))
+    (x_val : F p) (i₀ : ℕ)
+    (h0 : env.get (i₀ + 2) = x_val * x_val)
+    (hk : ∀ i, i + 1 < k + 1 → …) :
+    ∀ i, i ≤ k → env.get (i₀ + i * 3 + 2) = x_val ^ (2 ^ (i + 1)) := …
+
+theorem soundness (k : ℕ) : Soundness … := by
+  circuit_proof_start [Mul.circuit, …]
+  …
+  have wire_k := wire_value_eq_pow k env input i₀ h0 hk k (le_refl k)
+  …
+```
+
+Lean unifies `input : field (F p)` with the lemma's `x_val : F p` parameter cleanly at the call site (`field (F p)` *is* `F p` definitionally via `abbrev`), so the inner proof sees an honest `F p` and HPow synthesis works. Both `EnforceRootOfUnity.wire_value_eq_pow` and `Fold.wire_value_eq_horner` follow this pattern.
+
+A related warning to expect: `automatically included section variable(s) unused — [Fact (Nat.Prime p)]`. The helper does pure ring/field arithmetic, no primality. Suppress with `omit [Fact p.Prime] in` immediately before the lemma declaration (line-comment any docstring out — `omit` doesn't bind through `/-- … -/`).
+
+### Autogen instance proofs for `Circuit.foldl`
+
+When `main` uses `Circuit.foldl`, the `same_constraints` proof in the corresponding `qa/lean/Ragu/Instances/<Module>/<Gadget>.lean` file needs to unfold the foldl iteratively to byte-match the autogen's flat op list. The recipe:
+
+```lean
+same_constraints := by
+  intro input
+  simp [Core.Statements.FlatOperation.eraseCompute, List.map,
+    Operations.toFlat, circuit_norm,
+    FormalCircuit.isGeneralFormalCircuit,   -- or FormalAssertion.… for assertion-shaped gadgets
+    GeneralFormalCircuit.toWithHint,
+    GeneralFormalCircuit.WithHint.toSubcircuit, FormalCircuit.toSubcircuit,
+    deserializeInput, exportedOperations,
+    Circuits.Element.<Gadget>.circuit,
+    Circuits.Element.<Gadget>.elaborated,
+    Circuits.Element.<Gadget>.main,
+    Circuit.foldl, Vector.foldlM_toList,
+    Vector.finRange, Vector.ofFn, Vector.toList,
+    List.foldlM, List.foldlM_cons,
+    Circuits.Element.<Sub>.circuit, Circuits.Element.<Sub>.main]
+  constructor
+same_output := by intro input; rfl
+```
+
+The key unfolds: `Circuit.foldl` → `Vector.foldlM` → `Vector.foldlM_toList` → `List.foldlM_cons` (peels one iteration at a time until the list is exhausted). Lake's linter will flag any of `Vector.cast`, `List.foldlM_nil`, `Vector.finRange` etc. as unused if a particular gadget's shape doesn't need them — trim the list per the lint. CI treats those linter warnings as errors.
+
 ## Watch for false justifications
 
 Reviewers flag explanatory comments that aren't actually true (literal review verdict: "lie"). If a doc comment claims "Clean doesn't support X" or "this requires dependent types we don't expose", verify against the Clean codebase before writing it — those claims tend to be wrong.
@@ -269,5 +365,6 @@ Steps 1–2 can swap. Sub-gadgets stop after step 5.
 - [tachyon-zcash/ragu#642](https://github.com/tachyon-zcash/ragu/pull/642) — clean integration foundation. Trust-model artifact map (r3102920311); input/output struct shape is part of the trusted spec, wire order is not (r3105702381, r3115790860 — `assertLt` shadowed-bug example, composition-as-mitigation side note); per-gadget extension workflow distilled from the 102-commit history (artifact set, sub-gadget carve-out per Tal's approval comment, framework co-evolution via upstream Clean PRs).
 - [tachyon-zcash/ragu#672](https://github.com/tachyon-zcash/ragu/pull/672) — mitschabaude review (initial extraction)
 - [tachyon-zcash/ragu#674](https://github.com/tachyon-zcash/ragu/pull/674) — mitschabaude review (Boolean gadget). Verdict: "agents missed the compositionality of clean and wrote specs that just repeat the math equations instead of translating them into higher-level programming statements." Threads: r3138867768, r3138904103, r3138963958, r3138965755, r3138972958, r3138991793, r3139002146, r3139003436, r3139007420, r3139012715.
+- [tachyon-zcash/ragu#710](https://github.com/tachyon-zcash/ragu/pull/710) — mitschabaude review (`EnforceRootOfUnity`, `Fold` polymorphism). Top-level note: "clean has a couple of loop constructs with simp support in `circuit_proof_start` / `circuit_norm`. We use these whenever we need a loop: `Circuit.forEach`, `Circuit.map`, `Circuit.mapFinRange`, `Circuit.foldl`, `Circuit.foldlRange`." Inline suggestions r3265194082, r3265194093. Slack follow-up clarified the principle: "use foldl which behaves well" (not "make foldlRange behave better"); "clean users are not supposed to have to call simplification lemmas explicitly." Worked examples in `qa/lean/Ragu/Circuits/Element/{EnforceRootOfUnity,Fold}.lean`.
 
 <!-- Append new lessons below this line as they emerge from review feedback. -->

--- a/qa/crates/lean_extraction/src/instances/element_enforce_root_of_unity.rs
+++ b/qa/crates/lean_extraction/src/instances/element_enforce_root_of_unity.rs
@@ -7,9 +7,9 @@ use crate::{
     instance::{CircuitInstance, WireDeserializer},
 };
 
-pub struct ElementEnforceRootOfUnityInstance;
+pub struct ElementEnforceRootOfUnityInstanceK2;
 
-impl CircuitInstance for ElementEnforceRootOfUnityInstance {
+impl CircuitInstance for ElementEnforceRootOfUnityInstanceK2 {
     type Field = Fp;
 
     fn circuit(dr: &mut ExtractionDriver<Fp>) -> ragu_core::Result<Vec<Expr<Fp>>> {
@@ -18,12 +18,37 @@ impl CircuitInstance for ElementEnforceRootOfUnityInstance {
         let element_template = Element::constant(dr, Fp::zero());
         let input = WireDeserializer::new(input_wires).into_gadget(&element_template)?;
 
-        // k = 2: enforce `self^4 = 1`. This is the smallest non-trivial case
-        // (k = 0 is `self = 1`, k = 1 is `self^2 = 1`). Other values of k
-        // require analogous instances with the appropriate number of squares.
+        // k = 2: smallest non-trivial case (k = 0 is `self = 1`,
+        // k = 1 is `self^2 = 1`). The polymorphic Lean reimpl is universal
+        // in `k`; this instance pins it to k=2 for byte-equality against the
+        // extracted trace. See `ElementEnforceRootOfUnityInstanceK5` for the
+        // production-shape instance.
         input.enforce_root_of_unity(dr, 2)?;
 
         // No output wires; the gadget is an action, not a value.
+        Ok(Vec::new())
+    }
+}
+
+pub struct ElementEnforceRootOfUnityInstanceK5;
+
+impl CircuitInstance for ElementEnforceRootOfUnityInstanceK5 {
+    type Field = Fp;
+
+    fn circuit(dr: &mut ExtractionDriver<Fp>) -> ragu_core::Result<Vec<Expr<Fp>>> {
+        let input_wires = dr.alloc_input_wires(1);
+
+        let element_template = Element::constant(dr, Fp::zero());
+        let input = WireDeserializer::new(input_wires).into_gadget(&element_template)?;
+
+        // k = 5: enforce `self^32 = 1`. This matches the production
+        // `log2_circuits` value used by Applications with up to 17 registered
+        // steps (the common case in `ragu_pcd`). See
+        // `crates/ragu_pcd/src/internal/native/mod.rs::total_circuit_counts`
+        // for the derivation; with 13 internal circuits + 2 internal steps,
+        // any app step count in [1, 17] gives `log2_circuits = 5`.
+        input.enforce_root_of_unity(dr, 5)?;
+
         Ok(Vec::new())
     }
 }

--- a/qa/crates/lean_extraction/src/instances/element_fold.rs
+++ b/qa/crates/lean_extraction/src/instances/element_fold.rs
@@ -7,27 +7,49 @@ use crate::{
     instance::{CircuitInstance, WireCollector, WireDeserializer},
 };
 
-pub struct ElementFoldInstance;
+pub struct ElementFoldInstanceN3;
 
-impl CircuitInstance for ElementFoldInstance {
+impl CircuitInstance for ElementFoldInstanceN3 {
     type Field = Fp;
 
     fn circuit(dr: &mut ExtractionDriver<Fp>) -> ragu_core::Result<Vec<Expr<Fp>>> {
-        // Length 3: representative of the variadic `Element::fold`. The
-        // scale factor is itself an input wire (not a compile-time parameter).
-        let input_wires_0 = dr.alloc_input_wires(1);
-        let input_wires_1 = dr.alloc_input_wires(1);
-        let input_wires_2 = dr.alloc_input_wires(1);
-        let scale_wires = dr.alloc_input_wires(1);
-
-        let element_template = Element::constant(dr, Fp::zero());
-        let x0 = WireDeserializer::new(input_wires_0).into_gadget(&element_template)?;
-        let x1 = WireDeserializer::new(input_wires_1).into_gadget(&element_template)?;
-        let x2 = WireDeserializer::new(input_wires_2).into_gadget(&element_template)?;
-        let scale = WireDeserializer::new(scale_wires).into_gadget(&element_template)?;
-
-        let result = Element::fold(dr, [&x0, &x1, &x2], &scale)?;
-
-        WireCollector::collect_from(&result)
+        // n = 3: smallest non-trivial Horner shape (one element gives a no-op,
+        // two elements is one Mul). The polymorphic Lean reimpl is universal
+        // in `n`; this instance pins it to n=3 for byte-equality against the
+        // extracted trace. See N7/N19 for production-shape instances.
+        fold_at_length::<3>(dr)
     }
+}
+
+pub struct ElementFoldInstanceN7;
+
+impl CircuitInstance for ElementFoldInstanceN7 {
+    type Field = Fp;
+
+    fn circuit(dr: &mut ExtractionDriver<Fp>) -> ragu_core::Result<Vec<Expr<Fp>>> {
+        // n = 7: matches `RevdotParameters::GroupSize` in
+        // `crates/ragu_pcd/src/internal/native/mod.rs`. This is the inner-fold
+        // length used by `fold_revdot.rs::fold_two_layer` for each chunk of
+        // group sources.
+        fold_at_length::<7>(dr)
+    }
+}
+
+fn fold_at_length<const N: usize>(
+    dr: &mut ExtractionDriver<Fp>,
+) -> ragu_core::Result<Vec<Expr<Fp>>> {
+    let element_template = Element::constant(dr, Fp::zero());
+
+    let mut xs = Vec::with_capacity(N);
+    for _ in 0..N {
+        let input_wires = dr.alloc_input_wires(1);
+        let x = WireDeserializer::new(input_wires).into_gadget(&element_template)?;
+        xs.push(x);
+    }
+    let scale_wires = dr.alloc_input_wires(1);
+    let scale = WireDeserializer::new(scale_wires).into_gadget(&element_template)?;
+
+    let result = Element::fold(dr, xs.iter(), &scale)?;
+
+    WireCollector::collect_from(&result)
 }

--- a/qa/crates/lean_extraction/src/main.rs
+++ b/qa/crates/lean_extraction/src/main.rs
@@ -27,7 +27,7 @@ use crate::instances::{
         ElementEnforceRootOfUnityInstanceK2, ElementEnforceRootOfUnityInstanceK5,
     },
     element_enforce_zero::ElementEnforceZeroInstance,
-    element_fold::ElementFoldInstance,
+    element_fold::{ElementFoldInstanceN3, ElementFoldInstanceN7},
     element_invert::ElementInvertInstance,
     element_invert_with::ElementInvertWithInstance,
     element_is_equal::ElementIsEqualInstance,
@@ -111,9 +111,14 @@ static EXPORT_TARGETS: &[ExportTarget] = &[
         generated_file: generated_file_instance::<ElementDivNonzeroInstance>,
     },
     ExportTarget {
-        name: "Ragu.Instances.Autogen.Element.Fold",
-        export: export_instance::<ElementFoldInstance>,
-        generated_file: generated_file_instance::<ElementFoldInstance>,
+        name: "Ragu.Instances.Autogen.Element.FoldN3",
+        export: export_instance::<ElementFoldInstanceN3>,
+        generated_file: generated_file_instance::<ElementFoldInstanceN3>,
+    },
+    ExportTarget {
+        name: "Ragu.Instances.Autogen.Element.FoldN7",
+        export: export_instance::<ElementFoldInstanceN7>,
+        generated_file: generated_file_instance::<ElementFoldInstanceN7>,
     },
     ExportTarget {
         name: "Ragu.Instances.Autogen.Element.EnforceRootOfUnityK2",

--- a/qa/crates/lean_extraction/src/main.rs
+++ b/qa/crates/lean_extraction/src/main.rs
@@ -23,7 +23,9 @@ use crate::instances::{
     element_alloc::ElementAllocInstance,
     element_alloc_square::ElementAllocSquareInstance,
     element_div_nonzero::ElementDivNonzeroInstance,
-    element_enforce_root_of_unity::ElementEnforceRootOfUnityInstance,
+    element_enforce_root_of_unity::{
+        ElementEnforceRootOfUnityInstanceK2, ElementEnforceRootOfUnityInstanceK5,
+    },
     element_enforce_zero::ElementEnforceZeroInstance,
     element_fold::ElementFoldInstance,
     element_invert::ElementInvertInstance,
@@ -114,9 +116,14 @@ static EXPORT_TARGETS: &[ExportTarget] = &[
         generated_file: generated_file_instance::<ElementFoldInstance>,
     },
     ExportTarget {
-        name: "Ragu.Instances.Autogen.Element.EnforceRootOfUnity",
-        export: export_instance::<ElementEnforceRootOfUnityInstance>,
-        generated_file: generated_file_instance::<ElementEnforceRootOfUnityInstance>,
+        name: "Ragu.Instances.Autogen.Element.EnforceRootOfUnityK2",
+        export: export_instance::<ElementEnforceRootOfUnityInstanceK2>,
+        generated_file: generated_file_instance::<ElementEnforceRootOfUnityInstanceK2>,
+    },
+    ExportTarget {
+        name: "Ragu.Instances.Autogen.Element.EnforceRootOfUnityK5",
+        export: export_instance::<ElementEnforceRootOfUnityInstanceK5>,
+        generated_file: generated_file_instance::<ElementEnforceRootOfUnityInstanceK5>,
     },
     ExportTarget {
         name: "Ragu.Instances.Autogen.Element.EnforceZero",

--- a/qa/lean/Ragu.lean
+++ b/qa/lean/Ragu.lean
@@ -10,7 +10,8 @@ import Ragu.Instances.Element.Square
 import Ragu.Instances.Element.Alloc
 import Ragu.Instances.Element.AllocSquare
 import Ragu.Instances.Element.DivNonzero
-import Ragu.Instances.Element.Fold
+import Ragu.Instances.Element.FoldN3
+import Ragu.Instances.Element.FoldN7
 import Ragu.Instances.Element.EnforceRootOfUnityK2
 import Ragu.Instances.Element.EnforceRootOfUnityK5
 import Ragu.Instances.Element.EnforceZero

--- a/qa/lean/Ragu.lean
+++ b/qa/lean/Ragu.lean
@@ -11,7 +11,8 @@ import Ragu.Instances.Element.Alloc
 import Ragu.Instances.Element.AllocSquare
 import Ragu.Instances.Element.DivNonzero
 import Ragu.Instances.Element.Fold
-import Ragu.Instances.Element.EnforceRootOfUnity
+import Ragu.Instances.Element.EnforceRootOfUnityK2
+import Ragu.Instances.Element.EnforceRootOfUnityK5
 import Ragu.Instances.Element.EnforceZero
 import Ragu.Instances.Element.Invert
 import Ragu.Instances.Element.InvertWith

--- a/qa/lean/Ragu/Circuits/Element/EnforceRootOfUnity.lean
+++ b/qa/lean/Ragu/Circuits/Element/EnforceRootOfUnity.lean
@@ -14,17 +14,16 @@ Modeled as a `FormalAssertion`: the gadget is constraint-only (no
 output), `Spec` acts as both assumption for completeness and conclusion
 for soundness.
 
-The body iteratively squares the input via `squareIter`, matching the
-Rust `for _ in 0..k { value = value.square(dr)?; }` loop. -/
-def squareIter : (k : ℕ) → Expression (F p) → Circuit (F p) (Expression (F p))
-  | 0, x => pure x
-  | k+1, x => do
-    let sq ← Mul.circuit ⟨x, x⟩
-    squareIter k sq
-
-def main (k : ℕ) (input : Expression (F p)) : Circuit (F p) (Var unit (F p)) := do
-  let final ← squareIter k input
-  assertZero (final - 1)
+The `k+1` branch uses `Circuit.foldl (.finRange (k+1))` so that
+`ConstantOutput` (the body's output is a fresh wire, independent of
+`acc`) is auto-discharged and `foldl.output_eq` / `foldl.soundness` /
+`foldl.completeness` fire under `circuit_norm`. The `k = 0` branch is
+handled explicitly because `Inhabited (Fin 0)` doesn't exist. -/
+def main : (k : ℕ) → Expression (F p) → Circuit (F p) (Var unit (F p))
+  | 0, input => assertZero (input - 1)
+  | k + 1, input => do
+    let final ← Circuit.foldl (.finRange (k + 1)) input fun x _ => Mul.circuit ⟨x, x⟩
+    assertZero (final - 1)
 
 def Assumptions (_ : F p) := True
 
@@ -32,117 +31,73 @@ def Assumptions (_ : F p) := True
 def Spec (k : ℕ) (input : F p) :=
   input ^ (2 ^ k) = 1
 
-/-- `squareIter k x` has local length `3 * k` (one `Mul.circuit` of length
-3 per iteration), for any input `x` and any starting offset `n`. -/
-private lemma squareIter_localLength (k : ℕ) (x : Expression (F p)) (n : ℕ) :
-    Operations.localLength (squareIter k x n).2 = 3 * k := by
-  induction k generalizing x n with
-  | zero => rfl
-  | succ k ih =>
-    simp only [squareIter, Circuit.bind_def, circuit_norm, Mul.circuit, Mul.elaborated]
-    rw [ih]
-    ring
-
-/-- `squareIter k x` produces subcircuit-consistent operations for any
-input and any starting offset. -/
-private lemma squareIter_subcircuitsConsistent (k : ℕ) (x : Expression (F p)) (n : ℕ) :
-    Operations.forAll n
-      { subcircuit := fun offset {m} _ => m = offset }
-      (squareIter k x n).2 := by
-  induction k generalizing x n with
-  | zero => simp [squareIter, circuit_norm]
-  | succ k ih =>
-    simp only [squareIter, Circuit.bind_def, circuit_norm, Mul.circuit, Mul.elaborated]
-    rw [show (3 + n : ℕ) = n + 3 from Nat.add_comm 3 n]
-    exact ih (var ⟨n + 2⟩) (n + 3)
-
 instance elaborated (k : ℕ) : ElaboratedCircuit (F p) field unit where
   main := main k
   localLength _ := 3 * k
-  localLength_eq input offset := by
-    show Operations.localLength (main k input offset).2 = 3 * k
-    simp only [main, Circuit.bind_def]
-    show Operations.localLength
-      (((squareIter k input).bind (fun final => assertZero (final - 1))) offset).2 = 3 * k
-    simp only [Circuit.bind_def, circuit_norm]
-    exact squareIter_localLength k input offset
-  subcircuitsConsistent input offset := by
-    simp only [main, Circuit.bind_def, circuit_norm]
-    exact squareIter_subcircuitsConsistent k input offset
+  localLength_eq := by
+    rcases k with _ | k
+    · simp [main, circuit_norm]
+    · simp +arith [main, circuit_norm, Mul.circuit]
+  subcircuitsConsistent := by
+    rcases k with _ | k
+    · simp [main, circuit_norm]
+    · simp +arith [main, circuit_norm, Mul.circuit]
 
-/-- The output of `squareIter k x_var` evaluates to `x_val ^ (2^k)`,
-provided the constraints emitted by `squareIter` are satisfied and the
-input expression evaluates to `x_val`. Proved by induction on `k`,
-delegating each step's product equality to `Mul.Spec`. -/
-private lemma squareIter_eval_correct (k : ℕ) :
-    ∀ (env : Environment (F p)) (x_var : Expression (F p)) (x_val : F p) (n : ℕ),
-      Expression.eval env x_var = x_val →
-      Circuit.ConstraintsHold.Soundness env (squareIter k x_var n).2 →
-      Expression.eval env (squareIter k x_var n).1 = x_val ^ (2 ^ k) := by
-  induction k with
+/-- Each wire in the squaring chain holds `x_val^(2^(i+1))`. Parameterized so
+both soundness and completeness can apply it without the `field (F p) = F p`
+typeclass-synthesis snag at the `have`-site. -/
+private lemma wire_value_eq_pow (k : ℕ) (env : Environment (F p))
+    (x_val : F p) (i₀ : ℕ)
+    (h0 : env.get (i₀ + 2) = x_val * x_val)
+    (hk : ∀ i, i + 1 < k + 1 →
+          env.get (i₀ + (i + 1) * 3 + 2) =
+            env.get (i₀ + i * 3 + 2) * env.get (i₀ + i * 3 + 2)) :
+    ∀ i, i ≤ k → env.get (i₀ + i * 3 + 2) = x_val ^ (2 ^ (i + 1)) := by
+  intro i hi
+  induction i with
   | zero =>
-    intros env x_var x_val n h_eval _
-    simp [squareIter]
-    exact h_eval
-  | succ k ih =>
-    intros env x_var x_val n h_eval h_sound
-    simp only [squareIter, Circuit.bind_def, circuit_norm,
-      Mul.circuit, Mul.Assumptions, Mul.Spec, Mul.elaborated] at h_sound ⊢
-    obtain ⟨h_mul, h_rest⟩ := h_sound
-    -- h_mul : env.get (n+2) = eval x_var * eval x_var, i.e. wire = x_val^2
-    -- h_rest : ConstraintsHold over squareIter k at offset n+3, with the wire as input
-    have h_sq_eval : Expression.eval env (var ⟨n + 2⟩) = x_val * x_val := by
-      simp [Expression.eval, h_mul, h_eval]
-    rw [ih env (var ⟨n + 2⟩) (x_val * x_val) (n + 3) h_sq_eval h_rest]
+    simp only [zero_mul, Nat.add_zero, zero_add, pow_one]
+    rw [pow_two]
+    exact h0
+  | succ i ih =>
+    have ih' := ih (by omega)
+    have hstep := hk i (by omega)
+    rw [hstep, ih', ← pow_add]
+    congr 1
+    rw [Nat.pow_succ]
     ring
 
 theorem soundness (k : ℕ) :
     FormalAssertion.Soundness (F p) (elaborated k) Assumptions (Spec k) := by
-  circuit_proof_start [Mul.circuit, Mul.Assumptions, Mul.Spec]
-  obtain ⟨h_sound, h_final⟩ := h_holds
-  have h_out := squareIter_eval_correct k env input_var input i₀ h_input h_sound
-  rw [add_neg_eq_zero] at h_final
-  rw [h_out] at h_final
-  exact h_final
-
-/-- Companion to `squareIter_eval_correct` for the completeness side:
-given that the prover environment uses the canonical local witnesses for
-`squareIter k x_var`, the Mul constraints all hold by construction and
-the output evaluates to `x_val ^ (2^k)`. -/
-private lemma squareIter_completeness (k : ℕ) :
-    ∀ (env : ProverEnvironment (F p)) (x_var : Expression (F p)) (x_val : F p) (n : ℕ),
-      Expression.eval env.toEnvironment x_var = x_val →
-      env.UsesLocalWitnessesCompleteness n (squareIter k x_var n).2 →
-      Circuit.ConstraintsHold.Completeness env (squareIter k x_var n).2 ∧
-        Expression.eval env.toEnvironment (squareIter k x_var n).1 = x_val ^ (2 ^ k) := by
-  induction k with
-  | zero =>
-    intros env x_var x_val n h_eval _
-    refine ⟨?_, ?_⟩
-    · simp [squareIter, circuit_norm]
-    · simp [squareIter]; exact h_eval
-  | succ k ih =>
-    intros env x_var x_val n h_eval h_env
-    simp only [squareIter, Circuit.bind_def, circuit_norm,
-      Mul.circuit, Mul.Assumptions, Mul.Spec, Mul.elaborated] at h_env ⊢
-    obtain ⟨h_wit, h_rest⟩ := h_env
-    -- h_wit : env.get (n+2) = eval x_var * eval x_var (the canonical Mul witness)
-    -- h_rest : UsesLocalWitnessesCompleteness for squareIter k at offset n+3
-    have h_sq_eval : Expression.eval env.toEnvironment (var ⟨n + 2⟩) = x_val * x_val := by
-      simp [Expression.eval, h_wit, h_eval]
-    obtain ⟨h_inner_constr, h_inner_eval⟩ :=
-      ih env (var ⟨n + 2⟩) (x_val * x_val) (n + 3) h_sq_eval h_rest
-    refine ⟨h_inner_constr, ?_⟩
-    rw [h_inner_eval]
-    ring
+  rcases k with _ | k
+  · -- k=0: main = assertZero (input - 1); spec collapses to input = 1.
+    circuit_proof_start
+    rw [add_neg_eq_zero] at h_holds
+    simp [pow_zero, h_holds]
+  · -- k+1: chain of squarings; apply wire_value_eq_pow at i = k.
+    circuit_proof_start [Mul.circuit, Mul.Assumptions, Mul.Spec]
+    obtain ⟨⟨h0, hk⟩, h_final⟩ := h_holds
+    have wire_k := wire_value_eq_pow k env input i₀ h0 hk k (le_refl k)
+    simp only [Nat.add_sub_cancel] at h_final
+    rw [add_neg_eq_zero, wire_k] at h_final
+    exact h_final
 
 theorem completeness (k : ℕ) :
     FormalAssertion.Completeness (F p) (elaborated k) Assumptions (Spec k) := by
-  circuit_proof_start [Mul.circuit, Mul.Assumptions, Mul.Spec]
-  obtain ⟨h_constr, h_out⟩ := squareIter_completeness k env input_var input i₀ h_input h_env
-  refine ⟨h_constr, ?_⟩
-  rw [h_out, h_spec]
-  ring
+  rcases k with _ | k
+  · -- k=0: spec is input^1=1; goal is input - 1 = 0.
+    circuit_proof_start
+    rw [pow_zero, pow_one] at h_spec
+    rw [h_spec]
+    ring
+  · -- k+1: canonical witnesses give the squaring chain; conclude the final wire = 1.
+    circuit_proof_start [Mul.circuit, Mul.Assumptions, Mul.Spec]
+    obtain ⟨h0, hk⟩ := h_env
+    have wire_k :=
+      wire_value_eq_pow k env.toEnvironment input i₀ h0 hk k (le_refl k)
+    simp only [Nat.add_sub_cancel]
+    rw [add_neg_eq_zero, wire_k]
+    exact h_spec
 
 def circuit (k : ℕ) : FormalAssertion (F p) field :=
   { elaborated k with

--- a/qa/lean/Ragu/Circuits/Element/EnforceRootOfUnity.lean
+++ b/qa/lean/Ragu/Circuits/Element/EnforceRootOfUnity.lean
@@ -1,52 +1,154 @@
 import Clean.Circuit
+import Clean.Circuit.Loops
 import Ragu.Circuits.Element.Mul
 
 namespace Ragu.Circuits.Element.EnforceRootOfUnity
 variable {p : ℕ} [Fact p.Prime]
 
-/-- `Element::enforce_root_of_unity(k)` is parameterized on `k` in Rust
-and enforces `self^(2^k) = 1` by squaring `k` times. This Lean reimpl
-is monomorphized to `k = 2` (enforces `self^4 = 1`): it does not
-capture the full generality of the Rust gadget.
-
-TODO: generalize to a `k`-polymorphic reimpl that mirrors the Rust
-gadget's full generality (parameterize on `k : ℕ`, recurse on `k`).
+/-- `Element::enforce_root_of_unity(k)` enforces `self ^ (2^k) = 1` by
+squaring `k` times. This Lean reimpl is polymorphic on `k : ℕ`, mirroring
+the Rust gadget's full generality (parameter `k : u32` in
+`crates/ragu_primitives/src/element.rs::enforce_root_of_unity`).
 
 Modeled as a `FormalAssertion`: the gadget is constraint-only (no
-output), `Spec` acts as both assumption for completeness and conclusion for soundness,
-and the constraints are an exact reformulation of the spec. -/
-def main (input : Expression (F p)) : Circuit (F p) (Var unit (F p)) := do
-  let square1 ← Mul.circuit ⟨input, input⟩
-  let square2 ← Mul.circuit ⟨square1, square1⟩
-  assertZero (square2 - 1)
+output), `Spec` acts as both assumption for completeness and conclusion
+for soundness.
+
+The body iteratively squares the input via `squareIter`, matching the
+Rust `for _ in 0..k { value = value.square(dr)?; }` loop. -/
+def squareIter : (k : ℕ) → Expression (F p) → Circuit (F p) (Expression (F p))
+  | 0, x => pure x
+  | k+1, x => do
+    let sq ← Mul.circuit ⟨x, x⟩
+    squareIter k sq
+
+def main (k : ℕ) (input : Expression (F p)) : Circuit (F p) (Var unit (F p)) := do
+  let final ← squareIter k input
+  assertZero (final - 1)
 
 def Assumptions (_ : F p) := True
 
-/-- The verifier learns `input^4 = 1`. -/
-def Spec (input : F p) :=
-  input * input * (input * input) = 1
+/-- The verifier learns `input ^ (2^k) = 1`. -/
+def Spec (k : ℕ) (input : F p) :=
+  input ^ (2 ^ k) = 1
 
-instance elaborated : ElaboratedCircuit (F p) field unit where
-  main
-  localLength _ := 6
+/-- `squareIter k x` has local length `3 * k` (one `Mul.circuit` of length
+3 per iteration), for any input `x` and any starting offset `n`. -/
+private lemma squareIter_localLength (k : ℕ) (x : Expression (F p)) (n : ℕ) :
+    Operations.localLength (squareIter k x n).2 = 3 * k := by
+  induction k generalizing x n with
+  | zero => rfl
+  | succ k ih =>
+    simp only [squareIter, Circuit.bind_def, circuit_norm, Mul.circuit, Mul.elaborated]
+    rw [ih]
+    ring
 
-theorem soundness : FormalAssertion.Soundness (F p) elaborated Assumptions Spec := by
-  circuit_proof_start
-  simp [circuit_norm, Mul.circuit, Mul.Assumptions, Mul.Spec] at h_holds ⊢
-  obtain ⟨h_sq1, h_sq2, h_assert⟩ := h_holds
-  rw [add_neg_eq_zero] at h_assert
-  rw [h_sq1] at h_sq2
-  rw [h_sq2] at h_assert
-  exact h_assert
+/-- `squareIter k x` produces subcircuit-consistent operations for any
+input and any starting offset. -/
+private lemma squareIter_subcircuitsConsistent (k : ℕ) (x : Expression (F p)) (n : ℕ) :
+    Operations.forAll n
+      { subcircuit := fun offset {m} _ => m = offset }
+      (squareIter k x n).2 := by
+  induction k generalizing x n with
+  | zero => simp [squareIter, circuit_norm]
+  | succ k ih =>
+    simp only [squareIter, Circuit.bind_def, circuit_norm, Mul.circuit, Mul.elaborated]
+    rw [show (3 + n : ℕ) = n + 3 from Nat.add_comm 3 n]
+    exact ih (var ⟨n + 2⟩) (n + 3)
 
-theorem completeness : FormalAssertion.Completeness (F p) elaborated Assumptions Spec := by
+instance elaborated (k : ℕ) : ElaboratedCircuit (F p) field unit where
+  main := main k
+  localLength _ := 3 * k
+  localLength_eq input offset := by
+    show Operations.localLength (main k input offset).2 = 3 * k
+    simp only [main, Circuit.bind_def]
+    show Operations.localLength
+      (((squareIter k input).bind (fun final => assertZero (final - 1))) offset).2 = 3 * k
+    simp only [Circuit.bind_def, circuit_norm]
+    exact squareIter_localLength k input offset
+  subcircuitsConsistent input offset := by
+    simp only [main, Circuit.bind_def, circuit_norm]
+    exact squareIter_subcircuitsConsistent k input offset
+
+/-- The output of `squareIter k x_var` evaluates to `x_val ^ (2^k)`,
+provided the constraints emitted by `squareIter` are satisfied and the
+input expression evaluates to `x_val`. Proved by induction on `k`,
+delegating each step's product equality to `Mul.Spec`. -/
+private lemma squareIter_eval_correct (k : ℕ) :
+    ∀ (env : Environment (F p)) (x_var : Expression (F p)) (x_val : F p) (n : ℕ),
+      Expression.eval env x_var = x_val →
+      Circuit.ConstraintsHold.Soundness env (squareIter k x_var n).2 →
+      Expression.eval env (squareIter k x_var n).1 = x_val ^ (2 ^ k) := by
+  induction k with
+  | zero =>
+    intros env x_var x_val n h_eval _
+    simp [squareIter]
+    exact h_eval
+  | succ k ih =>
+    intros env x_var x_val n h_eval h_sound
+    simp only [squareIter, Circuit.bind_def, circuit_norm,
+      Mul.circuit, Mul.Assumptions, Mul.Spec, Mul.elaborated] at h_sound ⊢
+    obtain ⟨h_mul, h_rest⟩ := h_sound
+    -- h_mul : env.get (n+2) = eval x_var * eval x_var, i.e. wire = x_val^2
+    -- h_rest : ConstraintsHold over squareIter k at offset n+3, with the wire as input
+    have h_sq_eval : Expression.eval env (var ⟨n + 2⟩) = x_val * x_val := by
+      simp [Expression.eval, h_mul, h_eval]
+    rw [ih env (var ⟨n + 2⟩) (x_val * x_val) (n + 3) h_sq_eval h_rest]
+    ring
+
+theorem soundness (k : ℕ) :
+    FormalAssertion.Soundness (F p) (elaborated k) Assumptions (Spec k) := by
   circuit_proof_start [Mul.circuit, Mul.Assumptions, Mul.Spec]
-  obtain ⟨h_sq1, h_sq2⟩ := h_env
-  rw [add_neg_eq_zero]
-  rw [h_sq2, h_sq1]
-  exact h_spec
+  obtain ⟨h_sound, h_final⟩ := h_holds
+  have h_out := squareIter_eval_correct k env input_var input i₀ h_input h_sound
+  rw [add_neg_eq_zero] at h_final
+  rw [h_out] at h_final
+  exact h_final
 
-def circuit : FormalAssertion (F p) field :=
-  { elaborated with Assumptions, Spec, soundness, completeness }
+/-- Companion to `squareIter_eval_correct` for the completeness side:
+given that the prover environment uses the canonical local witnesses for
+`squareIter k x_var`, the Mul constraints all hold by construction and
+the output evaluates to `x_val ^ (2^k)`. -/
+private lemma squareIter_completeness (k : ℕ) :
+    ∀ (env : ProverEnvironment (F p)) (x_var : Expression (F p)) (x_val : F p) (n : ℕ),
+      Expression.eval env.toEnvironment x_var = x_val →
+      env.UsesLocalWitnessesCompleteness n (squareIter k x_var n).2 →
+      Circuit.ConstraintsHold.Completeness env (squareIter k x_var n).2 ∧
+        Expression.eval env.toEnvironment (squareIter k x_var n).1 = x_val ^ (2 ^ k) := by
+  induction k with
+  | zero =>
+    intros env x_var x_val n h_eval _
+    refine ⟨?_, ?_⟩
+    · simp [squareIter, circuit_norm]
+    · simp [squareIter]; exact h_eval
+  | succ k ih =>
+    intros env x_var x_val n h_eval h_env
+    simp only [squareIter, Circuit.bind_def, circuit_norm,
+      Mul.circuit, Mul.Assumptions, Mul.Spec, Mul.elaborated] at h_env ⊢
+    obtain ⟨h_wit, h_rest⟩ := h_env
+    -- h_wit : env.get (n+2) = eval x_var * eval x_var (the canonical Mul witness)
+    -- h_rest : UsesLocalWitnessesCompleteness for squareIter k at offset n+3
+    have h_sq_eval : Expression.eval env.toEnvironment (var ⟨n + 2⟩) = x_val * x_val := by
+      simp [Expression.eval, h_wit, h_eval]
+    obtain ⟨h_inner_constr, h_inner_eval⟩ :=
+      ih env (var ⟨n + 2⟩) (x_val * x_val) (n + 3) h_sq_eval h_rest
+    refine ⟨h_inner_constr, ?_⟩
+    rw [h_inner_eval]
+    ring
+
+theorem completeness (k : ℕ) :
+    FormalAssertion.Completeness (F p) (elaborated k) Assumptions (Spec k) := by
+  circuit_proof_start [Mul.circuit, Mul.Assumptions, Mul.Spec]
+  obtain ⟨h_constr, h_out⟩ := squareIter_completeness k env input_var input i₀ h_input h_env
+  refine ⟨h_constr, ?_⟩
+  rw [h_out, h_spec]
+  ring
+
+def circuit (k : ℕ) : FormalAssertion (F p) field :=
+  { elaborated k with
+    Assumptions
+    Spec := Spec k
+    soundness := soundness k
+    completeness := completeness k }
 
 end Ragu.Circuits.Element.EnforceRootOfUnity

--- a/qa/lean/Ragu/Circuits/Element/Fold.lean
+++ b/qa/lean/Ragu/Circuits/Element/Fold.lean
@@ -4,49 +4,193 @@ import Ragu.Circuits.Element.Mul
 namespace Ragu.Circuits.Element.Fold
 variable {p : ℕ} [Fact p.Prime]
 
-/-- `Element::fold` is variadic (`IntoIterator<Element>`) in Rust. This
-Lean reimpl is monomorphized to length 3: it does not capture the full
-generality of the Rust gadget. The scale factor is an input wire (not
-a compile-time parameter), so it appears in `Input`.
-
-TODO: generalize to a length-polymorphic reimpl that mirrors the Rust
-gadget's full generality (parameterize on `n : ℕ`, recurse on `n`). -/
-structure Input (F : Type) where
-  x0 : F
-  x1 : F
-  x2 : F
-  s : F  -- scale factor
+/-- `Element::fold` is a variadic Horner reduction in Rust: given
+elements `[x₀, x₁, …, x_{n-1}]` and a scale factor `s`, returns
+`((…((x₀·s + x₁)·s + x₂)…)·s + x_{n-1})`, with the empty-input case
+returning zero. This Lean reimpl is polymorphic on `n : ℕ`, mirroring
+the Rust gadget's full generality. -/
+structure Input (n : ℕ) (F : Type) where
+  xs : Vector F n
+  s : F
 deriving ProvableStruct
 
-/-- Horner fold: `((x0 · s) + x1) · s + x2 = x0·s² + x1·s + x2`. -/
-def main (input : Var Input (F p)) : Circuit (F p) (Expression (F p)) := do
-  let acc0_s ← Mul.circuit ⟨input.x0, input.s⟩
-  let acc1 := acc0_s + input.x1
-  let acc1_s ← Mul.circuit ⟨acc1, input.s⟩
-  return acc1_s + input.x2
+/-- Horner reduction step: given an accumulator and a vector of `m`
+remaining elements, produces the final accumulator after `m` Mul-then-add
+iterations. Each iteration calls `Mul.circuit`, matching the autogen's
+per-step shape of one witness-3 + three asserts. -/
+def hornerStep :
+    (m : ℕ) → Expression (F p) → Vector (Expression (F p)) m → Expression (F p) →
+      Circuit (F p) (Expression (F p))
+  | 0, acc, _, _ => pure acc
+  | m+1, acc, rest, s => do
+    let scaled ← Mul.circuit ⟨acc, s⟩
+    hornerStep m (scaled + rest[0]) rest.tail s
 
-def Assumptions (_input : Input (F p)) := True
+def main : (n : ℕ) → Var (Input n) (F p) → Circuit (F p) (Expression (F p))
+  | 0, _ => pure 0
+  | _+1, input => hornerStep _ input.xs[0] input.xs.tail input.s
 
-def Spec (input : Input (F p)) (output : F p) :=
-  output = (input.x0 * input.s + input.x1) * input.s + input.x2
+/-- Native (no-circuit) Horner reduction, mirrors `hornerStep`. -/
+def hornerVal : (m : ℕ) → F p → Vector (F p) m → F p → F p
+  | 0, acc, _, _ => acc
+  | m+1, acc, rest, s => hornerVal m (acc * s + rest[0]) rest.tail s
 
-instance elaborated : ElaboratedCircuit (F p) Input field where
-  main
-  localLength _ := 6
+def Assumptions {n : ℕ} (_input : Input n (F p)) := True
 
-theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
-  circuit_proof_start
-  simp [circuit_norm, Mul.circuit, Mul.Assumptions, Mul.Spec] at h_holds ⊢
-  obtain ⟨h1, h2⟩ := h_holds
-  -- h1: first mul output = x0 * s
-  -- h2: second mul output = (first mul output + x1) * s
-  rw [h1] at h2
-  rw [h2]
+/-- For `n = 0` the output is `0` (matching `Element::zero`).
+For `n ≥ 1` the output is the Horner reduction of `xs` with scale `s`. -/
+def Spec {n : ℕ} (input : Input n (F p)) (output : F p) :=
+  output = match n, input.xs with
+    | 0, _ => 0
+    | _+1, xs => hornerVal _ xs[0] xs.tail input.s
 
-theorem completeness : Completeness (F p) elaborated Assumptions := by
-  circuit_proof_start [Mul.circuit, Mul.Assumptions]
+/-- `hornerStep m acc rest s` has local length `3 * m` (one `Mul.circuit`
+of length 3 per iteration), for any accumulator, remaining vector, and
+starting offset. -/
+private lemma hornerStep_localLength (m : ℕ) (acc : Expression (F p))
+    (rest : Vector (Expression (F p)) m) (s : Expression (F p)) (n : ℕ) :
+    Operations.localLength (hornerStep m acc rest s n).2 = 3 * m := by
+  induction m generalizing acc s n with
+  | zero => rfl
+  | succ m ih =>
+    simp only [hornerStep, Circuit.bind_def, circuit_norm, Mul.circuit, Mul.elaborated]
+    rw [ih]
+    ring
 
-def circuit : FormalCircuit (F p) Input field :=
-  { elaborated with Assumptions, Spec, soundness, completeness }
+/-- `hornerStep m acc rest s` produces subcircuit-consistent operations. -/
+private lemma hornerStep_subcircuitsConsistent (m : ℕ) (acc : Expression (F p))
+    (rest : Vector (Expression (F p)) m) (s : Expression (F p)) (n : ℕ) :
+    Operations.forAll n
+      { subcircuit := fun offset {k} _ => k = offset }
+      (hornerStep m acc rest s n).2 := by
+  induction m generalizing acc s n with
+  | zero => simp [hornerStep, circuit_norm]
+  | succ m ih =>
+    simp only [hornerStep, Circuit.bind_def, circuit_norm, Mul.circuit, Mul.elaborated]
+    rw [show (3 + n : ℕ) = n + 3 from Nat.add_comm 3 n]
+    exact ih _ _ _ (n + 3)
+
+instance elaborated (n : ℕ) : ElaboratedCircuit (F p) (Input n) field where
+  main := main n
+  localLength _ := 3 * (n - 1)
+  localLength_eq input offset := by
+    rcases n with _ | n
+    · simp [main, circuit_norm]
+    · simp only [main, circuit_norm]
+      exact hornerStep_localLength n _ _ _ _
+  subcircuitsConsistent input offset := by
+    rcases n with _ | n
+    · simp [main, circuit_norm]
+    · simp only [main, circuit_norm]
+      exact hornerStep_subcircuitsConsistent n _ _ _ _
+
+/-- `(map f v).tail = map f v.tail`. -/
+private lemma Vector.map_tail {α β : Type*} {n : ℕ} (f : α → β) (v : Vector α (n+1)) :
+    (v.map f).tail = v.tail.map f := by
+  apply Vector.ext
+  intros i hi
+  simp
+
+/-- The output of `hornerStep m acc_var rest_var s_var` evaluates to
+`hornerVal m acc_val rest_val s_val` (where rest_val / s_val / acc_val
+are the evaluations of the corresponding expression args), provided the
+Mul constraints from each iteration are satisfied. Proved by induction
+on `m`, delegating each step's product equality to `Mul.Spec`. -/
+private lemma hornerStep_eval_correct (m : ℕ) (env : Environment (F p))
+    (acc_var : Expression (F p)) (acc_val : F p)
+    (rest_var : Vector (Expression (F p)) m)
+    (s_var : Expression (F p)) (s_val : F p) (n : ℕ)
+    (h_acc : Expression.eval env acc_var = acc_val)
+    (h_s : Expression.eval env s_var = s_val)
+    (h_sound : Circuit.ConstraintsHold.Soundness env (hornerStep m acc_var rest_var s_var n).2) :
+    Expression.eval env (hornerStep m acc_var rest_var s_var n).1
+      = hornerVal m acc_val (rest_var.map (Expression.eval env)) s_val := by
+  induction m generalizing acc_var acc_val s_var s_val n with
+  | zero =>
+    simp only [hornerStep, hornerVal, circuit_norm]
+    exact h_acc
+  | succ m ih =>
+    simp only [hornerStep, Circuit.bind_def, circuit_norm,
+      Mul.circuit, Mul.Assumptions, Mul.Spec, Mul.elaborated] at h_sound ⊢
+    obtain ⟨h_mul, h_rest⟩ := h_sound
+    have h_new_acc : Expression.eval env (var ⟨n + 2⟩ + rest_var[0])
+        = acc_val * s_val + Expression.eval env rest_var[0] := by
+      simp [Expression.eval, h_mul, h_acc, h_s]
+    rw [ih (var ⟨n + 2⟩ + rest_var[0]) (acc_val * s_val + Expression.eval env rest_var[0])
+        rest_var.tail s_var s_val (n + 3) h_new_acc h_s h_rest]
+    -- Goal: hornerVal m (acc_val * s_val + eval rest_var[0]) (map eval rest_var.tail) s_val
+    --     = hornerVal (m + 1) acc_val (map eval rest_var) s_val
+    -- RHS unfolds (via hornerVal definition for m+1):
+    --   = hornerVal m (acc_val * s_val + (map eval rest_var)[0]) (map eval rest_var).tail s_val
+    show _ = hornerVal (m + 1) acc_val (Vector.map (Expression.eval env) rest_var) s_val
+    rw [hornerVal]
+    congr 1
+    · simp [Vector.getElem_map]
+    · apply Vector.ext
+      intro i hi
+      simp [Vector.getElem_map]
+
+theorem soundness (n : ℕ) :
+    Soundness (F p) (elaborated n) Assumptions Spec := by
+  circuit_proof_start [Mul.circuit, Mul.Assumptions, Mul.Spec]
+  rcases n with _ | n
+  · -- n = 0: main returns pure 0, output = 0, Spec is `output = 0`
+    simp [circuit_norm] at h_holds ⊢
+  · -- n = n'+1: main = hornerStep n' xs[0] xs.tail s
+    simp only [circuit_norm] at h_holds ⊢
+    have h_eval := hornerStep_eval_correct n env
+      input_var.xs[0] (Expression.eval env input_var.xs[0])
+      input_var.xs.tail input_var.s (Expression.eval env input_var.s) i₀
+      rfl rfl h_holds
+    -- Decompose h_input into per-field equalities
+    have h_xs : input.xs = Vector.map (Expression.eval env) input_var.xs := by
+      rw [← h_input]
+    have h_s : input.s = Expression.eval env input_var.s := by
+      rw [← h_input]
+    -- Unfold Spec for the n+1 branch
+    show Expression.eval env _ = hornerVal n input.xs[0] input.xs.tail input.s
+    rw [h_xs, h_s, Vector.getElem_map, Vector.map_tail]
+    exact h_eval
+
+/-- Companion to `hornerStep_eval_correct` for the completeness side:
+given that the prover environment uses the canonical local witnesses for
+`hornerStep`, the Mul constraints all hold by construction. -/
+private lemma hornerStep_completeness (m : ℕ) (env : ProverEnvironment (F p))
+    (acc_var : Expression (F p)) (acc_val : F p)
+    (rest_var : Vector (Expression (F p)) m)
+    (s_var : Expression (F p)) (s_val : F p) (n : ℕ)
+    (h_acc : Expression.eval env.toEnvironment acc_var = acc_val)
+    (h_s : Expression.eval env.toEnvironment s_var = s_val)
+    (h_env : env.UsesLocalWitnessesCompleteness n (hornerStep m acc_var rest_var s_var n).2) :
+    Circuit.ConstraintsHold.Completeness env (hornerStep m acc_var rest_var s_var n).2 := by
+  induction m generalizing acc_var acc_val s_var s_val n with
+  | zero =>
+    simp [hornerStep, circuit_norm]
+  | succ m ih =>
+    simp only [hornerStep, Circuit.bind_def, circuit_norm,
+      Mul.circuit, Mul.Assumptions, Mul.Spec, Mul.elaborated] at h_env ⊢
+    obtain ⟨h_wit, h_rest⟩ := h_env
+    have h_new_acc : Expression.eval env.toEnvironment (var ⟨n + 2⟩ + rest_var[0])
+        = acc_val * s_val + Expression.eval env.toEnvironment rest_var[0] := by
+      simp [Expression.eval, h_wit, h_acc, h_s]
+    exact ih (var ⟨n + 2⟩ + rest_var[0]) _ rest_var.tail s_var s_val (n + 3) h_new_acc h_s h_rest
+
+theorem completeness (n : ℕ) :
+    Completeness (F p) (elaborated n) Assumptions := by
+  circuit_proof_start [Mul.circuit, Mul.Assumptions, Mul.Spec]
+  rcases n with _ | n
+  · simp [circuit_norm]
+  · simp only [circuit_norm] at h_env ⊢
+    exact hornerStep_completeness n env
+      input_var.xs[0] (Expression.eval env.toEnvironment input_var.xs[0])
+      input_var.xs.tail input_var.s (Expression.eval env.toEnvironment input_var.s) i₀
+      rfl rfl h_env
+
+def circuit (n : ℕ) : FormalCircuit (F p) (Input n) field :=
+  { elaborated n with
+    Assumptions
+    Spec
+    soundness := soundness n
+    completeness := completeness n }
 
 end Ragu.Circuits.Element.Fold

--- a/qa/lean/Ragu/Circuits/Element/Fold.lean
+++ b/qa/lean/Ragu/Circuits/Element/Fold.lean
@@ -1,4 +1,5 @@
 import Clean.Circuit
+import Clean.Circuit.Loops
 import Ragu.Circuits.Element.Mul
 
 namespace Ragu.Circuits.Element.Fold
@@ -8,32 +9,34 @@ variable {p : ℕ} [Fact p.Prime]
 elements `[x₀, x₁, …, x_{n-1}]` and a scale factor `s`, returns
 `((…((x₀·s + x₁)·s + x₂)…)·s + x_{n-1})`, with the empty-input case
 returning zero. This Lean reimpl is polymorphic on `n : ℕ`, mirroring
-the Rust gadget's full generality. -/
+the Rust gadget's full generality.
+
+The `n+3` branch uses `Circuit.foldl (.finRange (n+1))` per
+mitschabaude's PR #710 review. The body `fun acc i => Mul.circuit
+⟨acc + xs[i+1], s⟩` returns the fresh `Mul` wire (an offset-relative
+`var`), which is `ConstantOutput` — independent of both `acc` and the
+iteration index. The first Horner step (`xs[0] * s`) is done *outside*
+the loop as an explicit `Mul.circuit ⟨xs[0], s⟩`, threading the
+resulting wire into the foldl as `init`. The final `+ xs[n+2]` adds
+the last element after the loop (Horner's trailing addition has no
+multiplication). The `0`, `1`, `2` branches handle the cases where the
+loop would be empty (`Fin 0` is not `Inhabited`) or absent. -/
 structure Input (n : ℕ) (F : Type) where
   xs : Vector F n
   s : F
 deriving ProvableStruct
 
-/-- Horner reduction step: given an accumulator and a vector of `m`
-remaining elements, produces the final accumulator after `m` Mul-then-add
-iterations. Each iteration calls `Mul.circuit`, matching the autogen's
-per-step shape of one witness-3 + three asserts. -/
-def hornerStep :
-    (m : ℕ) → Expression (F p) → Vector (Expression (F p)) m → Expression (F p) →
-      Circuit (F p) (Expression (F p))
-  | 0, acc, _, _ => pure acc
-  | m+1, acc, rest, s => do
-    let scaled ← Mul.circuit ⟨acc, s⟩
-    hornerStep m (scaled + rest[0]) rest.tail s
-
 def main : (n : ℕ) → Var (Input n) (F p) → Circuit (F p) (Expression (F p))
   | 0, _ => pure 0
-  | _+1, input => hornerStep _ input.xs[0] input.xs.tail input.s
-
-/-- Native (no-circuit) Horner reduction, mirrors `hornerStep`. -/
-def hornerVal : (m : ℕ) → F p → Vector (F p) m → F p → F p
-  | 0, acc, _, _ => acc
-  | m+1, acc, rest, s => hornerVal m (acc * s + rest[0]) rest.tail s
+  | 1, input => pure input.xs[0]
+  | 2, input => do
+    let scaled ← Mul.circuit ⟨input.xs[0], input.s⟩
+    pure (scaled + input.xs[1])
+  | n+3, input => do
+    let scaled_0 ← Mul.circuit ⟨input.xs[0], input.s⟩
+    let scaled_last ← Circuit.foldl (.finRange (n+1)) scaled_0 fun acc i =>
+      Mul.circuit ⟨acc + input.xs[i.val + 1], input.s⟩
+    pure (scaled_last + input.xs[n+2])
 
 def Assumptions {n : ℕ} (_input : Input n (F p)) := True
 
@@ -42,149 +45,133 @@ For `n ≥ 1` the output is the Horner reduction of `xs` with scale `s`. -/
 def Spec {n : ℕ} (input : Input n (F p)) (output : F p) :=
   output = match n, input.xs with
     | 0, _ => 0
-    | _+1, xs => hornerVal _ xs[0] xs.tail input.s
-
-/-- `hornerStep m acc rest s` has local length `3 * m` (one `Mul.circuit`
-of length 3 per iteration), for any accumulator, remaining vector, and
-starting offset. -/
-private lemma hornerStep_localLength (m : ℕ) (acc : Expression (F p))
-    (rest : Vector (Expression (F p)) m) (s : Expression (F p)) (n : ℕ) :
-    Operations.localLength (hornerStep m acc rest s n).2 = 3 * m := by
-  induction m generalizing acc s n with
-  | zero => rfl
-  | succ m ih =>
-    simp only [hornerStep, Circuit.bind_def, circuit_norm, Mul.circuit, Mul.elaborated]
-    rw [ih]
-    ring
-
-/-- `hornerStep m acc rest s` produces subcircuit-consistent operations. -/
-private lemma hornerStep_subcircuitsConsistent (m : ℕ) (acc : Expression (F p))
-    (rest : Vector (Expression (F p)) m) (s : Expression (F p)) (n : ℕ) :
-    Operations.forAll n
-      { subcircuit := fun offset {k} _ => k = offset }
-      (hornerStep m acc rest s n).2 := by
-  induction m generalizing acc s n with
-  | zero => simp [hornerStep, circuit_norm]
-  | succ m ih =>
-    simp only [hornerStep, Circuit.bind_def, circuit_norm, Mul.circuit, Mul.elaborated]
-    rw [show (3 + n : ℕ) = n + 3 from Nat.add_comm 3 n]
-    exact ih _ _ _ (n + 3)
+    | m+1, xs => Fin.foldl m
+        (fun acc (i : Fin m) => acc * input.s + xs[i.val + 1]) xs[0]
 
 instance elaborated (n : ℕ) : ElaboratedCircuit (F p) (Input n) field where
   main := main n
   localLength _ := 3 * (n - 1)
   localLength_eq input offset := by
-    rcases n with _ | n
+    rcases n with _ | _ | _ | n
     · simp [main, circuit_norm]
-    · simp only [main, circuit_norm]
-      exact hornerStep_localLength n _ _ _ _
+    · simp [main, circuit_norm]
+    · simp +arith [main, circuit_norm, Mul.circuit]
+    · simp +arith [main, circuit_norm, Mul.circuit]
   subcircuitsConsistent input offset := by
-    rcases n with _ | n
+    rcases n with _ | _ | _ | n
     · simp [main, circuit_norm]
-    · simp only [main, circuit_norm]
-      exact hornerStep_subcircuitsConsistent n _ _ _ _
+    · simp [main, circuit_norm]
+    · simp +arith [main, circuit_norm, Mul.circuit]
+    · simp +arith [main, circuit_norm, Mul.circuit]
 
-/-- `(map f v).tail = map f v.tail`. -/
-private lemma Vector.map_tail {α β : Type*} {n : ℕ} (f : α → β) (v : Vector α (n+1)) :
-    (v.map f).tail = v.tail.map f := by
-  apply Vector.ext
-  intros i hi
-  simp
-
-/-- The output of `hornerStep m acc_var rest_var s_var` evaluates to
-`hornerVal m acc_val rest_val s_val` (where rest_val / s_val / acc_val
-are the evaluations of the corresponding expression args), provided the
-Mul constraints from each iteration are satisfied. Proved by induction
-on `m`, delegating each step's product equality to `Mul.Spec`. -/
-private lemma hornerStep_eval_correct (m : ℕ) (env : Environment (F p))
-    (acc_var : Expression (F p)) (acc_val : F p)
-    (rest_var : Vector (Expression (F p)) m)
-    (s_var : Expression (F p)) (s_val : F p) (n : ℕ)
-    (h_acc : Expression.eval env acc_var = acc_val)
-    (h_s : Expression.eval env s_var = s_val)
-    (h_sound : Circuit.ConstraintsHold.Soundness env (hornerStep m acc_var rest_var s_var n).2) :
-    Expression.eval env (hornerStep m acc_var rest_var s_var n).1
-      = hornerVal m acc_val (rest_var.map (Expression.eval env)) s_val := by
-  induction m generalizing acc_var acc_val s_var s_val n with
+/-- For n+3 elements, each foldl Mul wire `wire(k) = env.get (i₀+3+k*3+2)`
+holds `horner(k+1) * s`, where `horner` is the value-level Horner partial.
+Sidesteps the `field (F p) = F p` HPow snag the same way as
+`EnforceRootOfUnity.wire_value_eq_pow`: parameterize by `xs_val : Vector
+(F p) _` and `s_val : F p`. -/
+private lemma wire_value_eq_horner (n : ℕ) (env : Environment (F p))
+    (xs_val : Vector (F p) (n+3)) (s_val : F p) (i₀ : ℕ)
+    (h0 : env.get (i₀ + 2) = xs_val[0] * s_val)
+    (h_iter0 : env.get (i₀ + 3 + 2) =
+      (env.get (i₀ + 2) + xs_val[1]) * s_val)
+    (h_iterk : ∀ (i : ℕ) (_ : i + 1 < n + 1),
+        env.get (i₀ + 3 + (i + 1) * 3 + 2) =
+          (env.get (i₀ + 3 + i * 3 + 2) + xs_val[i + 2]) * s_val) :
+    ∀ (k : ℕ) (_ : k ≤ n),
+      env.get (i₀ + 3 + k * 3 + 2) =
+        (Fin.foldl (k + 1) (fun acc (i : Fin (k + 1)) =>
+          acc * s_val + xs_val[i.val + 1]'(by omega))
+          xs_val[0]) * s_val := by
+  intro k hk
+  induction k with
   | zero =>
-    simp only [hornerStep, hornerVal, circuit_norm]
-    exact h_acc
-  | succ m ih =>
-    simp only [hornerStep, Circuit.bind_def, circuit_norm,
-      Mul.circuit, Mul.Assumptions, Mul.Spec, Mul.elaborated] at h_sound ⊢
-    obtain ⟨h_mul, h_rest⟩ := h_sound
-    have h_new_acc : Expression.eval env (var ⟨n + 2⟩ + rest_var[0])
-        = acc_val * s_val + Expression.eval env rest_var[0] := by
-      simp [Expression.eval, h_mul, h_acc, h_s]
-    rw [ih (var ⟨n + 2⟩ + rest_var[0]) (acc_val * s_val + Expression.eval env rest_var[0])
-        rest_var.tail s_var s_val (n + 3) h_new_acc h_s h_rest]
-    -- Goal: hornerVal m (acc_val * s_val + eval rest_var[0]) (map eval rest_var.tail) s_val
-    --     = hornerVal (m + 1) acc_val (map eval rest_var) s_val
-    -- RHS unfolds (via hornerVal definition for m+1):
-    --   = hornerVal m (acc_val * s_val + (map eval rest_var)[0]) (map eval rest_var).tail s_val
-    show _ = hornerVal (m + 1) acc_val (Vector.map (Expression.eval env) rest_var) s_val
-    rw [hornerVal]
-    congr 1
-    · simp [Vector.getElem_map]
-    · apply Vector.ext
-      intro i hi
-      simp [Vector.getElem_map]
+    simp only [zero_mul, add_zero]
+    rw [h_iter0, h0]
+    rw [Fin.foldl_succ_last, Fin.foldl_zero]
+    simp [Fin.val_last]
+  | succ k ih =>
+    have ih' := ih (by omega)
+    have hstep := h_iterk k (by omega)
+    rw [hstep, ih']
+    -- Peel only the RHS Fin.foldl (k+1+1).
+    conv_rhs => rw [Fin.foldl_succ_last]
+    simp [Fin.val_last, Fin.val_castSucc]
 
 theorem soundness (n : ℕ) :
     Soundness (F p) (elaborated n) Assumptions Spec := by
-  circuit_proof_start [Mul.circuit, Mul.Assumptions, Mul.Spec]
-  rcases n with _ | n
-  · -- n = 0: main returns pure 0, output = 0, Spec is `output = 0`
-    simp [circuit_norm] at h_holds ⊢
-  · -- n = n'+1: main = hornerStep n' xs[0] xs.tail s
-    simp only [circuit_norm] at h_holds ⊢
-    have h_eval := hornerStep_eval_correct n env
-      input_var.xs[0] (Expression.eval env input_var.xs[0])
-      input_var.xs.tail input_var.s (Expression.eval env input_var.s) i₀
-      rfl rfl h_holds
-    -- Decompose h_input into per-field equalities
-    have h_xs : input.xs = Vector.map (Expression.eval env) input_var.xs := by
-      rw [← h_input]
-    have h_s : input.s = Expression.eval env input_var.s := by
-      rw [← h_input]
-    -- Unfold Spec for the n+1 branch
-    show Expression.eval env _ = hornerVal n input.xs[0] input.xs.tail input.s
-    rw [h_xs, h_s, Vector.getElem_map, Vector.map_tail]
-    exact h_eval
-
-/-- Companion to `hornerStep_eval_correct` for the completeness side:
-given that the prover environment uses the canonical local witnesses for
-`hornerStep`, the Mul constraints all hold by construction. -/
-private lemma hornerStep_completeness (m : ℕ) (env : ProverEnvironment (F p))
-    (acc_var : Expression (F p)) (acc_val : F p)
-    (rest_var : Vector (Expression (F p)) m)
-    (s_var : Expression (F p)) (s_val : F p) (n : ℕ)
-    (h_acc : Expression.eval env.toEnvironment acc_var = acc_val)
-    (h_s : Expression.eval env.toEnvironment s_var = s_val)
-    (h_env : env.UsesLocalWitnessesCompleteness n (hornerStep m acc_var rest_var s_var n).2) :
-    Circuit.ConstraintsHold.Completeness env (hornerStep m acc_var rest_var s_var n).2 := by
-  induction m generalizing acc_var acc_val s_var s_val n with
-  | zero =>
-    simp [hornerStep, circuit_norm]
-  | succ m ih =>
-    simp only [hornerStep, Circuit.bind_def, circuit_norm,
-      Mul.circuit, Mul.Assumptions, Mul.Spec, Mul.elaborated] at h_env ⊢
-    obtain ⟨h_wit, h_rest⟩ := h_env
-    have h_new_acc : Expression.eval env.toEnvironment (var ⟨n + 2⟩ + rest_var[0])
-        = acc_val * s_val + Expression.eval env.toEnvironment rest_var[0] := by
-      simp [Expression.eval, h_wit, h_acc, h_s]
-    exact ih (var ⟨n + 2⟩ + rest_var[0]) _ rest_var.tail s_var s_val (n + 3) h_new_acc h_s h_rest
+  rcases n with _ | _ | _ | n
+  · -- 0 elements
+    circuit_proof_start
+  · -- 1 element: goal is eval input_var.xs[0] = Fin.foldl 0 ... = input.xs[0].
+    circuit_proof_start
+    simp only [Fin.foldl_zero]
+    have := congrArg (fun v => v.xs[0]) h_input
+    simpa [Vector.getElem_map] using this
+  · -- 2 elements
+    circuit_proof_start [Mul.circuit, Mul.Assumptions, Mul.Spec]
+    -- h_holds : env.get (i₀ + 2) = eval xs[0] * eval s
+    -- Goal: env.get (i₀ + 2) + eval xs[1] = Fin.foldl 1 val_body input.xs[0]
+    have h_s : Expression.eval env input_var.s = input.s := congrArg Input.s h_input
+    have h_xs0 : Expression.eval env input_var.xs[0] = input.xs[0] := by
+      have heq : Vector.map (Expression.eval env) input_var.xs = input.xs :=
+        congrArg Input.xs h_input
+      have := congrArg (fun v => v[0]) heq
+      simpa [Vector.getElem_map] using this
+    have h_xs1 : Expression.eval env input_var.xs[1] = input.xs[1] := by
+      have heq : Vector.map (Expression.eval env) input_var.xs = input.xs :=
+        congrArg Input.xs h_input
+      have := congrArg (fun v => v[1]) heq
+      simpa [Vector.getElem_map] using this
+    rw [h_xs0, h_s] at h_holds
+    -- Fin.foldl 1 val_body xs[0] = val_body xs[0] ⟨0,_⟩ = xs[0]*s + xs[1]
+    rw [Fin.foldl_succ_last, Fin.foldl_zero, h_holds, h_xs1]
+  · -- n+3 elements
+    circuit_proof_start [Mul.circuit, Mul.Assumptions, Mul.Spec]
+    obtain ⟨h0, h_iter0, h_iterk⟩ := h_holds
+    have h_s : Expression.eval env input_var.s = input.s := congrArg Input.s h_input
+    have heq : Vector.map (Expression.eval env) input_var.xs = input.xs :=
+      congrArg Input.xs h_input
+    have h_xs : ∀ (i : ℕ) (hi : i < n + 3),
+        Expression.eval env (input_var.xs[i]'hi) = input.xs[i]'hi := by
+      intro i hi
+      have := congrArg (fun v => v[i]'hi) heq
+      simpa [Vector.getElem_map] using this
+    -- Promote h0 to value-level form.
+    rw [h_xs 0 (by omega), h_s] at h0
+    -- Build h_iter0' in value form via convert.
+    have h_iter0' : env.get (i₀ + 3 + 2) =
+        (env.get (i₀ + 2) + input.xs[1]) * input.s := by
+      have e1 := h_xs 1 (by omega)
+      have heq0 : (input_var.xs[0 + 1] : Expression (F p)) = input_var.xs[1] := by
+        congr 1
+      rw [heq0, e1, h_s] at h_iter0
+      exact h_iter0
+    -- Build h_iterk' in value form.
+    have h_iterk' : ∀ (i : ℕ) (_ : i + 1 < n + 1),
+        env.get (i₀ + 3 + (i + 1) * 3 + 2) =
+          (env.get (i₀ + 3 + i * 3 + 2) + input.xs[i + 2]'(by omega)) * input.s := by
+      intro i hi
+      have e2 := h_xs (i + 2) (by omega)
+      have heqi : (input_var.xs[i + 1 + 1] : Expression (F p)) = input_var.xs[i + 2] := by
+        congr 1
+      have := h_iterk i hi
+      rw [heqi, e2, h_s] at this
+      exact this
+    -- Apply wire_value_eq_horner at k = n.
+    have wire_n := wire_value_eq_horner n env input.xs input.s i₀ h0 h_iter0' h_iterk' n (le_refl n)
+    -- Goal: env.get (i₀ + 3 + (n + 1 - 1)*3 + 2) + eval xs[n+2] = Fin.foldl (n+2) val_body input.xs[0]
+    rw [show n + 1 - 1 = n from by omega, h_xs (n + 2) (by omega), wire_n]
+    -- Goal: Fin.foldl (n+1) ... * s + xs[n+2] = Fin.foldl (n+2) ...
+    conv_rhs => rw [Fin.foldl_succ_last]
+    simp [Fin.val_last, Fin.val_castSucc]
 
 theorem completeness (n : ℕ) :
     Completeness (F p) (elaborated n) Assumptions := by
-  circuit_proof_start [Mul.circuit, Mul.Assumptions, Mul.Spec]
-  rcases n with _ | n
-  · simp [circuit_norm]
-  · simp only [circuit_norm] at h_env ⊢
-    exact hornerStep_completeness n env
-      input_var.xs[0] (Expression.eval env.toEnvironment input_var.xs[0])
-      input_var.xs.tail input_var.s (Expression.eval env.toEnvironment input_var.s) i₀
-      rfl rfl h_env
+  rcases n with _ | _ | _ | n
+  · circuit_proof_start
+  · circuit_proof_start
+  · circuit_proof_start [Mul.circuit, Mul.Assumptions, Mul.Spec]
+  · circuit_proof_start [Mul.circuit, Mul.Assumptions, Mul.Spec]
 
 def circuit (n : ℕ) : FormalCircuit (F p) (Input n) field :=
   { elaborated n with

--- a/qa/lean/Ragu/Circuits/Element/Fold.lean
+++ b/qa/lean/Ragu/Circuits/Element/Fold.lean
@@ -64,12 +64,13 @@ instance elaborated (n : ℕ) : ElaboratedCircuit (F p) (Input n) field where
     · simp +arith [main, circuit_norm, Mul.circuit]
     · simp +arith [main, circuit_norm, Mul.circuit]
 
-/-- For n+3 elements, each foldl Mul wire `wire(k) = env.get (i₀+3+k*3+2)`
-holds `horner(k+1) * s`, where `horner` is the value-level Horner partial.
-Sidesteps the `field (F p) = F p` HPow snag the same way as
-`EnforceRootOfUnity.wire_value_eq_pow`: parameterize by `xs_val : Vector
-(F p) _` and `s_val : F p`. -/
-private lemma wire_value_eq_horner (n : ℕ) (env : Environment (F p))
+-- For n+3 elements, each foldl Mul wire `wire(k) = env.get (i₀+3+k*3+2)`
+-- holds `horner(k+1) * s`, where `horner` is the value-level Horner partial.
+-- Sidesteps the `field (F p) = F p` HPow snag the same way as
+-- `EnforceRootOfUnity.wire_value_eq_pow`: parameterize by `xs_val : Vector
+-- (F p) _` and `s_val : F p`.
+omit [Fact p.Prime] in
+private theorem wire_value_eq_horner (n : ℕ) (env : Environment (F p))
     (xs_val : Vector (F p) (n+3)) (s_val : F p) (i₀ : ℕ)
     (h0 : env.get (i₀ + 2) = xs_val[0] * s_val)
     (h_iter0 : env.get (i₀ + 3 + 2) =
@@ -86,9 +87,8 @@ private lemma wire_value_eq_horner (n : ℕ) (env : Environment (F p))
   induction k with
   | zero =>
     simp only [zero_mul, add_zero]
-    rw [h_iter0, h0]
-    rw [Fin.foldl_succ_last, Fin.foldl_zero]
-    simp [Fin.val_last]
+    rw [h_iter0, h0, Fin.foldl_succ_last, Fin.foldl_zero]
+    simp
   | succ k ih =>
     have ih' := ih (by omega)
     have hstep := h_iterk k (by omega)

--- a/qa/lean/Ragu/Instances/Autogen/Element/EnforceRootOfUnityK2.lean
+++ b/qa/lean/Ragu/Instances/Autogen/Element/EnforceRootOfUnityK2.lean
@@ -1,6 +1,6 @@
 import Ragu.Core
 
-namespace Ragu.Instances.Autogen.Element.EnforceRootOfUnity
+namespace Ragu.Instances.Autogen.Element.EnforceRootOfUnityK2
 open Core.Primes
 
 @[reducible]
@@ -30,4 +30,4 @@ set_option linter.unusedVariables false in
 def exportedOutput (input_var : Vector (Expression (F p)) inputLen) : Vector (Expression (F p)) outputLen := #v[
 ]
 
-end Ragu.Instances.Autogen.Element.EnforceRootOfUnity
+end Ragu.Instances.Autogen.Element.EnforceRootOfUnityK2

--- a/qa/lean/Ragu/Instances/Autogen/Element/EnforceRootOfUnityK5.lean
+++ b/qa/lean/Ragu/Instances/Autogen/Element/EnforceRootOfUnityK5.lean
@@ -1,0 +1,45 @@
+import Ragu.Core
+
+namespace Ragu.Instances.Autogen.Element.EnforceRootOfUnityK5
+open Core.Primes
+
+@[reducible]
+def p := Core.Primes.p
+
+@[reducible]
+def inputLen := 1
+
+@[reducible]
+def outputLen := 0
+
+set_option linter.unusedVariables false in
+def exportedOperations (input_var : Vector (Expression (F p)) inputLen) : Operations (F p) := [
+  Operation.witness 3 (fun _env => default),
+  Operation.assert ((((var ⟨0⟩) * (var ⟨1⟩)) + (((-1 : F p) : Expression (F p)) * (var ⟨2⟩)))),
+  Operation.assert (((var ⟨0⟩) + (((-1 : F p) : Expression (F p)) * (input_var[0])))),
+  Operation.assert (((var ⟨1⟩) + (((-1 : F p) : Expression (F p)) * (input_var[0])))),
+  Operation.witness 3 (fun _env => default),
+  Operation.assert ((((var ⟨3⟩) * (var ⟨4⟩)) + (((-1 : F p) : Expression (F p)) * (var ⟨5⟩)))),
+  Operation.assert (((var ⟨3⟩) + (((-1 : F p) : Expression (F p)) * (var ⟨2⟩)))),
+  Operation.assert (((var ⟨4⟩) + (((-1 : F p) : Expression (F p)) * (var ⟨2⟩)))),
+  Operation.witness 3 (fun _env => default),
+  Operation.assert ((((var ⟨6⟩) * (var ⟨7⟩)) + (((-1 : F p) : Expression (F p)) * (var ⟨8⟩)))),
+  Operation.assert (((var ⟨6⟩) + (((-1 : F p) : Expression (F p)) * (var ⟨5⟩)))),
+  Operation.assert (((var ⟨7⟩) + (((-1 : F p) : Expression (F p)) * (var ⟨5⟩)))),
+  Operation.witness 3 (fun _env => default),
+  Operation.assert ((((var ⟨9⟩) * (var ⟨10⟩)) + (((-1 : F p) : Expression (F p)) * (var ⟨11⟩)))),
+  Operation.assert (((var ⟨9⟩) + (((-1 : F p) : Expression (F p)) * (var ⟨8⟩)))),
+  Operation.assert (((var ⟨10⟩) + (((-1 : F p) : Expression (F p)) * (var ⟨8⟩)))),
+  Operation.witness 3 (fun _env => default),
+  Operation.assert ((((var ⟨12⟩) * (var ⟨13⟩)) + (((-1 : F p) : Expression (F p)) * (var ⟨14⟩)))),
+  Operation.assert (((var ⟨12⟩) + (((-1 : F p) : Expression (F p)) * (var ⟨11⟩)))),
+  Operation.assert (((var ⟨13⟩) + (((-1 : F p) : Expression (F p)) * (var ⟨11⟩)))),
+  Operation.assert (((var ⟨14⟩) + (((-1 : F p) : Expression (F p)) * ((1 : F p) : Expression (F p))))),
+]
+
+set_option linter.unusedVariables false in
+@[reducible]
+def exportedOutput (input_var : Vector (Expression (F p)) inputLen) : Vector (Expression (F p)) outputLen := #v[
+]
+
+end Ragu.Instances.Autogen.Element.EnforceRootOfUnityK5

--- a/qa/lean/Ragu/Instances/Autogen/Element/FoldN3.lean
+++ b/qa/lean/Ragu/Instances/Autogen/Element/FoldN3.lean
@@ -1,6 +1,6 @@
 import Ragu.Core
 
-namespace Ragu.Instances.Autogen.Element.Fold
+namespace Ragu.Instances.Autogen.Element.FoldN3
 open Core.Primes
 
 @[reducible]
@@ -30,4 +30,4 @@ def exportedOutput (input_var : Vector (Expression (F p)) inputLen) : Vector (Ex
   ((var ⟨5⟩) + (input_var[2]))
 ]
 
-end Ragu.Instances.Autogen.Element.Fold
+end Ragu.Instances.Autogen.Element.FoldN3

--- a/qa/lean/Ragu/Instances/Autogen/Element/FoldN7.lean
+++ b/qa/lean/Ragu/Instances/Autogen/Element/FoldN7.lean
@@ -1,0 +1,49 @@
+import Ragu.Core
+
+namespace Ragu.Instances.Autogen.Element.FoldN7
+open Core.Primes
+
+@[reducible]
+def p := Core.Primes.p
+
+@[reducible]
+def inputLen := 8
+
+@[reducible]
+def outputLen := 1
+
+set_option linter.unusedVariables false in
+def exportedOperations (input_var : Vector (Expression (F p)) inputLen) : Operations (F p) := [
+  Operation.witness 3 (fun _env => default),
+  Operation.assert ((((var ⟨0⟩) * (var ⟨1⟩)) + (((-1 : F p) : Expression (F p)) * (var ⟨2⟩)))),
+  Operation.assert (((var ⟨0⟩) + (((-1 : F p) : Expression (F p)) * (input_var[0])))),
+  Operation.assert (((var ⟨1⟩) + (((-1 : F p) : Expression (F p)) * (input_var[7])))),
+  Operation.witness 3 (fun _env => default),
+  Operation.assert ((((var ⟨3⟩) * (var ⟨4⟩)) + (((-1 : F p) : Expression (F p)) * (var ⟨5⟩)))),
+  Operation.assert (((var ⟨3⟩) + (((-1 : F p) : Expression (F p)) * ((var ⟨2⟩) + (input_var[1]))))),
+  Operation.assert (((var ⟨4⟩) + (((-1 : F p) : Expression (F p)) * (input_var[7])))),
+  Operation.witness 3 (fun _env => default),
+  Operation.assert ((((var ⟨6⟩) * (var ⟨7⟩)) + (((-1 : F p) : Expression (F p)) * (var ⟨8⟩)))),
+  Operation.assert (((var ⟨6⟩) + (((-1 : F p) : Expression (F p)) * ((var ⟨5⟩) + (input_var[2]))))),
+  Operation.assert (((var ⟨7⟩) + (((-1 : F p) : Expression (F p)) * (input_var[7])))),
+  Operation.witness 3 (fun _env => default),
+  Operation.assert ((((var ⟨9⟩) * (var ⟨10⟩)) + (((-1 : F p) : Expression (F p)) * (var ⟨11⟩)))),
+  Operation.assert (((var ⟨9⟩) + (((-1 : F p) : Expression (F p)) * ((var ⟨8⟩) + (input_var[3]))))),
+  Operation.assert (((var ⟨10⟩) + (((-1 : F p) : Expression (F p)) * (input_var[7])))),
+  Operation.witness 3 (fun _env => default),
+  Operation.assert ((((var ⟨12⟩) * (var ⟨13⟩)) + (((-1 : F p) : Expression (F p)) * (var ⟨14⟩)))),
+  Operation.assert (((var ⟨12⟩) + (((-1 : F p) : Expression (F p)) * ((var ⟨11⟩) + (input_var[4]))))),
+  Operation.assert (((var ⟨13⟩) + (((-1 : F p) : Expression (F p)) * (input_var[7])))),
+  Operation.witness 3 (fun _env => default),
+  Operation.assert ((((var ⟨15⟩) * (var ⟨16⟩)) + (((-1 : F p) : Expression (F p)) * (var ⟨17⟩)))),
+  Operation.assert (((var ⟨15⟩) + (((-1 : F p) : Expression (F p)) * ((var ⟨14⟩) + (input_var[5]))))),
+  Operation.assert (((var ⟨16⟩) + (((-1 : F p) : Expression (F p)) * (input_var[7])))),
+]
+
+set_option linter.unusedVariables false in
+@[reducible]
+def exportedOutput (input_var : Vector (Expression (F p)) inputLen) : Vector (Expression (F p)) outputLen := #v[
+  ((var ⟨17⟩) + (input_var[6]))
+]
+
+end Ragu.Instances.Autogen.Element.FoldN7

--- a/qa/lean/Ragu/Instances/Element/EnforceRootOfUnityK2.lean
+++ b/qa/lean/Ragu/Instances/Element/EnforceRootOfUnityK2.lean
@@ -37,8 +37,8 @@ def formal_instance : Core.Statements.FormalInstance where
       Circuits.Element.EnforceRootOfUnity.elaborated,
       Circuits.Element.EnforceRootOfUnity.main,
       Circuit.foldl, Vector.foldlM_toList,
-      Vector.finRange, Vector.ofFn, Vector.toList, Vector.cast,
-      List.foldlM, List.foldlM_cons, List.foldlM_nil,
+      Vector.finRange, Vector.ofFn, Vector.toList,
+      List.foldlM, List.foldlM_cons,
       Circuits.Element.Mul.circuit, Circuits.Element.Mul.main]
     constructor
   same_output := by

--- a/qa/lean/Ragu/Instances/Element/EnforceRootOfUnityK2.lean
+++ b/qa/lean/Ragu/Instances/Element/EnforceRootOfUnityK2.lean
@@ -23,6 +23,10 @@ def formal_instance : Core.Statements.FormalInstance where
 
   same_constraints := by
     intro input
+    -- Unfold the `Circuit.foldl` chain into a flat list of `Mul.circuit`
+    -- subcircuits + the final `assertZero`, matching the autogen byte-for-byte.
+    -- The key unfolds are `Vector.foldlM_toList` (foldl over Vector → List)
+    -- then `List.foldlM_cons` reduces the 2-element list iteration.
     simp [Core.Statements.FlatOperation.eraseCompute, List.map,
       Operations.toFlat, circuit_norm,
       FormalAssertion.isGeneralFormalCircuit,
@@ -32,8 +36,10 @@ def formal_instance : Core.Statements.FormalInstance where
       Circuits.Element.EnforceRootOfUnity.circuit,
       Circuits.Element.EnforceRootOfUnity.elaborated,
       Circuits.Element.EnforceRootOfUnity.main,
-      Circuits.Element.EnforceRootOfUnity.squareIter,
-      Circuits.Element.Mul.circuit, Circuits.Element.Mul.elaborated, Circuits.Element.Mul.main]
+      Circuit.foldl, Vector.foldlM_toList,
+      Vector.finRange, Vector.ofFn, Vector.toList, Vector.cast,
+      List.foldlM, List.foldlM_cons, List.foldlM_nil,
+      Circuits.Element.Mul.circuit, Circuits.Element.Mul.main]
     constructor
   same_output := by
     intro input

--- a/qa/lean/Ragu/Instances/Element/EnforceRootOfUnityK2.lean
+++ b/qa/lean/Ragu/Instances/Element/EnforceRootOfUnityK2.lean
@@ -1,0 +1,42 @@
+import Ragu.Circuits.Element.EnforceRootOfUnity
+import Ragu.Instances.Autogen.Element.EnforceRootOfUnityK2
+import Ragu.Core
+
+namespace Ragu.Instances.Element.EnforceRootOfUnityK2
+open Ragu.Instances.Autogen.Element.EnforceRootOfUnityK2
+
+def deserializeInput (input : Vector (Expression (F p)) inputLen) : Var field (F p) :=
+  input[0]
+
+def serializeOutput (_output : Var unit (F p)) : Vector (Expression (F p)) 0 :=
+  #v[]
+
+def formal_instance : Core.Statements.FormalInstance where
+  p
+  exportedOperations
+  exportedOutput
+
+  deserializeInput
+  serializeOutput
+
+  reimplementation := (Circuits.Element.EnforceRootOfUnity.circuit 2).isGeneralFormalCircuit.toWithHint
+
+  same_constraints := by
+    intro input
+    simp [Core.Statements.FlatOperation.eraseCompute, List.map,
+      Operations.toFlat, circuit_norm,
+      FormalAssertion.isGeneralFormalCircuit,
+      GeneralFormalCircuit.toWithHint,
+      GeneralFormalCircuit.WithHint.toSubcircuit, FormalCircuit.toSubcircuit,
+      deserializeInput, exportedOperations,
+      Circuits.Element.EnforceRootOfUnity.circuit,
+      Circuits.Element.EnforceRootOfUnity.elaborated,
+      Circuits.Element.EnforceRootOfUnity.main,
+      Circuits.Element.EnforceRootOfUnity.squareIter,
+      Circuits.Element.Mul.circuit, Circuits.Element.Mul.elaborated, Circuits.Element.Mul.main]
+    constructor
+  same_output := by
+    intro input
+    rfl
+
+end Ragu.Instances.Element.EnforceRootOfUnityK2

--- a/qa/lean/Ragu/Instances/Element/EnforceRootOfUnityK5.lean
+++ b/qa/lean/Ragu/Instances/Element/EnforceRootOfUnityK5.lean
@@ -33,8 +33,8 @@ def formal_instance : Core.Statements.FormalInstance where
       Circuits.Element.EnforceRootOfUnity.elaborated,
       Circuits.Element.EnforceRootOfUnity.main,
       Circuit.foldl, Vector.foldlM_toList,
-      Vector.finRange, Vector.ofFn, Vector.toList, Vector.cast,
-      List.foldlM, List.foldlM_cons, List.foldlM_nil,
+      Vector.finRange, Vector.ofFn, Vector.toList,
+      List.foldlM, List.foldlM_cons,
       Circuits.Element.Mul.circuit, Circuits.Element.Mul.main]
     constructor
   same_output := by

--- a/qa/lean/Ragu/Instances/Element/EnforceRootOfUnityK5.lean
+++ b/qa/lean/Ragu/Instances/Element/EnforceRootOfUnityK5.lean
@@ -1,9 +1,9 @@
 import Ragu.Circuits.Element.EnforceRootOfUnity
-import Ragu.Instances.Autogen.Element.EnforceRootOfUnity
+import Ragu.Instances.Autogen.Element.EnforceRootOfUnityK5
 import Ragu.Core
 
-namespace Ragu.Instances.Element.EnforceRootOfUnity
-open Ragu.Instances.Autogen.Element.EnforceRootOfUnity
+namespace Ragu.Instances.Element.EnforceRootOfUnityK5
+open Ragu.Instances.Autogen.Element.EnforceRootOfUnityK5
 
 def deserializeInput (input : Vector (Expression (F p)) inputLen) : Var field (F p) :=
   input[0]
@@ -19,7 +19,7 @@ def formal_instance : Core.Statements.FormalInstance where
   deserializeInput
   serializeOutput
 
-  reimplementation := Circuits.Element.EnforceRootOfUnity.circuit.isGeneralFormalCircuit.toWithHint
+  reimplementation := (Circuits.Element.EnforceRootOfUnity.circuit 5).isGeneralFormalCircuit.toWithHint
 
   same_constraints := by
     intro input
@@ -32,10 +32,11 @@ def formal_instance : Core.Statements.FormalInstance where
       Circuits.Element.EnforceRootOfUnity.circuit,
       Circuits.Element.EnforceRootOfUnity.elaborated,
       Circuits.Element.EnforceRootOfUnity.main,
+      Circuits.Element.EnforceRootOfUnity.squareIter,
       Circuits.Element.Mul.circuit, Circuits.Element.Mul.elaborated, Circuits.Element.Mul.main]
     constructor
   same_output := by
     intro input
     rfl
 
-end Ragu.Instances.Element.EnforceRootOfUnity
+end Ragu.Instances.Element.EnforceRootOfUnityK5

--- a/qa/lean/Ragu/Instances/Element/EnforceRootOfUnityK5.lean
+++ b/qa/lean/Ragu/Instances/Element/EnforceRootOfUnityK5.lean
@@ -32,8 +32,10 @@ def formal_instance : Core.Statements.FormalInstance where
       Circuits.Element.EnforceRootOfUnity.circuit,
       Circuits.Element.EnforceRootOfUnity.elaborated,
       Circuits.Element.EnforceRootOfUnity.main,
-      Circuits.Element.EnforceRootOfUnity.squareIter,
-      Circuits.Element.Mul.circuit, Circuits.Element.Mul.elaborated, Circuits.Element.Mul.main]
+      Circuit.foldl, Vector.foldlM_toList,
+      Vector.finRange, Vector.ofFn, Vector.toList, Vector.cast,
+      List.foldlM, List.foldlM_cons, List.foldlM_nil,
+      Circuits.Element.Mul.circuit, Circuits.Element.Mul.main]
     constructor
   same_output := by
     intro input

--- a/qa/lean/Ragu/Instances/Element/FoldN3.lean
+++ b/qa/lean/Ragu/Instances/Element/FoldN3.lean
@@ -1,0 +1,53 @@
+import Ragu.Circuits.Element.Fold
+import Ragu.Instances.Autogen.Element.FoldN3
+import Ragu.Core
+
+namespace Ragu.Instances.Element.FoldN3
+open Ragu.Instances.Autogen.Element.FoldN3
+
+def deserializeInput (input : Vector (Expression (F p)) inputLen)
+    : Var (Circuits.Element.Fold.Input 3) (F p) :=
+  { xs := #v[input[0], input[1], input[2]], s := input[3] }
+
+def serializeOutput (output : Var field (F p)) : Vector (Expression (F p)) 1 :=
+  #v[output]
+
+def formal_instance : Core.Statements.FormalInstance where
+  p
+  exportedOperations
+  exportedOutput
+
+  deserializeInput
+  serializeOutput
+
+  reimplementation := (Circuits.Element.Fold.circuit 3).isGeneralFormalCircuit.toWithHint
+
+  same_constraints := by
+    intro input
+    simp [Core.Statements.FlatOperation.eraseCompute, List.map,
+      Operations.toFlat, circuit_norm,
+      FormalCircuit.isGeneralFormalCircuit,
+      GeneralFormalCircuit.toWithHint,
+      GeneralFormalCircuit.WithHint.toSubcircuit, FormalCircuit.toSubcircuit,
+      deserializeInput, exportedOperations,
+      Circuits.Element.Fold.circuit,
+      Circuits.Element.Fold.elaborated,
+      Circuits.Element.Fold.main,
+      Circuits.Element.Fold.hornerStep,
+      Circuits.Element.Mul.circuit, Circuits.Element.Mul.elaborated, Circuits.Element.Mul.main]
+    rfl
+  same_output := by
+    intro input
+    simp [circuit_norm,
+      FormalCircuit.isGeneralFormalCircuit,
+      GeneralFormalCircuit.toWithHint,
+      GeneralFormalCircuit.WithHint.toSubcircuit, FormalCircuit.toSubcircuit,
+      deserializeInput, serializeOutput,
+      Circuits.Element.Fold.circuit,
+      Circuits.Element.Fold.elaborated,
+      Circuits.Element.Fold.main,
+      Circuits.Element.Fold.hornerStep,
+      Circuits.Element.Mul.circuit, Circuits.Element.Mul.elaborated, Circuits.Element.Mul.main]
+    rfl
+
+end Ragu.Instances.Element.FoldN3

--- a/qa/lean/Ragu/Instances/Element/FoldN3.lean
+++ b/qa/lean/Ragu/Instances/Element/FoldN3.lean
@@ -36,8 +36,8 @@ def formal_instance : Core.Statements.FormalInstance where
       Circuits.Element.Fold.elaborated,
       Circuits.Element.Fold.main,
       Circuit.foldl, Vector.foldlM_toList,
-      Vector.finRange, Vector.ofFn, Vector.toList, Vector.cast,
-      List.foldlM, List.foldlM_cons, List.foldlM_nil,
+      Vector.finRange, Vector.ofFn, Vector.toList,
+      List.foldlM, List.foldlM_cons,
       Circuits.Element.Mul.circuit, Circuits.Element.Mul.main]
     constructor
   same_output := by

--- a/qa/lean/Ragu/Instances/Element/FoldN3.lean
+++ b/qa/lean/Ragu/Instances/Element/FoldN3.lean
@@ -24,6 +24,8 @@ def formal_instance : Core.Statements.FormalInstance where
 
   same_constraints := by
     intro input
+    -- Unfold the explicit Mul + `Circuit.foldl` chain into the flat list of
+    -- `Mul.circuit` subcircuits that matches the autogen byte-for-byte.
     simp [Core.Statements.FlatOperation.eraseCompute, List.map,
       Operations.toFlat, circuit_norm,
       FormalCircuit.isGeneralFormalCircuit,
@@ -33,21 +35,13 @@ def formal_instance : Core.Statements.FormalInstance where
       Circuits.Element.Fold.circuit,
       Circuits.Element.Fold.elaborated,
       Circuits.Element.Fold.main,
-      Circuits.Element.Fold.hornerStep,
-      Circuits.Element.Mul.circuit, Circuits.Element.Mul.elaborated, Circuits.Element.Mul.main]
-    rfl
+      Circuit.foldl, Vector.foldlM_toList,
+      Vector.finRange, Vector.ofFn, Vector.toList, Vector.cast,
+      List.foldlM, List.foldlM_cons, List.foldlM_nil,
+      Circuits.Element.Mul.circuit, Circuits.Element.Mul.main]
+    constructor
   same_output := by
     intro input
-    simp [circuit_norm,
-      FormalCircuit.isGeneralFormalCircuit,
-      GeneralFormalCircuit.toWithHint,
-      GeneralFormalCircuit.WithHint.toSubcircuit, FormalCircuit.toSubcircuit,
-      deserializeInput, serializeOutput,
-      Circuits.Element.Fold.circuit,
-      Circuits.Element.Fold.elaborated,
-      Circuits.Element.Fold.main,
-      Circuits.Element.Fold.hornerStep,
-      Circuits.Element.Mul.circuit, Circuits.Element.Mul.elaborated, Circuits.Element.Mul.main]
     rfl
 
 end Ragu.Instances.Element.FoldN3

--- a/qa/lean/Ragu/Instances/Element/FoldN7.lean
+++ b/qa/lean/Ragu/Instances/Element/FoldN7.lean
@@ -1,13 +1,16 @@
 import Ragu.Circuits.Element.Fold
-import Ragu.Instances.Autogen.Element.Fold
+import Ragu.Instances.Autogen.Element.FoldN7
 import Ragu.Core
 
-namespace Ragu.Instances.Element.Fold
-open Ragu.Instances.Autogen.Element.Fold
+set_option maxHeartbeats 1000000
+
+namespace Ragu.Instances.Element.FoldN7
+open Ragu.Instances.Autogen.Element.FoldN7
 
 def deserializeInput (input : Vector (Expression (F p)) inputLen)
-    : Var Circuits.Element.Fold.Input (F p) :=
-  { x0 := input[0], x1 := input[1], x2 := input[2], s := input[3] }
+    : Var (Circuits.Element.Fold.Input 7) (F p) :=
+  { xs := #v[input[0], input[1], input[2], input[3], input[4], input[5], input[6]],
+    s := input[7] }
 
 def serializeOutput (output : Var field (F p)) : Vector (Expression (F p)) 1 :=
   #v[output]
@@ -20,7 +23,7 @@ def formal_instance : Core.Statements.FormalInstance where
   deserializeInput
   serializeOutput
 
-  reimplementation := Circuits.Element.Fold.circuit.isGeneralFormalCircuit.toWithHint
+  reimplementation := (Circuits.Element.Fold.circuit 7).isGeneralFormalCircuit.toWithHint
 
   same_constraints := by
     intro input
@@ -30,9 +33,12 @@ def formal_instance : Core.Statements.FormalInstance where
       GeneralFormalCircuit.toWithHint,
       GeneralFormalCircuit.WithHint.toSubcircuit, FormalCircuit.toSubcircuit,
       deserializeInput, exportedOperations,
-      Circuits.Element.Fold.circuit, Circuits.Element.Fold.elaborated, Circuits.Element.Fold.main,
+      Circuits.Element.Fold.circuit,
+      Circuits.Element.Fold.elaborated,
+      Circuits.Element.Fold.main,
+      Circuits.Element.Fold.hornerStep,
       Circuits.Element.Mul.circuit, Circuits.Element.Mul.elaborated, Circuits.Element.Mul.main]
-    constructor
+    rfl
   same_output := by
     intro input
     simp [circuit_norm,
@@ -40,7 +46,11 @@ def formal_instance : Core.Statements.FormalInstance where
       GeneralFormalCircuit.toWithHint,
       GeneralFormalCircuit.WithHint.toSubcircuit, FormalCircuit.toSubcircuit,
       deserializeInput, serializeOutput,
-      Circuits.Element.Fold.circuit, Circuits.Element.Fold.elaborated, Circuits.Element.Fold.main,
+      Circuits.Element.Fold.circuit,
+      Circuits.Element.Fold.elaborated,
+      Circuits.Element.Fold.main,
+      Circuits.Element.Fold.hornerStep,
       Circuits.Element.Mul.circuit, Circuits.Element.Mul.elaborated, Circuits.Element.Mul.main]
+    rfl
 
-end Ragu.Instances.Element.Fold
+end Ragu.Instances.Element.FoldN7

--- a/qa/lean/Ragu/Instances/Element/FoldN7.lean
+++ b/qa/lean/Ragu/Instances/Element/FoldN7.lean
@@ -37,8 +37,8 @@ def formal_instance : Core.Statements.FormalInstance where
       Circuits.Element.Fold.elaborated,
       Circuits.Element.Fold.main,
       Circuit.foldl, Vector.foldlM_toList,
-      Vector.finRange, Vector.ofFn, Vector.toList, Vector.cast,
-      List.foldlM, List.foldlM_cons, List.foldlM_nil,
+      Vector.finRange, Vector.ofFn, Vector.toList,
+      List.foldlM, List.foldlM_cons,
       Circuits.Element.Mul.circuit, Circuits.Element.Mul.main]
     constructor
   same_output := by

--- a/qa/lean/Ragu/Instances/Element/FoldN7.lean
+++ b/qa/lean/Ragu/Instances/Element/FoldN7.lean
@@ -36,21 +36,13 @@ def formal_instance : Core.Statements.FormalInstance where
       Circuits.Element.Fold.circuit,
       Circuits.Element.Fold.elaborated,
       Circuits.Element.Fold.main,
-      Circuits.Element.Fold.hornerStep,
-      Circuits.Element.Mul.circuit, Circuits.Element.Mul.elaborated, Circuits.Element.Mul.main]
-    rfl
+      Circuit.foldl, Vector.foldlM_toList,
+      Vector.finRange, Vector.ofFn, Vector.toList, Vector.cast,
+      List.foldlM, List.foldlM_cons, List.foldlM_nil,
+      Circuits.Element.Mul.circuit, Circuits.Element.Mul.main]
+    constructor
   same_output := by
     intro input
-    simp [circuit_norm,
-      FormalCircuit.isGeneralFormalCircuit,
-      GeneralFormalCircuit.toWithHint,
-      GeneralFormalCircuit.WithHint.toSubcircuit, FormalCircuit.toSubcircuit,
-      deserializeInput, serializeOutput,
-      Circuits.Element.Fold.circuit,
-      Circuits.Element.Fold.elaborated,
-      Circuits.Element.Fold.main,
-      Circuits.Element.Fold.hornerStep,
-      Circuits.Element.Mul.circuit, Circuits.Element.Mul.elaborated, Circuits.Element.Mul.main]
     rfl
 
 end Ragu.Instances.Element.FoldN7

--- a/qa/lean/docs/src/clean/core/circuit.md
+++ b/qa/lean/docs/src/clean/core/circuit.md
@@ -64,3 +64,7 @@ def output (circuit : Circuit F α) (offset : ℕ) : α := (circuit offset).1
 def localLength (circuit : Circuit F α) (offset := 0) : ℕ :=
   Operations.localLength (circuit offset).2
 ```
+
+## Iteration: use Clean's loop combinators
+
+For any iterative circuit body, use one of Clean's built-in loop combinators — `Circuit.forEach`, `Circuit.map`, `Circuit.mapFinRange`, `Circuit.foldl`, `Circuit.foldlRange` — rather than writing a custom recursive helper. The combinators carry `circuit_norm`-tagged simp lemmas so that `circuit_proof_start` collapses the loop machinery for free, leaving you with goals expressed in plain Lean/Mathlib terms. See [Clean's loop combinators reference](https://deepwiki.com/Verified-zkEVM/clean/2.5-circuit-loops-and-iteration) for the menu and semantics. `EnforceRootOfUnity` and `Fold` in the Ragu repository (`qa/lean/Ragu/Circuits/Element/`) are worked examples of the `Circuit.foldl (.finRange (k + 1))` pattern, including the standard rcases for the `Fin 0`-not-`Inhabited` boundary.


### PR DESCRIPTION
Closes https://github.com/tachyon-zcash/ragu/issues/686. For some gadget impls like `EnforceRootOfUnity` / `Fold`, we'll need a polymorphic reimpl plus a few monomorphic autogen and formal instance impls (for assurance, since this is an extractor limitation). Recall our IRL discussion during the conference on this, cc @gio54321 @alxiong (@mitschabaude for visibility). 