### PR TITLE
chore(pcd): support larger header sizes

### DIFF
--- a/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
@@ -23,12 +23,9 @@
 //! the [`outer_error`][super::super::stages::outer_error] stage and verified here to
 //! enable resumption in `hashes_2`.
 //!
-//! ### $k(y)$ evaluations
-//!
-//! This circuit also is responsible for using the derived $y$ value to compute
-//! the $k(y)$ (instance polynomial evaluations) for the child proofs. These
-//! are witnessed in the [`outer_error`][super::super::stages::outer_error] stage and
-//! enforced to be consistent by this circuit.
+//! The $k(y)$ (instance polynomial) consistency checks against the witnessed
+//! values in the [`outer_error`][super::super::stages::outer_error] stage are
+//! performed in [`outer_collapse`][super::outer_collapse].
 //!
 //! ### Valid circuit IDs
 //!
@@ -161,7 +158,7 @@ impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Para
 /// Witness data for the first hash circuit.
 ///
 /// Combines the unified instance with stage witnesses needed to perform the
-/// Fiat-Shamir derivations and $k(y)$ consistency checks.
+/// Fiat-Shamir derivations and transcript-state verification.
 pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters> {
     /// The unified instance containing expected challenge values and
     /// accumulated coverage from prior circuits.
@@ -170,14 +167,15 @@ pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_rev
     /// Witness for the [`preamble`](super::super::stages::preamble) stage
     /// (unenforced).
     ///
-    /// Provides output headers and data for computing $k(y)$ evaluations.
+    /// Provides output headers (included in this circuit's instance) and
+    /// circuit IDs for the root-of-unity check.
     pub preamble_witness: &'a native_preamble::Witness<'a, C, R, HEADER_SIZE>,
 
     /// Witness for the [`outer_error`](super::super::stages::outer_error) stage
     /// (unenforced).
     ///
-    /// Provides the saved sponge state and pre-computed $k(y)$ values for
-    /// consistency verification.
+    /// Provides the saved sponge state used to verify resumption into
+    /// [`hashes_2`](super::hashes_2).
     pub outer_error_witness: &'a native_outer_error::Witness<C, FP>,
 }
 
@@ -256,28 +254,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
             let z = transcript.challenge(dr)?;
             (y, z)
         };
-        unified_output.y.provide(y.clone());
+        unified_output.y.provide(y);
         unified_output.z.provide(z);
-
-        // Compute k(y) values from preamble and enforce equality with staged
-        // values.
-        {
-            let left_application_ky = preamble.left.application_ky(dr, &y)?;
-            let right_application_ky = preamble.right.application_ky(dr, &y)?;
-
-            left_application_ky.enforce_equal(dr, &outer_error.left.application)?;
-            right_application_ky.enforce_equal(dr, &outer_error.right.application)?;
-
-            let (left_unified_ky, left_unified_bridge_ky) =
-                preamble.left.unified_ky_values(dr, &y)?;
-            let (right_unified_ky, right_unified_bridge_ky) =
-                preamble.right.unified_ky_values(dr, &y)?;
-
-            left_unified_ky.enforce_equal(dr, &outer_error.left.unified)?;
-            right_unified_ky.enforce_equal(dr, &outer_error.right.unified)?;
-            left_unified_bridge_ky.enforce_equal(dr, &outer_error.left.unified_bridge)?;
-            right_unified_bridge_ky.enforce_equal(dr, &outer_error.right.unified_bridge)?;
-        }
 
         // Absorb bridge_inner_error_commitment and verify saved transcript state
         {

--- a/crates/ragu_pcd/src/internal/native/circuits/inner_collapse.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/inner_collapse.rs
@@ -26,7 +26,7 @@
 //! - Child [$c$] values from the [`preamble`] (representing the children's
 //!   final revdot claims).
 //! - Application and unified $k(y)$ evaluations from [`outer_error`] (computed and
-//!   verified in [`hashes_1`]).
+//!   verified in [`outer_collapse`]).
 //!
 //! ## Staging
 //!
@@ -49,7 +49,6 @@
 //! [`inner_error`]: super::super::stages::inner_error
 //! [`outer_error`]: super::super::stages::outer_error
 //! [`preamble`]: super::super::stages::preamble
-//! [`hashes_1`]: super::hashes_1
 //! [`ClaimFolder::fold_inner`]: fold_revdot::ClaimFolder::fold_inner
 //! [`TwoProofKySource`]: crate::internal::native::claims::TwoProofKySource
 

--- a/crates/ragu_pcd/src/internal/native/circuits/outer_collapse.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/outer_collapse.rs
@@ -23,6 +23,14 @@
 //! initial proofs that don't yet carry meaningful revdot claims. The constraint
 //! is enforced only when [`is_base_case`] returns false.
 //!
+//! ### $k(y)$ consistency
+//!
+//! This circuit also enforces that the $k(y)$ (instance polynomial evaluations)
+//! for the child proofs, witnessed in the [`outer_error`] stage, are consistent
+//! with the headers and unified instance data from the [`preamble`] stage. The
+//! $y$ challenge is derived in [`hashes_1`][super::hashes_1] and read from the
+//! unified instance here.
+//!
 //! ## Staging
 //!
 //! This circuit uses [`outer_error`] as its final stage, which inherits in the
@@ -57,7 +65,7 @@ use ragu_circuits::{
 use ragu_core::{
     Result,
     drivers::{Driver, DriverValue},
-    gadgets::Bound,
+    gadgets::{Bound, Gadget},
     maybe::Maybe,
 };
 use ragu_primitives::allocator::Standard;
@@ -102,13 +110,15 @@ pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_rev
     /// (unenforced).
     ///
     /// Provides access to [`is_base_case`](super::super::stages::preamble::Output::is_base_case)
-    /// for conditional constraint enforcement.
+    /// for conditional constraint enforcement, and the child headers used to
+    /// compute $k(y)$ evaluations.
     pub preamble_witness: &'a preamble::Witness<'a, C, R, HEADER_SIZE>,
 
     /// Witness for the [`outer_error`] stage
     /// (unenforced).
     ///
-    /// Provides layer 2 error terms and collapsed values from layer 1.
+    /// Provides layer 2 error terms, collapsed values from layer 1, and the
+    /// witnessed $k(y)$ values verified for consistency by this circuit.
     pub outer_error_witness: &'a outer_error::Witness<C, FP>,
 }
 
@@ -152,6 +162,29 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
 
         let allocator = &mut Standard::new();
         let mut unified_output = OutputBuilder::new(witness.map(|w| w.unified));
+
+        // Compute k(y) values from preamble and enforce equality with staged
+        // values witnessed in outer_error. The y challenge is derived in
+        // hashes_1 and read (not received) here, since hashes_1 owns coverage.
+        {
+            let y = unified_output.y.read(dr, allocator)?;
+
+            let left_application_ky = preamble.left.application_ky(dr, &y)?;
+            let right_application_ky = preamble.right.application_ky(dr, &y)?;
+
+            left_application_ky.enforce_equal(dr, &outer_error.left.application)?;
+            right_application_ky.enforce_equal(dr, &outer_error.right.application)?;
+
+            let (left_unified_ky, left_unified_bridge_ky) =
+                preamble.left.unified_ky_values(dr, &y)?;
+            let (right_unified_ky, right_unified_bridge_ky) =
+                preamble.right.unified_ky_values(dr, &y)?;
+
+            left_unified_ky.enforce_equal(dr, &outer_error.left.unified)?;
+            right_unified_ky.enforce_equal(dr, &outer_error.right.unified)?;
+            left_unified_bridge_ky.enforce_equal(dr, &outer_error.left.unified_bridge)?;
+            right_unified_bridge_ky.enforce_equal(dr, &outer_error.right.unified_bridge)?;
+        }
 
         // Get layer 2 folding challenges. These are distinct from the layer 1
         // challenges (mu, nu) used in inner_collapse.

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -40,7 +40,7 @@ where
 // When changing HEADER_SIZE, update the constraint counts by running:
 //   cargo test -p ragu_pcd --release print_internal_circuit -- --nocapture
 // Then copy-paste the output into the check_constraints! calls in the test below.
-pub const HEADER_SIZE: usize = 65;
+pub const HEADER_SIZE: usize = 105;
 
 // Number of dummy application circuits to register before testing internal
 // circuits. This ensures the tests work correctly even when application
@@ -88,11 +88,11 @@ fn test_internal_circuit_constraint_counts() {
         }};
     }
 
-    check_constraints!(Hashes1Circuit,        mul = 1331, lin = 1988);
-    check_constraints!(Hashes2Circuit,        mul = 1879, lin = 2951);
-    check_constraints!(InnerCollapseCircuit,  mul = 1756, lin = 1918);
-    check_constraints!(OuterCollapseCircuit,  mul = 1523, lin = 2242);
-    check_constraints!(ComputeVCircuit,       mul = 1135, lin = 1773);
+    check_constraints!(Hashes1Circuit,        mul = 1451, lin = 2068);
+    check_constraints!(Hashes2Circuit,        mul = 1999, lin = 2951);
+    check_constraints!(InnerCollapseCircuit,  mul = 1876, lin = 1918);
+    check_constraints!(OuterCollapseCircuit,  mul = 2043, lin = 3042);
+    check_constraints!(ComputeVCircuit,       mul = 1255, lin = 1773);
 }
 
 #[rustfmt::skip]
@@ -105,11 +105,11 @@ fn test_internal_stage_parameters() {
         }};
     }
 
-    check_stage!(Preamble, skip =   1, num = 225);
-    check_stage!(OuterError,  skip = 226, num = 186);
-    check_stage!(InnerError,  skip = 412, num = 399);
-    check_stage!(Query,   skip = 226, num =  23);
-    check_stage!(Eval,    skip = 249, num =  18);
+    check_stage!(Preamble, skip =   1, num = 345);
+    check_stage!(OuterError,  skip = 346, num = 186);
+    check_stage!(InnerError,  skip = 532, num = 399);
+    check_stage!(Query,   skip = 346, num =  23);
+    check_stage!(Eval,    skip = 369, num =  18);
 }
 
 /// Helper test to print current constraint counts in copy-pasteable format.
@@ -197,7 +197,7 @@ fn test_native_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fp!(0x1c6ec7e52886d33074765bb42a83413fffafe2486e63d48ad367adb15c79b6ff);
+    let expected = fp!(0x170e23fd3b4c2e35138a4225efeea3a8aacb95bcc1c26afc100b480ab3c61bc5);
 
     assert_eq!(
         app.native_registry.digest(),

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -88,11 +88,11 @@ fn test_internal_circuit_constraint_counts() {
         }};
     }
 
-    check_constraints!(Hashes1Circuit,         mul = 2045, lin = 3422);
-    check_constraints!(Hashes2Circuit,         mul = 1879, lin = 2951);
+    check_constraints!(Hashes1Circuit,        mul = 1331, lin = 1988);
+    check_constraints!(Hashes2Circuit,        mul = 1879, lin = 2951);
     check_constraints!(InnerCollapseCircuit,  mul = 1756, lin = 1918);
-    check_constraints!(OuterCollapseCircuit,  mul = 809 , lin = 808);
-    check_constraints!(ComputeVCircuit,        mul = 1135, lin = 1773);
+    check_constraints!(OuterCollapseCircuit,  mul = 1523, lin = 2242);
+    check_constraints!(ComputeVCircuit,       mul = 1135, lin = 1773);
 }
 
 #[rustfmt::skip]
@@ -197,7 +197,7 @@ fn test_native_registry_digest() {
         .finalize(pasta)
         .unwrap();
 
-    let expected = fp!(0x39bb8de1c0aac1d53ccb0895096a7b18c10b2cc248123289edab8ec76a74c05d);
+    let expected = fp!(0x1c6ec7e52886d33074765bb42a83413fffafe2486e63d48ad367adb15c79b6ff);
 
     assert_eq!(
         app.native_registry.digest(),


### PR DESCRIPTION
References https://github.com/tachyon-zcash/ragu/issues/707, rebalancing the internal recursion circuits to make space for extra header sizes that application circuits may need (ran a binary search to find the current limit).