### PR TITLE
docs: fix broken doc links in wiring module and pcs page

### DIFF
--- a/book/src/protocol/core/accumulation/pcs.md
+++ b/book/src/protocol/core/accumulation/pcs.md
@@ -195,7 +195,7 @@ Instead, Ragu proposes two encodings of the same input $\inst$ such that the
 encoded values contains either purely $\F_p$ elements or $\F_q$ elements.
 Then, by marking these encoded values as the witness for a dedicated
 [stage](../../extensions/staging.md), Ragu can leverage the
-[staging well-formedness checks]()
+[staging well-formedness checks](../../extensions/staging.md)
 to enforce the same underlying input during the _recursion at the next step_.
 
 **Encoding in the primary circuit** (over $\F_p$):

--- a/crates/ragu_circuits/src/wiring/mod.rs
+++ b/crates/ragu_circuits/src/wiring/mod.rs
@@ -87,7 +87,7 @@
 //! [`Routine`]: ragu_core::routines::Routine
 //! [`enforce_zero`]: ragu_core::drivers::Driver::enforce_zero
 //! [`floor_plan`]: crate::floor_planner::floor_plan
-//! [wiring polynomials]: http://TODO
+//! [wiring polynomials]: https://tachyon.z.cash/ragu/protocol/local/wiring.html
 
 pub mod sx;
 pub mod sxy;


### PR DESCRIPTION
- wiring/mod.rs: replace `http://TODO` placeholder with canonical book URL (tachyon.z.cash/ragu/protocol/local/wiring.html)
- pcs.md: fill empty link for "staging well-formedness checks" with relative path to protocol/extensions/staging.md