### PR TITLE
perf: step capacity and proving-cost investigation

### DIFF
--- a/crates/ragu_pcd/tests/distinct_headers.rs
+++ b/crates/ragu_pcd/tests/distinct_headers.rs
@@ -209,7 +209,12 @@ fn sweep_distinct_headers() -> Result<()> {
     std::println!("\n[distinct headers, iters={ITERS}]");
     std::println!(
         "{:>8}{:>8}{:>10}{:>6}{:>11}{:>11}",
-        "levels", "nodes", "circuits", "log2", "avg(ms)", "per-node"
+        "levels",
+        "nodes",
+        "circuits",
+        "log2",
+        "avg(ms)",
+        "per-node"
     );
 
     sweep!(pasta, 1; 0 => 1);

--- a/crates/ragu_pcd/tests/distinct_headers.rs
+++ b/crates/ragu_pcd/tests/distinct_headers.rs
@@ -1,13 +1,13 @@
-//! Investigation C: does registering many *distinct step types that each carry a
-//! distinct header* raise per-proof cost (case 4 of the complexity gradient)?
+//! Investigation C: does *executing* a chain whose every level carries a
+//! distinct header raise per-node proving cost?
 //!
-//! Identical to `distinct_steps.rs` in every way — same fixed used tree (seed two
-//! leaves -> one fuse, 3 proofs), same `N` registered-but-unused fillers, same
-//! circuit count at equal `N` — EXCEPT each `Filler<const I>` outputs its own
-//! `FillerHeader<const I>` instead of a shared one. So comparing this file's
-//! timings to `distinct_steps.rs` at equal `N` isolates the marginal cost of
-//! header multiplicity at fixed circuit count. This is the const-param'd
-//! distinct-steps-and-headers case hypothesized to "should increase" complexity.
+//! Identical shape to `distinct_steps.rs` — a left-leaning chain folding a fresh
+//! seed in at each level — EXCEPT each level produces its own distinct header
+//! `Hdr<const I>` via a distinct `Fuse<IN, OUT>`. A depth-N chain threads N + 1
+//! distinct headers through N distinct fuse circuits, all executed. Sweeping N
+//! grows the executed node count, so we report **per-node** time; comparing it
+//! to `distinct_steps.rs` (one shared header) at equal N isolates the marginal
+//! cost of header multiplicity.
 //!
 //! Run with (serialized so the timings don't contend):
 //!   cargo test --features multicore -p ragu_pcd --release --test distinct_headers \
@@ -37,31 +37,16 @@ use rand::{SeedableRng, rngs::StdRng};
 
 const HEADER_SIZE: usize = 4;
 const WARMUP: usize = 1;
-const ITERS: usize = 3;
+const ITERS: usize = 2;
 
-// --- Headers -------------------------------------------------------------
+// --- One distinct header per level ---------------------------------------
 
-/// Leaf / used-fuse header (plain). The used tree is homogeneous in it.
-struct LeafHeader;
-/// Per-filler header, one distinct type per index (`Suffix::new(I + 2)`).
-struct FillerHeader<const I: usize>;
+/// Level-`I` node header (`Suffix::new(I)`). Leaves are `Hdr<0>`; each fuse
+/// lifts its accumulator from `Hdr<IN>` to `Hdr<OUT>`.
+struct Hdr<const I: usize>;
 
-impl<F: Field> Header<F> for LeafHeader {
-    const SUFFIX: Suffix = Suffix::new(0);
-    type Data = F;
-    type Output = Kind![F; Element<'_, _>];
-
-    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
-        dr: &mut D,
-        allocator: &mut A,
-        witness: DriverValue<D, Self::Data>,
-    ) -> Result<Bound<'dr, D, Self::Output>> {
-        Element::alloc(dr, allocator, witness)
-    }
-}
-
-impl<const I: usize, F: Field> Header<F> for FillerHeader<I> {
-    const SUFFIX: Suffix = Suffix::new(I + 2);
+impl<const I: usize, F: Field> Header<F> for Hdr<I> {
+    const SUFFIX: Suffix = Suffix::new(I);
     type Data = F;
     type Output = Kind![F; Element<'_, _>];
 
@@ -76,7 +61,7 @@ impl<const I: usize, F: Field> Header<F> for FillerHeader<I> {
 
 // --- Steps ---------------------------------------------------------------
 
-/// Plain seed leaf (one allocation).
+/// Seed leaf; every folded-in leaf (and the anchor) is `Hdr<0>`.
 struct Leaf;
 
 impl Step<Pasta> for Leaf {
@@ -85,7 +70,7 @@ impl Step<Pasta> for Leaf {
     type Aux<'source> = ();
     type Left = ();
     type Right = ();
-    type Output = LeafHeader;
+    type Output = Hdr<0>;
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
         &self,
@@ -117,16 +102,17 @@ impl Step<Pasta> for Leaf {
     }
 }
 
-/// The one fuse actually executed by the measured tree (minimal, self-chaining).
-struct UsedFuse;
+/// Folds an `Hdr<0>` leaf into an `Hdr<IN>` accumulator, producing `Hdr<OUT>`.
+/// `INDEX = OUT`, so registering `Fuse<0,1>, Fuse<1,2>, …` is sequential.
+struct Fuse<const IN: usize, const OUT: usize>;
 
-impl Step<Pasta> for UsedFuse {
-    const INDEX: Index = Index::new(1);
+impl<const IN: usize, const OUT: usize> Step<Pasta> for Fuse<IN, OUT> {
+    const INDEX: Index = Index::new(OUT);
     type Witness<'source> = ();
     type Aux<'source> = ();
-    type Left = LeafHeader;
-    type Right = LeafHeader;
-    type Output = LeafHeader;
+    type Left = Hdr<IN>;
+    type Right = Hdr<0>;
+    type Output = Hdr<OUT>;
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
         &self,
@@ -157,130 +143,80 @@ impl Step<Pasta> for UsedFuse {
     }
 }
 
-/// Registered-but-unused filler seed step, `INDEX = I + 2`, each with its own
-/// distinct `FillerHeader<I>` — so `N` fillers add `N` circuits AND `N` headers.
-struct Filler<const I: usize>;
-
-impl<const I: usize> Step<Pasta> for Filler<I> {
-    const INDEX: Index = Index::new(I + 2);
-    type Witness<'source> = Fp;
-    type Aux<'source> = ();
-    type Left = ();
-    type Right = ();
-    type Output = FillerHeader<I>;
-
-    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
-        &self,
-        dr: &mut D,
-        witness: DriverValue<D, Fp>,
-        _left: DriverValue<D, ()>,
-        _right: DriverValue<D, ()>,
-    ) -> Result<(
-        (
-            Encoded<'dr, D, Self::Left, HS>,
-            Encoded<'dr, D, Self::Right, HS>,
-            Encoded<'dr, D, Self::Output, HS>,
-        ),
-        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
-        DriverValue<D, Self::Aux<'source>>,
-    )>
-    where
-        Self: 'dr,
-    {
-        let allocator = &mut Standard::new();
-        let leaf = Element::alloc(dr, allocator, witness)?;
-        let output_data = leaf.value().map(|v| *v);
-        let output = Encoded::from_gadget(leaf);
-        Ok((
-            (Encoded::from_gadget(()), Encoded::from_gadget(()), output),
-            output_data,
-            D::unit(),
-        ))
-    }
-}
-
-/// Build an application with `Leaf` + `UsedFuse` plus the listed fillers (each
-/// bringing its own header), then finalize. Requires the enclosing fn to return
-/// `Result`.
-macro_rules! app_with_fillers {
-    ($pasta:expr $(, $i:literal)* $(,)?) => {{
-        #[allow(unused_mut)]
-        let mut b = ApplicationBuilder::<Pasta, ProductionRank, HEADER_SIZE>::new()
-            .register(Leaf)?
-            .register(UsedFuse)?;
-        $( b = b.register(Filler::<$i>)?; )*
-        b.finalize($pasta)?
-    }};
-}
-
 fn summarize(times: &[Duration]) -> (f64, f64) {
     let min = times.iter().min().unwrap().as_secs_f64() * 1e3;
     let mean = times.iter().map(|d| d.as_secs_f64()).sum::<f64>() / times.len() as f64 * 1e3;
     (min, mean)
 }
 
-/// The fixed measured work: seed two leaves and fuse them (3 proofs).
-fn build_used(
-    app: &Application<'_, Pasta, ProductionRank, HEADER_SIZE>,
-    rng: &mut StdRng,
-) -> Result<()> {
-    let v = Fp::from(7u64);
-    let a = app.seed(rng, Leaf, v)?.0;
-    let b = app.seed(rng, Leaf, v)?.0;
-    let _ = app.fuse(rng, UsedFuse, (), a, b)?.0;
-    Ok(())
-}
-
-/// Time the fixed tree in `app` and print `N` (registered fillers = distinct
-/// headers), total circuits, `log2`, and min/mean time.
+/// Time `build` (which proves an N-level chain → `2n + 1` nodes) and print
+/// `n`, node count, total circuits, `log2`, and total / per-node time.
 fn measure(
     app: &Application<'_, Pasta, ProductionRank, HEADER_SIZE>,
-    n_fillers: usize,
+    n: usize,
+    build: impl Fn(&Application<'_, Pasta, ProductionRank, HEADER_SIZE>, &mut StdRng) -> Result<()>,
 ) -> Result<()> {
+    let nodes = 2 * n + 1;
     let total = app.native_registry().num_circuits();
     let log2 = total.next_power_of_two().trailing_zeros();
 
     let mut rng = StdRng::seed_from_u64(1234);
     for _ in 0..WARMUP {
-        build_used(app, &mut rng)?;
+        build(app, &mut rng)?;
     }
 
     let mut t = Vec::new();
     for _ in 0..ITERS {
         let start = Instant::now();
-        build_used(app, &mut rng)?;
+        build(app, &mut rng)?;
         t.push(start.elapsed());
     }
 
-    let (min, mean) = summarize(&t);
-    std::println!("{n_fillers:>10}{total:>10}{log2:>10}{min:>11.1}{mean:>11.1}");
+    let (_min, mean) = summarize(&t);
+    let per_node = mean / nodes as f64;
+    std::println!("{n:>8}{nodes:>8}{total:>10}{log2:>6}{mean:>11.1}{per_node:>11.1}");
     Ok(())
 }
 
-/// Sweep the number of distinct registered fillers, each with its own header.
-/// Same circuit totals as `distinct_steps.rs` (`N + 17`), so compare row-for-row.
+/// One sweep point: register `Leaf` + the listed per-level fuses, then prove a
+/// chain that lifts through each distinct header. `acc` is re-bound (shadowed)
+/// each level because its header type changes from `Hdr<IN>` to `Hdr<OUT>`.
+macro_rules! sweep {
+    ($pasta:expr, $n:expr $(; $in:literal => $out:literal)*) => {{
+        #[allow(unused_mut)]
+        let mut b = ApplicationBuilder::<Pasta, ProductionRank, HEADER_SIZE>::new()
+            .register(Leaf)?;
+        $( b = b.register(Fuse::<$in, $out>)?; )*
+        let app = b.finalize($pasta)?;
+        measure(&app, $n, |app, rng| {
+            let v = Fp::from(7u64);
+            let acc = app.seed(rng, Leaf, v)?.0;
+            $(
+                let leaf = app.seed(rng, Leaf, v)?.0;
+                let acc = app.fuse(rng, Fuse::<$in, $out>, (), acc, leaf)?.0;
+            )*
+            let _ = acc;
+            Ok(())
+        })?;
+    }};
+}
+
+/// Sweep the number of distinct headers threaded through the chain. `total
+/// circuits = N + 16`, so N = 16 crosses the `log2` 5 → 6 boundary.
 #[test]
 fn sweep_distinct_headers() -> Result<()> {
     let pasta = Pasta::baked();
     std::println!("\n[distinct headers, iters={ITERS}]");
     std::println!(
-        "{:>10}{:>10}{:>10}{:>11}{:>11}",
-        "fillers",
-        "circuits",
-        "log2",
-        "min(ms)",
-        "avg(ms)"
+        "{:>8}{:>8}{:>10}{:>6}{:>11}{:>11}",
+        "levels", "nodes", "circuits", "log2", "avg(ms)", "per-node"
     );
 
-    measure(&app_with_fillers!(pasta), 0)?;
-    measure(&app_with_fillers!(pasta, 0, 1, 2, 3, 4, 5, 6, 7), 8)?;
-    measure(
-        &app_with_fillers!(pasta, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14),
-        15,
-    )?;
-    measure(
-        &app_with_fillers!(pasta, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
-        16,
-    )?;
+    sweep!(pasta, 1; 0 => 1);
+    sweep!(pasta, 4; 0 => 1; 1 => 2; 2 => 3; 3 => 4);
+    sweep!(pasta, 8; 0 => 1; 1 => 2; 2 => 3; 3 => 4; 4 => 5; 5 => 6; 6 => 7; 7 => 8);
+    sweep!(pasta, 16;
+        0 => 1; 1 => 2; 2 => 3; 3 => 4; 4 => 5; 5 => 6; 6 => 7; 7 => 8;
+        8 => 9; 9 => 10; 10 => 11; 11 => 12; 12 => 13; 13 => 14; 14 => 15; 15 => 16);
     Ok(())
 }

--- a/crates/ragu_pcd/tests/distinct_headers.rs
+++ b/crates/ragu_pcd/tests/distinct_headers.rs
@@ -1,0 +1,276 @@
+//! Investigation C: does registering many *distinct step types that each carry a
+//! distinct header* raise per-proof cost (case 4 of the complexity gradient)?
+//!
+//! Identical to `distinct_steps.rs` in every way — same fixed used tree (seed two
+//! leaves -> one fuse, 3 proofs), same `N` registered-but-unused fillers, same
+//! circuit count at equal `N` — EXCEPT each `Filler<const I>` outputs its own
+//! `FillerHeader<const I>` instead of a shared one. So comparing this file's
+//! timings to `distinct_steps.rs` at equal `N` isolates the marginal cost of
+//! header multiplicity at fixed circuit count. This is the const-param'd
+//! distinct-steps-and-headers case hypothesized to "should increase" complexity.
+//!
+//! Run with (serialized so the timings don't contend):
+//!   cargo test --features multicore -p ragu_pcd --release --test distinct_headers \
+//!       -- --nocapture --test-threads=1
+
+use std::time::{Duration, Instant};
+
+use ff::Field;
+use ragu_circuits::polynomials::ProductionRank;
+use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue},
+    gadgets::{Bound, Kind},
+    maybe::Maybe,
+};
+use ragu_pasta::{Fp, Pasta};
+use ragu_pcd::{
+    Application, ApplicationBuilder,
+    header::{Header, Suffix},
+    step::{Encoded, Index, Step},
+};
+use ragu_primitives::{
+    Element,
+    allocator::{Allocator, Standard},
+};
+use rand::{SeedableRng, rngs::StdRng};
+
+const HEADER_SIZE: usize = 4;
+const WARMUP: usize = 1;
+const ITERS: usize = 3;
+
+// --- Headers -------------------------------------------------------------
+
+/// Leaf / used-fuse header (plain). The used tree is homogeneous in it.
+struct LeafHeader;
+/// Per-filler header, one distinct type per index (`Suffix::new(I + 2)`).
+struct FillerHeader<const I: usize>;
+
+impl<F: Field> Header<F> for LeafHeader {
+    const SUFFIX: Suffix = Suffix::new(0);
+    type Data = F;
+    type Output = Kind![F; Element<'_, _>];
+
+    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
+        dr: &mut D,
+        allocator: &mut A,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, allocator, witness)
+    }
+}
+
+impl<const I: usize, F: Field> Header<F> for FillerHeader<I> {
+    const SUFFIX: Suffix = Suffix::new(I + 2);
+    type Data = F;
+    type Output = Kind![F; Element<'_, _>];
+
+    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
+        dr: &mut D,
+        allocator: &mut A,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, allocator, witness)
+    }
+}
+
+// --- Steps ---------------------------------------------------------------
+
+/// Plain seed leaf (one allocation).
+struct Leaf;
+
+impl Step<Pasta> for Leaf {
+    const INDEX: Index = Index::new(0);
+    type Witness<'source> = Fp;
+    type Aux<'source> = ();
+    type Left = ();
+    type Right = ();
+    type Output = LeafHeader;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Fp>,
+        _left: DriverValue<D, ()>,
+        _right: DriverValue<D, ()>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let leaf = Element::alloc(dr, allocator, witness)?;
+        let output_data = leaf.value().map(|v| *v);
+        let output = Encoded::from_gadget(leaf);
+        Ok((
+            (Encoded::from_gadget(()), Encoded::from_gadget(()), output),
+            output_data,
+            D::unit(),
+        ))
+    }
+}
+
+/// The one fuse actually executed by the measured tree (minimal, self-chaining).
+struct UsedFuse;
+
+impl Step<Pasta> for UsedFuse {
+    const INDEX: Index = Index::new(1);
+    type Witness<'source> = ();
+    type Aux<'source> = ();
+    type Left = LeafHeader;
+    type Right = LeafHeader;
+    type Output = LeafHeader;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        _: DriverValue<D, ()>,
+        left: DriverValue<D, Fp>,
+        right: DriverValue<D, Fp>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let left = Encoded::new(dr, allocator, left)?;
+        let right = Encoded::new(dr, allocator, right)?;
+        let l: &Element<'dr, D> = left.as_gadget();
+        let out = l.clone();
+        let output_data = out.value().map(|v| *v);
+        let output = Encoded::from_gadget(out);
+        Ok(((left, right, output), output_data, D::unit()))
+    }
+}
+
+/// Registered-but-unused filler seed step, `INDEX = I + 2`, each with its own
+/// distinct `FillerHeader<I>` — so `N` fillers add `N` circuits AND `N` headers.
+struct Filler<const I: usize>;
+
+impl<const I: usize> Step<Pasta> for Filler<I> {
+    const INDEX: Index = Index::new(I + 2);
+    type Witness<'source> = Fp;
+    type Aux<'source> = ();
+    type Left = ();
+    type Right = ();
+    type Output = FillerHeader<I>;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Fp>,
+        _left: DriverValue<D, ()>,
+        _right: DriverValue<D, ()>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let leaf = Element::alloc(dr, allocator, witness)?;
+        let output_data = leaf.value().map(|v| *v);
+        let output = Encoded::from_gadget(leaf);
+        Ok((
+            (Encoded::from_gadget(()), Encoded::from_gadget(()), output),
+            output_data,
+            D::unit(),
+        ))
+    }
+}
+
+/// Build an application with `Leaf` + `UsedFuse` plus the listed fillers (each
+/// bringing its own header), then finalize. Requires the enclosing fn to return
+/// `Result`.
+macro_rules! app_with_fillers {
+    ($pasta:expr $(, $i:literal)* $(,)?) => {{
+        #[allow(unused_mut)]
+        let mut b = ApplicationBuilder::<Pasta, ProductionRank, HEADER_SIZE>::new()
+            .register(Leaf)?
+            .register(UsedFuse)?;
+        $( b = b.register(Filler::<$i>)?; )*
+        b.finalize($pasta)?
+    }};
+}
+
+fn summarize(times: &[Duration]) -> (f64, f64) {
+    let min = times.iter().min().unwrap().as_secs_f64() * 1e3;
+    let mean = times.iter().map(|d| d.as_secs_f64()).sum::<f64>() / times.len() as f64 * 1e3;
+    (min, mean)
+}
+
+/// The fixed measured work: seed two leaves and fuse them (3 proofs).
+fn build_used(app: &Application<'_, Pasta, ProductionRank, HEADER_SIZE>, rng: &mut StdRng) -> Result<()> {
+    let v = Fp::from(7u64);
+    let a = app.seed(rng, Leaf, v)?.0;
+    let b = app.seed(rng, Leaf, v)?.0;
+    let _ = app.fuse(rng, UsedFuse, (), a, b)?.0;
+    Ok(())
+}
+
+/// Time the fixed tree in `app` and print `N` (registered fillers = distinct
+/// headers), total circuits, `log2`, and min/mean time.
+fn measure(
+    app: &Application<'_, Pasta, ProductionRank, HEADER_SIZE>,
+    n_fillers: usize,
+) -> Result<()> {
+    let total = app.native_registry().num_circuits();
+    let log2 = total.next_power_of_two().trailing_zeros();
+
+    let mut rng = StdRng::seed_from_u64(1234);
+    for _ in 0..WARMUP {
+        build_used(app, &mut rng)?;
+    }
+
+    let mut t = Vec::new();
+    for _ in 0..ITERS {
+        let start = Instant::now();
+        build_used(app, &mut rng)?;
+        t.push(start.elapsed());
+    }
+
+    let (min, mean) = summarize(&t);
+    std::println!("{n_fillers:>10}{total:>10}{log2:>10}{min:>11.1}{mean:>11.1}");
+    Ok(())
+}
+
+/// Sweep the number of distinct registered fillers, each with its own header.
+/// Same circuit totals as `distinct_steps.rs` (`N + 17`), so compare row-for-row.
+#[test]
+fn sweep_distinct_headers() -> Result<()> {
+    let pasta = Pasta::baked();
+    std::println!("\n[distinct headers, iters={ITERS}]");
+    std::println!("{:>10}{:>10}{:>10}{:>11}{:>11}", "fillers", "circuits", "log2", "min(ms)", "avg(ms)");
+
+    measure(&app_with_fillers!(pasta), 0)?;
+    measure(&app_with_fillers!(pasta, 0, 1, 2, 3, 4, 5, 6, 7), 8)?;
+    measure(
+        &app_with_fillers!(pasta, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14),
+        15,
+    )?;
+    measure(
+        &app_with_fillers!(pasta, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+        16,
+    )?;
+    Ok(())
+}

--- a/crates/ragu_pcd/tests/distinct_headers.rs
+++ b/crates/ragu_pcd/tests/distinct_headers.rs
@@ -220,7 +220,10 @@ fn summarize(times: &[Duration]) -> (f64, f64) {
 }
 
 /// The fixed measured work: seed two leaves and fuse them (3 proofs).
-fn build_used(app: &Application<'_, Pasta, ProductionRank, HEADER_SIZE>, rng: &mut StdRng) -> Result<()> {
+fn build_used(
+    app: &Application<'_, Pasta, ProductionRank, HEADER_SIZE>,
+    rng: &mut StdRng,
+) -> Result<()> {
     let v = Fp::from(7u64);
     let a = app.seed(rng, Leaf, v)?.0;
     let b = app.seed(rng, Leaf, v)?.0;
@@ -260,7 +263,14 @@ fn measure(
 fn sweep_distinct_headers() -> Result<()> {
     let pasta = Pasta::baked();
     std::println!("\n[distinct headers, iters={ITERS}]");
-    std::println!("{:>10}{:>10}{:>10}{:>11}{:>11}", "fillers", "circuits", "log2", "min(ms)", "avg(ms)");
+    std::println!(
+        "{:>10}{:>10}{:>10}{:>11}{:>11}",
+        "fillers",
+        "circuits",
+        "log2",
+        "min(ms)",
+        "avg(ms)"
+    );
 
     measure(&app_with_fillers!(pasta), 0)?;
     measure(&app_with_fillers!(pasta, 0, 1, 2, 3, 4, 5, 6, 7), 8)?;

--- a/crates/ragu_pcd/tests/distinct_steps.rs
+++ b/crates/ragu_pcd/tests/distinct_steps.rs
@@ -1,16 +1,14 @@
-//! Investigation B: does registering many *distinct step types that share one
-//! header* raise per-proof cost (cases 2/3 of the complexity gradient)?
+//! Investigation B: does *executing* many distinct step types that share one
+//! header raise per-node proving cost?
 //!
-//! A fixed, tiny "used" tree (seed two leaves -> one fuse, 3 proofs) is proved in
-//! every configuration. On top of it, `N` distinct `Filler<const I>` seed steps
-//! are registered but never executed — they only grow the registry. Crucially,
-//! every filler outputs the *same* shared header, so `N` varies the number of
-//! distinct step circuits while the header count stays at one.
-//!
-//! Compare against `distinct_headers.rs` (identical, except each filler gets its
-//! own header) at equal `N`: same circuit count, so the difference isolates the
-//! marginal cost of header multiplicity. Here we measure the step-circuit axis
-//! alone.
+//! Builds a left-leaning chain: a seed leaf, then at each level a distinct
+//! `Filler<const I>` seed is folded into the accumulator via a shared `Fuse`
+//! (everything on a single self-chaining header). Every registered filler is
+//! actually executed. Sweeping the chain length N grows both the executed node
+//! count and the number of distinct step circuits, so we report **per-node**
+//! time: if it stays flat, distinct step *types* cost nothing beyond the node
+//! itself. Compare with `distinct_headers.rs` (each filler carries its own
+//! header) to isolate header multiplicity.
 //!
 //! Run with (serialized so the timings don't contend):
 //!   cargo test --features multicore -p ragu_pcd --release --test distinct_steps \
@@ -40,31 +38,15 @@ use rand::{SeedableRng, rngs::StdRng};
 
 const HEADER_SIZE: usize = 4;
 const WARMUP: usize = 1;
-const ITERS: usize = 3;
+const ITERS: usize = 2;
 
-// --- Headers -------------------------------------------------------------
+// --- One shared, self-chaining header ------------------------------------
 
-/// Leaf / used-fuse header (plain). The used tree is homogeneous in it.
-struct LeafHeader;
-/// The single shared header every filler outputs (plain).
-struct FillerHeader;
+/// Every node (leaf, filler, fuse output) carries this one header.
+struct NodeHeader;
 
-impl<F: Field> Header<F> for LeafHeader {
+impl<F: Field> Header<F> for NodeHeader {
     const SUFFIX: Suffix = Suffix::new(0);
-    type Data = F;
-    type Output = Kind![F; Element<'_, _>];
-
-    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
-        dr: &mut D,
-        allocator: &mut A,
-        witness: DriverValue<D, Self::Data>,
-    ) -> Result<Bound<'dr, D, Self::Output>> {
-        Element::alloc(dr, allocator, witness)
-    }
-}
-
-impl<F: Field> Header<F> for FillerHeader {
-    const SUFFIX: Suffix = Suffix::new(2);
     type Data = F;
     type Output = Kind![F; Element<'_, _>];
 
@@ -79,7 +61,7 @@ impl<F: Field> Header<F> for FillerHeader {
 
 // --- Steps ---------------------------------------------------------------
 
-/// Plain seed leaf (one allocation).
+/// Seed leaf anchoring the chain.
 struct Leaf;
 
 impl Step<Pasta> for Leaf {
@@ -88,7 +70,7 @@ impl Step<Pasta> for Leaf {
     type Aux<'source> = ();
     type Left = ();
     type Right = ();
-    type Output = LeafHeader;
+    type Output = NodeHeader;
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
         &self,
@@ -120,16 +102,16 @@ impl Step<Pasta> for Leaf {
     }
 }
 
-/// The one fuse actually executed by the measured tree (minimal, self-chaining).
-struct UsedFuse;
+/// Shared fuse that folds a filler into the accumulator (minimal, self-chaining).
+struct Fuse;
 
-impl Step<Pasta> for UsedFuse {
+impl Step<Pasta> for Fuse {
     const INDEX: Index = Index::new(1);
     type Witness<'source> = ();
     type Aux<'source> = ();
-    type Left = LeafHeader;
-    type Right = LeafHeader;
-    type Output = LeafHeader;
+    type Left = NodeHeader;
+    type Right = NodeHeader;
+    type Output = NodeHeader;
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
         &self,
@@ -160,8 +142,9 @@ impl Step<Pasta> for UsedFuse {
     }
 }
 
-/// Registered-but-unused filler seed step, `INDEX = I + 2`. All fillers share
-/// `FillerHeader`, so `N` fillers add `N` distinct circuits but one header.
+/// A distinct seed step per `I` (`INDEX = I + 2`), all sharing `NodeHeader`.
+/// Each one folded into the chain is executed, so N of them = N distinct step
+/// circuits with one header.
 struct Filler<const I: usize>;
 
 impl<const I: usize> Step<Pasta> for Filler<I> {
@@ -170,7 +153,7 @@ impl<const I: usize> Step<Pasta> for Filler<I> {
     type Aux<'source> = ();
     type Left = ();
     type Right = ();
-    type Output = FillerHeader;
+    type Output = NodeHeader;
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
         &self,
@@ -202,87 +185,79 @@ impl<const I: usize> Step<Pasta> for Filler<I> {
     }
 }
 
-/// Build an application with `Leaf` + `UsedFuse` plus the listed fillers, then
-/// finalize. Requires the enclosing fn to return `Result`.
-macro_rules! app_with_fillers {
-    ($pasta:expr $(, $i:literal)* $(,)?) => {{
-        #[allow(unused_mut)]
-        let mut b = ApplicationBuilder::<Pasta, ProductionRank, HEADER_SIZE>::new()
-            .register(Leaf)?
-            .register(UsedFuse)?;
-        $( b = b.register(Filler::<$i>)?; )*
-        b.finalize($pasta)?
-    }};
-}
-
 fn summarize(times: &[Duration]) -> (f64, f64) {
     let min = times.iter().min().unwrap().as_secs_f64() * 1e3;
     let mean = times.iter().map(|d| d.as_secs_f64()).sum::<f64>() / times.len() as f64 * 1e3;
     (min, mean)
 }
 
-/// The fixed measured work: seed two leaves and fuse them (3 proofs).
-fn build_used(
-    app: &Application<'_, Pasta, ProductionRank, HEADER_SIZE>,
-    rng: &mut StdRng,
-) -> Result<()> {
-    let v = Fp::from(7u64);
-    let a = app.seed(rng, Leaf, v)?.0;
-    let b = app.seed(rng, Leaf, v)?.0;
-    let _ = app.fuse(rng, UsedFuse, (), a, b)?.0;
-    Ok(())
-}
-
-/// Time the fixed tree in `app` and print `N` (registered fillers), total
-/// circuits, `log2`, and min/mean time.
+/// Time `build` (which proves a chain that folds in `n` distinct fillers →
+/// `2n + 1` nodes) and print `n`, node count, total circuits, `log2`, and
+/// total / per-node time.
 fn measure(
     app: &Application<'_, Pasta, ProductionRank, HEADER_SIZE>,
-    n_fillers: usize,
+    n: usize,
+    build: impl Fn(&Application<'_, Pasta, ProductionRank, HEADER_SIZE>, &mut StdRng) -> Result<()>,
 ) -> Result<()> {
+    let nodes = 2 * n + 1;
     let total = app.native_registry().num_circuits();
     let log2 = total.next_power_of_two().trailing_zeros();
 
     let mut rng = StdRng::seed_from_u64(1234);
     for _ in 0..WARMUP {
-        build_used(app, &mut rng)?;
+        build(app, &mut rng)?;
     }
 
     let mut t = Vec::new();
     for _ in 0..ITERS {
         let start = Instant::now();
-        build_used(app, &mut rng)?;
+        build(app, &mut rng)?;
         t.push(start.elapsed());
     }
 
-    let (min, mean) = summarize(&t);
-    std::println!("{n_fillers:>10}{total:>10}{log2:>10}{min:>11.1}{mean:>11.1}");
+    let (_min, mean) = summarize(&t);
+    let per_node = mean / nodes as f64;
+    std::println!("{n:>8}{nodes:>8}{total:>10}{log2:>6}{mean:>11.1}{per_node:>11.1}");
     Ok(())
 }
 
-/// Sweep the number of distinct registered filler steps (shared header). Totals
-/// are `N + 17` circuits, so `N = 16` crosses `log2` 5 -> 6 (32 -> 33).
+/// One sweep point: register `Leaf` + `Fuse` + the listed distinct fillers, then
+/// prove a chain that folds each filler in once. Both lists are the same literals.
+macro_rules! sweep {
+    ($pasta:expr, $n:expr $(; $i:literal)*) => {{
+        #[allow(unused_mut)]
+        let mut b = ApplicationBuilder::<Pasta, ProductionRank, HEADER_SIZE>::new()
+            .register(Leaf)?
+            .register(Fuse)?;
+        $( b = b.register(Filler::<$i>)?; )*
+        let app = b.finalize($pasta)?;
+        measure(&app, $n, |app, rng| {
+            let v = Fp::from(7u64);
+            let mut acc = app.seed(rng, Leaf, v)?.0;
+            $(
+                let f = app.seed(rng, Filler::<$i>, v)?.0;
+                acc = app.fuse(rng, Fuse, (), acc, f)?.0;
+            )*
+            let _ = acc;
+            Ok(())
+        })?;
+    }};
+}
+
+/// Sweep the number of distinct fuse-fed step types actually executed in the
+/// chain. `total circuits = N + 17`, so N = 16 crosses the `log2` 5 → 6 boundary.
 #[test]
 fn sweep_distinct_steps() -> Result<()> {
     let pasta = Pasta::baked();
     std::println!("\n[shared header, iters={ITERS}]");
     std::println!(
-        "{:>10}{:>10}{:>10}{:>11}{:>11}",
-        "fillers",
-        "circuits",
-        "log2",
-        "min(ms)",
-        "avg(ms)"
+        "{:>8}{:>8}{:>10}{:>6}{:>11}{:>11}",
+        "steps", "nodes", "circuits", "log2", "avg(ms)", "per-node"
     );
 
-    measure(&app_with_fillers!(pasta), 0)?;
-    measure(&app_with_fillers!(pasta, 0, 1, 2, 3, 4, 5, 6, 7), 8)?;
-    measure(
-        &app_with_fillers!(pasta, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14),
-        15,
-    )?;
-    measure(
-        &app_with_fillers!(pasta, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
-        16,
-    )?;
+    sweep!(pasta, 1; 0);
+    sweep!(pasta, 4; 0; 1; 2; 3);
+    sweep!(pasta, 8; 0; 1; 2; 3; 4; 5; 6; 7);
+    sweep!(pasta, 16; 0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12; 13; 14; 15);
     Ok(())
 }

--- a/crates/ragu_pcd/tests/distinct_steps.rs
+++ b/crates/ragu_pcd/tests/distinct_steps.rs
@@ -222,7 +222,10 @@ fn summarize(times: &[Duration]) -> (f64, f64) {
 }
 
 /// The fixed measured work: seed two leaves and fuse them (3 proofs).
-fn build_used(app: &Application<'_, Pasta, ProductionRank, HEADER_SIZE>, rng: &mut StdRng) -> Result<()> {
+fn build_used(
+    app: &Application<'_, Pasta, ProductionRank, HEADER_SIZE>,
+    rng: &mut StdRng,
+) -> Result<()> {
     let v = Fp::from(7u64);
     let a = app.seed(rng, Leaf, v)?.0;
     let b = app.seed(rng, Leaf, v)?.0;
@@ -262,7 +265,14 @@ fn measure(
 fn sweep_distinct_steps() -> Result<()> {
     let pasta = Pasta::baked();
     std::println!("\n[shared header, iters={ITERS}]");
-    std::println!("{:>10}{:>10}{:>10}{:>11}{:>11}", "fillers", "circuits", "log2", "min(ms)", "avg(ms)");
+    std::println!(
+        "{:>10}{:>10}{:>10}{:>11}{:>11}",
+        "fillers",
+        "circuits",
+        "log2",
+        "min(ms)",
+        "avg(ms)"
+    );
 
     measure(&app_with_fillers!(pasta), 0)?;
     measure(&app_with_fillers!(pasta, 0, 1, 2, 3, 4, 5, 6, 7), 8)?;

--- a/crates/ragu_pcd/tests/distinct_steps.rs
+++ b/crates/ragu_pcd/tests/distinct_steps.rs
@@ -252,7 +252,12 @@ fn sweep_distinct_steps() -> Result<()> {
     std::println!("\n[shared header, iters={ITERS}]");
     std::println!(
         "{:>8}{:>8}{:>10}{:>6}{:>11}{:>11}",
-        "steps", "nodes", "circuits", "log2", "avg(ms)", "per-node"
+        "steps",
+        "nodes",
+        "circuits",
+        "log2",
+        "avg(ms)",
+        "per-node"
     );
 
     sweep!(pasta, 1; 0);

--- a/crates/ragu_pcd/tests/distinct_steps.rs
+++ b/crates/ragu_pcd/tests/distinct_steps.rs
@@ -1,0 +1,278 @@
+//! Investigation B: does registering many *distinct step types that share one
+//! header* raise per-proof cost (cases 2/3 of the complexity gradient)?
+//!
+//! A fixed, tiny "used" tree (seed two leaves -> one fuse, 3 proofs) is proved in
+//! every configuration. On top of it, `N` distinct `Filler<const I>` seed steps
+//! are registered but never executed — they only grow the registry. Crucially,
+//! every filler outputs the *same* shared header, so `N` varies the number of
+//! distinct step circuits while the header count stays at one.
+//!
+//! Compare against `distinct_headers.rs` (identical, except each filler gets its
+//! own header) at equal `N`: same circuit count, so the difference isolates the
+//! marginal cost of header multiplicity. Here we measure the step-circuit axis
+//! alone.
+//!
+//! Run with (serialized so the timings don't contend):
+//!   cargo test --features multicore -p ragu_pcd --release --test distinct_steps \
+//!       -- --nocapture --test-threads=1
+
+use std::time::{Duration, Instant};
+
+use ff::Field;
+use ragu_circuits::polynomials::ProductionRank;
+use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue},
+    gadgets::{Bound, Kind},
+    maybe::Maybe,
+};
+use ragu_pasta::{Fp, Pasta};
+use ragu_pcd::{
+    Application, ApplicationBuilder,
+    header::{Header, Suffix},
+    step::{Encoded, Index, Step},
+};
+use ragu_primitives::{
+    Element,
+    allocator::{Allocator, Standard},
+};
+use rand::{SeedableRng, rngs::StdRng};
+
+const HEADER_SIZE: usize = 4;
+const WARMUP: usize = 1;
+const ITERS: usize = 3;
+
+// --- Headers -------------------------------------------------------------
+
+/// Leaf / used-fuse header (plain). The used tree is homogeneous in it.
+struct LeafHeader;
+/// The single shared header every filler outputs (plain).
+struct FillerHeader;
+
+impl<F: Field> Header<F> for LeafHeader {
+    const SUFFIX: Suffix = Suffix::new(0);
+    type Data = F;
+    type Output = Kind![F; Element<'_, _>];
+
+    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
+        dr: &mut D,
+        allocator: &mut A,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, allocator, witness)
+    }
+}
+
+impl<F: Field> Header<F> for FillerHeader {
+    const SUFFIX: Suffix = Suffix::new(2);
+    type Data = F;
+    type Output = Kind![F; Element<'_, _>];
+
+    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
+        dr: &mut D,
+        allocator: &mut A,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, allocator, witness)
+    }
+}
+
+// --- Steps ---------------------------------------------------------------
+
+/// Plain seed leaf (one allocation).
+struct Leaf;
+
+impl Step<Pasta> for Leaf {
+    const INDEX: Index = Index::new(0);
+    type Witness<'source> = Fp;
+    type Aux<'source> = ();
+    type Left = ();
+    type Right = ();
+    type Output = LeafHeader;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Fp>,
+        _left: DriverValue<D, ()>,
+        _right: DriverValue<D, ()>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let leaf = Element::alloc(dr, allocator, witness)?;
+        let output_data = leaf.value().map(|v| *v);
+        let output = Encoded::from_gadget(leaf);
+        Ok((
+            (Encoded::from_gadget(()), Encoded::from_gadget(()), output),
+            output_data,
+            D::unit(),
+        ))
+    }
+}
+
+/// The one fuse actually executed by the measured tree (minimal, self-chaining).
+struct UsedFuse;
+
+impl Step<Pasta> for UsedFuse {
+    const INDEX: Index = Index::new(1);
+    type Witness<'source> = ();
+    type Aux<'source> = ();
+    type Left = LeafHeader;
+    type Right = LeafHeader;
+    type Output = LeafHeader;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        _: DriverValue<D, ()>,
+        left: DriverValue<D, Fp>,
+        right: DriverValue<D, Fp>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let left = Encoded::new(dr, allocator, left)?;
+        let right = Encoded::new(dr, allocator, right)?;
+        let l: &Element<'dr, D> = left.as_gadget();
+        let out = l.clone();
+        let output_data = out.value().map(|v| *v);
+        let output = Encoded::from_gadget(out);
+        Ok(((left, right, output), output_data, D::unit()))
+    }
+}
+
+/// Registered-but-unused filler seed step, `INDEX = I + 2`. All fillers share
+/// `FillerHeader`, so `N` fillers add `N` distinct circuits but one header.
+struct Filler<const I: usize>;
+
+impl<const I: usize> Step<Pasta> for Filler<I> {
+    const INDEX: Index = Index::new(I + 2);
+    type Witness<'source> = Fp;
+    type Aux<'source> = ();
+    type Left = ();
+    type Right = ();
+    type Output = FillerHeader;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Fp>,
+        _left: DriverValue<D, ()>,
+        _right: DriverValue<D, ()>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let leaf = Element::alloc(dr, allocator, witness)?;
+        let output_data = leaf.value().map(|v| *v);
+        let output = Encoded::from_gadget(leaf);
+        Ok((
+            (Encoded::from_gadget(()), Encoded::from_gadget(()), output),
+            output_data,
+            D::unit(),
+        ))
+    }
+}
+
+/// Build an application with `Leaf` + `UsedFuse` plus the listed fillers, then
+/// finalize. Requires the enclosing fn to return `Result`.
+macro_rules! app_with_fillers {
+    ($pasta:expr $(, $i:literal)* $(,)?) => {{
+        #[allow(unused_mut)]
+        let mut b = ApplicationBuilder::<Pasta, ProductionRank, HEADER_SIZE>::new()
+            .register(Leaf)?
+            .register(UsedFuse)?;
+        $( b = b.register(Filler::<$i>)?; )*
+        b.finalize($pasta)?
+    }};
+}
+
+fn summarize(times: &[Duration]) -> (f64, f64) {
+    let min = times.iter().min().unwrap().as_secs_f64() * 1e3;
+    let mean = times.iter().map(|d| d.as_secs_f64()).sum::<f64>() / times.len() as f64 * 1e3;
+    (min, mean)
+}
+
+/// The fixed measured work: seed two leaves and fuse them (3 proofs).
+fn build_used(app: &Application<'_, Pasta, ProductionRank, HEADER_SIZE>, rng: &mut StdRng) -> Result<()> {
+    let v = Fp::from(7u64);
+    let a = app.seed(rng, Leaf, v)?.0;
+    let b = app.seed(rng, Leaf, v)?.0;
+    let _ = app.fuse(rng, UsedFuse, (), a, b)?.0;
+    Ok(())
+}
+
+/// Time the fixed tree in `app` and print `N` (registered fillers), total
+/// circuits, `log2`, and min/mean time.
+fn measure(
+    app: &Application<'_, Pasta, ProductionRank, HEADER_SIZE>,
+    n_fillers: usize,
+) -> Result<()> {
+    let total = app.native_registry().num_circuits();
+    let log2 = total.next_power_of_two().trailing_zeros();
+
+    let mut rng = StdRng::seed_from_u64(1234);
+    for _ in 0..WARMUP {
+        build_used(app, &mut rng)?;
+    }
+
+    let mut t = Vec::new();
+    for _ in 0..ITERS {
+        let start = Instant::now();
+        build_used(app, &mut rng)?;
+        t.push(start.elapsed());
+    }
+
+    let (min, mean) = summarize(&t);
+    std::println!("{n_fillers:>10}{total:>10}{log2:>10}{min:>11.1}{mean:>11.1}");
+    Ok(())
+}
+
+/// Sweep the number of distinct registered filler steps (shared header). Totals
+/// are `N + 17` circuits, so `N = 16` crosses `log2` 5 -> 6 (32 -> 33).
+#[test]
+fn sweep_distinct_steps() -> Result<()> {
+    let pasta = Pasta::baked();
+    std::println!("\n[shared header, iters={ITERS}]");
+    std::println!("{:>10}{:>10}{:>10}{:>11}{:>11}", "fillers", "circuits", "log2", "min(ms)", "avg(ms)");
+
+    measure(&app_with_fillers!(pasta), 0)?;
+    measure(&app_with_fillers!(pasta, 0, 1, 2, 3, 4, 5, 6, 7), 8)?;
+    measure(
+        &app_with_fillers!(pasta, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14),
+        15,
+    )?;
+    measure(
+        &app_with_fillers!(pasta, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+        16,
+    )?;
+    Ok(())
+}

--- a/crates/ragu_pcd/tests/endoscalar_capacity.rs
+++ b/crates/ragu_pcd/tests/endoscalar_capacity.rs
@@ -1,0 +1,122 @@
+//! How many endoscalar `group_scale` calls fit in one application step
+
+use ff::Field;
+use ragu_circuits::{polynomials::ProductionRank, registry::CircuitIndex};
+use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue},
+    gadgets::{Bound, Kind},
+    maybe::Maybe,
+};
+use ragu_pasta::{EpAffine, Fp, Pasta};
+use ragu_pcd::{
+    ApplicationBuilder,
+    header::{Header, Suffix},
+    step::{Encoded, Index, Step},
+};
+use ragu_primitives::{
+    Element, Endoscalar, Point,
+    allocator::{Allocator, Standard},
+};
+
+const HEADER_SIZE: usize = 2;
+
+/// 1-element input header, sized to fit a single `Fp` plus the suffix slot.
+struct InputHeader;
+
+impl<F: Field> Header<F> for InputHeader {
+    const SUFFIX: Suffix = Suffix::new(0);
+    type Data = F;
+    type Output = Kind![F; Element<'_, _>];
+
+    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
+        dr: &mut D,
+        allocator: &mut A,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, allocator, witness)
+    }
+}
+
+/// Step performing exactly K endoscalar `group_scale` calls chained against
+/// a running point accumulator. Each iteration scales the accumulator by the
+/// same allocated scalar, so the total work is K independent scalings.
+struct ScaleK<const K: usize>;
+
+impl<const K: usize> Step<Pasta> for ScaleK<K> {
+    const INDEX: Index = Index::new(0);
+    type Witness<'source> = (EpAffine, u128);
+    type Aux<'source> = ();
+    type Left = InputHeader;
+    type Right = ();
+    type Output = InputHeader;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, (EpAffine, u128)>,
+        left: DriverValue<D, Fp>,
+        _right: DriverValue<D, ()>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let left = Encoded::new(dr, allocator, left)?;
+        let right = Encoded::from_gadget(());
+
+        let (p, r) = witness.cast();
+        let mut acc = Point::alloc(dr, p)?;
+        let r = Endoscalar::alloc(dr, r)?;
+        for _ in 0..K {
+            acc = r.group_scale(dr, &acc)?;
+        }
+
+        let l: &Element<'dr, D> = left.as_gadget();
+        let output_gadget: Element<'dr, D> = l.clone();
+        let output_data = output_gadget.value().map(|v| *v);
+        let output = Encoded::from_gadget(output_gadget);
+        Ok(((left, right, output), output_data, D::unit()))
+    }
+}
+
+fn measure<const K: usize>() -> Result<(usize, usize)> {
+    let pasta = Pasta::baked();
+    let app = ApplicationBuilder::<Pasta, ProductionRank, HEADER_SIZE>::new()
+        .register(ScaleK::<K>)?
+        .finalize(pasta)?;
+    let last = CircuitIndex::new(app.native_registry().num_circuits() - 1);
+    Ok(app.native_registry().constraint_counts(last))
+}
+
+fn report<const K: usize>() -> Result<()> {
+    match measure::<K>() {
+        Ok((g, c)) => {
+            std::println!("{K:>10}{g:>10}{c:>10}");
+            Ok(())
+        }
+        Err(e) => {
+            std::println!("{K:>10}  {e}");
+            Err(e)
+        }
+    }
+}
+
+#[test]
+fn k_sweep() {
+    std::println!("\n{:>10}{:>10}{:>10}", "K", "gates", "constr");
+
+    report::<1>().expect("should fit");
+    report::<2>().expect("should fit");
+    report::<3>().expect("should fit");
+    report::<4>().expect("should fit");
+    report::<5>().expect_err("should bust");
+}

--- a/crates/ragu_pcd/tests/num_steps.rs
+++ b/crates/ragu_pcd/tests/num_steps.rs
@@ -260,7 +260,14 @@ fn sweep_num_steps() -> Result<()> {
     std::println!(
         "\n(registered 3 steps -> {total} circuits, log2 {log2}, fixed across sweep; iters={ITERS})"
     );
-    std::println!("{:>10}{:>10}{:>11}{:>11}{:>11}", "depth", "nodes", "min(ms)", "avg(ms)", "per-node");
+    std::println!(
+        "{:>10}{:>10}{:>11}{:>11}{:>11}",
+        "depth",
+        "nodes",
+        "min(ms)",
+        "avg(ms)",
+        "per-node"
+    );
 
     measure(&app, 1)?;
     measure(&app, 2)?;

--- a/crates/ragu_pcd/tests/num_steps.rs
+++ b/crates/ragu_pcd/tests/num_steps.rs
@@ -1,0 +1,270 @@
+//! Investigation A: does proving cost grow with the *size* of the PCD tree when
+//! every node reuses the same step and header types (case 1 of the complexity
+//! gradient)?
+//!
+//! Builds a balanced binary tree of increasing depth from a fixed, reused set of
+//! steps: `Leaf` (seed), `LeafFuse` (lifts a leaf pair to an internal node), and
+//! `NodeFuse` (self-chains internal nodes). The registered set is fixed at 3
+//! steps / 2 headers regardless of depth, so only the executed node count varies.
+//! Expectation: per-node cost is flat (PCD proofs are constant-size), so total
+//! time grows ~linearly with node count while the registry stays unchanged.
+//!
+//! Run with (serialized so the timings don't contend):
+//!   cargo test --features multicore -p ragu_pcd --release --test num_steps \
+//!       -- --nocapture --test-threads=1
+
+use std::time::{Duration, Instant};
+
+use ff::Field;
+use ragu_circuits::polynomials::ProductionRank;
+use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue},
+    gadgets::{Bound, Kind},
+    maybe::Maybe,
+};
+use ragu_pasta::{Fp, Pasta};
+use ragu_pcd::{
+    Application, ApplicationBuilder, Pcd,
+    header::{Header, Suffix},
+    step::{Encoded, Index, Step},
+};
+use ragu_primitives::{
+    Element,
+    allocator::{Allocator, Standard},
+};
+use rand::{SeedableRng, rngs::StdRng};
+
+const HEADER_SIZE: usize = 4;
+const WARMUP: usize = 1;
+const ITERS: usize = 2;
+
+// --- Headers (both plain) ------------------------------------------------
+
+/// Leaf output header.
+struct LeafHeader;
+/// Internal / root node output header (self-chaining).
+struct NodeHeader;
+
+impl<F: Field> Header<F> for LeafHeader {
+    const SUFFIX: Suffix = Suffix::new(0);
+    type Data = F;
+    type Output = Kind![F; Element<'_, _>];
+
+    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
+        dr: &mut D,
+        allocator: &mut A,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, allocator, witness)
+    }
+}
+
+impl<F: Field> Header<F> for NodeHeader {
+    const SUFFIX: Suffix = Suffix::new(1);
+    type Data = F;
+    type Output = Kind![F; Element<'_, _>];
+
+    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
+        dr: &mut D,
+        allocator: &mut A,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, allocator, witness)
+    }
+}
+
+// --- Steps (all plain, reused at every node) -----------------------------
+
+/// Minimal seed leaf (one allocation).
+struct Leaf;
+
+impl Step<Pasta> for Leaf {
+    const INDEX: Index = Index::new(0);
+    type Witness<'source> = Fp;
+    type Aux<'source> = ();
+    type Left = ();
+    type Right = ();
+    type Output = LeafHeader;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Fp>,
+        _left: DriverValue<D, ()>,
+        _right: DriverValue<D, ()>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let leaf = Element::alloc(dr, allocator, witness)?;
+        let output_data = leaf.value().map(|v| *v);
+        let output = Encoded::from_gadget(leaf);
+        Ok((
+            (Encoded::from_gadget(()), Encoded::from_gadget(()), output),
+            output_data,
+            D::unit(),
+        ))
+    }
+}
+
+/// Lifts a pair of leaves to an internal node (minimal — no hashing).
+struct LeafFuse;
+
+impl Step<Pasta> for LeafFuse {
+    const INDEX: Index = Index::new(1);
+    type Witness<'source> = ();
+    type Aux<'source> = ();
+    type Left = LeafHeader;
+    type Right = LeafHeader;
+    type Output = NodeHeader;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        _: DriverValue<D, ()>,
+        left: DriverValue<D, Fp>,
+        right: DriverValue<D, Fp>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let left = Encoded::new(dr, allocator, left)?;
+        let right = Encoded::new(dr, allocator, right)?;
+        let l: &Element<'dr, D> = left.as_gadget();
+        let out = l.clone();
+        let output_data = out.value().map(|v| *v);
+        let output = Encoded::from_gadget(out);
+        Ok(((left, right, output), output_data, D::unit()))
+    }
+}
+
+/// Self-chains two internal nodes into one (minimal — no hashing).
+struct NodeFuse;
+
+impl Step<Pasta> for NodeFuse {
+    const INDEX: Index = Index::new(2);
+    type Witness<'source> = ();
+    type Aux<'source> = ();
+    type Left = NodeHeader;
+    type Right = NodeHeader;
+    type Output = NodeHeader;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        _: DriverValue<D, ()>,
+        left: DriverValue<D, Fp>,
+        right: DriverValue<D, Fp>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let left = Encoded::new(dr, allocator, left)?;
+        let right = Encoded::new(dr, allocator, right)?;
+        let l: &Element<'dr, D> = left.as_gadget();
+        let out = l.clone();
+        let output_data = out.value().map(|v| *v);
+        let output = Encoded::from_gadget(out);
+        Ok(((left, right, output), output_data, D::unit()))
+    }
+}
+
+fn summarize(times: &[Duration]) -> (f64, f64) {
+    let min = times.iter().min().unwrap().as_secs_f64() * 1e3;
+    let mean = times.iter().map(|d| d.as_secs_f64()).sum::<f64>() / times.len() as f64 * 1e3;
+    (min, mean)
+}
+
+/// Build and prove a balanced binary tree of the given `depth` (>= 1). Returns
+/// the root proof. Uniform `NodeHeader` return type at every depth means the
+/// recursion needs no const-generic arithmetic.
+fn build_subtree(
+    app: &Application<'_, Pasta, ProductionRank, HEADER_SIZE>,
+    rng: &mut StdRng,
+    depth: u32,
+) -> Result<Pcd<Pasta, ProductionRank, NodeHeader>> {
+    let v = Fp::from(7u64);
+    if depth == 1 {
+        let a = app.seed(rng, Leaf, v)?.0;
+        let b = app.seed(rng, Leaf, v)?.0;
+        Ok(app.fuse(rng, LeafFuse, (), a, b)?.0)
+    } else {
+        let l = build_subtree(app, rng, depth - 1)?;
+        let r = build_subtree(app, rng, depth - 1)?;
+        Ok(app.fuse(rng, NodeFuse, (), l, r)?.0)
+    }
+}
+
+/// Prove a depth-`d` tree `ITERS` times and print `depth`, node count, timing.
+fn measure(app: &Application<'_, Pasta, ProductionRank, HEADER_SIZE>, depth: u32) -> Result<()> {
+    let nodes = (1u64 << (depth + 1)) - 1; // 2^(d+1) - 1
+
+    let mut rng = StdRng::seed_from_u64(1234);
+    for _ in 0..WARMUP {
+        build_subtree(app, &mut rng, depth)?;
+    }
+
+    let mut t = Vec::new();
+    for _ in 0..ITERS {
+        let start = Instant::now();
+        build_subtree(app, &mut rng, depth)?;
+        t.push(start.elapsed());
+    }
+
+    let (min, mean) = summarize(&t);
+    let per_node = mean / nodes as f64;
+    std::println!("{depth:>10}{nodes:>10}{min:>11.1}{mean:>11.1}{per_node:>11.1}");
+    Ok(())
+}
+
+/// Sweep the tree depth (node count) with a fixed, reused step/header set.
+#[test]
+fn sweep_num_steps() -> Result<()> {
+    let pasta = Pasta::baked();
+    let app = ApplicationBuilder::<Pasta, ProductionRank, HEADER_SIZE>::new()
+        .register(Leaf)?
+        .register(LeafFuse)?
+        .register(NodeFuse)?
+        .finalize(pasta)?;
+
+    let total = app.native_registry().num_circuits();
+    let log2 = total.next_power_of_two().trailing_zeros();
+    std::println!(
+        "\n(registered 3 steps -> {total} circuits, log2 {log2}, fixed across sweep; iters={ITERS})"
+    );
+    std::println!("{:>10}{:>10}{:>11}{:>11}{:>11}", "depth", "nodes", "min(ms)", "avg(ms)", "per-node");
+
+    measure(&app, 1)?;
+    measure(&app, 2)?;
+    measure(&app, 3)?;
+    measure(&app, 4)?;
+    Ok(())
+}

--- a/crates/ragu_pcd/tests/num_witnesses.rs
+++ b/crates/ragu_pcd/tests/num_witnesses.rs
@@ -1,0 +1,295 @@
+//! Investigation: does proving a PCD *tree* cost more as each step holds more
+//! witnesses (allocated wires)?
+//!
+//! Builds a depth-2 binary tree — 4 leaves -> 2 inner fuses -> 1 root (7 proofs)
+//! — where each leaf allocates `N` witness elements and does no hashing or
+//! multiplication. This isolates the witness/wire dimension from the
+//! multiplication-gate dimension. The application shape is fixed (3 registered
+//! step types), so only the leaves' wire count varies across the sweep.
+//! Expectation: total tree proving time stays roughly flat, since allocations
+//! are cheap sparse-commitment coefficients and the fixed recursion pipeline
+//! dominates.
+//!
+//! Run with (serialized so the timings don't contend):
+//!   cargo test --features multicore -p ragu_pcd --release --test num_witnesses \
+//!       -- --nocapture --test-threads=1
+
+use std::time::{Duration, Instant};
+
+use ff::Field;
+use ragu_circuits::{polynomials::ProductionRank, registry::CircuitIndex};
+use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue},
+    gadgets::{Bound, Kind},
+    maybe::Maybe,
+};
+use ragu_pasta::{Fp, Pasta};
+use ragu_pcd::{
+    Application, ApplicationBuilder,
+    header::{Header, Suffix},
+    step::{Encoded, Index, Step},
+};
+use ragu_primitives::{
+    Element,
+    allocator::{Allocator, Standard},
+};
+use rand::{SeedableRng, rngs::StdRng};
+
+const HEADER_SIZE: usize = 4;
+const WARMUP: usize = 1;
+const SWEEP_ITERS: usize = 3;
+
+/// Leaf output header.
+struct LeafHdr;
+/// Inner-fuse output header.
+struct MidHdr;
+/// Root-fuse output header.
+struct RootHdr;
+
+impl<F: Field> Header<F> for LeafHdr {
+    const SUFFIX: Suffix = Suffix::new(0);
+    type Data = F;
+    type Output = Kind![F; Element<'_, _>];
+
+    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
+        dr: &mut D,
+        allocator: &mut A,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, allocator, witness)
+    }
+}
+
+impl<F: Field> Header<F> for MidHdr {
+    const SUFFIX: Suffix = Suffix::new(1);
+    type Data = F;
+    type Output = Kind![F; Element<'_, _>];
+
+    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
+        dr: &mut D,
+        allocator: &mut A,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, allocator, witness)
+    }
+}
+
+impl<F: Field> Header<F> for RootHdr {
+    const SUFFIX: Suffix = Suffix::new(2);
+    type Data = F;
+    type Output = Kind![F; Element<'_, _>];
+
+    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
+        dr: &mut D,
+        allocator: &mut A,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, allocator, witness)
+    }
+}
+
+/// Seed leaf that allocates exactly `N` witness elements (no hashing) and
+/// outputs the last. Each allocation is one wire.
+struct Leaf<const N: usize>;
+
+impl<const N: usize> Step<Pasta> for Leaf<N> {
+    const INDEX: Index = Index::new(0);
+    type Witness<'source> = Fp;
+    type Aux<'source> = ();
+    type Left = ();
+    type Right = ();
+    type Output = LeafHdr;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Fp>,
+        _left: DriverValue<D, ()>,
+        _right: DriverValue<D, ()>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let mut last = Element::alloc(dr, allocator, witness)?;
+        for _ in 1..N {
+            let v = last.value().map(|x| *x);
+            last = Element::alloc(dr, allocator, v)?;
+        }
+        let output_data = last.value().map(|v| *v);
+        let output = Encoded::from_gadget(last);
+        Ok((
+            (Encoded::from_gadget(()), Encoded::from_gadget(()), output),
+            output_data,
+            D::unit(),
+        ))
+    }
+}
+
+/// Inner fuse: combines two leaves into a mid node (minimal — no hashing).
+struct MidFuse;
+
+impl Step<Pasta> for MidFuse {
+    const INDEX: Index = Index::new(1);
+    type Witness<'source> = ();
+    type Aux<'source> = ();
+    type Left = LeafHdr;
+    type Right = LeafHdr;
+    type Output = MidHdr;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        _: DriverValue<D, ()>,
+        left: DriverValue<D, Fp>,
+        right: DriverValue<D, Fp>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let left = Encoded::new(dr, allocator, left)?;
+        let right = Encoded::new(dr, allocator, right)?;
+        let l: &Element<'dr, D> = left.as_gadget();
+        let out = l.clone();
+        let output_data = out.value().map(|v| *v);
+        let output = Encoded::from_gadget(out);
+        Ok(((left, right, output), output_data, D::unit()))
+    }
+}
+
+/// Root fuse: combines the two mid nodes into the root (minimal — no hashing).
+struct RootFuse;
+
+impl Step<Pasta> for RootFuse {
+    const INDEX: Index = Index::new(2);
+    type Witness<'source> = ();
+    type Aux<'source> = ();
+    type Left = MidHdr;
+    type Right = MidHdr;
+    type Output = RootHdr;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        _: DriverValue<D, ()>,
+        left: DriverValue<D, Fp>,
+        right: DriverValue<D, Fp>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let left = Encoded::new(dr, allocator, left)?;
+        let right = Encoded::new(dr, allocator, right)?;
+        let l: &Element<'dr, D> = left.as_gadget();
+        let out = l.clone();
+        let output_data = out.value().map(|v| *v);
+        let output = Encoded::from_gadget(out);
+        Ok(((left, right, output), output_data, D::unit()))
+    }
+}
+
+fn summarize(times: &[Duration]) -> (f64, f64) {
+    let min = times.iter().min().unwrap().as_secs_f64() * 1e3;
+    let mean = times.iter().map(|d| d.as_secs_f64()).sum::<f64>() / times.len() as f64 * 1e3;
+    (min, mean)
+}
+
+/// Build and prove the full depth-2 tree: 4 leaves -> 2 inner fuses -> 1 root.
+fn build_tree<const N: usize>(
+    app: &Application<'_, Pasta, ProductionRank, HEADER_SIZE>,
+    rng: &mut StdRng,
+) -> Result<()> {
+    let v = Fp::from(7u64);
+    let l0 = app.seed(rng, Leaf::<N>, v)?.0;
+    let l1 = app.seed(rng, Leaf::<N>, v)?.0;
+    let l2 = app.seed(rng, Leaf::<N>, v)?.0;
+    let l3 = app.seed(rng, Leaf::<N>, v)?.0;
+    let m0 = app.fuse(rng, MidFuse, (), l0, l1)?.0;
+    let m1 = app.fuse(rng, MidFuse, (), l2, l3)?.0;
+    let _root = app.fuse(rng, RootFuse, (), m0, m1)?.0;
+    Ok(())
+}
+
+/// Build the 3-step application whose leaves each hold `N` witnesses, then time
+/// building the whole tree. Prints witness count, the leaf's gate/constraint
+/// counts, and min/mean tree-proving time.
+fn sweep_point<const N: usize>() -> Result<()> {
+    let pasta = Pasta::baked();
+    let app = ApplicationBuilder::<Pasta, ProductionRank, HEADER_SIZE>::new()
+        .register(Leaf::<N>)?
+        .register(MidFuse)?
+        .register(RootFuse)?
+        .finalize(pasta)?;
+
+    let reg = app.native_registry();
+    // Application circuits are the last three; the leaf is the first of them.
+    let (leaf_gates, leaf_constr) =
+        reg.constraint_counts(CircuitIndex::new(reg.num_circuits() - 3));
+
+    let mut rng = StdRng::seed_from_u64(1234);
+    for _ in 0..WARMUP {
+        build_tree::<N>(&app, &mut rng)?;
+    }
+
+    let mut t = Vec::new();
+    for _ in 0..SWEEP_ITERS {
+        let start = Instant::now();
+        build_tree::<N>(&app, &mut rng)?;
+        t.push(start.elapsed());
+    }
+
+    let (min, mean) = summarize(&t);
+    std::println!("{N:>10}{leaf_gates:>10}{leaf_constr:>10}{min:>11.1}{mean:>11.1}");
+    Ok(())
+}
+
+/// Sweep the per-leaf witness count from 1 up toward the wire cap and watch how
+/// total tree proving time responds. Each allocation costs ~half a gate
+/// (`gates ~= N/2 + 1`), so the ceiling is ~4092 allocations; 4096 already
+/// exceeds the 2048-gate bound, so the top point is 4000 (≈2001 gates).
+#[test]
+fn sweep_num_witnesses() -> Result<()> {
+    std::println!("\n[iters={SWEEP_ITERS}]");
+    std::println!(
+        "{:>10}{:>10}{:>10}{:>11}{:>11}",
+        "witnesses",
+        "gates",
+        "constr",
+        "min(ms)",
+        "avg(ms)"
+    );
+    sweep_point::<1>()?;
+    sweep_point::<{ 1 << 9 }>()?;
+    sweep_point::<{ 1 << 10 }>()?;
+    sweep_point::<{ 1 << 11 }>()?;
+    sweep_point::<{ (1 << 12) - 4 }>()?;
+    sweep_point::<{ 1 << 12 }>().expect_err("should bust");
+    Ok(())
+}

--- a/crates/ragu_pcd/tests/poseidon_capacity.rs
+++ b/crates/ragu_pcd/tests/poseidon_capacity.rs
@@ -1,0 +1,129 @@
+//! How many Poseidon permutations fit in one application step
+
+use ff::Field;
+use ragu_arithmetic::Cycle;
+use ragu_circuits::{polynomials::ProductionRank, registry::CircuitIndex};
+use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue},
+    gadgets::{Bound, Kind},
+    maybe::Maybe,
+};
+use ragu_pasta::{Fp, Pasta};
+use ragu_pcd::{
+    ApplicationBuilder,
+    header::{Header, Suffix},
+    step::{Encoded, Index, Step},
+};
+use ragu_primitives::{
+    Element,
+    allocator::{Allocator, Standard},
+    poseidon::Sponge,
+};
+
+const HEADER_SIZE: usize = 2;
+
+/// 1-element input header, sized to fit a single `Fp` plus the suffix slot.
+struct InputHeader;
+
+impl<F: Field> Header<F> for InputHeader {
+    const SUFFIX: Suffix = Suffix::new(0);
+    type Data = F;
+    type Output = Kind![F; Element<'_, _>];
+
+    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
+        dr: &mut D,
+        allocator: &mut A,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, allocator, witness)
+    }
+}
+
+/// Step performing exactly K Poseidon permutations chained linearly. Each
+/// iteration creates a fresh sponge so the total work is K independent
+/// permutations regardless of sponge rate.
+struct HashK<const K: usize>;
+
+impl<const K: usize> Step<Pasta> for HashK<K> {
+    const INDEX: Index = Index::new(0);
+    type Witness<'source> = ();
+    type Aux<'source> = ();
+    type Left = InputHeader;
+    type Right = ();
+    type Output = InputHeader;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        _: DriverValue<D, ()>,
+        left: DriverValue<D, Fp>,
+        _right: DriverValue<D, ()>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let left = Encoded::new(dr, allocator, left)?;
+        let right = Encoded::from_gadget(());
+
+        let l: &Element<'dr, D> = left.as_gadget();
+        let mut current: Element<'dr, D> = l.clone();
+        for _ in 0..K {
+            let mut sponge = Sponge::<'_, _, <Pasta as Cycle>::CircuitPoseidon>::new(
+                dr,
+                Pasta::circuit_poseidon(Pasta::baked()),
+            );
+            sponge.absorb(dr, &current)?;
+            current = sponge.squeeze(dr)?;
+        }
+
+        let output_data = current.value().map(|v| *v);
+        let output = Encoded::from_gadget(current);
+        Ok(((left, right, output), output_data, D::unit()))
+    }
+}
+
+fn measure<const K: usize>() -> Result<(usize, usize)> {
+    let pasta = Pasta::baked();
+    let app = ApplicationBuilder::<Pasta, ProductionRank, HEADER_SIZE>::new()
+        .register(HashK::<K>)?
+        .finalize(pasta)?;
+    let last = CircuitIndex::new(app.native_registry().num_circuits() - 1);
+    Ok(app.native_registry().constraint_counts(last))
+}
+
+fn report<const K: usize>() -> Result<()> {
+    match measure::<K>() {
+        Ok((g, c)) => {
+            std::println!("{K:>10}{g:>10}{c:>10}");
+            Ok(())
+        }
+        Err(e) => {
+            std::println!("{K:>10}  {e}");
+            Err(e)
+        }
+    }
+}
+
+#[test]
+fn k_sweep() {
+    std::println!("\n{:>10}{:>10}{:>10}", "K", "gates", "constr");
+
+    report::<1>().expect("should fit");
+    report::<2>().expect("should fit");
+    report::<3>().expect("should fit");
+    report::<4>().expect("should fit");
+    report::<5>().expect("should fit");
+    report::<6>().expect("should fit");
+    report::<7>().expect("should fit");
+    report::<8>().expect_err("should bust");
+}

--- a/crates/ragu_pcd/tests/poseidon_squeeze_capacity.rs
+++ b/crates/ragu_pcd/tests/poseidon_squeeze_capacity.rs
@@ -1,0 +1,141 @@
+//! How many squeezes from a single Poseidon sponge fit in one application step
+//!
+//! Companion to `poseidon_capacity.rs`. That test runs K *independent*
+//! permutations (a fresh sponge per iteration, absorb + squeeze), so its cost
+//! is linear in K. This test instead absorbs once and squeezes one sponge K
+//! times. Each permutation refills `RATE` rate elements that subsequent
+//! squeezes pop for free, so K squeezes trigger only `ceil(K / RATE)`
+//! permutations (`RATE = 4` for `PoseidonFp`). The gate count therefore climbs
+//! as a staircase -- one step every `RATE` squeezes -- instead of linearly.
+
+use ff::Field;
+use ragu_arithmetic::Cycle;
+use ragu_circuits::{polynomials::ProductionRank, registry::CircuitIndex};
+use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue},
+    gadgets::{Bound, Kind},
+    maybe::Maybe,
+};
+use ragu_pasta::{Fp, Pasta};
+use ragu_pcd::{
+    ApplicationBuilder,
+    header::{Header, Suffix},
+    step::{Encoded, Index, Step},
+};
+use ragu_primitives::{
+    Element,
+    allocator::{Allocator, Standard},
+    poseidon::Sponge,
+};
+
+const HEADER_SIZE: usize = 2;
+
+/// 1-element input header, sized to fit a single `Fp` plus the suffix slot.
+struct InputHeader;
+
+impl<F: Field> Header<F> for InputHeader {
+    const SUFFIX: Suffix = Suffix::new(0);
+    type Data = F;
+    type Output = Kind![F; Element<'_, _>];
+
+    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
+        dr: &mut D,
+        allocator: &mut A,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, allocator, witness)
+    }
+}
+
+/// Step that absorbs the input once into a single sponge and then squeezes it
+/// exactly K times, chaining each squeeze into the next so none is dropped.
+/// Because squeezes pop buffered rate elements between permutations, the total
+/// work is `ceil(K / RATE)` permutations regardless of K.
+struct SqueezeK<const K: usize>;
+
+impl<const K: usize> Step<Pasta> for SqueezeK<K> {
+    const INDEX: Index = Index::new(0);
+    type Witness<'source> = ();
+    type Aux<'source> = ();
+    type Left = InputHeader;
+    type Right = ();
+    type Output = InputHeader;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        _: DriverValue<D, ()>,
+        left: DriverValue<D, Fp>,
+        _right: DriverValue<D, ()>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let left = Encoded::new(dr, allocator, left)?;
+        let right = Encoded::from_gadget(());
+
+        let l: &Element<'dr, D> = left.as_gadget();
+        let mut sponge = Sponge::<'_, _, <Pasta as Cycle>::CircuitPoseidon>::new(
+            dr,
+            Pasta::circuit_poseidon(Pasta::baked()),
+        );
+        sponge.absorb(dr, l)?;
+        let mut current = sponge.squeeze(dr)?;
+        for _ in 1..K {
+            current = sponge.squeeze(dr)?;
+        }
+
+        let output_data = current.value().map(|v| *v);
+        let output = Encoded::from_gadget(current);
+        Ok(((left, right, output), output_data, D::unit()))
+    }
+}
+
+fn measure<const K: usize>() -> Result<(usize, usize)> {
+    let pasta = Pasta::baked();
+    let app = ApplicationBuilder::<Pasta, ProductionRank, HEADER_SIZE>::new()
+        .register(SqueezeK::<K>)?
+        .finalize(pasta)?;
+    let last = CircuitIndex::new(app.native_registry().num_circuits() - 1);
+    Ok(app.native_registry().constraint_counts(last))
+}
+
+fn report<const K: usize>() -> Result<()> {
+    match measure::<K>() {
+        Ok((g, c)) => {
+            std::println!("{K:>10}{g:>10}{c:>10}");
+            Ok(())
+        }
+        Err(e) => {
+            std::println!("{K:>10}  {e}");
+            Err(e)
+        }
+    }
+}
+
+#[test]
+fn k_sweep() {
+    std::println!("\n{:>10}{:>10}{:>10}", "K", "gates", "constr");
+
+    report::<1>().expect("should fit"); // 1 permutation
+    report::<4>().expect("should fit"); // 1 permutation
+    report::<5>().expect("should fit"); // 2 permutations
+    report::<8>().expect("should fit"); // 2 permutations
+    report::<9>().expect("should fit"); // 3 permutations
+    report::<12>().expect("should fit"); // 3 permutations
+    report::<16>().expect("should fit"); // 4 permutations
+    report::<20>().expect("should fit"); // 5 permutations
+    report::<24>().expect("should fit"); // 6 permutations
+    report::<28>().expect("should fit"); // 7 permutations
+    report::<29>().expect_err("should bust"); // 8 permutations
+}

--- a/crates/ragu_pcd/tests/uniform_step_cost.rs
+++ b/crates/ragu_pcd/tests/uniform_step_cost.rs
@@ -505,7 +505,14 @@ fn sweep_point<
     ];
 
     std::println!("\n[iters={iters}]");
-    std::println!("{:<10}{:>10}{:>10}{:>11}{:>11}", "step", "gates", "constr", "min(ms)", "avg(ms)");
+    std::println!(
+        "{:<10}{:>10}{:>10}{:>11}{:>11}",
+        "step",
+        "gates",
+        "constr",
+        "min(ms)",
+        "avg(ms)"
+    );
     for (name, (gates, constraints), (min, mean)) in rows {
         std::println!("{name:<10}{gates:>10}{constraints:>10}{min:>11.1}{mean:>11.1}");
     }

--- a/crates/ragu_pcd/tests/uniform_step_cost.rs
+++ b/crates/ragu_pcd/tests/uniform_step_cost.rs
@@ -1,0 +1,567 @@
+//! Does per-step proving cost depend on how much work a step does?
+//!
+//! Hypothesis under test: within a *single fixed application*, every step of a
+//! given kind costs about the same to prove, regardless of the number of gates
+//! it fills, because the dominant cost is the fixed recursion pipeline
+//! (preamble, error terms, query, dense `f` commitment) rather than the step's
+//! own trace.
+//!
+//! This test is a self-contained knob-turning harness: it defines its own
+//! headers and steps, and each step's workload is an independent compile-time
+//! const generic (the number of Poseidon permutations). Flip a knob and re-run
+//! to observe how gate count moves while proving time stays ~flat.
+//!
+//! The PCD tree:
+//!   * `LeafA<KA>`  — seed step, near-empty when `KA = 0`.
+//!   * `LeafB<KB>`  — seed step, near-full when `KB = 7` (the cap).
+//!   * `Fuse1<K1>`  — fuse `A` (left) with `B` (right).
+//!   * `Fuse2<K2>`  — `Fuse1` with left/right swapped: fuse `B` (left), `A` (right).
+//!   * `FuseF<KF>`  — final fuse of the two sibling outputs (two *internal* proofs).
+//!
+//! `Fuse1` vs `Fuse2` isolates whether left/right ordering matters; `FuseF`
+//! (fusing internal proofs) vs the sibling fuses (fusing leaves) isolates
+//! leaf-vs-internal input cost.
+
+use std::time::{Duration, Instant};
+
+use ff::Field;
+use ragu_arithmetic::Cycle;
+use ragu_circuits::{polynomials::ProductionRank, registry::CircuitIndex};
+use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue},
+    gadgets::{Bound, Kind},
+    maybe::Maybe,
+};
+use ragu_pasta::{Fp, Pasta};
+use ragu_pcd::{
+    ApplicationBuilder,
+    header::{Header, Suffix},
+    step::{Encoded, Index, Step},
+};
+use ragu_primitives::{
+    Element,
+    allocator::{Allocator, Standard},
+    poseidon::Sponge,
+};
+use rand::{SeedableRng, rngs::StdRng};
+
+const HEADER_SIZE: usize = 4;
+
+// Timing configuration.
+const WARMUP: usize = 1;
+/// Iterations per sweep point (kept small — a sweep rebuilds and proves at
+/// every point).
+const SWEEP_ITERS: usize = 3;
+/// Value at which the non-swept step knobs are held while one step is swept.
+const BASE: usize = 1;
+
+// --- Distinct headers, one per step output -------------------------------
+
+/// Output header of `LeafA`.
+struct HeaderA;
+/// Output header of `LeafB`.
+struct HeaderB;
+/// Output header of `Fuse1`.
+struct Header1;
+/// Output header of `Fuse2`.
+struct Header2;
+/// Output header of `FuseF`.
+struct HeaderF;
+
+impl<F: Field> Header<F> for HeaderA {
+    const SUFFIX: Suffix = Suffix::new(0);
+    type Data = F;
+    type Output = Kind![F; Element<'_, _>];
+
+    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
+        dr: &mut D,
+        allocator: &mut A,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, allocator, witness)
+    }
+}
+
+impl<F: Field> Header<F> for HeaderB {
+    const SUFFIX: Suffix = Suffix::new(1);
+    type Data = F;
+    type Output = Kind![F; Element<'_, _>];
+
+    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
+        dr: &mut D,
+        allocator: &mut A,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, allocator, witness)
+    }
+}
+
+impl<F: Field> Header<F> for Header1 {
+    const SUFFIX: Suffix = Suffix::new(2);
+    type Data = F;
+    type Output = Kind![F; Element<'_, _>];
+
+    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
+        dr: &mut D,
+        allocator: &mut A,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, allocator, witness)
+    }
+}
+
+impl<F: Field> Header<F> for Header2 {
+    const SUFFIX: Suffix = Suffix::new(3);
+    type Data = F;
+    type Output = Kind![F; Element<'_, _>];
+
+    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
+        dr: &mut D,
+        allocator: &mut A,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, allocator, witness)
+    }
+}
+
+impl<F: Field> Header<F> for HeaderF {
+    const SUFFIX: Suffix = Suffix::new(4);
+    type Data = F;
+    type Output = Kind![F; Element<'_, _>];
+
+    fn encode<'dr, D: Driver<'dr, F = F>, A: Allocator<'dr, D>>(
+        dr: &mut D,
+        allocator: &mut A,
+        witness: DriverValue<D, Self::Data>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, allocator, witness)
+    }
+}
+
+// --- Shared circuit helpers ----------------------------------------------
+
+/// Chains `k` independent Poseidon permutations starting from `input`, using a
+/// fresh sponge each iteration so total work is exactly `k` permutations.
+fn chain_poseidons<'dr, D: Driver<'dr, F = Fp>>(
+    dr: &mut D,
+    mut current: Element<'dr, D>,
+    k: usize,
+) -> Result<Element<'dr, D>> {
+    for _ in 0..k {
+        let mut sponge = Sponge::<'_, _, <Pasta as Cycle>::CircuitPoseidon>::new(
+            dr,
+            Pasta::circuit_poseidon(Pasta::baked()),
+        );
+        sponge.absorb(dr, &current)?;
+        current = sponge.squeeze(dr)?;
+    }
+    Ok(current)
+}
+
+/// Combines two input elements with `k` total Poseidon permutations. The first
+/// permutation absorbs both inputs; the remaining `k - 1` chain from the result.
+/// `k = 0` does no hashing and returns the left input (both are still allocated
+/// by the caller).
+fn fuse_elements<'dr, D: Driver<'dr, F = Fp>>(
+    dr: &mut D,
+    left: &Element<'dr, D>,
+    right: &Element<'dr, D>,
+    k: usize,
+) -> Result<Element<'dr, D>> {
+    if k == 0 {
+        return Ok(left.clone());
+    }
+    let mut sponge = Sponge::<'_, _, <Pasta as Cycle>::CircuitPoseidon>::new(
+        dr,
+        Pasta::circuit_poseidon(Pasta::baked()),
+    );
+    sponge.absorb(dr, left)?;
+    sponge.absorb(dr, right)?;
+    let combined = sponge.squeeze(dr)?;
+    chain_poseidons(dr, combined, k - 1)
+}
+
+// --- Step 1: LeafA -------------------------------------------------------
+
+struct LeafA<const K: usize>;
+
+impl<const K: usize> Step<Pasta> for LeafA<K> {
+    const INDEX: Index = Index::new(0);
+    type Witness<'source> = Fp;
+    type Aux<'source> = ();
+    type Left = ();
+    type Right = ();
+    type Output = HeaderA;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Fp>,
+        _left: DriverValue<D, ()>,
+        _right: DriverValue<D, ()>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let leaf = Element::alloc(dr, allocator, witness)?;
+        let out = chain_poseidons(dr, leaf, K)?;
+        let output_data = out.value().map(|v| *v);
+        let output = Encoded::from_gadget(out);
+        Ok((
+            (Encoded::from_gadget(()), Encoded::from_gadget(()), output),
+            output_data,
+            D::unit(),
+        ))
+    }
+}
+
+// --- Step 2: LeafB -------------------------------------------------------
+
+struct LeafB<const K: usize>;
+
+impl<const K: usize> Step<Pasta> for LeafB<K> {
+    const INDEX: Index = Index::new(1);
+    type Witness<'source> = Fp;
+    type Aux<'source> = ();
+    type Left = ();
+    type Right = ();
+    type Output = HeaderB;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Fp>,
+        _left: DriverValue<D, ()>,
+        _right: DriverValue<D, ()>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let leaf = Element::alloc(dr, allocator, witness)?;
+        let out = chain_poseidons(dr, leaf, K)?;
+        let output_data = out.value().map(|v| *v);
+        let output = Encoded::from_gadget(out);
+        Ok((
+            (Encoded::from_gadget(()), Encoded::from_gadget(()), output),
+            output_data,
+            D::unit(),
+        ))
+    }
+}
+
+// --- Step 3: Fuse1 (A left, B right) -------------------------------------
+
+struct Fuse1<const K: usize>;
+
+impl<const K: usize> Step<Pasta> for Fuse1<K> {
+    const INDEX: Index = Index::new(2);
+    type Witness<'source> = ();
+    type Aux<'source> = ();
+    type Left = HeaderA;
+    type Right = HeaderB;
+    type Output = Header1;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        _: DriverValue<D, ()>,
+        left: DriverValue<D, Fp>,
+        right: DriverValue<D, Fp>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let left = Encoded::new(dr, allocator, left)?;
+        let right = Encoded::new(dr, allocator, right)?;
+        let out = fuse_elements(dr, left.as_gadget(), right.as_gadget(), K)?;
+        let output_data = out.value().map(|v| *v);
+        let output = Encoded::from_gadget(out);
+        Ok(((left, right, output), output_data, D::unit()))
+    }
+}
+
+// --- Step 4: Fuse2 (Fuse1 with left/right swapped: B left, A right) ------
+
+struct Fuse2<const K: usize>;
+
+impl<const K: usize> Step<Pasta> for Fuse2<K> {
+    const INDEX: Index = Index::new(3);
+    type Witness<'source> = ();
+    type Aux<'source> = ();
+    type Left = HeaderB;
+    type Right = HeaderA;
+    type Output = Header2;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        _: DriverValue<D, ()>,
+        left: DriverValue<D, Fp>,
+        right: DriverValue<D, Fp>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let left = Encoded::new(dr, allocator, left)?;
+        let right = Encoded::new(dr, allocator, right)?;
+        let out = fuse_elements(dr, left.as_gadget(), right.as_gadget(), K)?;
+        let output_data = out.value().map(|v| *v);
+        let output = Encoded::from_gadget(out);
+        Ok(((left, right, output), output_data, D::unit()))
+    }
+}
+
+// --- Step 5: FuseF (final fuse of the two sibling outputs) ---------------
+
+struct FuseF<const K: usize>;
+
+impl<const K: usize> Step<Pasta> for FuseF<K> {
+    const INDEX: Index = Index::new(4);
+    type Witness<'source> = ();
+    type Aux<'source> = ();
+    type Left = Header1;
+    type Right = Header2;
+    type Output = HeaderF;
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
+        &self,
+        dr: &mut D,
+        _: DriverValue<D, ()>,
+        left: DriverValue<D, Fp>,
+        right: DriverValue<D, Fp>,
+    ) -> Result<(
+        (
+            Encoded<'dr, D, Self::Left, HS>,
+            Encoded<'dr, D, Self::Right, HS>,
+            Encoded<'dr, D, Self::Output, HS>,
+        ),
+        DriverValue<D, <Self::Output as Header<Fp>>::Data>,
+        DriverValue<D, Self::Aux<'source>>,
+    )>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let left = Encoded::new(dr, allocator, left)?;
+        let right = Encoded::new(dr, allocator, right)?;
+        let out = fuse_elements(dr, left.as_gadget(), right.as_gadget(), K)?;
+        let output_data = out.value().map(|v| *v);
+        let output = Encoded::from_gadget(out);
+        Ok(((left, right, output), output_data, D::unit()))
+    }
+}
+
+// --- Reporting -----------------------------------------------------------
+
+fn summarize(times: &[Duration]) -> (f64, f64) {
+    let min = times.iter().min().unwrap().as_secs_f64() * 1e3;
+    let mean = times.iter().map(|d| d.as_secs_f64()).sum::<f64>() / times.len() as f64 * 1e3;
+    (min, mean)
+}
+
+/// Build the fixed-shape 5-step application with every step parameterized by the
+/// given knobs, prove each step `iters` times (after `WARMUP` warmups), and
+/// print a detailed per-step block: gate/constraint counts and min/mean proving
+/// time for `LeafA`, `LeafB`, `Fuse1`, `Fuse2`, and `FuseF`.
+///
+/// The circuit *count* is fixed at five regardless of the knobs, so the registry
+/// domain (`num_circuits`, `log2_circuits`) is identical across configurations —
+/// only the parameterized steps' trace density changes, isolating the gate-count
+/// effect from the fixed recursion pipeline. The printed block echoes all five
+/// knobs so the output fully reflects the parameterization.
+fn sweep_point<
+    const LEAF_A: usize,
+    const LEAF_B: usize,
+    const FUSE_1: usize,
+    const FUSE_2: usize,
+    const FUSE_F: usize,
+>(
+    iters: usize,
+) -> Result<()> {
+    let pasta = Pasta::baked();
+    let app = ApplicationBuilder::<Pasta, ProductionRank, HEADER_SIZE>::new()
+        .register(LeafA::<LEAF_A>)?
+        .register(LeafB::<LEAF_B>)?
+        .register(Fuse1::<FUSE_1>)?
+        .register(Fuse2::<FUSE_2>)?
+        .register(FuseF::<FUSE_F>)?
+        .finalize(pasta)?;
+
+    // Application circuits are registered last (after internal circuits, masks,
+    // and internal steps), so the five step circuits are the final five indices
+    // in registration order: LeafA, LeafB, Fuse1, Fuse2, FuseF.
+    let reg = app.native_registry();
+    let base = reg.num_circuits() - 5;
+    let gate_counts: Vec<(usize, usize)> = (0..5)
+        .map(|i| reg.constraint_counts(CircuitIndex::new(base + i)))
+        .collect();
+
+    let mut rng = StdRng::seed_from_u64(1234);
+
+    // Warmup: also triggers any lazy one-time initialization for this fresh app.
+    for _ in 0..WARMUP {
+        let (a, _) = app.seed(&mut rng, LeafA::<LEAF_A>, Fp::from(1u64))?;
+        let (b, _) = app.seed(&mut rng, LeafB::<LEAF_B>, Fp::from(1u64))?;
+        let (n1, _) = app.fuse(&mut rng, Fuse1::<FUSE_1>, (), a.clone(), b.clone())?;
+        let (n2, _) = app.fuse(&mut rng, Fuse2::<FUSE_2>, (), b, a)?;
+        let _ = app.fuse(&mut rng, FuseF::<FUSE_F>, (), n1, n2)?;
+    }
+
+    let mut leaf_a_t = Vec::new();
+    let mut leaf_b_t = Vec::new();
+    let mut fuse1_t = Vec::new();
+    let mut fuse2_t = Vec::new();
+    let mut fusef_t = Vec::new();
+
+    for i in 0..iters {
+        let seed = Fp::from(i as u64 + 7);
+
+        let t = Instant::now();
+        let (a, _) = app.seed(&mut rng, LeafA::<LEAF_A>, seed)?;
+        leaf_a_t.push(t.elapsed());
+
+        let t = Instant::now();
+        let (b, _) = app.seed(&mut rng, LeafB::<LEAF_B>, seed)?;
+        leaf_b_t.push(t.elapsed());
+
+        let t = Instant::now();
+        let (n1, _) = app.fuse(&mut rng, Fuse1::<FUSE_1>, (), a.clone(), b.clone())?;
+        fuse1_t.push(t.elapsed());
+
+        let t = Instant::now();
+        let (n2, _) = app.fuse(&mut rng, Fuse2::<FUSE_2>, (), b, a)?;
+        fuse2_t.push(t.elapsed());
+
+        let t = Instant::now();
+        let (_f, _) = app.fuse(&mut rng, FuseF::<FUSE_F>, (), n1, n2)?;
+        fusef_t.push(t.elapsed());
+    }
+
+    // The step column carries each step's parameter (e.g. `LeafB<7>`), so the
+    // whole configuration is visible by reading down the block.
+    let rows = [
+        (
+            std::format!("LeafA={LEAF_A}"),
+            &gate_counts[0],
+            summarize(&leaf_a_t),
+        ),
+        (
+            std::format!("LeafB={LEAF_B}"),
+            &gate_counts[1],
+            summarize(&leaf_b_t),
+        ),
+        (
+            std::format!("Fuse1={FUSE_1}"),
+            &gate_counts[2],
+            summarize(&fuse1_t),
+        ),
+        (
+            std::format!("Fuse2={FUSE_2}"),
+            &gate_counts[3],
+            summarize(&fuse2_t),
+        ),
+        (
+            std::format!("FuseF={FUSE_F}"),
+            &gate_counts[4],
+            summarize(&fusef_t),
+        ),
+    ];
+
+    std::println!("\n[iters={iters}]");
+    std::println!("{:<10}{:>10}{:>10}{:>11}{:>11}", "step", "gates", "constr", "min(ms)", "avg(ms)");
+    for (name, (gates, constraints), (min, mean)) in rows {
+        std::println!("{name:<10}{gates:>10}{constraints:>10}{min:>11.1}{mean:>11.1}");
+    }
+    Ok(())
+}
+
+// One test per step: sweep that step's parameter from empty to the gate cap
+// while holding the others at `BASE`. In each block the swept step's row shows
+// its gate count climbing while every step's proving time stays roughly flat.
+
+#[test]
+fn sweep_leaf_a() -> Result<()> {
+    sweep_point::<0, BASE, BASE, BASE, BASE>(SWEEP_ITERS)?;
+    sweep_point::<1, BASE, BASE, BASE, BASE>(SWEEP_ITERS)?;
+    sweep_point::<3, BASE, BASE, BASE, BASE>(SWEEP_ITERS)?;
+    sweep_point::<5, BASE, BASE, BASE, BASE>(SWEEP_ITERS)?;
+    sweep_point::<7, BASE, BASE, BASE, BASE>(SWEEP_ITERS)?;
+    Ok(())
+}
+
+#[test]
+fn sweep_leaf_b() -> Result<()> {
+    sweep_point::<BASE, 0, BASE, BASE, BASE>(SWEEP_ITERS)?;
+    sweep_point::<BASE, 1, BASE, BASE, BASE>(SWEEP_ITERS)?;
+    sweep_point::<BASE, 3, BASE, BASE, BASE>(SWEEP_ITERS)?;
+    sweep_point::<BASE, 5, BASE, BASE, BASE>(SWEEP_ITERS)?;
+    sweep_point::<BASE, 7, BASE, BASE, BASE>(SWEEP_ITERS)?;
+    Ok(())
+}
+
+#[test]
+fn sweep_fuse1() -> Result<()> {
+    sweep_point::<BASE, BASE, 0, BASE, BASE>(SWEEP_ITERS)?;
+    sweep_point::<BASE, BASE, 1, BASE, BASE>(SWEEP_ITERS)?;
+    sweep_point::<BASE, BASE, 3, BASE, BASE>(SWEEP_ITERS)?;
+    sweep_point::<BASE, BASE, 5, BASE, BASE>(SWEEP_ITERS)?;
+    sweep_point::<BASE, BASE, 7, BASE, BASE>(SWEEP_ITERS)?;
+    Ok(())
+}
+
+#[test]
+fn sweep_fuse2() -> Result<()> {
+    sweep_point::<BASE, BASE, BASE, 0, BASE>(SWEEP_ITERS)?;
+    sweep_point::<BASE, BASE, BASE, 1, BASE>(SWEEP_ITERS)?;
+    sweep_point::<BASE, BASE, BASE, 3, BASE>(SWEEP_ITERS)?;
+    sweep_point::<BASE, BASE, BASE, 5, BASE>(SWEEP_ITERS)?;
+    sweep_point::<BASE, BASE, BASE, 7, BASE>(SWEEP_ITERS)?;
+    Ok(())
+}
+
+#[test]
+fn sweep_fusef() -> Result<()> {
+    sweep_point::<BASE, BASE, BASE, BASE, 0>(SWEEP_ITERS)?;
+    sweep_point::<BASE, BASE, BASE, BASE, 1>(SWEEP_ITERS)?;
+    sweep_point::<BASE, BASE, BASE, BASE, 3>(SWEEP_ITERS)?;
+    sweep_point::<BASE, BASE, BASE, BASE, 5>(SWEEP_ITERS)?;
+    sweep_point::<BASE, BASE, BASE, BASE, 7>(SWEEP_ITERS)?;
+    Ok(())
+}


### PR DESCRIPTION

Test harnesses that empirically map a Ragu PCD step's **budget** (how much fits) and **proving cost** (what moves the clock) under `ProductionRank` (`R<13>`, 2048-gate cap). Each file is one experiment with one knob; they print tables rather than assert, so run with `--nocapture`. Cargo runs the test binaries serially, so one command is fine; `--test-threads=1` serializes execution. Timing numbers are release + `multicore` on my machine.

Run all of them:

```sh
cargo test --features multicore -p ragu_pcd --release \
  --test distinct_headers \
  --test distinct_steps \
  --test endoscalar_capacity \
  --test num_steps \
  --test num_witnesses \
  --test poseidon_capacity \
  --test poseidon_squeeze_capacity \
  --test uniform_step_cost \
  -- --nocapture --test-threads=1
```

## Capacity — how much fits in one step

### Poseidon permutations

One step performs K chained Poseidon permutations; K rises until it busts the gate cap.

```sh
cargo test --features multicore -p ragu_pcd --release --test poseidon_capacity -- --nocapture --test-threads=1
```

|  K | gates |
| -: | ----: |
|  1 |   290 |
|  2 |   578 |
|  3 |   866 |
|  4 |  1154 |
|  5 |  1442 |
|  6 |  1730 |
|  7 |  2018 |
|  8 |  bust |

Constant **+288 gates per permutation** → the 2048-gate budget holds ~7 Poseidons.

### Endoscalar ops

Same, with K chained endoscalar operations.

```sh
cargo test --features multicore -p ragu_pcd --release --test endoscalar_capacity -- --nocapture --test-threads=1
```

|  K | gates |
| -: | ----: |
|  1 |   588 |
|  2 |  1043 |
|  3 |  1498 |
|  4 |  1953 |
|  5 |  bust |

Constant **+455 gates per op** → ~4 endoscalars per step. Budget a step in these units; if you're over, split the work across steps (the cost section shows why splitting is nearly free).

### Repeated squeezes

One step squeezes K field elements from a single sponge; reports gates as K grows.

```sh
cargo test --features multicore -p ragu_pcd --release --test poseidon_squeeze_capacity -- --nocapture --test-threads=1
```

|  K | gates |
| -: | ----: |
|  1 |   290 |
|  4 |   290 |
|  5 |   578 |
|  8 |   578 |
|  9 |   866 |
| 16 |  1154 |
| 28 |  2018 |
| 29 |  bust |

Squeezing is near-free within a permutation's rate: gates hold flat across 4 squeezes and only step up when a fresh permutation is forced. Pulling many outputs from one sponge costs far less than the same number of permutations.

## Cost — what actually moves per-proof time

The recurring result: within a fixed application, per-proof cost is dominated by the fixed recursion pipeline, and almost nothing done *inside* a step changes it.

### Per-step gate work

A fixed 5-step application (two leaf seeds, two sibling fuses, a final fuse); one step's Poseidon count is swept while the others stay minimal, timing every step. Below: a swept fuse and a swept leaf (seed), each vs its own gate count.

```sh
cargo test --features multicore -p ragu_pcd --release --test uniform_step_cost -- --nocapture --test-threads=1
```

| gates | fuse avg(ms) | seed avg(ms) |
| ----: | -----------: | -----------: |
|     2 |        197.8 |        352.1 |
|   290 |        199.8 |        361.3 |
|   866 |        203.8 |        353.6 |
|  1442 |        204.1 |        355.7 |
|  2018 |        210.8 |        359.9 |

Filling a step from 2 → 2018 gates (a 1000× swing) moves its time ~7% (fuse) / ~2% (seed). Gate count is a *capacity* constraint, not a *speed* one — no runtime reason to shave gates until near the cap. A `seed` costs ~1.75× a `fuse` (the base-case path); the full output also shows operand order and leaf-vs-internal inputs make no difference.

### Witness (wire) count

A depth-2 tree (4 leaves → 2 fuses → 1 root) where each leaf allocates N witness wires and does no hashing; times the whole tree as N grows.

```sh
cargo test --features multicore -p ragu_pcd --release --test num_witnesses -- --nocapture --test-threads=1
```

| witnesses | gates | avg(ms) |
| --------: | ----: | ------: |
|         1 |     2 |  1986.9 |
|       512 |   257 |  1981.9 |
|      1024 |   513 |  2007.1 |
|      2048 |  1025 |  2025.5 |
|      4092 |  2047 |  2047.3 |

Allocating many witness wires is ~free per proof — holding large amounts of witness data in a step is cheap. (Incidental limits: the wire ceiling is ~4092 allocations, since `gates ≈ N/2 + 1` against a strict `< 2048` bound, and pure allocations add no constraints — `constr` stays 13.)

### Tree node count

Balanced binary trees of increasing depth, built from a fixed 3-step reuse set; times the whole tree against node count.

```sh
cargo test --features multicore -p ragu_pcd --release --test num_steps -- --nocapture --test-threads=1
```

| depth | nodes | avg(ms) | per-node |
| ----: | ----: | ------: | -------: |
|     1 |     3 |   887.2 |    295.7 |
|     2 |     7 |  1969.8 |    281.4 |
|     3 |    15 |  4139.4 |    276.0 |
|     4 |    31 |  8541.6 |    275.5 |

The one knob that scales cost: total proving time is **linear** in the number of executed nodes, at a ~constant ~276 ms/node. Cost tracks the size of the computation (how many folds you run), exactly as constant-size PCD proofs predict.

### Distinct step types vs distinct headers

A left-leaning chain folds a fresh seed into the accumulator at each of N levels, so every registered step is actually executed. `distinct_steps` uses N distinct step types that share one header; `distinct_headers` threads a distinct header through each level. Node count is `2N+1`, so the per-node column isolates the marginal cost of distinctness.

```sh
cargo test --features multicore -p ragu_pcd --release --test distinct_steps -- --nocapture --test-threads=1
```

| steps | nodes | circuits | log2 | avg(ms) | per-node |
| ----: | ----: | -------: | ---: | ------: | -------: |
|     1 |     3 |       18 |    5 |   887.6 |    295.9 |
|     4 |     9 |       21 |    5 |  2542.1 |    282.5 |
|     8 |    17 |       25 |    5 |  4786.3 |    281.5 |
|    16 |    33 |       33 |    6 |  9323.6 |    282.5 |

```sh
cargo test --features multicore -p ragu_pcd --release --test distinct_headers -- --nocapture --test-threads=1
```

| levels | nodes | circuits | log2 | avg(ms) | per-node |
| -----: | ----: | -------: | ---: | ------: | -------: |
|      1 |     3 |       17 |    5 |   976.9 |    325.6 |
|      4 |     9 |       20 |    5 |  2794.8 |    310.5 |
|      8 |    17 |       24 |    5 |  4835.6 |    284.4 |
|     16 |    33 |       32 |    5 |  9294.4 |    281.6 |

Both converge to ~282 ms/node — the same as the reused-type tree above (`num_steps`, ~276). Executing distinct step types, or threading a distinct header per level, costs nothing per node beyond a plain node (the elevated per-node at N=1 is just the seed-heavy small chain). Application breadth — many distinct registered step types and headers, and crossing the `log2_circuits` boundary — does not tax proving; only the executed node count does.

## Net

Proving cost scales only with the number of **executed** steps (tree size), linearly. Everything structural inside or around a step — gate work, witness count, step-type count, header count — is essentially free per proof, swamped by the fixed recursion pipeline. Design for the gate *capacity* cap, and split work across more steps freely; it costs nothing per proof beyond the extra nodes themselves.
