### PR TITLE
Bump zkcrypto patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,9 @@ version = 4
 
 [[package]]
 name = "addchain"
-version = "0.2.0"
-source = "git+https://github.com/ebfull/addchain?rev=da4099a81bc29c895f3ca0ebcaae21c860494c12#da4099a81bc29c895f3ca0ebcaae21c860494c12"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5665045de74fda906c0abfaec40cf2551f88c34dccea869f3fe950dde7209764"
 dependencies = [
  "num-bigint",
  "num-integer",
@@ -382,7 +383,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 [[package]]
 name = "ff"
 version = "0.14.0-pre.0"
-source = "git+https://github.com/ebfull/ff?branch=release-0.14.0-with-rand-0.10#f4ca7c23e6ea693b13aba0c690ad7c43852c561c"
+source = "git+https://github.com/zkcrypto/ff?rev=bdd74a3f75c4c378d69e954944a61bb0930532a0#bdd74a3f75c4c378d69e954944a61bb0930532a0"
 dependencies = [
  "bitvec",
  "ff_derive",
@@ -393,7 +394,7 @@ dependencies = [
 [[package]]
 name = "ff_derive"
 version = "0.14.0-pre.0"
-source = "git+https://github.com/ebfull/ff?branch=release-0.14.0-with-rand-0.10#f4ca7c23e6ea693b13aba0c690ad7c43852c561c"
+source = "git+https://github.com/zkcrypto/ff?rev=bdd74a3f75c4c378d69e954944a61bb0930532a0#bdd74a3f75c4c378d69e954944a61bb0930532a0"
 dependencies = [
  "addchain",
  "num-bigint",
@@ -451,7 +452,7 @@ dependencies = [
 [[package]]
 name = "group"
 version = "0.14.0-pre.0"
-source = "git+https://github.com/ebfull/group?branch=release-0.14.0-with-rand-0.10#5f5c693275598d7885827e153c21ff99c60e18f3"
+source = "git+https://github.com/ebfull/group?rev=3a5c728f27700cf8767e926e2566d6c5cf1879ef#3a5c728f27700cf8767e926e2566d6c5cf1879ef"
 dependencies = [
  "ff",
  "rand_core 0.10.0",
@@ -694,7 +695,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 [[package]]
 name = "pasta_curves"
 version = "0.5.1"
-source = "git+https://github.com/ebfull/pasta_curves?branch=ff-0.14-with-rand-0.10-and-deferred#66b3b687dedcdbed18ff2bf71bd1fc31aeefaa11"
+source = "git+https://github.com/ebfull/pasta_curves?rev=10fbf911b176854d8eafb58da1184f56f1b10944#10fbf911b176854d8eafb58da1184f56f1b10944"
 dependencies = [
  "blake2b_simd",
  "ff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,30 +84,28 @@ criterion = { version = "0.5", default-features = false }
 # the change in that file or fuzz builds will resolve different versions
 # than the rest of the workspace.
 [patch.crates-io]
-# `ebfull/addchain` branch `bump-num-bigint` is a replica of
-# https://github.com/str4d/addchain/pull/3
-# that updates `addchain` to use `num_bigint 0.4`
-addchain = { git = "https://github.com/ebfull/addchain", rev = "da4099a81bc29c895f3ca0ebcaae21c860494c12" }
+# `zkcrypto/ff` branch `release-0.14.0` HEAD as of 2026-05-21.
+# Speculative release branch for ff 0.14.0; merges PR #150 (bump
+# `num-bigint`/`syn` and `addchain` to `0.3`), PR #151 (rename
+# `try_from_rng` → `try_random`), and PR #149 (`rand_core 0.10`,
+# MSRV 1.85). Pinned by rev since the branch is still moving.
+ff = { git = "https://github.com/zkcrypto/ff", rev = "bdd74a3f75c4c378d69e954944a61bb0930532a0" }
 
-# `ebfull/ff` branch `release-0.14.0-with-rand-0.10` is a fork of
-# https://github.com/zkcrypto/ff/pull/130
-# which updates `ff` to bump `num-bigint` and `syn`
-# then merges https://github.com/zkcrypto/ff/pull/149
-# dependencies to align with our local usage in `ragu_macros`
-ff = { git = "https://github.com/ebfull/ff", branch = "release-0.14.0-with-rand-0.10" }
+# `ebfull/group` branch `release-0.14.0-with-rand-0.10-modulo-curveaffine`
+# HEAD as of 2026-05-21. Forked from upstream `zkcrypto/group`
+# `release-0.14.0` before the `CurveAffine` trait refactor (PR #48),
+# so `pasta_curves` still compiles against the old
+# `PrimeCurveAffine`/`CofactorCurveAffine` shape. Bumps `rand_core`
+# to `0.10` and renames `Group::try_from_rng` → `Group::try_random`
+# to match upstream ff PR #151.
+group = { git = "https://github.com/ebfull/group", rev = "3a5c728f27700cf8767e926e2566d6c5cf1879ef" }
 
-# `ebfull/group` branch `release-0.14.0-with-rand-0.10` is a fork of
-# https://github.com/zkcrypto/group/pull/63
-# which updates `group` to bump `ff` to `0.14` (as well as other
-# changes, including bumping to `rand 0.9`)
-# then merges https://github.com/zkcrypto/group/pull/71
-group = { git = "https://github.com/ebfull/group", branch = "release-0.14.0-with-rand-0.10" }
-
-# `ebfull/pasta_curves` branch `ff-0.14-with-rand-0.10` is a replica of
-# https://github.com/zcash/pasta_curves/pull/86
-# that updates `pasta_curves` to use `ff`/`group` `0.14.0-pre.0`
-# then bumps to `rand 0.9`.
-#
-# We then merge in deferred reduction support from `zcash/pasta_curves`
-# into `ff-0.14-with-rand-0.10-and-deferred`.
-pasta_curves = { git = "https://github.com/ebfull/pasta_curves", branch = "ff-0.14-with-rand-0.10-and-deferred" }
+# `ebfull/pasta_curves` branch `ff-0.14-with-rand-0.10-and-deferred-redux`
+# HEAD as of 2026-05-21. On top of upstream `zcash/pasta_curves`
+# branch `ff-0.14` (which migrates to `ff`/`group` `0.14.0-pre.0`),
+# adds a `rand 0.10` bump, deferred-reduction support (`DeferredField`
+# trait + lazy Montgomery reduction via `Product` accumulator, PR #87
+# from `alxiong/lazy-mont-red`), and renames `try_from_rng` →
+# `try_random` to match upstream ff PR #151 and the corresponding
+# rename on the `ebfull/group` fork.
+pasta_curves = { git = "https://github.com/ebfull/pasta_curves", rev = "10fbf911b176854d8eafb58da1184f56f1b10944" }

--- a/qa/fuzz/Cargo.toml
+++ b/qa/fuzz/Cargo.toml
@@ -42,10 +42,9 @@ rand = "0.10"
 # nested workspaces, so the same overrides must be repeated here to keep
 # fuzz builds resolving the same forks the rest of the workspace uses.
 [patch.crates-io]
-addchain = { git = "https://github.com/ebfull/addchain", rev = "da4099a81bc29c895f3ca0ebcaae21c860494c12" }
-ff = { git = "https://github.com/ebfull/ff", branch = "release-0.14.0-with-rand-0.10" }
-group = { git = "https://github.com/ebfull/group", branch = "release-0.14.0-with-rand-0.10" }
-pasta_curves = { git = "https://github.com/ebfull/pasta_curves", branch = "ff-0.14-with-rand-0.10-and-deferred" }
+ff = { git = "https://github.com/zkcrypto/ff", rev = "bdd74a3f75c4c378d69e954944a61bb0930532a0" }
+group = { git = "https://github.com/ebfull/group", rev = "3a5c728f27700cf8767e926e2566d6c5cf1879ef" }
+pasta_curves = { git = "https://github.com/ebfull/pasta_curves", rev = "10fbf911b176854d8eafb58da1184f56f1b10944" }
 
 # Poseidon sponge: absorb/squeeze mode transitions + save/resume consistency
 [[bin]]

--- a/qa/supply-chain/config.toml
+++ b/qa/supply-chain/config.toml
@@ -29,9 +29,6 @@ url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/
 ours = "crypto-reviewed"
 theirs = "crypto-reviewed"
 
-[policy.addchain]
-audit-as-crates-io = true
-
 [policy.ff]
 audit-as-crates-io = true
 
@@ -49,10 +46,6 @@ audit-as-crates-io = true
 
 [policy.ragu_testing]
 audit-as-crates-io = true
-
-[[exemptions.addchain]]
-version = "0.2.0@git:da4099a81bc29c895f3ca0ebcaae21c860494c12"
-criteria = "safe-to-deploy"
 
 [[exemptions.bincode]]
 version = "1.3.3"


### PR DESCRIPTION
* This uses the upstream `ff`'s own `0.14.0` release branch now that `addchain` was released and that branch has been updated.
* Removes the `addchain` patch; don't need it now.
* `group`'s own `0.14.0` release branch is also aligned with these changes now, except that there are some additional trait changes in that branch that are left out here.
* `pasta_curves` is just simply bumped to use (and account for) the `group` update.
