### PR TITLE
align `group` with upstream 0.14.0 prerelease branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "group"
 version = "0.14.0-pre.0"
-source = "git+https://github.com/ebfull/group?rev=3a5c728f27700cf8767e926e2566d6c5cf1879ef#3a5c728f27700cf8767e926e2566d6c5cf1879ef"
+source = "git+https://github.com/zkcrypto/group?rev=326b36b0c43dcb1507b89017323f43a57c3bffd8#326b36b0c43dcb1507b89017323f43a57c3bffd8"
 dependencies = [
  "ff",
  "rand_core 0.10.0",
@@ -695,7 +695,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 [[package]]
 name = "pasta_curves"
 version = "0.5.1"
-source = "git+https://github.com/ebfull/pasta_curves?rev=10fbf911b176854d8eafb58da1184f56f1b10944#10fbf911b176854d8eafb58da1184f56f1b10944"
+source = "git+https://github.com/ebfull/pasta_curves?rev=4f9da85aeebc650a57610501d50d036454dcdc48#4f9da85aeebc650a57610501d50d036454dcdc48"
 dependencies = [
  "blake2b_simd",
  "ff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,27 +85,16 @@ criterion = { version = "0.5", default-features = false }
 # than the rest of the workspace.
 [patch.crates-io]
 # `zkcrypto/ff` branch `release-0.14.0` HEAD as of 2026-05-21.
-# Speculative release branch for ff 0.14.0; merges PR #150 (bump
-# `num-bigint`/`syn` and `addchain` to `0.3`), PR #151 (rename
-# `try_from_rng` → `try_random`), and PR #149 (`rand_core 0.10`,
-# MSRV 1.85). Pinned by rev since the branch is still moving.
+# Speculative release branch for ff 0.14.0
 ff = { git = "https://github.com/zkcrypto/ff", rev = "bdd74a3f75c4c378d69e954944a61bb0930532a0" }
 
-# `ebfull/group` branch `release-0.14.0-with-rand-0.10-modulo-curveaffine`
-# HEAD as of 2026-05-21. Forked from upstream `zkcrypto/group`
-# `release-0.14.0` before the `CurveAffine` trait refactor (PR #48),
-# so `pasta_curves` still compiles against the old
-# `PrimeCurveAffine`/`CofactorCurveAffine` shape. Bumps `rand_core`
-# to `0.10` and renames `Group::try_from_rng` → `Group::try_random`
-# to match upstream ff PR #151.
-group = { git = "https://github.com/ebfull/group", rev = "3a5c728f27700cf8767e926e2566d6c5cf1879ef" }
+# `zkcrypto/group` branch `release-0.14.0` HEAD as of 2026-05-21.
+# Speculative release branch for group 0.14.0
+group = { git = "https://github.com/zkcrypto/group", rev = "326b36b0c43dcb1507b89017323f43a57c3bffd8" }
 
-# `ebfull/pasta_curves` branch `ff-0.14-with-rand-0.10-and-deferred-redux`
-# HEAD as of 2026-05-21. On top of upstream `zcash/pasta_curves`
-# branch `ff-0.14` (which migrates to `ff`/`group` `0.14.0-pre.0`),
-# adds a `rand 0.10` bump, deferred-reduction support (`DeferredField`
-# trait + lazy Montgomery reduction via `Product` accumulator, PR #87
-# from `alxiong/lazy-mont-red`), and renames `try_from_rng` →
-# `try_random` to match upstream ff PR #151 and the corresponding
-# rename on the `ebfull/group` fork.
-pasta_curves = { git = "https://github.com/ebfull/pasta_curves", rev = "10fbf911b176854d8eafb58da1184f56f1b10944" }
+# `ebfull/pasta_curves` branch `ff-0.14-for-ragu` HEAD as of 2026-05-21.
+# Stacks on the prior `ff-0.14-with-rand-0.10-and-deferred-redux` work
+# (ff/group 0.14.0-pre.0, rand 0.10, deferred reduction, try_random rename)
+# and adds adaptation for the new `CurveAffine` API from upstream `group`
+# release-0.14.0 (PR #48).
+pasta_curves = { git = "https://github.com/ebfull/pasta_curves", rev = "4f9da85aeebc650a57610501d50d036454dcdc48" }

--- a/crates/ragu_arithmetic/benches/criterion/msm.rs
+++ b/crates/ragu_arithmetic/benches/criterion/msm.rs
@@ -1,6 +1,6 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use ff::Field;
-use pasta_curves::{EpAffine, Fq, group::prime::PrimeCurveAffine};
+use pasta_curves::{EpAffine, Fq, group::CurveAffine};
 use ragu_arithmetic::mul;
 use rand::{SeedableRng, rngs::StdRng};
 

--- a/crates/ragu_arithmetic/benches/setup/mod.rs
+++ b/crates/ragu_arithmetic/benches/setup/mod.rs
@@ -1,5 +1,5 @@
 use ff::Field;
-use pasta_curves::{EpAffine, Fp, Fq, group::prime::PrimeCurveAffine};
+use pasta_curves::{EpAffine, Fp, Fq, group::CurveAffine};
 use ragu_arithmetic::Domain;
 use rand::{SeedableRng, rngs::StdRng};
 

--- a/crates/ragu_arithmetic/src/util.rs
+++ b/crates/ragu_arithmetic/src/util.rs
@@ -740,7 +740,7 @@ mod proptests {
 
 #[test]
 fn test_mul() {
-    use pasta_curves::group::{Curve, prime::PrimeCurveAffine};
+    use pasta_curves::group::{Curve, CurveAffine};
 
     let mut coeffs = vec![];
     for i in 0..1000 {

--- a/crates/ragu_circuits/src/staging/mask.rs
+++ b/crates/ragu_circuits/src/staging/mask.rs
@@ -238,7 +238,7 @@ mod tests {
     use core::marker::PhantomData;
 
     use ff::Field;
-    use group::{Curve, prime::PrimeCurveAffine};
+    use group::{Curve, CurveAffine as _};
     use proptest::prelude::*;
     use ragu_arithmetic::{CurveAffine, Cycle, FixedGenerators, Uendo};
     use ragu_core::{

--- a/crates/ragu_pasta/pasta_common.rs
+++ b/crates/ragu_pasta/pasta_common.rs
@@ -1,5 +1,5 @@
 use ragu_arithmetic::CurveExt;
-use group::{Curve, prime::PrimeCurveAffine};
+use group::{Curve, CurveAffine};
 use pasta_curves::{
     EpAffine,
     EqAffine,

--- a/crates/ragu_pcd/src/internal/endoscalar.rs
+++ b/crates/ragu_pcd/src/internal/endoscalar.rs
@@ -19,7 +19,7 @@
 use alloc::vec;
 
 use ff::{Field, WithSmallOrderMulGroup};
-use pasta_curves::group::{Curve, WnafBase, WnafScalar, prime::PrimeCurveAffine};
+use pasta_curves::group::{Curve, WnafBase, WnafScalar};
 use ragu_arithmetic::{CurveAffine, Uendo};
 use ragu_circuits::{
     WithAux,
@@ -107,7 +107,7 @@ pub struct PointsWitness<C: CurveAffine, const NUM_POINTS: usize> {
     pub interstitials: FixedVec<C, NumStepsLen<NUM_POINTS>>,
 }
 
-impl<C: CurveAffine + PrimeCurveAffine, const NUM_POINTS: usize> PointsWitness<C, NUM_POINTS>
+impl<C: CurveAffine, const NUM_POINTS: usize> PointsWitness<C, NUM_POINTS>
 where
     C::Scalar: WithSmallOrderMulGroup<3>,
 {
@@ -328,7 +328,7 @@ mod tests {
     use alloc::vec::Vec;
 
     use ff::Field;
-    use pasta_curves::group::{Curve, Group, prime::PrimeCurveAffine};
+    use pasta_curves::group::{Curve, CurveAffine as _, Group};
     use ragu_arithmetic::Uendo;
     use ragu_circuits::{
         CircuitExt,

--- a/crates/ragu_primitives/benches/setup/mod.rs
+++ b/crates/ragu_primitives/benches/setup/mod.rs
@@ -1,5 +1,5 @@
 use ff::Field;
-use group::prime::PrimeCurveAffine;
+use group::CurveAffine;
 use ragu_arithmetic::{Cycle, Uendo};
 use ragu_core::{
     drivers::{

--- a/crates/ragu_primitives/src/endoscalar.rs
+++ b/crates/ragu_primitives/src/endoscalar.rs
@@ -252,7 +252,7 @@ pub fn extract_endoscalar<F: PrimeField + WithSmallOrderMulGroup<3>>(value: F) -
 #[cfg(test)]
 mod tests {
     use ff::{Field, PrimeField, WithSmallOrderMulGroup};
-    use group::{Group, prime::PrimeCurveAffine};
+    use group::{CurveAffine as _, Group};
     use ragu_arithmetic::{CurveAffine, CurveExt, Uendo};
     use ragu_core::Result;
     use ragu_pasta::{EpAffine, Fp};
@@ -299,7 +299,7 @@ mod tests {
     #[test]
     #[allow(clippy::useless_conversion)]
     fn test_endoscaling_consistency() {
-        use group::prime::PrimeCurveAffine;
+        use group::CurveAffine as _;
         use ragu_pasta::{EpAffine, Fq};
 
         let p = EpAffine::generator();

--- a/crates/ragu_primitives/src/point.rs
+++ b/crates/ragu_primitives/src/point.rs
@@ -216,7 +216,7 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Consistent<'dr, D> for Po
 
 #[test]
 fn test_point_alloc() -> Result<()> {
-    use group::prime::PrimeCurveAffine;
+    use group::CurveAffine;
 
     type F = ragu_pasta::Fp;
     type C = ragu_pasta::EpAffine;
@@ -238,7 +238,7 @@ fn test_point_alloc() -> Result<()> {
 
 #[test]
 fn test_point_double() -> Result<()> {
-    use group::{Group, prime::PrimeCurveAffine};
+    use group::{CurveAffine, Group};
 
     type F = ragu_pasta::Fp;
     type C = ragu_pasta::EpAffine;
@@ -272,7 +272,7 @@ fn test_point_double() -> Result<()> {
 fn test_add_incomplete() -> Result<()> {
     use alloc::vec;
 
-    use group::{Group, prime::PrimeCurveAffine};
+    use group::{CurveAffine, Group};
     use ragu_arithmetic::CurveExt;
 
     type F = ragu_pasta::Fp;
@@ -323,7 +323,7 @@ fn test_add_incomplete() -> Result<()> {
 fn test_double_and_add_incomplete() -> Result<()> {
     use alloc::{vec, vec::Vec};
 
-    use group::{Group, prime::PrimeCurveAffine};
+    use group::{CurveAffine, Group};
     use ragu_arithmetic::CurveExt;
 
     type F = ragu_pasta::Fp;

--- a/qa/crates/lean_extraction/src/instances/point_add_incomplete.rs
+++ b/qa/crates/lean_extraction/src/instances/point_add_incomplete.rs
@@ -1,4 +1,4 @@
-use group::prime::PrimeCurveAffine;
+use group::CurveAffine;
 use ragu_pasta::{EpAffine, Fp};
 use ragu_primitives::{Element, Point};
 

--- a/qa/crates/lean_extraction/src/instances/point_double.rs
+++ b/qa/crates/lean_extraction/src/instances/point_double.rs
@@ -1,4 +1,4 @@
-use group::prime::PrimeCurveAffine;
+use group::CurveAffine;
 use ragu_pasta::{EpAffine, Fp};
 use ragu_primitives::Point;
 

--- a/qa/crates/lean_extraction/src/instances/point_double_and_add_incomplete.rs
+++ b/qa/crates/lean_extraction/src/instances/point_double_and_add_incomplete.rs
@@ -1,4 +1,4 @@
-use group::prime::PrimeCurveAffine;
+use group::CurveAffine;
 use ragu_pasta::{EpAffine, Fp};
 use ragu_primitives::Point;
 

--- a/qa/fuzz/Cargo.toml
+++ b/qa/fuzz/Cargo.toml
@@ -43,8 +43,8 @@ rand = "0.10"
 # fuzz builds resolving the same forks the rest of the workspace uses.
 [patch.crates-io]
 ff = { git = "https://github.com/zkcrypto/ff", rev = "bdd74a3f75c4c378d69e954944a61bb0930532a0" }
-group = { git = "https://github.com/ebfull/group", rev = "3a5c728f27700cf8767e926e2566d6c5cf1879ef" }
-pasta_curves = { git = "https://github.com/ebfull/pasta_curves", rev = "10fbf911b176854d8eafb58da1184f56f1b10944" }
+group = { git = "https://github.com/zkcrypto/group", rev = "326b36b0c43dcb1507b89017323f43a57c3bffd8" }
+pasta_curves = { git = "https://github.com/ebfull/pasta_curves", rev = "4f9da85aeebc650a57610501d50d036454dcdc48" }
 
 # Poseidon sponge: absorb/squeeze mode transitions + save/resume consistency
 [[bin]]

--- a/qa/fuzz/fuzz_targets/fuzz_consistent.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_consistent.rs
@@ -29,7 +29,7 @@
 use arbitrary::Arbitrary;
 use ff::PrimeField;
 use group::Curve;
-use group::prime::PrimeCurveAffine;
+use group::CurveAffine;
 use libfuzzer_sys::fuzz_target;
 use pasta_curves::Fp;
 use ragu_core::maybe::Maybe;

--- a/qa/fuzz/fuzz_targets/fuzz_endoscalar.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_endoscalar.rs
@@ -15,7 +15,7 @@ use ff::Field;
 use ff::PrimeField;
 use ff::WithSmallOrderMulGroup;
 use group::{Curve, Group};
-use group::prime::PrimeCurveAffine;
+use group::CurveAffine as _;
 use pasta_curves::arithmetic::CurveAffine;
 use libfuzzer_sys::fuzz_target;
 use pasta_curves::Fp;

--- a/qa/fuzz/fuzz_targets/fuzz_point_identities.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_point_identities.rs
@@ -34,7 +34,7 @@
 use arbitrary::Arbitrary;
 use ff::WithSmallOrderMulGroup;
 use group::{Curve, Group};
-use group::prime::PrimeCurveAffine;
+use group::CurveAffine as _;
 use libfuzzer_sys::fuzz_target;
 use pasta_curves::Fp;
 use pasta_curves::arithmetic::CurveAffine;


### PR DESCRIPTION
Same as #721, except now fully aligning `group` while partially aligning `pasta_curves`.