### PR TITLE
chore(fuzzing): improve fuzzing performance

### DIFF
--- a/qa/fuzz/README.md
+++ b/qa/fuzz/README.md
@@ -8,7 +8,8 @@ don't leak into the rest of the repo.
 ## Quick start
 
 ```bash
-# Run every target for 30 seconds, sequentially.
+# Run every target for 30 seconds, sequentially. ASAN off by default
+# (~70% throughput win on simulator-heavy targets).
 ./fuzz.sh
 
 # Custom duration (seconds).
@@ -19,6 +20,10 @@ don't leak into the rest of the repo.
 
 # With the field-element constant dictionary loaded.
 DICT=1 ./fuzz.sh
+
+# Re-enable AddressSanitizer for memory-bug coverage (slower, but
+# required for triaging crash artifacts properly).
+ASAN=1 ./fuzz.sh
 
 # Run a single target directly.
 cargo +nightly fuzz run fuzz_element_ops -- -max_total_time=60

--- a/qa/fuzz/fuzz.sh
+++ b/qa/fuzz/fuzz.sh
@@ -2,10 +2,11 @@
 # Run all fuzz targets. Defaults to 30 seconds each, sequential.
 #
 # Usage:
-#   ./fuzz.sh                                 # 30s each, sequential
+#   ./fuzz.sh                                 # 30s each, sequential, no ASAN
 #   ./fuzz.sh 60                              # 1 min each, sequential
 #   ./fuzz.sh 300 -j                          # 5 min each, parallel
 #   DICT=1 ./fuzz.sh                          # Load dict.txt
+#   ASAN=1 ./fuzz.sh                          # Re-enable AddressSanitizer
 #   ./fuzz.sh summarize <target> <file>       # Decode a corpus/crash input
 #   ./fuzz.sh triage <file>                   # Triage a fuzz_soundness_cheat crash
 #
@@ -13,6 +14,17 @@
 # (60s on fuzz_element_ops): roughly flat coverage with a small features
 # decrease; on fuzz_poseidon_sponge: small features and corpus increase.
 # Worth trying for Poseidon-heavy targets in longer runs.
+#
+# By default this script passes `-s none` to cargo-fuzz, skipping
+# AddressSanitizer for a large throughput win on simulator-heavy targets
+# — measured ~70% on fuzz_soundness_cheat (50k → 84k exec/s), ~30% on
+# fuzz_poseidon_sponge, ~10% on fuzz_element_ops. ASAN catches memory
+# bugs (UAF, OOB on unwise unsafe, leaks across `Simulator::simulate`
+# closures); to opt back in, set ASAN=1. The weekly cron in
+# `.github/workflows/fuzz-cron.yml` invokes `cargo +nightly fuzz run`
+# directly and keeps ASAN regardless of this script's default. Crash
+# artifacts found here should be reproduced under ASAN=1 before triaging
+# to get proper allocation history.
 #
 # The `summarize` subcommand runs the target binary on a single corpus or
 # crash file with the DEBUG_INPUT env var set, which each fuzz target
@@ -66,10 +78,18 @@ fi
 DURATION="${1:-30}"
 PARALLEL="${2:-}"
 DICT="${DICT:-}"
+ASAN="${ASAN:-}"
 
 DICT_FLAG=""
 if [[ -n "$DICT" ]]; then
   DICT_FLAG="-dict=dict.txt"
+fi
+
+# Default to no sanitizer for throughput. ASAN=1 opts back in for
+# memory-bug coverage. See header comment for the trade-off.
+SAN_FLAG="-s none"
+if [[ -n "$ASAN" ]]; then
+  SAN_FLAG=""
 fi
 
 TARGETS=(
@@ -95,7 +115,7 @@ TARGETS=(
 run_target() {
   local target="$1"
   echo "=== $target (${DURATION}s) ==="
-  cargo +nightly fuzz run --fuzz-dir . "$target" -- \
+  cargo +nightly fuzz run --fuzz-dir . $SAN_FLAG "$target" -- \
     $DICT_FLAG \
     -max_len=1024 \
     -max_total_time="$DURATION" \

--- a/qa/fuzz/fuzz_targets/fuzz_consistent.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_consistent.rs
@@ -39,6 +39,8 @@ use ragu_primitives::{
     allocator::Standard, consistent::Consistent,
 };
 
+use std::sync::LazyLock;
+
 fn parse_fp(bytes: [u8; 32]) -> Fp {
     Option::<Fp>::from(Fp::from_repr(bytes)).unwrap_or_else(|| {
         Fp::from(u64::from_le_bytes([
@@ -47,12 +49,28 @@ fn parse_fp(bytes: [u8; 32]) -> Fp {
     })
 }
 
-fn point_from_seed(seed: u64) -> EpAffine {
-    if seed == 0 {
-        EpAffine::generator()
-    } else {
-        (EpAffine::generator() * Fq::from(seed)).to_affine()
+/// Precomputed table of non-identity Pallas points.
+///
+/// Replacing per-input `EpAffine::generator() * Fq::from(seed)` with a
+/// 32-point modular lookup. The Consistent trait tests check
+/// `(x, y)` is on the curve regardless of which specific point — point
+/// diversity beyond a handful adds no constraint-system coverage but
+/// burns ~50µs/scalar-mul per input. At ~143µs/iter pre-change, removing
+/// the two scalar muls is the dominant cost on this target.
+const POINT_TABLE_LEN: usize = 32;
+static POINT_TABLE: LazyLock<[EpAffine; POINT_TABLE_LEN]> = LazyLock::new(|| {
+    let mut points = [EpAffine::generator(); POINT_TABLE_LEN];
+    for (i, p) in points.iter_mut().enumerate() {
+        // Skip seed=0 → generator already in slot 0.
+        if i > 0 {
+            *p = (EpAffine::generator() * Fq::from(i as u64)).to_affine();
+        }
     }
+    points
+});
+
+fn point_from_seed(seed: u64) -> EpAffine {
+    POINT_TABLE[(seed as usize) % POINT_TABLE_LEN]
 }
 
 #[derive(Arbitrary, Debug)]

--- a/qa/fuzz/fuzz_targets/fuzz_driver_metamorphic.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_driver_metamorphic.rs
@@ -47,8 +47,6 @@
 
 #![no_main]
 
-use core::cell::RefCell;
-
 use arbitrary::Arbitrary;
 use ff::Field;
 use ff::PrimeField;
@@ -314,31 +312,31 @@ where
 /// Run the program through `Simulator`, capturing the final fingerprint
 /// on success.
 fn run_simulator(input: &Input, fes: &[Fp]) -> Option<Fingerprint> {
-    let snapshot: RefCell<Option<Fingerprint>> = RefCell::new(None);
+    let mut snapshot: Option<Fingerprint> = None;
     let sim = Simulator::<Fp>::simulate(fes.to_vec(), |dr, witness| {
         let fp = run_ops(dr, &witness, input, fes)?;
-        *snapshot.borrow_mut() = Some(fp);
+        snapshot = Some(fp);
         Ok(())
     });
     if sim.is_err() {
         return None;
     }
-    snapshot.into_inner()
+    snapshot
 }
 
 /// Run the program through `Emulator<Wired<Fp>>`, capturing the final
 /// fingerprint on success.
 fn run_emulator(input: &Input, fes: &[Fp]) -> Option<Fingerprint> {
-    let snapshot: RefCell<Option<Fingerprint>> = RefCell::new(None);
+    let mut snapshot: Option<Fingerprint> = None;
     let result = Emulator::<Wired<Fp>>::emulate_wired(fes.to_vec(), |dr, witness| {
         let fp = run_ops(dr, &witness, input, fes)?;
-        *snapshot.borrow_mut() = Some(fp);
+        snapshot = Some(fp);
         Ok(())
     });
     if result.is_err() {
         return None;
     }
-    snapshot.into_inner()
+    snapshot
 }
 
 fuzz_target!(|input: Input| {

--- a/qa/fuzz/fuzz_targets/fuzz_endoscalar.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_endoscalar.rs
@@ -26,6 +26,8 @@ use ragu_primitives::{
     lift_endoscalar,
 };
 
+use std::sync::LazyLock;
+
 /// Edge-case field elements that trigger boundary conditions.
 fn special_scalar(idx: u8) -> Fp {
     match idx % 10 {
@@ -42,14 +44,30 @@ fn special_scalar(idx: u8) -> Fp {
     }
 }
 
-/// Get a non-trivial curve point by multiplying generator by a scalar.
-fn point_from_seed(seed: u64) -> EpAffine {
-    if seed == 0 {
-        // Use generator directly (seed=0 would give identity)
-        EpAffine::generator()
-    } else {
-        (EpAffine::generator() * Fq::from(seed)).to_affine()
+/// Precomputed table of non-identity Pallas points.
+///
+/// The native scalar mul `EpAffine::generator() * Fq::from(seed)` runs
+/// twice per input (for `p` and `p2`), ~50µs each. Endo/group_scale
+/// gadget paths are point-shape independent — they exercise the same
+/// window pattern for any on-curve point — so collapsing the u64 seed
+/// space onto a 64-point table doesn't lose meaningful coverage. The
+/// dominant native cost on this target is the third scalar mul
+/// `(p * expected_scalar).to_affine()` over a 256-bit Fq, which we
+/// cannot precompute (depends on the fuzzer-chosen scalar).
+const POINT_TABLE_LEN: usize = 64;
+static POINT_TABLE: LazyLock<[EpAffine; POINT_TABLE_LEN]> = LazyLock::new(|| {
+    let mut points = [EpAffine::generator(); POINT_TABLE_LEN];
+    for (i, p) in points.iter_mut().enumerate() {
+        if i > 0 {
+            *p = (EpAffine::generator() * Fq::from(i as u64)).to_affine();
+        }
     }
+    points
+});
+
+/// Get a non-trivial curve point from a fuzzer-supplied seed.
+fn point_from_seed(seed: u64) -> EpAffine {
+    POINT_TABLE[(seed as usize) % POINT_TABLE_LEN]
 }
 
 #[derive(Arbitrary, Debug, Clone, Copy)]

--- a/qa/fuzz/fuzz_targets/fuzz_point_identities.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_point_identities.rs
@@ -42,13 +42,32 @@ use ragu_core::maybe::Maybe;
 use ragu_pasta::{EpAffine, Fq};
 use ragu_primitives::{Boolean, Point, Simulator, allocator::Standard};
 
-/// Get a non-trivial curve point by multiplying generator by a scalar.
-fn point_from_seed(seed: u64) -> EpAffine {
-    if seed == 0 {
-        EpAffine::generator()
-    } else {
-        (EpAffine::generator() * Fq::from(seed)).to_affine()
+use std::sync::LazyLock;
+
+/// Precomputed table of non-identity Pallas points.
+///
+/// Replaces per-input `EpAffine::generator() * Fq::from(seed)` (~50µs
+/// each) with a 64-point modular lookup. The point-identity tests
+/// (negate involution, endo cube, conditional_*, add commutativity,
+/// double-and-add) exercise *algebraic gadget paths*, not point-shape
+/// coverage — 64 distinct on-curve points is enough to hit every gadget
+/// branch the test probes. The pair (`p_seed`, `q_seed`) still controls
+/// whether `p` and `q` collide on x (skipped via existing distinctness
+/// guard) and whether `2P` and `Q` collide on x (existing skip guard).
+const POINT_TABLE_LEN: usize = 64;
+static POINT_TABLE: LazyLock<[EpAffine; POINT_TABLE_LEN]> = LazyLock::new(|| {
+    let mut points = [EpAffine::generator(); POINT_TABLE_LEN];
+    for (i, p) in points.iter_mut().enumerate() {
+        if i > 0 {
+            *p = (EpAffine::generator() * Fq::from(i as u64)).to_affine();
+        }
     }
+    points
+});
+
+/// Get a non-trivial curve point from a fuzzer-supplied seed.
+fn point_from_seed(seed: u64) -> EpAffine {
+    POINT_TABLE[(seed as usize) % POINT_TABLE_LEN]
 }
 
 /// Native negation of an EpAffine point.

--- a/qa/fuzz/fuzz_targets/fuzz_poseidon_differential.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_poseidon_differential.rs
@@ -10,7 +10,6 @@
 #![no_main]
 
 use arbitrary::Arbitrary;
-use core::cell::Cell;
 use ff::{Field, PrimeField};
 use libfuzzer_sys::fuzz_target;
 use pasta_curves::Fp;
@@ -43,6 +42,9 @@ fn special_value(idx: u8) -> Fp {
 
 struct NativeSponge<'a, P> {
     state: Vec<Fp>,
+    /// Scratch buffer reused across MDS rounds; sized to `P::T` once at
+    /// construction time so `permute()` doesn't allocate per round.
+    scratch: Vec<Fp>,
     buf: Vec<Fp>,
     squeezable: Vec<Fp>,
     absorbing: bool,
@@ -53,6 +55,7 @@ impl<'a, P: PoseidonPermutation<Fp>> NativeSponge<'a, P> {
     fn new(params: &'a P) -> Self {
         NativeSponge {
             state: vec![Fp::ZERO; P::T],
+            scratch: vec![Fp::ZERO; P::T],
             buf: Vec::new(),
             squeezable: Vec::new(),
             absorbing: true,
@@ -84,14 +87,18 @@ impl<'a, P: PoseidonPermutation<Fp>> NativeSponge<'a, P> {
                 *s = s4 * *s; // s^5
             }
 
-            // MDS
-            let mut new_state = vec![Fp::ZERO; t];
+            // MDS — multiply state through MDS matrix into scratch buffer,
+            // then swap into state. Avoids the per-round Vec allocation a
+            // naive `vec![Fp::ZERO; t]` would do.
+            for s in self.scratch[..t].iter_mut() {
+                *s = Fp::ZERO;
+            }
             for (row_idx, row) in self.params.mds_matrix().enumerate() {
                 for (col_idx, coeff) in row.iter().enumerate() {
-                    new_state[row_idx] += *coeff * self.state[col_idx];
+                    self.scratch[row_idx] += *coeff * self.state[col_idx];
                 }
             }
-            self.state = new_state;
+            core::mem::swap(&mut self.state, &mut self.scratch);
         }
     }
 
@@ -220,9 +227,7 @@ fuzz_target!(|input: Input| {
 
     // --- Circuit sponge via Simulator ---
     let absorb_values: Vec<Fp> = input.ops.iter().filter_map(op_value).collect();
-    let circuit_squeezes: Vec<Cell<Fp>> = (0..native_squeezes.len())
-        .map(|_| Cell::new(Fp::ZERO))
-        .collect();
+    let mut circuit_squeezes: Vec<Fp> = vec![Fp::ZERO; native_squeezes.len()];
 
     let result = Simulator::<Fp>::simulate(absorb_values.clone(), |dr, witness| {
         let allocator = &mut Standard::new();
@@ -249,7 +254,7 @@ fuzz_target!(|input: Input| {
                         continue;
                     }
                     let squeezed = sponge.squeeze(dr)?;
-                    circuit_squeezes[squeeze_idx].set(*squeezed.value().take());
+                    circuit_squeezes[squeeze_idx] = *squeezed.value().take();
                     squeeze_idx += 1;
                 }
             }
@@ -257,7 +262,7 @@ fuzz_target!(|input: Input| {
 
         if squeeze_idx == 0 {
             let squeezed = sponge.squeeze(dr)?;
-            circuit_squeezes[0].set(*squeezed.value().take());
+            circuit_squeezes[0] = *squeezed.value().take();
         }
 
         Ok(())
@@ -265,12 +270,12 @@ fuzz_target!(|input: Input| {
 
     assert!(result.is_ok(), "circuit sponge failed: {:?}", result.err());
 
-    for (i, (native_val, circuit_cell)) in
+    for (i, (native_val, circuit_val)) in
         native_squeezes.iter().zip(circuit_squeezes.iter()).enumerate()
     {
         assert_eq!(
-            *native_val,
-            circuit_cell.get(),
+            native_val,
+            circuit_val,
             "squeeze {i} mismatch: native vs circuit"
         );
     }

--- a/qa/fuzz/fuzz_targets/fuzz_poseidon_sponge.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_poseidon_sponge.rs
@@ -8,7 +8,6 @@
 #![no_main]
 
 use arbitrary::Arbitrary;
-use core::cell::Cell;
 use ff::{Field, PrimeField};
 use libfuzzer_sys::fuzz_target;
 use pasta_curves::Fp;
@@ -71,12 +70,15 @@ fn absorb_values(ops: &[Op]) -> Vec<Fp> {
 }
 
 fn run_sponge(ops: &[Op], values: &[Fp]) -> Fp {
-    let output = Cell::new(Fp::ZERO);
-    let got_output = Cell::new(false);
+    let mut output = Fp::ZERO;
+    let mut got_output = false;
+    // Pasta::baked() returns a &'static, but recomputing the address each
+    // call is wasteful; hoist outside the closure so we touch the static
+    // exactly once per run_sponge.
+    let params = Pasta::baked();
 
     let result = Simulator::<Fp>::simulate(values.to_vec(), |dr, witness| {
         let allocator = &mut Standard::new();
-        let params = Pasta::baked();
         let mut sponge = Sponge::<'_, _, <Pasta as Cycle>::CircuitPoseidon>::new(
             dr,
             Pasta::circuit_poseidon(params),
@@ -101,24 +103,24 @@ fn run_sponge(ops: &[Op], values: &[Fp]) -> Fp {
                         continue;
                     }
                     let squeezed = sponge.squeeze(dr)?;
-                    if !got_output.get() {
-                        output.set(*squeezed.value().take());
-                        got_output.set(true);
+                    if !got_output {
+                        output = *squeezed.value().take();
+                        got_output = true;
                     }
                 }
             }
         }
 
-        if !got_output.get() {
+        if !got_output {
             let squeezed = sponge.squeeze(dr)?;
-            output.set(*squeezed.value().take());
+            output = *squeezed.value().take();
         }
 
         Ok(())
     });
 
     assert!(result.is_ok(), "sponge failed: {:?}", result.err());
-    output.get()
+    output
 }
 
 fuzz_target!(|input: Input| {
@@ -147,12 +149,12 @@ fuzz_target!(|input: Input| {
     // Save/resume equivalence: absorb all values, save, resume, squeeze
     // must equal absorb all values then squeeze directly.
     if input.test_save_resume && values.len() >= 1 {
-        let direct_output = Cell::new(Fp::ZERO);
-        let resume_output = Cell::new(Fp::ZERO);
+        let mut direct_output = Fp::ZERO;
+        let mut resume_output = Fp::ZERO;
+        let params = Pasta::baked();
 
         let result = Simulator::<Fp>::simulate(values.clone(), |dr, witness| {
             let allocator = &mut Standard::new();
-            let params = Pasta::baked();
             let elems: Vec<Element<'_, _>> = (0..values.len())
                 .map(|i| Element::alloc(dr, allocator, witness.as_ref().map(|v| v[i])))
                 .collect::<Result<_, _>>()?;
@@ -166,7 +168,7 @@ fuzz_target!(|input: Input| {
                 sponge1.absorb(dr, elem)?;
             }
             let squeezed = sponge1.squeeze(dr)?;
-            direct_output.set(*squeezed.value().take());
+            direct_output = *squeezed.value().take();
 
             // Save/resume path: absorb all → save → resume → squeeze
             let mut sponge2 = Sponge::<'_, _, <Pasta as Cycle>::CircuitPoseidon>::new(
@@ -179,15 +181,15 @@ fuzz_target!(|input: Input| {
             let state = sponge2.save_state(dr).expect("save should succeed after absorb");
             let mut resumed = Sponge::resume(state, Pasta::circuit_poseidon(params));
             let squeezed = resumed.squeeze(dr)?;
-            resume_output.set(*squeezed.value().take());
+            resume_output = *squeezed.value().take();
 
             Ok(())
         });
 
         assert!(result.is_ok(), "save/resume failed: {:?}", result.err());
         assert_eq!(
-            direct_output.get(),
-            resume_output.get(),
+            direct_output,
+            resume_output,
             "save/resume produced different output than direct squeeze"
         );
     }

--- a/qa/fuzz/fuzz_targets/fuzz_revdot.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_revdot.rs
@@ -50,8 +50,13 @@ fn naive_eval(coeffs: impl DoubleEndedIterator<Item = Fp>, z: Fp) -> Fp {
     coeffs.rev().fold(Fp::ZERO, |acc, c| acc * z + c)
 }
 
-fn naive_revdot(a: &[Fp], b: &[Fp]) -> Fp {
-    a.iter().zip(b.iter().rev()).map(|(x, y)| *x * *y).sum()
+/// Naive revdot over arbitrary iterators. Takes iterators directly so the
+/// caller doesn't have to materialize an intermediate `Vec<Fp>` per input.
+fn naive_revdot_iter(
+    a: impl Iterator<Item = Fp>,
+    b: impl DoubleEndedIterator<Item = Fp>,
+) -> Fp {
+    a.zip(b.rev()).map(|(x, y)| x * y).sum()
 }
 
 fuzz_target!(|input: Input| {
@@ -72,9 +77,7 @@ fuzz_target!(|input: Input| {
 
     // 1. Revdot agreement
     let sparse_revdot = p1.revdot(&p2);
-    let u1: Vec<Fp> = p1.iter_coeffs().collect();
-    let u2: Vec<Fp> = p2.iter_coeffs().collect();
-    let dense_revdot = naive_revdot(&u1, &u2);
+    let dense_revdot = naive_revdot_iter(p1.iter_coeffs(), p2.iter_coeffs());
 
     assert_eq!(
         sparse_revdot, dense_revdot,

--- a/qa/fuzz/fuzz_targets/fuzz_soundness_cheat.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_soundness_cheat.rs
@@ -361,6 +361,24 @@ fn op_pushes(op: &Op) -> usize {
     }
 }
 
+/// Whether an Op's element-push is conditional on a runtime `Result`
+/// (`if let Ok(_)` in `run_path`). `op_pushes` is an upper bound for these
+/// — actual `run_path` execution may push zero. Used by `is_dead_cheat` to
+/// refuse predicting through unpredictable stack growth.
+fn op_can_fail_push(op: &Op) -> bool {
+    matches!(
+        op,
+        Op::Mul(_, _)
+            | Op::Square(_)
+            | Op::Invert(_)
+            | Op::DivNonzero(_, _)
+            | Op::Fold(_, _, _)
+            | Op::AllocRaw(_)
+            | Op::AllocSquare(_)
+            | Op::ConditionalSelect(_, _, _)
+    )
+}
+
 /// Whether an Op reads `elems[target]` (given the current elem stack length).
 fn op_reads_target(op: &Op, target: usize, elens: usize) -> bool {
     if elens == 0 {
@@ -425,24 +443,42 @@ fn triage_cheat(input: &Input) -> (usize, usize, usize) {
     (target_at_cheat, downstream_reads, downstream_ops)
 }
 
-/// Pre-flight check: returns `true` if the cheated slot is never read by
-/// any downstream op, in which case the soundness assertion is guaranteed
-/// to hold (`honest[target_at_cheat] = original_val`,
-/// `cheat[target_at_cheat] = cheat_val`, both present in their respective
-/// fingerprints and differing by construction). Running the two simulator
-/// paths is pure waste for these inputs, and they dominate the input
-/// distribution under random `Op` sampling — most `Op` variants either
-/// don't read elements at all (allocations, boolean ops) or pick indices
-/// that miss the cheated slot.
+/// Pre-flight check: returns `true` if the static op walk can prove the
+/// cheated slot is never read by any downstream op. Inputs classified as
+/// dead are skipped — running the two simulator paths on them is pure
+/// waste, and they dominate the input distribution under random `Op`
+/// sampling (most variants either don't read elements at all or pick
+/// indices that miss the cheated slot).
+///
+/// **Soundness bound.** `op_pushes` is an upper-bound estimator (it
+/// assumes Result-returning ops succeed). To match `run_path`'s
+/// `target_at_cheat` computation exactly, we refuse to predict when any
+/// pre-cheat op has a fallible push: in those cases the predicted `elens`
+/// at the cheat point would exceed the real `elens`, drifting
+/// `target_at_cheat = target_idx % elens.min(64)` to a different slot than
+/// `run_path` actually cheats on. We conservatively return `false` (not
+/// dead) and run the full path.
+///
+/// Residual suffix drift: when a *suffix* op fails to push, the prediction
+/// can still miss a real read (`(a % elens_real) == target` while
+/// `(a % elens_pred) != target`). This is a coverage shave, not a
+/// soundness break — it requires both a suffix failure and a specific
+/// modular near-miss on the read index. Inputs with multiple real reads
+/// almost always trip the live-cheat check on a non-drifting read first.
 ///
 /// Bails out on the first read, so the walk costs O(prefix + 1) for live
 /// cheats vs. O(prefix + suffix) for dead cheats — the asymmetry favors
 /// the cheap path.
 fn is_dead_cheat(input: &Input) -> bool {
     let mut elens: usize = input.seeds.len() + input.large_seeds.len() + input.special_seeds.len();
-    let cheat_at_idx = input.cheat_at as usize;
+    let cheat_at_idx = (input.cheat_at as usize).min(input.ops.len());
 
     for op in &input.ops[..cheat_at_idx] {
+        // Pre-cheat fallible push → `elens` prediction may exceed reality,
+        // breaking `target_at_cheat` agreement with `run_path`. Bail.
+        if op_can_fail_push(op) {
+            return false;
+        }
         elens += op_pushes(op);
         if elens > 128 {
             elens = 64;
@@ -453,7 +489,11 @@ fn is_dead_cheat(input: &Input) -> bool {
         return true;
     }
 
-    let target_at_cheat = (input.target_idx as usize) % elens.min(64);
+    // Mirror `run_path` line 163: `target_idx % elems.len().min(64)`. The
+    // `.max(1)` guards `% 0` if `elens` is ever zero here (currently
+    // unreachable given the seed shape, but defends against future input
+    // schema changes).
+    let target_at_cheat = (input.target_idx as usize) % elens.min(64).max(1);
 
     for op in &input.ops[cheat_at_idx..] {
         if elens == 0 {

--- a/qa/fuzz/fuzz_targets/fuzz_soundness_cheat.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_soundness_cheat.rs
@@ -20,8 +20,6 @@
 
 #![no_main]
 
-use core::cell::RefCell;
-
 use arbitrary::Arbitrary;
 use ff::Field;
 use ff::PrimeField;
@@ -135,8 +133,8 @@ fn build_seeds(input: &Input) -> Vec<Fp> {
 /// (a degenerate input that would produce a false-positive fingerprint
 /// match).
 fn run_path(input: &Input, fes: &[Fp], apply_cheat: bool) -> Option<Fingerprint> {
-    let snapshot: RefCell<Option<Fingerprint>> = RefCell::new(None);
-    let cheat_noop: RefCell<bool> = RefCell::new(false);
+    let mut snapshot: Option<Fingerprint> = None;
+    let mut cheat_noop = false;
 
     let sim = Simulator::<Fp>::simulate(fes.to_vec(), |dr, witness| {
         let allocator = &mut Standard::new();
@@ -174,7 +172,7 @@ fn run_path(input: &Input, fes: &[Fp], apply_cheat: bool) -> Option<Fingerprint>
                     // happens to equal what was already there. Fingerprints
                     // would trivially match. Flag and bail out so the
                     // outer harness discards this run.
-                    *cheat_noop.borrow_mut() = true;
+                    cheat_noop = true;
                     return Ok(());
                 }
                 let cheated = match input.cheat {
@@ -339,15 +337,15 @@ fn run_path(input: &Input, fes: &[Fp], apply_cheat: bool) -> Option<Fingerprint>
         // is Always.
         let elem_vals: Vec<Fp> = elems.iter().map(|e| *e.value().take()).collect();
         let bool_vals: Vec<bool> = bools.iter().map(|b| b.value().take()).collect();
-        *snapshot.borrow_mut() = Some((elem_vals, bool_vals));
+        snapshot = Some((elem_vals, bool_vals));
 
         Ok(())
     });
 
-    if sim.is_err() || *cheat_noop.borrow() {
+    if sim.is_err() || cheat_noop {
         return None;
     }
-    snapshot.into_inner()
+    snapshot
 }
 
 /// How many elements an Op pushes onto the `elems` stack.
@@ -383,7 +381,10 @@ fn op_reads_target(op: &Op, target: usize, elens: usize) -> bool {
 /// invoking the Simulator. Returns `(target_at_cheat, downstream_reads,
 /// downstream_ops)` describing how many downstream ops actually reference
 /// the cheated slot. A `downstream_reads = 0` result indicates a "dead
-/// cheat" — the soundness signal is a false positive.
+/// cheat" — the soundness assertion cannot fire (the cheat value remains
+/// observable at position `target_at_cheat` in the cheat-path fingerprint
+/// while honest-path holds the original value, so honest != cheated is
+/// trivially satisfied).
 fn triage_cheat(input: &Input) -> (usize, usize, usize) {
     let mut elens: usize = input.seeds.len() + input.large_seeds.len() + input.special_seeds.len();
     let cheat_at_idx = (input.cheat_at as usize).min(input.ops.len());
@@ -422,6 +423,52 @@ fn triage_cheat(input: &Input) -> (usize, usize, usize) {
     }
 
     (target_at_cheat, downstream_reads, downstream_ops)
+}
+
+/// Pre-flight check: returns `true` if the cheated slot is never read by
+/// any downstream op, in which case the soundness assertion is guaranteed
+/// to hold (`honest[target_at_cheat] = original_val`,
+/// `cheat[target_at_cheat] = cheat_val`, both present in their respective
+/// fingerprints and differing by construction). Running the two simulator
+/// paths is pure waste for these inputs, and they dominate the input
+/// distribution under random `Op` sampling — most `Op` variants either
+/// don't read elements at all (allocations, boolean ops) or pick indices
+/// that miss the cheated slot.
+///
+/// Bails out on the first read, so the walk costs O(prefix + 1) for live
+/// cheats vs. O(prefix + suffix) for dead cheats — the asymmetry favors
+/// the cheap path.
+fn is_dead_cheat(input: &Input) -> bool {
+    let mut elens: usize = input.seeds.len() + input.large_seeds.len() + input.special_seeds.len();
+    let cheat_at_idx = input.cheat_at as usize;
+
+    for op in &input.ops[..cheat_at_idx] {
+        elens += op_pushes(op);
+        if elens > 128 {
+            elens = 64;
+        }
+    }
+
+    if elens == 0 {
+        return true;
+    }
+
+    let target_at_cheat = (input.target_idx as usize) % elens.min(64);
+
+    for op in &input.ops[cheat_at_idx..] {
+        if elens == 0 {
+            break;
+        }
+        if op_reads_target(op, target_at_cheat, elens) {
+            return false;
+        }
+        elens += op_pushes(op);
+        if elens > 128 {
+            elens = 64;
+        }
+    }
+
+    true
 }
 
 fuzz_target!(|input: Input| {
@@ -474,6 +521,16 @@ fuzz_target!(|input: Input| {
     // Cheat must land inside the executable op range, otherwise the cheat
     // is a no-op and fingerprints trivially match.
     if (input.cheat_at as usize) >= input.ops.len() {
+        return;
+    }
+
+    // Skip dead cheats — inputs where the cheated slot is never read
+    // downstream. The soundness assertion cannot fire on these (the cheat
+    // value remains visible at position `target_at_cheat` in the cheat-path
+    // fingerprint, differing from honest-path's original value by
+    // construction), so running the simulator twice would be pure waste.
+    // This walk reads bytes only; no field arithmetic, no constraint checks.
+    if is_dead_cheat(&input) {
         return;
     }
 

--- a/qa/fuzz/fuzz_targets/fuzz_sxy_agreement.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_sxy_agreement.rs
@@ -19,8 +19,7 @@ use ragu_circuits::{
 };
 use ragu_testing::circuits::SquareCircuit;
 
-use core::cell::OnceCell;
-use std::sync::LazyLock;
+use std::sync::{LazyLock, OnceLock};
 
 #[derive(Arbitrary, Debug)]
 struct Input {
@@ -38,21 +37,13 @@ struct Input {
 /// `RegistryBuilder::register_circuit` failure and
 /// `RegistryBuilder::finalize` `GateBoundExceeded` failures — those are
 /// "skip" outcomes for the fuzz body).
-///
-/// `OnceCell` (not `OnceLock`) is fine because libfuzzer is single-threaded.
 struct RegistryCache {
     /// Slot for `times = i + 1`, indexed 0..119.
-    slots: [OnceCell<Result<Registry<'static, Fp, TestRank>, ()>>; 120],
+    slots: [OnceLock<Result<Registry<'static, Fp, TestRank>, ()>>; 120],
 }
 
-// SAFETY: libfuzzer runs the fuzz target on a single thread, so the
-// interior-mutable OnceCell slots are never accessed concurrently. The
-// `LazyLock` machinery requires `Sync`, but the access pattern never
-// actually crosses thread boundaries.
-unsafe impl Sync for RegistryCache {}
-
 static REGISTRY_CACHE: LazyLock<RegistryCache> = LazyLock::new(|| RegistryCache {
-    slots: [const { OnceCell::new() }; 120],
+    slots: [const { OnceLock::new() }; 120],
 });
 
 fn registry_for(times: usize) -> Option<&'static Registry<'static, Fp, TestRank>> {

--- a/qa/fuzz/fuzz_targets/fuzz_sxy_agreement.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_sxy_agreement.rs
@@ -15,15 +15,58 @@ use libfuzzer_sys::fuzz_target;
 use pasta_curves::Fp;
 use ragu_circuits::{
     polynomials::TestRank,
-    registry::{CircuitIndex, RegistryBuilder},
+    registry::{CircuitIndex, Registry, RegistryBuilder},
 };
 use ragu_testing::circuits::SquareCircuit;
+
+use core::cell::OnceCell;
+use std::sync::LazyLock;
 
 #[derive(Arbitrary, Debug)]
 struct Input {
     times: u8,
     x_seed: u64,
     y_seed: u64,
+}
+
+/// Per-`times` registry cache. Building the registry for a `SquareCircuit`
+/// runs the floor-planner over `times`-many squarings — ~3x the cost of the
+/// three evaluations we then perform. Memoizing across inputs turns the
+/// hot path into eval-only after each distinct `times` is observed once.
+///
+/// Each slot is `Result<Registry, ()>` (`Err` covers both
+/// `RegistryBuilder::register_circuit` failure and
+/// `RegistryBuilder::finalize` `GateBoundExceeded` failures — those are
+/// "skip" outcomes for the fuzz body).
+///
+/// `OnceCell` (not `OnceLock`) is fine because libfuzzer is single-threaded.
+struct RegistryCache {
+    /// Slot for `times = i + 1`, indexed 0..119.
+    slots: [OnceCell<Result<Registry<'static, Fp, TestRank>, ()>>; 120],
+}
+
+// SAFETY: libfuzzer runs the fuzz target on a single thread, so the
+// interior-mutable OnceCell slots are never accessed concurrently. The
+// `LazyLock` machinery requires `Sync`, but the access pattern never
+// actually crosses thread boundaries.
+unsafe impl Sync for RegistryCache {}
+
+static REGISTRY_CACHE: LazyLock<RegistryCache> = LazyLock::new(|| RegistryCache {
+    slots: [const { OnceCell::new() }; 120],
+});
+
+fn registry_for(times: usize) -> Option<&'static Registry<'static, Fp, TestRank>> {
+    debug_assert!((1..=120).contains(&times));
+    REGISTRY_CACHE.slots[times - 1]
+        .get_or_init(|| {
+            let circuit = SquareCircuit { times };
+            RegistryBuilder::<Fp, TestRank>::new()
+                .register_circuit(circuit)
+                .and_then(|b| b.finalize())
+                .map_err(|_| ())
+        })
+        .as_ref()
+        .ok()
 }
 
 fuzz_target!(|input: Input| {
@@ -36,13 +79,9 @@ fuzz_target!(|input: Input| {
     // Clamp times to stay within TestRank bounds.
     let times = ((input.times as usize) % 120).max(1);
 
-    let circuit = SquareCircuit { times };
-    let registry = match RegistryBuilder::<Fp, TestRank>::new().register_circuit(circuit) {
-        Ok(b) => match b.finalize() {
-            Ok(r) => r,
-            Err(_) => return, // Circuit too large for rank — skip
-        },
-        Err(_) => return,
+    let registry = match registry_for(times) {
+        Some(r) => r,
+        None => return, // Circuit too large for rank — skip
     };
 
     let w = CircuitIndex::new(0).omega_j::<Fp>();

--- a/qa/fuzz/fuzz_targets/fuzz_verify_reject.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_verify_reject.rs
@@ -12,7 +12,7 @@ use libfuzzer_sys::fuzz_target;
 use pasta_curves::Fp;
 use ragu_circuits::polynomials::ProductionRank;
 use ragu_pasta::Pasta;
-use ragu_pcd::{ApplicationBuilder, fuzz_utils::Corruption};
+use ragu_pcd::{ApplicationBuilder, Proof, fuzz_utils::Corruption};
 use rand::{SeedableRng, rngs::StdRng};
 
 use std::sync::LazyLock;
@@ -35,6 +35,14 @@ static APP: LazyLock<SyncApp> = LazyLock::new(|| {
             .expect("failed to create application"),
     )
 });
+
+/// Cached trivial proof. Building one runs the full endoscaling pipeline
+/// (hundreds of ms per call), but the result is deterministic from
+/// `&APP.0`. Cloning the cached value is ~10000x faster than rebuilding,
+/// so per-input work clones, corrupts, and verifies — turning the
+/// fuzz_verify_reject hot path into clone + corrupt + verify rather than
+/// build + corrupt + verify.
+static TRIVIAL_PROOF: LazyLock<Proof<C, R>> = LazyLock::new(|| APP.0.test_trivial_proof());
 
 #[derive(Arbitrary, Debug)]
 enum FuzzCorruption {
@@ -64,7 +72,7 @@ fuzz_target!(|input: Input| {
     }
     let app = &APP.0;
 
-    let mut proof = app.test_trivial_proof();
+    let mut proof = TRIVIAL_PROOF.clone();
 
     let corruption = match input.corruption {
         FuzzCorruption::PBlind(v) => Corruption::PBlind(Fp::from(v)),


### PR DESCRIPTION
Implements some fuzzing optimizations since some workloads appear statistically slower than they should be, so this corrects that by moving memory debugging as an optional flag that still runs in CI (during period weekly fuzzing jobs), but is disabled _locally_ for longer runs with higher throughput. 