### PR TITLE
feat(fuzz): higher-level abstraction targets

### DIFF
--- a/.github/workflows/fuzz-cron.yml
+++ b/.github/workflows/fuzz-cron.yml
@@ -50,7 +50,7 @@ jobs:
         target:
           - fuzz_element_ops
           - fuzz_witness_coverage
-          - fuzz_soundness_cheat
+          - fuzz_witness_cheat
           - fuzz_driver_metamorphic
           - fuzz_algebraic_identities
           - fuzz_element_assertions

--- a/qa/fuzz/Cargo.toml
+++ b/qa/fuzz/Cargo.toml
@@ -80,6 +80,17 @@ test = false
 doc = false
 bench = false
 
+# Algebraic identity bridging witness and constraint sides: for satisfying
+# witnesses, r.revdot(r + r.dilate(z) + s(X,y) + t(X,z)) must equal
+# circuit.ky(instance, y). Catches witness-pipeline regressions that would
+# pass the cheaper checks in fuzz_circuit_witness.
+[[bin]]
+name = "fuzz_circuit_revdot_identity"
+path = "fuzz_targets/fuzz_circuit_revdot_identity.rs"
+test = false
+doc = false
+bench = false
+
 # Structured polynomial revdot vs unstructured dot product
 [[bin]]
 name = "fuzz_revdot"

--- a/qa/fuzz/Cargo.toml
+++ b/qa/fuzz/Cargo.toml
@@ -70,6 +70,16 @@ test = false
 doc = false
 bench = false
 
+# Circuit::witness pipeline: synthesis output matches native spec, trace
+# pipeline agrees with Simulator on accept/reject, Registry::assemble_with_alpha
+# leaks alpha into exactly one coefficient position.
+[[bin]]
+name = "fuzz_circuit_witness"
+path = "fuzz_targets/fuzz_circuit_witness.rs"
+test = false
+doc = false
+bench = false
+
 # Structured polynomial revdot vs unstructured dot product
 [[bin]]
 name = "fuzz_revdot"

--- a/qa/fuzz/Cargo.toml
+++ b/qa/fuzz/Cargo.toml
@@ -91,6 +91,18 @@ test = false
 doc = false
 bench = false
 
+# Staging pipeline (issue #709 Layer 4): the same revdot identity as
+# fuzz_circuit_revdot_identity, but applied to MultiStage-as-Circuit
+# instances. Exercises StageBuilder wire reservation, StageGuard wire
+# injection, MultiStage::witness adapter, and skip_gates recursion that
+# the non-staged targets bypass.
+[[bin]]
+name = "fuzz_staging"
+path = "fuzz_targets/fuzz_staging.rs"
+test = false
+doc = false
+bench = false
+
 # Structured polynomial revdot vs unstructured dot product
 [[bin]]
 name = "fuzz_revdot"

--- a/qa/fuzz/Cargo.toml
+++ b/qa/fuzz/Cargo.toml
@@ -143,11 +143,12 @@ test = false
 doc = false
 bench = false
 
-# Soundness via mid-stream witness cheating: honest vs cheat paths through the
-# Simulator. Matching final fingerprints under a cheat is a soundness signal.
+# Mid-stream witness cheating: honest vs cheat paths through the Simulator.
+# Currently a Simulator-robustness fuzzer; intended as a soundness oracle once
+# the patcher work lands (see issue tracking the patcher technique).
 [[bin]]
-name = "fuzz_soundness_cheat"
-path = "fuzz_targets/fuzz_soundness_cheat.rs"
+name = "fuzz_witness_cheat"
+path = "fuzz_targets/fuzz_witness_cheat.rs"
 test = false
 doc = false
 bench = false

--- a/qa/fuzz/README.md
+++ b/qa/fuzz/README.md
@@ -1,6 +1,6 @@
 # `ragu_testing-fuzz`
 
-cargo-fuzz harness for the Ragu project. 17 fuzz targets + 1 auxiliary
+cargo-fuzz harness for the Ragu project. 20 fuzz targets + 1 auxiliary
 dictionary-extractor tool. Standalone workspace (the `[workspace]` table in
 `Cargo.toml` makes this crate its own root) so nightly + libfuzzer flags
 don't leak into the rest of the repo.
@@ -71,6 +71,19 @@ All four share an essentially identical `Op` enum and dispatch — see the
 | Target | What it catches |
 |---|---|
 | `fuzz_verify_reject` | Corrupt proof bytes via `fuzz_utils::Corruption`, assert verifier rejects. Uses `test_trivial_proof()` — tests verifier hardening, not soundness in the paper's sense. |
+
+### Circuit-pipeline targets
+
+Higher-layer targets that drive full `Circuit::witness` → `trace::eval` →
+`Registry::assemble_with_alpha` pipelines rather than calling gadgets
+directly through `Simulator`. These close issue #709's Layer 1, 2, and 4
+gaps.
+
+| Target | What it catches |
+|---|---|
+| `fuzz_circuit_witness` | `Circuit::witness` pipeline correctness across six reference circuits — `SquareCircuit`, `MySimpleCircuit`, `BoolCircuit`, `PointCircuit`, `RoutineCircuit` (Routine via `Prediction::Unknown`), `KnownRoutineCircuit` (Routine via `Prediction::Known`). Asserts Simulator output matches a native Rust spec, that `trace::eval` agrees with `Simulator` on accept/reject, and the `assemble_with_alpha` α-injection contract. |
+| `fuzz_circuit_revdot_identity` | The canonical algebraic identity from `tests/mod.rs:158-187` — `r.revdot(r + r.dilate(z) + s(X,y) + t(X,z)) == circuit.ky(instance, y)` — for satisfying witnesses. Bridges the witness-driver side and the wiring/constraint side. Uses only pub APIs by deriving `s(X, y)` from `Registry::wy(omega_0, y)` minus the registry key term. |
+| `fuzz_staging` | Full staging-system coverage: **Invariant A** (`rx.revdot(own_mask) == 0` per stage), **Invariant B** (combined revdot identity through `MultiStage::witness`), **final_mask** check on the bare assembled trace, plus structural **cross-mask** (rx coefficient positions stay within the stage's declared range — robust against adversarial witness/y) and `skip_gates`/`num_gates` hand-coded pins. Three variants exercise `Single2W`, `Single4W`, and `Chain2x4` (parent → child, exercising `skip_gates` recursion). |
 
 ## Auxiliary tooling
 

--- a/qa/fuzz/README.md
+++ b/qa/fuzz/README.md
@@ -41,7 +41,7 @@ All four share an essentially identical `Op` enum and dispatch — see the
 |---|---|
 | `fuzz_element_ops` | Completeness — random gadget compositions must not crash and must produce internally-consistent witnesses. The substrate. |
 | `fuzz_witness_coverage` | Same as `fuzz_element_ops` plus a post-run witness-state hash spread across coverage branches. Biases the fuzzer toward distinct internal witness states. Opt-in POC (~28% throughput cost). |
-| `fuzz_soundness_cheat` | Soundness — mid-stream replaces an element on the stack with a fresh allocation of a different value; matching final fingerprints under a cheat is a signal of an under-constrained gadget. |
+| `fuzz_witness_cheat` | Mid-stream replaces an element on the stack with a fresh allocation of a different value, then compares fingerprints against the honest run. Currently functions as a Simulator-robustness fuzzer (the soundness assertion is structurally tautological today); becomes a true under-constrained-gadget oracle once the patcher technique lands. The mutation scaffolding is in place. |
 | `fuzz_driver_metamorphic` | Differential — runs the same `Vec<Op>` through both `Simulator` and `Emulator<Wired<Fp>>`; wire values must match. Tests the model-vs-real-driver invariant. |
 
 ### Gadget-API property and identity targets
@@ -120,7 +120,7 @@ Or via the helper:
 ./fuzz.sh summarize fuzz_element_ops artifacts/fuzz_element_ops/crash-abc123
 ```
 
-### `TRIAGE_CHEAT` env var (`fuzz_soundness_cheat` only)
+### `TRIAGE_CHEAT` env var (`fuzz_witness_cheat` only)
 
 When a soundness signal fires, distinguishing a real signal from a "dead
 cheat" (cheated slot never read downstream) is important. Set
@@ -129,8 +129,8 @@ the op stream, track the cheated index, and report how many downstream
 ops actually read it:
 
 ```bash
-TRIAGE_CHEAT=1 cargo +nightly fuzz run fuzz_soundness_cheat \
-  artifacts/fuzz_soundness_cheat/crash-abc123
+TRIAGE_CHEAT=1 cargo +nightly fuzz run fuzz_witness_cheat \
+  artifacts/fuzz_witness_cheat/crash-abc123
 ```
 
 If the count is 0, the soundness signal is probably a dead-cheat false
@@ -155,7 +155,7 @@ Two workflows in `.github/workflows/`:
 ## Why several targets duplicate the same `Op` enum
 
 The four `Vec<Op>`-style targets (`fuzz_element_ops`,
-`fuzz_witness_coverage`, `fuzz_soundness_cheat`,
+`fuzz_witness_coverage`, `fuzz_witness_cheat`,
 `fuzz_driver_metamorphic`) each have a copy of the same `Op` enum and
 dispatch — roughly 200 lines of mechanical duplication per file.
 
@@ -163,7 +163,7 @@ This is deliberate. cargo-fuzz expects `[[bin]]`-style fuzz targets, and
 sharing a `src/lib.rs` between fuzz targets adds friction with the
 cargo-fuzz workflow and the patch-table mirroring this crate already
 needs. The duplication is annotated in each file (`Identical dispatch
-logic to fuzz_element_ops and fuzz_soundness_cheat`) so future edits
+logic to fuzz_element_ops and fuzz_witness_cheat`) so future edits
 propagate the same change everywhere.
 
 ## Patch table

--- a/qa/fuzz/fuzz.sh
+++ b/qa/fuzz/fuzz.sh
@@ -97,6 +97,7 @@ TARGETS=(
   fuzz_endoscalar
   fuzz_element_ops
   fuzz_circuit_witness
+  fuzz_circuit_revdot_identity
   fuzz_revdot
   fuzz_fold_revdot
   fuzz_sxy_agreement

--- a/qa/fuzz/fuzz.sh
+++ b/qa/fuzz/fuzz.sh
@@ -96,6 +96,7 @@ TARGETS=(
   fuzz_poseidon_sponge
   fuzz_endoscalar
   fuzz_element_ops
+  fuzz_circuit_witness
   fuzz_revdot
   fuzz_fold_revdot
   fuzz_sxy_agreement

--- a/qa/fuzz/fuzz.sh
+++ b/qa/fuzz/fuzz.sh
@@ -98,6 +98,7 @@ TARGETS=(
   fuzz_element_ops
   fuzz_circuit_witness
   fuzz_circuit_revdot_identity
+  fuzz_staging
   fuzz_revdot
   fuzz_fold_revdot
   fuzz_sxy_agreement

--- a/qa/fuzz/fuzz.sh
+++ b/qa/fuzz/fuzz.sh
@@ -8,7 +8,7 @@
 #   DICT=1 ./fuzz.sh                          # Load dict.txt
 #   ASAN=1 ./fuzz.sh                          # Re-enable AddressSanitizer
 #   ./fuzz.sh summarize <target> <file>       # Decode a corpus/crash input
-#   ./fuzz.sh triage <file>                   # Triage a fuzz_soundness_cheat crash
+#   ./fuzz.sh triage <file>                   # Triage a fuzz_witness_cheat crash
 #
 # The DICT=1 path passes -dict=dict.txt to libFuzzer. Empirical comparison
 # (60s on fuzz_element_ops): roughly flat coverage with a small features
@@ -17,7 +17,7 @@
 #
 # By default this script passes `-s none` to cargo-fuzz, skipping
 # AddressSanitizer for a large throughput win on simulator-heavy targets
-# — measured ~70% on fuzz_soundness_cheat (50k → 84k exec/s), ~30% on
+# — measured ~70% on fuzz_witness_cheat (50k → 84k exec/s), ~30% on
 # fuzz_poseidon_sponge, ~10% on fuzz_element_ops. ASAN catches memory
 # bugs (UAF, OOB on unwise unsafe, leaks across `Simulator::simulate`
 # closures); to opt back in, set ASAN=1. The weekly cron in
@@ -32,10 +32,10 @@
 # via Arbitrary, prints it via Debug, and exits. Useful for triaging
 # crash artifacts without manually decoding bytes.
 #
-# The `triage` subcommand runs fuzz_soundness_cheat with TRIAGE_CHEAT=1,
+# The `triage` subcommand runs fuzz_witness_cheat with TRIAGE_CHEAT=1,
 # which walks the op stream tracking the cheated slot and reports how
-# many downstream ops actually read it. A 0 count means the soundness
-# signal is a "dead cheat" false positive.
+# many downstream ops actually read it. A 0 count means the signal is a
+# "dead cheat" false positive.
 #
 # Regenerate dict.txt via:
 #   cargo +nightly run --release --bin extract_dict > dict.txt
@@ -59,7 +59,7 @@ if [[ "${1:-}" == "summarize" ]]; then
   exit
 fi
 
-# `triage` subcommand: walk the op stream of a fuzz_soundness_cheat crash
+# `triage` subcommand: walk the op stream of a fuzz_witness_cheat crash
 # input, report whether the cheated slot was read downstream.
 if [[ "${1:-}" == "triage" ]]; then
   if [[ -z "${2:-}" ]]; then
@@ -71,7 +71,7 @@ if [[ "${1:-}" == "triage" ]]; then
     echo "Input file not found: $INPUT_FILE" >&2
     exit 1
   fi
-  TRIAGE_CHEAT=1 cargo +nightly fuzz run --fuzz-dir . fuzz_soundness_cheat "$INPUT_FILE"
+  TRIAGE_CHEAT=1 cargo +nightly fuzz run --fuzz-dir . fuzz_witness_cheat "$INPUT_FILE"
   exit
 fi
 
@@ -104,7 +104,7 @@ TARGETS=(
   fuzz_sxy_agreement
   fuzz_poseidon_differential
   fuzz_verify_reject
-  fuzz_soundness_cheat
+  fuzz_witness_cheat
   fuzz_driver_metamorphic
   fuzz_witness_coverage
   fuzz_algebraic_identities

--- a/qa/fuzz/fuzz_targets/fuzz_circuit_revdot_identity.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_circuit_revdot_identity.rs
@@ -1,0 +1,288 @@
+//! Fuzz the canonical algebraic identity that bridges the witness-driver
+//! and wiring/constraint sides of the synthesis pipeline.
+//!
+//! For a satisfying witness `w` of a registered `Circuit`, with assembled
+//! trace polynomial `r`, the identity from `tests/mod.rs:158-187` is:
+//!
+//! ```text
+//! r.revdot(b) == circuit.ky(instance, y)
+//! where b = r + r.dilate(z) + s(X, y) + t(X, z)
+//! ```
+//!
+//! `r` is the witness-side polynomial (assembled trace); `s(X, y)` is
+//! the wiring polynomial restricted at `y`; `t(X, z)` is the registry
+//! key constraint polynomial restricted at `z`; `circuit.ky(instance, y)`
+//! is the instance polynomial evaluated at `y`. The equality is what
+//! actually proves "this witness satisfies this circuit's constraints"
+//! at the algebraic layer; under random `(y, z)` it holds with
+//! overwhelming probability iff the witness is satisfying.
+//!
+//! This is the deferred Layer-1 strong oracle that `fuzz_circuit_witness`
+//! could not implement with pub APIs alone. Here we sidestep the
+//! `pub(crate)` `WiringObject::sy` by deriving `s(X, y)` from the public
+//! `Registry::wy(omega_0, y)` minus the registry key term — valid for a
+//! single-circuit registry whose circuit doesn't `is_mask()` (covers
+//! `SquareCircuit` and `MySimpleCircuit`). When richer test circuits
+//! land (staging, masking), or when we want to fuzz multi-circuit
+//! registries, this trick stops working and the `unstable-fuzzing`
+//! feature exposure of `WiringObject::sy` becomes the necessary path.
+//!
+//! ## What this catches
+//!
+//! - Witness pipeline bugs that produce a `Trace` whose assembled
+//!   polynomial fails the algebraic identity — the strongest signal at
+//!   this layer, equivalent to "the witness doesn't satisfy the
+//!   constraint system."
+//! - `Registry::wy` regressions where the key term is double-counted,
+//!   omitted, or placed in the wrong slot.
+//! - `Rank::tz` regressions in the key constraint polynomial
+//!   construction.
+//! - `Polynomial::revdot` regressions where the dot product over the
+//!   reversed coefficient vector miscomputes.
+//!
+//! ## Circuit coverage
+//!
+//! Reuses `SquareCircuit { times }` and `MySimpleCircuit` from
+//! `ragu_testing::circuits`. `MySimpleCircuit` runs only on satisfying
+//! witnesses (`b = sqrt(a^5)`), since the algebraic identity is
+//! meaningful only for witnesses that satisfy the circuit. `SquareCircuit`
+//! has no `enforce_zero` constraints, so every witness is trivially
+//! satisfying.
+//!
+//! See `fuzz_circuit_witness.rs` for the weaker pub-API-only invariants
+//! (Simulator output vs native, trace/Simulator accept implication,
+//! alpha injection contract).
+
+#![no_main]
+
+use arbitrary::Arbitrary;
+use core::cell::OnceCell;
+use ff::Field;
+use ff::PrimeField;
+use libfuzzer_sys::fuzz_target;
+use pasta_curves::Fp;
+use ragu_circuits::{
+    CircuitExt, Trace,
+    polynomials::{Rank, TestRank, sparse},
+    registry::{CircuitIndex, Registry, RegistryBuilder},
+};
+use ragu_testing::circuits::{MySimpleCircuit, SquareCircuit};
+use std::sync::LazyLock;
+
+#[derive(Arbitrary, Debug)]
+enum CircuitChoice {
+    /// `SquareCircuit { times }` over a single-Fp witness.
+    Square {
+        times: u8,
+        witness_seed: u64,
+        use_special: Option<u8>,
+    },
+    /// `MySimpleCircuit` over `(a, b = sqrt(a^5))`. We force a satisfying
+    /// witness here because the algebraic identity is meaningful only
+    /// for accepted witnesses; the rejection path is covered by
+    /// `fuzz_circuit_witness`.
+    Simple {
+        a_seed: u64,
+        use_special_a: Option<u8>,
+    },
+}
+
+#[derive(Arbitrary, Debug)]
+struct Input {
+    circuit: CircuitChoice,
+    y_seed: u64,
+    z_seed: u64,
+}
+
+fn special_value(idx: u8) -> Fp {
+    match idx % 8 {
+        0 => Fp::ZERO,
+        1 => Fp::ONE,
+        2 => -Fp::ONE,
+        3 => Fp::TWO_INV,
+        4 => Fp::ROOT_OF_UNITY,
+        5 => Fp::MULTIPLICATIVE_GENERATOR,
+        6 => Fp::from(1u64 << 32),
+        _ => Fp::from(u64::MAX),
+    }
+}
+
+/// Per-`times` registry cache for `SquareCircuit`. Same shape as
+/// `fuzz_circuit_witness.rs`.
+struct SquareRegistryCache {
+    slots: [OnceCell<Result<Registry<'static, Fp, TestRank>, ()>>; 120],
+}
+
+// SAFETY: libfuzzer runs the fuzz target on a single thread.
+unsafe impl Sync for SquareRegistryCache {}
+
+static SQUARE_REGISTRY_CACHE: LazyLock<SquareRegistryCache> =
+    LazyLock::new(|| SquareRegistryCache {
+        slots: [const { OnceCell::new() }; 120],
+    });
+
+fn square_registry_for(times: usize) -> Option<&'static Registry<'static, Fp, TestRank>> {
+    debug_assert!((1..=120).contains(&times));
+    SQUARE_REGISTRY_CACHE.slots[times - 1]
+        .get_or_init(|| {
+            RegistryBuilder::<Fp, TestRank>::new()
+                .register_circuit(SquareCircuit { times })
+                .and_then(|b| b.finalize())
+                .map_err(|_| ())
+        })
+        .as_ref()
+        .ok()
+}
+
+static SIMPLE_REGISTRY: LazyLock<Option<Registry<'static, Fp, TestRank>>> = LazyLock::new(|| {
+    RegistryBuilder::<Fp, TestRank>::new()
+        .register_circuit(MySimpleCircuit)
+        .and_then(|b| b.finalize())
+        .ok()
+});
+
+fn square_native(witness: Fp, times: usize) -> Fp {
+    let mut acc = witness;
+    for _ in 0..times {
+        acc = acc.square();
+    }
+    acc
+}
+
+/// Try to compute `b = sqrt(a^5)` so that `(a, b)` is a satisfying witness
+/// for `MySimpleCircuit`. Returns `None` if `a^5` is a non-residue.
+fn derive_satisfying_b(a: Fp) -> Option<Fp> {
+    Option::<Fp>::from(a.pow_vartime([5u64]).sqrt())
+}
+
+/// Compute `s(X, y)` for a single-circuit registry by stripping the
+/// registry key term from `Registry::wy(omega_0, y)`. The key term lives
+/// at the `c` wire of slot `R::n() - 1` (the X^{4n-1} position), with
+/// coefficient `key.value() * y^{4n-1}` (see `registry.rs:589-597`).
+///
+/// Valid only when the circuit at index 0 doesn't `is_mask()` — true
+/// for both `SquareCircuit` and `MySimpleCircuit`. For masked or
+/// multi-circuit registries the wy decomposition picks up a global term
+/// and Lagrange-weighted sums of per-circuit `sy`s, so this trick
+/// stops working.
+fn sy_from_registry(
+    registry: &Registry<'_, Fp, TestRank>,
+    y: Fp,
+) -> sparse::Polynomial<Fp, TestRank> {
+    let omega_0 = CircuitIndex::new(0).omega_j::<Fp>();
+    let mut wy = registry.wy(omega_0, y);
+    if y != Fp::ZERO {
+        let y_4n_minus_1 = y.pow_vartime([(4 * TestRank::n() - 1) as u64]);
+        let mut key_view = sparse::View::<_, TestRank, _>::wiring();
+        key_view.c.push(registry.digest() * y_4n_minus_1);
+        let key_term = key_view.build();
+        wy.sub_assign(&key_term);
+    }
+    wy
+}
+
+/// Run the algebraic identity check on a satisfying witness's trace.
+/// Returns the actual revdot value so the caller's panic message can
+/// include both sides on failure.
+fn check_identity(
+    registry: &Registry<'_, Fp, TestRank>,
+    trace: &Trace<Fp>,
+    expected_ky: Fp,
+    y: Fp,
+    z: Fp,
+) -> (Fp, Fp) {
+    // Use alpha = 0 so the algebraic identity holds without a correction
+    // term. `assemble_with_alpha`'s alpha lives at `a[0]` and would
+    // contribute an unrelated revdot term for nonzero alpha.
+    let r = registry
+        .assemble_with_alpha(trace, CircuitIndex::new(0), Fp::ZERO)
+        .expect("assemble_with_alpha failed on a registered, satisfying witness");
+
+    let mut b = r.clone();
+    b.dilate(z);
+    b.add_assign(&sy_from_registry(registry, y));
+    b.add_assign(&TestRank::tz(z));
+
+    let actual = r.revdot(&b);
+    (expected_ky, actual)
+}
+
+fuzz_target!(|input: Input| {
+    if std::env::var("DEBUG_INPUT").is_ok() {
+        eprintln!("{:#?}", input);
+        return;
+    }
+
+    let y = Fp::from(input.y_seed);
+    let z = Fp::from(input.z_seed);
+
+    match input.circuit {
+        CircuitChoice::Square {
+            times,
+            witness_seed,
+            use_special,
+        } => {
+            let times = ((times as usize) % 120).max(1);
+            let witness: Fp = match use_special {
+                Some(idx) => special_value(idx),
+                None => Fp::from(witness_seed),
+            };
+
+            let registry = match square_registry_for(times) {
+                Some(r) => r,
+                None => return,
+            };
+            let circuit = SquareCircuit { times };
+            let instance = square_native(witness, times);
+            let trace = match circuit.trace(witness) {
+                Ok(t) => t.into_output(),
+                Err(_) => return,
+            };
+            let expected_ky = circuit
+                .ky(instance, y)
+                .expect("SquareCircuit::ky should not fail on Fp instance");
+            let (expected, actual) = check_identity(registry, &trace, expected_ky, y, z);
+            assert_eq!(
+                expected, actual,
+                "SquareCircuit identity violated: \
+                 times={times}, witness={witness:?}, instance={instance:?}, \
+                 y={y:?}, z={z:?}, expected_ky={expected:?}, actual_revdot={actual:?}"
+            );
+        }
+
+        CircuitChoice::Simple {
+            a_seed,
+            use_special_a,
+        } => {
+            let a: Fp = match use_special_a {
+                Some(idx) => special_value(idx),
+                None => Fp::from(a_seed),
+            };
+            let b = match derive_satisfying_b(a) {
+                Some(v) => v,
+                None => return,
+            };
+
+            let registry = match SIMPLE_REGISTRY.as_ref() {
+                Some(r) => r,
+                None => return,
+            };
+            let circuit = MySimpleCircuit;
+            let instance: (Fp, Fp) = (a + b, a - b);
+            let trace = match circuit.trace((a, b)) {
+                Ok(t) => t.into_output(),
+                Err(_) => return,
+            };
+            let expected_ky = circuit
+                .ky(instance, y)
+                .expect("MySimpleCircuit::ky should not fail on (Fp, Fp) instance");
+            let (expected, actual) = check_identity(registry, &trace, expected_ky, y, z);
+            assert_eq!(
+                expected, actual,
+                "MySimpleCircuit identity violated: \
+                 a={a:?}, b={b:?}, instance={instance:?}, y={y:?}, z={z:?}, \
+                 expected_ky={expected:?}, actual_revdot={actual:?}"
+            );
+        }
+    }
+});

--- a/qa/fuzz/fuzz_targets/fuzz_circuit_witness.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_circuit_witness.rs
@@ -56,7 +56,11 @@
 //!   complementing `fuzz_endoscalar`'s gadget-level coverage with an
 //!   end-to-end Circuit-pipeline path.
 //! - **`RoutineCircuit`** — `Driver::routine` plus an inline
-//!   `Routine::{predict, execute}` split (the `ScaleByThree` routine).
+//!   `Routine::{predict, execute}` split via `Prediction::Unknown(aux)`
+//!   (the `ScaleByThree` routine).
+//! - **`KnownRoutineCircuit`** — the `Prediction::Known(output, aux)`
+//!   branch of Routine, the path that lets witness drivers short-circuit
+//!   `execute` (the `DoubleKnown` routine).
 //!
 //! Multi-stage circuits (`StageBuilder`, `MultiStage`, `MultiStageCircuit`)
 //! are covered by the sibling `fuzz_staging` target, not here. The
@@ -140,8 +144,18 @@ enum CircuitChoice {
         scalar_seed: u64,
     },
     /// `RoutineCircuit` over a single Fp witness. Exercises
-    /// `Driver::routine` and the `Routine::{predict, execute}` split.
+    /// `Driver::routine` and the `Routine::{predict, execute}` split via
+    /// the `Prediction::Unknown(aux)` path.
     Routine {
+        witness_seed: u64,
+        use_special: Option<u8>,
+    },
+    /// `KnownRoutineCircuit` over a single Fp witness. Exercises the
+    /// `Prediction::Known(output, aux)` branch of the Routine trait —
+    /// the branch that lets witness drivers short-circuit `execute`.
+    /// Catches Routine impls that mis-construct the predicted-output
+    /// gadget while still satisfying the synthesis-side aux contract.
+    KnownRoutine {
         witness_seed: u64,
         use_special: Option<u8>,
     },
@@ -230,6 +244,14 @@ static ROUTINE_REGISTRY: LazyLock<Option<Registry<'static, Fp, TestRank>>> = Laz
         .and_then(|b| b.finalize())
         .ok()
 });
+
+static KNOWN_ROUTINE_REGISTRY: LazyLock<Option<Registry<'static, Fp, TestRank>>> =
+    LazyLock::new(|| {
+        RegistryBuilder::<Fp, TestRank>::new()
+            .register_circuit(KnownRoutineCircuit)
+            .and_then(|b| b.finalize())
+            .ok()
+    });
 
 /// Native spec for `SquareCircuit`: compute `w^(2^times)` by repeated
 /// squaring directly in the field.
@@ -433,6 +455,97 @@ impl Circuit<Fp> for RoutineCircuit {
 /// Native spec for `RoutineCircuit`: `output = 3 * witness`.
 fn routine_native(witness: Fp) -> Fp {
     witness * Fp::from(3u64)
+}
+
+// ---------------------------------------------------------------------------
+// KnownRoutineCircuit — exercises the `Prediction::Known(output, aux)`
+// branch of the Routine trait. `ScaleByThree` above uses
+// `Prediction::Unknown(aux)`; `DoubleKnown` returns
+// `Prediction::Known(predicted_output, aux)`, letting witness-extraction
+// drivers short-circuit execution if they choose to. Catches Routine
+// impls that mis-construct the predicted-output gadget (wrong wire shape
+// or wrong predicted value) — bugs that an Unknown-only routine cannot
+// surface because witness drivers never see the predicted output there.
+// ---------------------------------------------------------------------------
+
+/// Routine that doubles its input. `predict` returns
+/// `Prediction::Known(predicted_elem, aux)` so witness drivers can
+/// skip `execute`; synthesis drivers (which always call `execute`) use
+/// the `aux` value to allocate the output and enforce the relation.
+#[derive(Clone)]
+struct DoubleKnown;
+
+impl Routine<Fp> for DoubleKnown {
+    type Input = Kind![Fp; Element<'_, _>];
+    type Output = Kind![Fp; Element<'_, _>];
+    type Aux<'dr> = Fp;
+
+    fn execute<'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        input: Bound<'dr, D, Self::Input>,
+        aux: DriverValue<D, Self::Aux<'dr>>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        let allocator = &mut Standard::new();
+        let output = Element::alloc(dr, allocator, aux)?;
+        // Enforce: 2 * input - output == 0 via Element::double.
+        let two_input = input.double(dr);
+        dr.enforce_zero(|lc| lc.add(two_input.wire()).sub(output.wire()))?;
+        Ok(output)
+    }
+
+    fn predict<'dr, D: Driver<'dr, F = Fp, Wire = ()>>(
+        &self,
+        dr: &mut D,
+        input: &Bound<'dr, D, Self::Input>,
+    ) -> Result<Prediction<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'dr>>>> {
+        let aux = input.value().map(|v| *v * Fp::from(2u64));
+        // Allocate the predicted output on the wireless predict driver
+        // (Wire = ()). This is what distinguishes Known from Unknown:
+        // we hand the witness driver a fully-constructed output gadget,
+        // not just an aux value.
+        let allocator = &mut Standard::new();
+        let predicted_output =
+            Element::alloc(dr, allocator, input.value().map(|v| *v * Fp::from(2u64)))?;
+        Ok(Prediction::Known(predicted_output, aux))
+    }
+}
+
+struct KnownRoutineCircuit;
+
+impl Circuit<Fp> for KnownRoutineCircuit {
+    type Instance<'instance> = Fp;
+    type Output = Kind![Fp; Element<'_, _>];
+    type Witness<'witness> = Fp;
+    type Aux<'witness> = ();
+
+    fn instance<'dr, 'instance: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        instance: DriverValue<D, Self::Instance<'instance>>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        let allocator = &mut Standard::new();
+        Element::alloc(dr, allocator, instance)
+    }
+
+    fn witness<'dr, 'witness: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Self::Witness<'witness>>,
+    ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'witness>>>>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let x = Element::alloc(dr, allocator, witness)?;
+        let result = dr.routine(DoubleKnown, x)?;
+        Ok(WithAux::new(result, D::unit()))
+    }
+}
+
+/// Native spec for `KnownRoutineCircuit`: `output = 2 * witness`.
+fn known_routine_native(witness: Fp) -> Fp {
+    witness * Fp::from(2u64)
 }
 
 /// Run the differential alpha-injection check on an assembled trace.
@@ -783,6 +896,56 @@ fuzz_target!(|input: Input| {
                 Ok(t) => t.into_output(),
                 Err(_) => panic!(
                     "trace::eval rejected RoutineCircuit witness={witness:?} \
+                     but Simulator accepted — driver disagreement"
+                ),
+            };
+
+            if alphas_distinct {
+                check_alpha_injection(registry, &trace, alpha_a, alpha_b);
+            }
+        }
+
+        CircuitChoice::KnownRoutine {
+            witness_seed,
+            use_special,
+        } => {
+            let registry = match KNOWN_ROUTINE_REGISTRY.as_ref() {
+                Some(r) => r,
+                None => return,
+            };
+            let witness: Fp = match use_special {
+                Some(idx) => special_value(idx),
+                None => Fp::from(witness_seed),
+            };
+            let circuit = KnownRoutineCircuit;
+            let expected = known_routine_native(witness);
+
+            let mut sim_value: Option<Fp> = None;
+            let sim_result = Simulator::<Fp>::simulate(witness, |dr, w_just| {
+                let cw = circuit.witness(dr, w_just)?;
+                let elem = cw.into_output();
+                sim_value = Some(*elem.value().take());
+                Ok(())
+            });
+
+            if sim_result.is_err() {
+                panic!(
+                    "Simulator rejected KnownRoutineCircuit witness={witness:?} \
+                     — DoubleKnown should accept any Fp witness"
+                );
+            }
+
+            let sim_value = sim_value.expect("Simulator Ok without writing value");
+            assert_eq!(
+                sim_value, expected,
+                "KnownRoutineCircuit: synthesis output != native 2 * witness: \
+                 witness={witness:?}, sim={sim_value:?}, expected={expected:?}"
+            );
+
+            let trace = match circuit.trace(witness) {
+                Ok(t) => t.into_output(),
+                Err(_) => panic!(
+                    "trace::eval rejected KnownRoutineCircuit witness={witness:?} \
                      but Simulator accepted — driver disagreement"
                 ),
             };

--- a/qa/fuzz/fuzz_targets/fuzz_circuit_witness.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_circuit_witness.rs
@@ -1,0 +1,242 @@
+//! Fuzz `Circuit::witness` pipeline correctness against a native oracle.
+//!
+//! For arbitrary `witness: Fp` and `times: 1..=120`, this target runs
+//! `SquareCircuit { times }` through three pipelines and checks pairwise
+//! consistency:
+//!
+//! 1. **Native spec**: compute `w^(2^times)` directly via repeated squaring.
+//! 2. **Simulator synthesis**: `circuit.witness(&mut Simulator, w)`; the
+//!    `Simulator` driver enforces every gate identity inline, then exposes
+//!    the output `Element`'s witness value.
+//! 3. **Trace + assembly**: `circuit.trace(w)` produces a `Trace`, then
+//!    `Registry::assemble_with_alpha` writes it to a sparse polynomial.
+//!
+//! ## Invariants enforced
+//!
+//! - **Synthesis correctness**: the Simulator output value equals the native
+//!    `w^(2^times)`. Catches bugs in any `Circuit::witness` impl that
+//!    produces a non-spec output from a satisfying witness, and (because
+//!    `Simulator::gate` checks `a*b = c` inline) catches `Element::square`
+//!    plumbing bugs that would emit a constraint inconsistent with the
+//!    witness it returns.
+//! - **Trace-pipeline robustness**: `trace::eval` returns `Ok` whenever
+//!    Simulator synthesis returned `Ok`. The two drivers must be
+//!    observationally equivalent on `Circuit::witness`.
+//! - **`alpha` injection contract**: assembling the same trace twice with
+//!    distinct `alpha_a` and `alpha_b` produces two polynomials that
+//!    differ in exactly one coefficient position, with the difference
+//!    equal to `alpha_a - alpha_b`. `Registry::assemble_with_alpha`
+//!    documents that `alpha` is written to `a[0]` and used nowhere else;
+//!    this catches any future regression that leaks `alpha` into another
+//!    slot (which would break commit-blinding / point-at-infinity
+//!    protection).
+//!
+//! ## What this does not catch (deferred — issue #709)
+//!
+//! The full algebraic identity from `tests/mod.rs:158-187` —
+//! `a.revdot(b) == circuit.ky(instance, y)` where
+//! `b = r + r.dilate(z) + obj.sy(y, &plan) + Rank::tz(z)` — is the
+//! strongest oracle for the synthesis layer. Its construction requires
+//! `WiringObject::sy` and `Rank::tz`, both `pub(crate)` in `ragu_circuits`.
+//! Exposing them is an `unstable-fuzzing` feature flag away (per
+//! `feedback_fuzzing_standards.md`) but was scoped out of this target —
+//! see `fuzzing_perf.md` for the upgrade path.
+
+#![no_main]
+
+use arbitrary::Arbitrary;
+use core::cell::OnceCell;
+use ff::Field;
+use ff::PrimeField;
+use libfuzzer_sys::fuzz_target;
+use pasta_curves::Fp;
+use ragu_circuits::{
+    Circuit, CircuitExt,
+    polynomials::TestRank,
+    registry::{CircuitIndex, Registry, RegistryBuilder},
+};
+use ragu_core::maybe::Maybe;
+use ragu_primitives::Simulator;
+use ragu_testing::circuits::SquareCircuit;
+use std::sync::LazyLock;
+
+#[derive(Arbitrary, Debug)]
+struct Input {
+    times: u8,
+    witness_seed: u64,
+    /// If `Some`, override `witness_seed` with a special edge-case value.
+    use_special: Option<u8>,
+    alpha_a_seed: u64,
+    alpha_b_seed: u64,
+}
+
+/// Edge-case field elements that exercise boundary behavior.
+fn special_value(idx: u8) -> Fp {
+    match idx % 8 {
+        0 => Fp::ZERO,
+        1 => Fp::ONE,
+        2 => -Fp::ONE,
+        3 => Fp::TWO_INV,
+        4 => Fp::ROOT_OF_UNITY,
+        5 => Fp::MULTIPLICATIVE_GENERATOR,
+        6 => Fp::from(1u64 << 32),
+        _ => Fp::from(u64::MAX),
+    }
+}
+
+/// Per-`times` registry cache. Building a registry for `SquareCircuit`
+/// runs the floor planner over `times` squarings — comfortably more
+/// expensive than the per-input checks the fuzz body performs. Memoizing
+/// across inputs turns the hot path into trace + assemble + revdot after
+/// each distinct `times` is observed once. Mirrors the cache in
+/// `fuzz_sxy_agreement.rs:42-69`.
+struct RegistryCache {
+    /// Slot for `times = i + 1`, indexed 0..119.
+    slots: [OnceCell<Result<Registry<'static, Fp, TestRank>, ()>>; 120],
+}
+
+// SAFETY: libfuzzer runs the fuzz target on a single thread, so the
+// interior-mutable `OnceCell` slots are never accessed concurrently.
+// `LazyLock` requires `Sync` to compile.
+unsafe impl Sync for RegistryCache {}
+
+static REGISTRY_CACHE: LazyLock<RegistryCache> = LazyLock::new(|| RegistryCache {
+    slots: [const { OnceCell::new() }; 120],
+});
+
+fn registry_for(times: usize) -> Option<&'static Registry<'static, Fp, TestRank>> {
+    debug_assert!((1..=120).contains(&times));
+    REGISTRY_CACHE.slots[times - 1]
+        .get_or_init(|| {
+            let circuit = SquareCircuit { times };
+            RegistryBuilder::<Fp, TestRank>::new()
+                .register_circuit(circuit)
+                .and_then(|b| b.finalize())
+                .map_err(|_| ())
+        })
+        .as_ref()
+        .ok()
+}
+
+/// Native spec: compute `w^(2^times)` by repeated squaring.
+fn native_expected(witness: Fp, times: usize) -> Fp {
+    let mut acc = witness;
+    for _ in 0..times {
+        acc = acc.square();
+    }
+    acc
+}
+
+fuzz_target!(|input: Input| {
+    if std::env::var("DEBUG_INPUT").is_ok() {
+        eprintln!("{:#?}", input);
+        return;
+    }
+
+    let times = ((input.times as usize) % 120).max(1);
+
+    let witness: Fp = match input.use_special {
+        Some(idx) => special_value(idx),
+        None => Fp::from(input.witness_seed),
+    };
+
+    // Skip if registry build fails (rank-bound exceeded for high `times`).
+    let registry = match registry_for(times) {
+        Some(r) => r,
+        None => return,
+    };
+
+    let circuit = SquareCircuit { times };
+
+    // Oracle: native spec.
+    let expected = native_expected(witness, times);
+
+    // Synthesis via Simulator. The driver checks each `a * b = c` gate
+    // inline; the closure's return value is discarded by `Simulator::simulate`,
+    // so the synthesized output escapes through a captured mutable variable.
+    let mut sim_value: Option<Fp> = None;
+    let sim_result = Simulator::<Fp>::simulate(witness, |dr, w_just| {
+        let cw = circuit.witness(dr, w_just)?;
+        let elem = cw.into_output();
+        sim_value = Some(*elem.value().take());
+        Ok(())
+    });
+
+    if sim_result.is_err() {
+        // Simulator rejected — under SquareCircuit this only happens via
+        // gate-plumbing bugs. We still want the test to surface that, so
+        // assert that the trace pipeline also rejects (drivers must agree).
+        assert!(
+            circuit.trace(witness).is_err(),
+            "Simulator rejected witness {witness:?} at times={times} but \
+             trace::eval accepted — model/real driver disagreement"
+        );
+        return;
+    }
+
+    let sim_value = sim_value.expect("Simulator simulate returned Ok without writing value");
+    assert_eq!(
+        sim_value, expected,
+        "synthesis output != native w^(2^times): witness={witness:?}, times={times}, \
+         sim={sim_value:?}, expected={expected:?}"
+    );
+
+    // Trace must agree on accept/reject with Simulator. We already returned
+    // above on the Err path; here, both Ok.
+    let trace = match circuit.trace(witness) {
+        Ok(t) => t.into_output(),
+        Err(_) => panic!(
+            "trace::eval rejected witness {witness:?} at times={times} \
+             but Simulator accepted — model/real driver disagreement"
+        ),
+    };
+
+    // Assembly correctness: alpha is written to a[0] and nowhere else. Two
+    // assemblies with distinct alphas should differ in exactly one
+    // coefficient position by exactly the alpha delta.
+    if input.alpha_a_seed == input.alpha_b_seed {
+        return; // need distinct alphas for the differential check
+    }
+    let alpha_a = Fp::from(input.alpha_a_seed);
+    let alpha_b = Fp::from(input.alpha_b_seed);
+    if alpha_a == alpha_b {
+        return; // both seeds map to the same Fp (e.g., via reduction)
+    }
+
+    let idx = CircuitIndex::new(0);
+    let poly_a = match registry.assemble_with_alpha(&trace, idx, alpha_a) {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    let poly_b = match registry.assemble_with_alpha(&trace, idx, alpha_b) {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    let coeffs_a: Vec<Fp> = poly_a.iter_coeffs().collect();
+    let coeffs_b: Vec<Fp> = poly_b.iter_coeffs().collect();
+    assert_eq!(
+        coeffs_a.len(),
+        coeffs_b.len(),
+        "assemble_with_alpha produced polynomials of different length"
+    );
+
+    let mut diff_count = 0usize;
+    let mut diff_idx = usize::MAX;
+    for i in 0..coeffs_a.len() {
+        if coeffs_a[i] != coeffs_b[i] {
+            diff_count += 1;
+            diff_idx = i;
+        }
+    }
+    assert_eq!(
+        diff_count, 1,
+        "alpha leaked into {diff_count} coefficient positions (expected 1) \
+         at times={times}, witness={witness:?}"
+    );
+    assert_eq!(
+        coeffs_a[diff_idx] - coeffs_b[diff_idx],
+        alpha_a - alpha_b,
+        "alpha delta mismatch at coefficient position {diff_idx}"
+    );
+});

--- a/qa/fuzz/fuzz_targets/fuzz_circuit_witness.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_circuit_witness.rs
@@ -84,7 +84,7 @@ use ff::Field;
 use ff::PrimeField;
 use ff::WithSmallOrderMulGroup;
 use group::Curve;
-use group::prime::PrimeCurveAffine;
+use group::CurveAffine as _;
 use pasta_curves::arithmetic::CurveAffine;
 use libfuzzer_sys::fuzz_target;
 use pasta_curves::Fp;
@@ -355,7 +355,7 @@ fn point_native(base: EpAffine) -> Option<EpAffine> {
     let coords = base.coordinates().into_option()?;
     let endo_x = *coords.x() * Fp::ZETA;
     let endo_p = EpAffine::from_xy(endo_x, *coords.y()).into_option()?;
-    Some((-PrimeCurveAffine::to_curve(&endo_p)).to_affine())
+    Some((-endo_p.to_curve()).to_affine())
 }
 
 // ---------------------------------------------------------------------------
@@ -692,8 +692,7 @@ fuzz_target!(|input: Input| {
             if scalar_seed == 0 {
                 return;
             }
-            let base = (<EpAffine as PrimeCurveAffine>::generator() * Fq::from(scalar_seed))
-                .to_affine();
+            let base = (EpAffine::generator() * Fq::from(scalar_seed)).to_affine();
             let registry = match POINT_REGISTRY.as_ref() {
                 Some(r) => r,
                 None => return,

--- a/qa/fuzz/fuzz_targets/fuzz_circuit_witness.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_circuit_witness.rs
@@ -45,27 +45,24 @@
 //! two-element output. Together they cover most of `Element`'s arithmetic
 //! surface.
 //!
-//! TODO(issue #709): broaden circuit coverage by adding purpose-built
-//! reference circuits and another `CircuitChoice` arm for each:
-//! - **Boolean**: `Boolean::alloc`, `Boolean::not`, `Boolean::and`,
-//!   `conditional_select`. A reference circuit could allocate `n`
-//!   booleans from witness bits and assert a target value reconstructed
-//!   from them.
-//! - **Point**: `Point::alloc`, `endo`, `negate`, `double`,
-//!   `conditional_endo`, `conditional_negate`, `add_incomplete`. A
-//!   reference circuit could compute a Pasta scalar multiplication of a
-//!   fuzzer-chosen base by a fuzzer-chosen scalar and compare to native.
-//!   (`fuzz_endoscalar` already does the gadget-level differential; the
-//!   gap is exercising it through `Circuit::witness` end-to-end.)
-//! - **Routines / sub-circuits**: `Driver::routine`, the
-//!   `Routine::predict`/`Routine::execute` split. A reference circuit
-//!   could invoke a non-trivial `Routine` impl from
-//!   `ragu_testing::routines` and assert its `Aux<'_>` matches the
-//!   prediction.
-//! - **Multi-stage circuits**: `StageBuilder`, `MultiStage`,
-//!   `MultiStageCircuit`. This is the Tier-3B Layer 4 work flagged in
-//!   `fuzzing-follow-up-work.md`; needs an `Arbitrary` impl that builds
-//!   a stage chain with varying wire counts per stage.
+//! Circuit menu (each is a `CircuitChoice` arm exercising one gadget
+//! family end-to-end through `Circuit::witness`):
+//!
+//! - **`SquareCircuit`** — `Element::square` loop.
+//! - **`MySimpleCircuit`** — `Element::{square, mul, add, sub}` plus an
+//!   explicit `Driver::enforce_zero` constraint.
+//! - **`BoolCircuit`** — `Boolean::{alloc, and, not, conditional_select}`.
+//! - **`PointCircuit`** — `Point::{alloc, endo, negate}` over `EpAffine`,
+//!   complementing `fuzz_endoscalar`'s gadget-level coverage with an
+//!   end-to-end Circuit-pipeline path.
+//! - **`RoutineCircuit`** — `Driver::routine` plus an inline
+//!   `Routine::{predict, execute}` split (the `ScaleByThree` routine).
+//!
+//! Multi-stage circuits (`StageBuilder`, `MultiStage`, `MultiStageCircuit`)
+//! are covered by the sibling `fuzz_staging` target, not here. The
+//! remaining gaps (exotic point ops `double_and_add_incomplete`, longer
+//! routine chains, multi-routine compositions) can be added as further
+//! `CircuitChoice` arms when warranted.
 //!
 //! ## What this does not catch (deferred — issue #709)
 //!
@@ -85,15 +82,27 @@ use arbitrary::Arbitrary;
 use core::cell::OnceCell;
 use ff::Field;
 use ff::PrimeField;
+use ff::WithSmallOrderMulGroup;
+use group::Curve;
+use group::prime::PrimeCurveAffine;
 use libfuzzer_sys::fuzz_target;
 use pasta_curves::Fp;
+use pasta_curves::arithmetic::CurveAffine;
+use ragu_arithmetic::Coeff;
 use ragu_circuits::{
-    Circuit, CircuitExt,
+    Circuit, CircuitExt, WithAux,
     polynomials::TestRank,
     registry::{CircuitIndex, Registry, RegistryBuilder},
 };
-use ragu_core::maybe::Maybe;
-use ragu_primitives::Simulator;
+use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue, LinearExpression},
+    gadgets::{Bound, Kind},
+    maybe::Maybe,
+    routines::{Prediction, Routine},
+};
+use ragu_pasta::{EpAffine, Fq};
+use ragu_primitives::{Boolean, Element, Point, Simulator, allocator::Standard};
 use ragu_testing::circuits::{MySimpleCircuit, SquareCircuit};
 use std::sync::LazyLock;
 
@@ -114,6 +123,27 @@ enum CircuitChoice {
         b_seed: u64,
         use_special_a: Option<u8>,
         derive_b_from_a: bool,
+    },
+    /// `BoolCircuit` over a `(bool, bool, Fp, Fp)` witness. Exercises
+    /// `Boolean::{alloc, and, not, conditional_select}`.
+    Bool {
+        b0: bool,
+        b1: bool,
+        x_seed: u64,
+        y_seed: u64,
+        use_special_x: Option<u8>,
+    },
+    /// `PointCircuit` over an `EpAffine` witness derived from a fuzzer-chosen
+    /// Fq scalar. Exercises `Point::{alloc, endo, negate}` end-to-end through
+    /// `Circuit::witness`.
+    Point {
+        scalar_seed: u64,
+    },
+    /// `RoutineCircuit` over a single Fp witness. Exercises
+    /// `Driver::routine` and the `Routine::{predict, execute}` split.
+    Routine {
+        witness_seed: u64,
+        use_special: Option<u8>,
     },
 }
 
@@ -144,7 +174,7 @@ fn special_value(idx: u8) -> Fp {
 /// the hot path into trace + assemble after each distinct `times` is
 /// observed once. Mirrors the cache in `fuzz_sxy_agreement.rs:42-69`.
 struct SquareRegistryCache {
-    slots: [OnceCell<Result<Registry<'static, Fp, TestRank>, ()>>; 120],
+    slots: [OnceCell<core::result::Result<Registry<'static, Fp, TestRank>, ()>>; 120],
 }
 
 // SAFETY: libfuzzer runs the fuzz target on a single thread, so the
@@ -180,6 +210,27 @@ static SIMPLE_REGISTRY: LazyLock<Option<Registry<'static, Fp, TestRank>>> = Lazy
         .ok()
 });
 
+static BOOL_REGISTRY: LazyLock<Option<Registry<'static, Fp, TestRank>>> = LazyLock::new(|| {
+    RegistryBuilder::<Fp, TestRank>::new()
+        .register_circuit(BoolCircuit)
+        .and_then(|b| b.finalize())
+        .ok()
+});
+
+static POINT_REGISTRY: LazyLock<Option<Registry<'static, Fp, TestRank>>> = LazyLock::new(|| {
+    RegistryBuilder::<Fp, TestRank>::new()
+        .register_circuit(PointCircuit)
+        .and_then(|b| b.finalize())
+        .ok()
+});
+
+static ROUTINE_REGISTRY: LazyLock<Option<Registry<'static, Fp, TestRank>>> = LazyLock::new(|| {
+    RegistryBuilder::<Fp, TestRank>::new()
+        .register_circuit(RoutineCircuit)
+        .and_then(|b| b.finalize())
+        .ok()
+});
+
 /// Native spec for `SquareCircuit`: compute `w^(2^times)` by repeated
 /// squaring directly in the field.
 fn square_native(witness: Fp, times: usize) -> Fp {
@@ -208,6 +259,180 @@ fn simple_native(a: Fp, b: Fp) -> Option<(Fp, Fp)> {
 /// for `MySimpleCircuit`. Returns `None` if `a^5` is a non-residue.
 fn derive_satisfying_b(a: Fp) -> Option<Fp> {
     Option::<Fp>::from(a.pow_vartime([5u64]).sqrt())
+}
+
+// ---------------------------------------------------------------------------
+// BoolCircuit — exercises `Boolean::alloc`, `Boolean::and`, `Boolean::not`,
+// and `Boolean::conditional_select`. Output is the conditional-selected
+// element value.
+// ---------------------------------------------------------------------------
+
+struct BoolCircuit;
+
+impl Circuit<Fp> for BoolCircuit {
+    type Instance<'instance> = Fp;
+    type Output = Kind![Fp; Element<'_, _>];
+    type Witness<'witness> = (bool, bool, Fp, Fp);
+    type Aux<'witness> = ();
+
+    fn instance<'dr, 'instance: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        instance: DriverValue<D, Self::Instance<'instance>>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        let allocator = &mut Standard::new();
+        Element::alloc(dr, allocator, instance)
+    }
+
+    fn witness<'dr, 'witness: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Self::Witness<'witness>>,
+    ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'witness>>>> {
+        let allocator = &mut Standard::new();
+        let b0 = Boolean::alloc(dr, allocator, witness.as_ref().map(|w| w.0))?;
+        let b1 = Boolean::alloc(dr, allocator, witness.as_ref().map(|w| w.1))?;
+        let x = Element::alloc(dr, allocator, witness.as_ref().map(|w| w.2))?;
+        let y = Element::alloc(dr, allocator, witness.as_ref().map(|w| w.3))?;
+        let and_b = b0.and(dr, &b1)?;
+        // `not(b0)` constraint already pinned to `b0` by the alloc; we
+        // invoke it for its synthesis side-effect (exercises the
+        // linear-combination path that produces a new wire) and drop
+        // the result. The Bound is dropped without being written.
+        let _not_b = b0.not(dr);
+        let sel = and_b.conditional_select(dr, &x, &y)?;
+        Ok(WithAux::new(sel, D::unit()))
+    }
+}
+
+/// Native spec for `BoolCircuit`: matches the
+/// `and_b.conditional_select(x, y)` invocation in `witness`. Per
+/// `Boolean::conditional_select(a, b)` — returns `a` when the boolean
+/// is false, `b` when true — so the result is `y` iff `b0 && b1`.
+fn bool_native(b0: bool, b1: bool, x: Fp, y: Fp) -> Fp {
+    if b0 && b1 { y } else { x }
+}
+
+// ---------------------------------------------------------------------------
+// PointCircuit — exercises the `Point<EpAffine>` gadget end-to-end through
+// `Circuit::witness`. `fuzz_endoscalar` exercises the same gadgets at the
+// Vec<Op> dispatch level but never through the higher-layer Circuit
+// pipeline, so this closes a gap.
+// ---------------------------------------------------------------------------
+
+struct PointCircuit;
+
+impl Circuit<Fp> for PointCircuit {
+    type Instance<'instance> = EpAffine;
+    type Output = Kind![Fp; Point<'_, _, EpAffine>];
+    type Witness<'witness> = EpAffine;
+    type Aux<'witness> = ();
+
+    fn instance<'dr, 'instance: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        instance: DriverValue<D, Self::Instance<'instance>>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Point::alloc(dr, instance)
+    }
+
+    fn witness<'dr, 'witness: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Self::Witness<'witness>>,
+    ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'witness>>>> {
+        let p = Point::alloc(dr, witness)?;
+        let endo_p = p.endo(dr);
+        let negated = endo_p.negate(dr);
+        Ok(WithAux::new(negated, D::unit()))
+    }
+}
+
+/// Native spec for `PointCircuit`: apply endo then negate, on the base
+/// `EpAffine` value. Returns `None` if the witness or any intermediate
+/// would be the point at infinity (which `Point::alloc` rejects).
+fn point_native(base: EpAffine) -> Option<EpAffine> {
+    let coords = base.coordinates().into_option()?;
+    let endo_x = *coords.x() * Fp::ZETA;
+    let endo_p = EpAffine::from_xy(endo_x, *coords.y()).into_option()?;
+    Some((-endo_p.to_curve()).to_affine())
+}
+
+// ---------------------------------------------------------------------------
+// RoutineCircuit — exercises `Driver::routine` and the
+// `Routine::predict` / `Routine::execute` split. The routine triples its
+// input; the circuit invokes it once and returns the tripled element.
+// ---------------------------------------------------------------------------
+
+/// Routine that triples its input: `output = 3 * input`. Designed to
+/// exercise the full `predict` (native aux computation on a wireless
+/// emulator) + `execute` (driver-side constraint emission) split.
+#[derive(Clone)]
+struct ScaleByThree;
+
+impl Routine<Fp> for ScaleByThree {
+    type Input = Kind![Fp; Element<'_, _>];
+    type Output = Kind![Fp; Element<'_, _>];
+    type Aux<'dr> = Fp;
+
+    fn execute<'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        input: Bound<'dr, D, Self::Input>,
+        aux: DriverValue<D, Self::Aux<'dr>>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        let allocator = &mut Standard::new();
+        let output = Element::alloc(dr, allocator, aux)?;
+        let three_input = input.scale(dr, Coeff::Arbitrary(Fp::from(3u64)));
+        dr.enforce_zero(|lc| lc.add(three_input.wire()).sub(output.wire()))?;
+        Ok(output)
+    }
+
+    fn predict<'dr, D: Driver<'dr, F = Fp, Wire = ()>>(
+        &self,
+        _dr: &mut D,
+        input: &Bound<'dr, D, Self::Input>,
+    ) -> Result<Prediction<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'dr>>>> {
+        let aux = input.value().map(|v| *v * Fp::from(3u64));
+        Ok(Prediction::Unknown(aux))
+    }
+}
+
+struct RoutineCircuit;
+
+impl Circuit<Fp> for RoutineCircuit {
+    type Instance<'instance> = Fp;
+    type Output = Kind![Fp; Element<'_, _>];
+    type Witness<'witness> = Fp;
+    type Aux<'witness> = ();
+
+    fn instance<'dr, 'instance: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        instance: DriverValue<D, Self::Instance<'instance>>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        let allocator = &mut Standard::new();
+        Element::alloc(dr, allocator, instance)
+    }
+
+    fn witness<'dr, 'witness: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Self::Witness<'witness>>,
+    ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'witness>>>>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let x = Element::alloc(dr, allocator, witness)?;
+        let result = dr.routine(ScaleByThree, x)?;
+        Ok(WithAux::new(result, D::unit()))
+    }
+}
+
+/// Native spec for `RoutineCircuit`: `output = 3 * witness`.
+fn routine_native(witness: Fp) -> Fp {
+    witness * Fp::from(3u64)
 }
 
 /// Run the differential alpha-injection check on an assembled trace.
@@ -404,6 +629,166 @@ fuzz_target!(|input: Input| {
                 if alphas_distinct {
                     check_alpha_injection(registry, &trace, alpha_a, alpha_b);
                 }
+            }
+        }
+
+        CircuitChoice::Bool {
+            b0,
+            b1,
+            x_seed,
+            y_seed,
+            use_special_x,
+        } => {
+            let registry = match BOOL_REGISTRY.as_ref() {
+                Some(r) => r,
+                None => return,
+            };
+            let x: Fp = match use_special_x {
+                Some(idx) => special_value(idx),
+                None => Fp::from(x_seed),
+            };
+            let y = Fp::from(y_seed);
+            let witness = (b0, b1, x, y);
+            let circuit = BoolCircuit;
+            let expected = bool_native(b0, b1, x, y);
+
+            let mut sim_value: Option<Fp> = None;
+            let sim_result = Simulator::<Fp>::simulate(witness, |dr, w_just| {
+                let cw = circuit.witness(dr, w_just)?;
+                let elem = cw.into_output();
+                sim_value = Some(*elem.value().take());
+                Ok(())
+            });
+
+            if sim_result.is_err() {
+                panic!(
+                    "Simulator rejected BoolCircuit witness={witness:?} \
+                     — BoolCircuit has no constraints that should fail for bool inputs"
+                );
+            }
+
+            let sim_value = sim_value.expect("Simulator Ok without writing value");
+            assert_eq!(
+                sim_value, expected,
+                "BoolCircuit: synthesis output != native conditional_select: \
+                 witness={witness:?}, sim={sim_value:?}, expected={expected:?}"
+            );
+
+            let trace = match circuit.trace(witness) {
+                Ok(t) => t.into_output(),
+                Err(_) => panic!(
+                    "trace::eval rejected BoolCircuit witness={witness:?} \
+                     but Simulator accepted — driver disagreement"
+                ),
+            };
+
+            if alphas_distinct {
+                check_alpha_injection(registry, &trace, alpha_a, alpha_b);
+            }
+        }
+
+        CircuitChoice::Point { scalar_seed } => {
+            // scalar=0 gives the identity; Point::alloc rejects it. Skip.
+            if scalar_seed == 0 {
+                return;
+            }
+            let base = (EpAffine::generator() * Fq::from(scalar_seed)).to_affine();
+            let registry = match POINT_REGISTRY.as_ref() {
+                Some(r) => r,
+                None => return,
+            };
+            let circuit = PointCircuit;
+            let expected: EpAffine = match point_native(base) {
+                Some(p) => p,
+                None => return, // intermediate hit identity; skip
+            };
+
+            let mut sim_value: Option<EpAffine> = None;
+            let sim_result = Simulator::<Fp>::simulate(base, |dr, w_just| {
+                let cw = circuit.witness(dr, w_just)?;
+                let point = cw.into_output();
+                sim_value = Some(point.value().take());
+                Ok(())
+            });
+
+            if sim_result.is_err() {
+                // PointCircuit's only failure mode is Point::alloc on
+                // identity, which we filtered above. Anything else is a
+                // plumbing bug.
+                panic!(
+                    "Simulator rejected PointCircuit on a non-identity base \
+                     (scalar={scalar_seed}): {:?}",
+                    sim_result.err()
+                );
+            }
+
+            let sim_value = sim_value.expect("Simulator Ok without writing value");
+            assert_eq!(
+                sim_value, expected,
+                "PointCircuit: synthesis output != native endo→negate: \
+                 scalar={scalar_seed}, sim={sim_value:?}, expected={expected:?}"
+            );
+
+            let trace = match circuit.trace(base) {
+                Ok(t) => t.into_output(),
+                Err(_) => panic!(
+                    "trace::eval rejected PointCircuit scalar={scalar_seed} \
+                     but Simulator accepted — driver disagreement"
+                ),
+            };
+
+            if alphas_distinct {
+                check_alpha_injection(registry, &trace, alpha_a, alpha_b);
+            }
+        }
+
+        CircuitChoice::Routine {
+            witness_seed,
+            use_special,
+        } => {
+            let registry = match ROUTINE_REGISTRY.as_ref() {
+                Some(r) => r,
+                None => return,
+            };
+            let witness: Fp = match use_special {
+                Some(idx) => special_value(idx),
+                None => Fp::from(witness_seed),
+            };
+            let circuit = RoutineCircuit;
+            let expected = routine_native(witness);
+
+            let mut sim_value: Option<Fp> = None;
+            let sim_result = Simulator::<Fp>::simulate(witness, |dr, w_just| {
+                let cw = circuit.witness(dr, w_just)?;
+                let elem = cw.into_output();
+                sim_value = Some(*elem.value().take());
+                Ok(())
+            });
+
+            if sim_result.is_err() {
+                panic!(
+                    "Simulator rejected RoutineCircuit witness={witness:?} \
+                     — RoutineCircuit's ScaleByThree should accept any Fp witness"
+                );
+            }
+
+            let sim_value = sim_value.expect("Simulator Ok without writing value");
+            assert_eq!(
+                sim_value, expected,
+                "RoutineCircuit: synthesis output != native 3 * witness: \
+                 witness={witness:?}, sim={sim_value:?}, expected={expected:?}"
+            );
+
+            let trace = match circuit.trace(witness) {
+                Ok(t) => t.into_output(),
+                Err(_) => panic!(
+                    "trace::eval rejected RoutineCircuit witness={witness:?} \
+                     but Simulator accepted — driver disagreement"
+                ),
+            };
+
+            if alphas_distinct {
+                check_alpha_injection(registry, &trace, alpha_a, alpha_b);
             }
         }
     }

--- a/qa/fuzz/fuzz_targets/fuzz_circuit_witness.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_circuit_witness.rs
@@ -1,27 +1,32 @@
 //! Fuzz `Circuit::witness` pipeline correctness against a native oracle.
 //!
-//! For arbitrary `witness: Fp` and `times: 1..=120`, this target runs
-//! `SquareCircuit { times }` through three pipelines and checks pairwise
-//! consistency:
+//! Drives two reference circuits — `SquareCircuit { times }` and
+//! `MySimpleCircuit` — with fuzzer-chosen witnesses, and checks pairwise
+//! consistency across three pipelines:
 //!
-//! 1. **Native spec**: compute `w^(2^times)` directly via repeated squaring.
+//! 1. **Native spec**: a plain Rust function computing each circuit's
+//!    output directly from the witness, no driver involved.
 //! 2. **Simulator synthesis**: `circuit.witness(&mut Simulator, w)`; the
 //!    `Simulator` driver enforces every gate identity inline, then exposes
-//!    the output `Element`'s witness value.
+//!    each output `Element`'s witness value.
 //! 3. **Trace + assembly**: `circuit.trace(w)` produces a `Trace`, then
 //!    `Registry::assemble_with_alpha` writes it to a sparse polynomial.
 //!
 //! ## Invariants enforced
 //!
-//! - **Synthesis correctness**: the Simulator output value equals the native
-//!    `w^(2^times)`. Catches bugs in any `Circuit::witness` impl that
-//!    produces a non-spec output from a satisfying witness, and (because
-//!    `Simulator::gate` checks `a*b = c` inline) catches `Element::square`
-//!    plumbing bugs that would emit a constraint inconsistent with the
-//!    witness it returns.
-//! - **Trace-pipeline robustness**: `trace::eval` returns `Ok` whenever
-//!    Simulator synthesis returned `Ok`. The two drivers must be
-//!    observationally equivalent on `Circuit::witness`.
+//! - **Synthesis correctness**: the Simulator output values equal the
+//!    native spec. Catches bugs in any `Circuit::witness` impl that
+//!    produces a non-spec output from a satisfying witness, and catches
+//!    gadget plumbing bugs that would emit a constraint inconsistent
+//!    with the witness it returns.
+//! - **Trace-pipeline implication**: if `Simulator::simulate` accepted,
+//!    `circuit.trace` must also return `Ok`. The reverse direction does
+//!    *not* hold — `trace::eval`'s `enforce_zero` and `gate` are pure
+//!    recorders, not constraint checkers (see `trace.rs:226-261`), so an
+//!    unsatisfying witness produces `Err` from `Simulator` and `Ok` from
+//!    `trace::eval` by design. Constraint checking is the Simulator's
+//!    job; trace's job is to record values for later assembly into a
+//!    polynomial whose algebraic identity is checked downstream.
 //! - **`alpha` injection contract**: assembling the same trace twice with
 //!    distinct `alpha_a` and `alpha_b` produces two polynomials that
 //!    differ in exactly one coefficient position, with the difference
@@ -31,16 +36,48 @@
 //!    slot (which would break commit-blinding / point-at-infinity
 //!    protection).
 //!
+//! ## Circuit coverage
+//!
+//! `SquareCircuit` exercises a single gadget (`Element::square`) in a
+//! parameterized loop. `MySimpleCircuit` exercises `Element::square`,
+//! `Element::mul`, `Element::add`, `Element::sub`, and an explicit
+//! `Driver::enforce_zero` constraint over a two-element witness with a
+//! two-element output. Together they cover most of `Element`'s arithmetic
+//! surface.
+//!
+//! TODO(issue #709): broaden circuit coverage by adding purpose-built
+//! reference circuits and another `CircuitChoice` arm for each:
+//! - **Boolean**: `Boolean::alloc`, `Boolean::not`, `Boolean::and`,
+//!   `conditional_select`. A reference circuit could allocate `n`
+//!   booleans from witness bits and assert a target value reconstructed
+//!   from them.
+//! - **Point**: `Point::alloc`, `endo`, `negate`, `double`,
+//!   `conditional_endo`, `conditional_negate`, `add_incomplete`. A
+//!   reference circuit could compute a Pasta scalar multiplication of a
+//!   fuzzer-chosen base by a fuzzer-chosen scalar and compare to native.
+//!   (`fuzz_endoscalar` already does the gadget-level differential; the
+//!   gap is exercising it through `Circuit::witness` end-to-end.)
+//! - **Routines / sub-circuits**: `Driver::routine`, the
+//!   `Routine::predict`/`Routine::execute` split. A reference circuit
+//!   could invoke a non-trivial `Routine` impl from
+//!   `ragu_testing::routines` and assert its `Aux<'_>` matches the
+//!   prediction.
+//! - **Multi-stage circuits**: `StageBuilder`, `MultiStage`,
+//!   `MultiStageCircuit`. This is the Tier-3B Layer 4 work flagged in
+//!   `fuzzing-follow-up-work.md`; needs an `Arbitrary` impl that builds
+//!   a stage chain with varying wire counts per stage.
+//!
 //! ## What this does not catch (deferred — issue #709)
 //!
 //! The full algebraic identity from `tests/mod.rs:158-187` —
 //! `a.revdot(b) == circuit.ky(instance, y)` where
 //! `b = r + r.dilate(z) + obj.sy(y, &plan) + Rank::tz(z)` — is the
-//! strongest oracle for the synthesis layer. Its construction requires
-//! `WiringObject::sy` and `Rank::tz`, both `pub(crate)` in `ragu_circuits`.
-//! Exposing them is an `unstable-fuzzing` feature flag away (per
-//! `feedback_fuzzing_standards.md`) but was scoped out of this target —
-//! see `fuzzing_perf.md` for the upgrade path.
+//! strongest oracle for the synthesis layer and the algebraic bridge
+//! between this target (witness-driver side) and `fuzz_sxy_agreement`
+//! (wiring/constraint side). Its construction requires
+//! `WiringObject::sy` and `Rank::tz`, both `pub(crate)` in
+//! `ragu_circuits`, so it is deferred to a separate `unstable-fuzzing`-
+//! gated target.
 
 #![no_main]
 
@@ -57,15 +94,32 @@ use ragu_circuits::{
 };
 use ragu_core::maybe::Maybe;
 use ragu_primitives::Simulator;
-use ragu_testing::circuits::SquareCircuit;
+use ragu_testing::circuits::{MySimpleCircuit, SquareCircuit};
 use std::sync::LazyLock;
 
 #[derive(Arbitrary, Debug)]
+enum CircuitChoice {
+    /// `SquareCircuit { times }` over a single-Fp witness.
+    Square {
+        times: u8,
+        witness_seed: u64,
+        use_special: Option<u8>,
+    },
+    /// `MySimpleCircuit` over a `(Fp, Fp)` witness. The circuit's internal
+    /// constraint is `a^5 == b^2`; many randomly chosen `(a, b)` pairs will
+    /// not satisfy it (drivers will reject). The `derive_b_from_a` mode
+    /// picks `b = sqrt(a^5)` so the witness is always satisfying.
+    Simple {
+        a_seed: u64,
+        b_seed: u64,
+        use_special_a: Option<u8>,
+        derive_b_from_a: bool,
+    },
+}
+
+#[derive(Arbitrary, Debug)]
 struct Input {
-    times: u8,
-    witness_seed: u64,
-    /// If `Some`, override `witness_seed` with a special edge-case value.
-    use_special: Option<u8>,
+    circuit: CircuitChoice,
     alpha_a_seed: u64,
     alpha_b_seed: u64,
 }
@@ -84,29 +138,28 @@ fn special_value(idx: u8) -> Fp {
     }
 }
 
-/// Per-`times` registry cache. Building a registry for `SquareCircuit`
+/// Per-`times` registry cache for `SquareCircuit`. Building a registry
 /// runs the floor planner over `times` squarings — comfortably more
-/// expensive than the per-input checks the fuzz body performs. Memoizing
-/// across inputs turns the hot path into trace + assemble + revdot after
-/// each distinct `times` is observed once. Mirrors the cache in
-/// `fuzz_sxy_agreement.rs:42-69`.
-struct RegistryCache {
-    /// Slot for `times = i + 1`, indexed 0..119.
+/// expensive than the per-input checks. Memoizing across inputs turns
+/// the hot path into trace + assemble after each distinct `times` is
+/// observed once. Mirrors the cache in `fuzz_sxy_agreement.rs:42-69`.
+struct SquareRegistryCache {
     slots: [OnceCell<Result<Registry<'static, Fp, TestRank>, ()>>; 120],
 }
 
 // SAFETY: libfuzzer runs the fuzz target on a single thread, so the
 // interior-mutable `OnceCell` slots are never accessed concurrently.
 // `LazyLock` requires `Sync` to compile.
-unsafe impl Sync for RegistryCache {}
+unsafe impl Sync for SquareRegistryCache {}
 
-static REGISTRY_CACHE: LazyLock<RegistryCache> = LazyLock::new(|| RegistryCache {
-    slots: [const { OnceCell::new() }; 120],
-});
+static SQUARE_REGISTRY_CACHE: LazyLock<SquareRegistryCache> =
+    LazyLock::new(|| SquareRegistryCache {
+        slots: [const { OnceCell::new() }; 120],
+    });
 
-fn registry_for(times: usize) -> Option<&'static Registry<'static, Fp, TestRank>> {
+fn square_registry_for(times: usize) -> Option<&'static Registry<'static, Fp, TestRank>> {
     debug_assert!((1..=120).contains(&times));
-    REGISTRY_CACHE.slots[times - 1]
+    SQUARE_REGISTRY_CACHE.slots[times - 1]
         .get_or_init(|| {
             let circuit = SquareCircuit { times };
             RegistryBuilder::<Fp, TestRank>::new()
@@ -118,8 +171,18 @@ fn registry_for(times: usize) -> Option<&'static Registry<'static, Fp, TestRank>
         .ok()
 }
 
-/// Native spec: compute `w^(2^times)` by repeated squaring.
-fn native_expected(witness: Fp, times: usize) -> Fp {
+/// `MySimpleCircuit` takes no parameters, so a single global memoized
+/// registry suffices.
+static SIMPLE_REGISTRY: LazyLock<Option<Registry<'static, Fp, TestRank>>> = LazyLock::new(|| {
+    RegistryBuilder::<Fp, TestRank>::new()
+        .register_circuit(MySimpleCircuit)
+        .and_then(|b| b.finalize())
+        .ok()
+});
+
+/// Native spec for `SquareCircuit`: compute `w^(2^times)` by repeated
+/// squaring directly in the field.
+fn square_native(witness: Fp, times: usize) -> Fp {
     let mut acc = witness;
     for _ in 0..times {
         acc = acc.square();
@@ -127,91 +190,40 @@ fn native_expected(witness: Fp, times: usize) -> Fp {
     acc
 }
 
-fuzz_target!(|input: Input| {
-    if std::env::var("DEBUG_INPUT").is_ok() {
-        eprintln!("{:#?}", input);
-        return;
+/// Native spec for `MySimpleCircuit`. Returns:
+/// - `Some((c, d))` if the witness satisfies `a^5 == b^2`, with
+///    `c = a + b`, `d = a - b`.
+/// - `None` if the witness violates the constraint; both `Simulator` and
+///    `trace::eval` must reject.
+fn simple_native(a: Fp, b: Fp) -> Option<(Fp, Fp)> {
+    let a5 = a.pow_vartime([5u64]);
+    let b2 = b.square();
+    if a5 != b2 {
+        return None;
     }
+    Some((a + b, a - b))
+}
 
-    let times = ((input.times as usize) % 120).max(1);
+/// Try to compute `b = sqrt(a^5)` so that `(a, b)` is a satisfying witness
+/// for `MySimpleCircuit`. Returns `None` if `a^5` is a non-residue.
+fn derive_satisfying_b(a: Fp) -> Option<Fp> {
+    Option::<Fp>::from(a.pow_vartime([5u64]).sqrt())
+}
 
-    let witness: Fp = match input.use_special {
-        Some(idx) => special_value(idx),
-        None => Fp::from(input.witness_seed),
-    };
-
-    // Skip if registry build fails (rank-bound exceeded for high `times`).
-    let registry = match registry_for(times) {
-        Some(r) => r,
-        None => return,
-    };
-
-    let circuit = SquareCircuit { times };
-
-    // Oracle: native spec.
-    let expected = native_expected(witness, times);
-
-    // Synthesis via Simulator. The driver checks each `a * b = c` gate
-    // inline; the closure's return value is discarded by `Simulator::simulate`,
-    // so the synthesized output escapes through a captured mutable variable.
-    let mut sim_value: Option<Fp> = None;
-    let sim_result = Simulator::<Fp>::simulate(witness, |dr, w_just| {
-        let cw = circuit.witness(dr, w_just)?;
-        let elem = cw.into_output();
-        sim_value = Some(*elem.value().take());
-        Ok(())
-    });
-
-    if sim_result.is_err() {
-        // Simulator rejected — under SquareCircuit this only happens via
-        // gate-plumbing bugs. We still want the test to surface that, so
-        // assert that the trace pipeline also rejects (drivers must agree).
-        assert!(
-            circuit.trace(witness).is_err(),
-            "Simulator rejected witness {witness:?} at times={times} but \
-             trace::eval accepted — model/real driver disagreement"
-        );
-        return;
-    }
-
-    let sim_value = sim_value.expect("Simulator simulate returned Ok without writing value");
-    assert_eq!(
-        sim_value, expected,
-        "synthesis output != native w^(2^times): witness={witness:?}, times={times}, \
-         sim={sim_value:?}, expected={expected:?}"
-    );
-
-    // Trace must agree on accept/reject with Simulator. We already returned
-    // above on the Err path; here, both Ok.
-    let trace = match circuit.trace(witness) {
-        Ok(t) => t.into_output(),
-        Err(_) => panic!(
-            "trace::eval rejected witness {witness:?} at times={times} \
-             but Simulator accepted — model/real driver disagreement"
-        ),
-    };
-
-    // Assembly correctness: alpha is written to a[0] and nowhere else. Two
-    // assemblies with distinct alphas should differ in exactly one
-    // coefficient position by exactly the alpha delta.
-    if input.alpha_a_seed == input.alpha_b_seed {
-        return; // need distinct alphas for the differential check
-    }
-    let alpha_a = Fp::from(input.alpha_a_seed);
-    let alpha_b = Fp::from(input.alpha_b_seed);
-    if alpha_a == alpha_b {
-        return; // both seeds map to the same Fp (e.g., via reduction)
-    }
-
+/// Run the differential alpha-injection check on an assembled trace.
+/// Asserts that two assemblies with distinct `alpha`s differ in exactly
+/// one coefficient position, by exactly the alpha delta. Returns `()` on
+/// success, `None` if either assembly errored (skip the iteration), and
+/// panics on a violated invariant.
+fn check_alpha_injection(
+    registry: &Registry<'_, Fp, TestRank>,
+    trace: &ragu_circuits::Trace<Fp>,
+    alpha_a: Fp,
+    alpha_b: Fp,
+) -> Option<()> {
     let idx = CircuitIndex::new(0);
-    let poly_a = match registry.assemble_with_alpha(&trace, idx, alpha_a) {
-        Ok(p) => p,
-        Err(_) => return,
-    };
-    let poly_b = match registry.assemble_with_alpha(&trace, idx, alpha_b) {
-        Ok(p) => p,
-        Err(_) => return,
-    };
+    let poly_a = registry.assemble_with_alpha(trace, idx, alpha_a).ok()?;
+    let poly_b = registry.assemble_with_alpha(trace, idx, alpha_b).ok()?;
 
     let coeffs_a: Vec<Fp> = poly_a.iter_coeffs().collect();
     let coeffs_b: Vec<Fp> = poly_b.iter_coeffs().collect();
@@ -231,12 +243,168 @@ fuzz_target!(|input: Input| {
     }
     assert_eq!(
         diff_count, 1,
-        "alpha leaked into {diff_count} coefficient positions (expected 1) \
-         at times={times}, witness={witness:?}"
+        "alpha leaked into {diff_count} coefficient positions (expected 1)"
     );
     assert_eq!(
         coeffs_a[diff_idx] - coeffs_b[diff_idx],
         alpha_a - alpha_b,
         "alpha delta mismatch at coefficient position {diff_idx}"
     );
+    Some(())
+}
+
+fuzz_target!(|input: Input| {
+    if std::env::var("DEBUG_INPUT").is_ok() {
+        eprintln!("{:#?}", input);
+        return;
+    }
+
+    // Decode shared alpha pair. Differential check needs distinct values.
+    let alpha_a = Fp::from(input.alpha_a_seed);
+    let alpha_b = Fp::from(input.alpha_b_seed);
+    let alphas_distinct = input.alpha_a_seed != input.alpha_b_seed && alpha_a != alpha_b;
+
+    match input.circuit {
+        CircuitChoice::Square {
+            times,
+            witness_seed,
+            use_special,
+        } => {
+            let times = ((times as usize) % 120).max(1);
+            let witness: Fp = match use_special {
+                Some(idx) => special_value(idx),
+                None => Fp::from(witness_seed),
+            };
+            let registry = match square_registry_for(times) {
+                Some(r) => r,
+                None => return, // rank-bound exceeded for high `times`
+            };
+            let circuit = SquareCircuit { times };
+            let expected = square_native(witness, times);
+
+            let mut sim_value: Option<Fp> = None;
+            let sim_result = Simulator::<Fp>::simulate(witness, |dr, w_just| {
+                let cw = circuit.witness(dr, w_just)?;
+                let elem = cw.into_output();
+                sim_value = Some(*elem.value().take());
+                Ok(())
+            });
+
+            if sim_result.is_err() {
+                // `SquareCircuit` has no `enforce_zero` constraints, so
+                // any Simulator rejection here would be a plumbing bug;
+                // surface it before returning.
+                panic!(
+                    "Simulator rejected SquareCircuit witness={witness:?} times={times} \
+                     — SquareCircuit has no constraints that could fail"
+                );
+            }
+
+            let sim_value = sim_value.expect("Simulator Ok without writing value");
+            assert_eq!(
+                sim_value, expected,
+                "SquareCircuit: synthesis output != native w^(2^times): \
+                 witness={witness:?}, times={times}, sim={sim_value:?}, expected={expected:?}"
+            );
+
+            // Simulator accepted, so trace::eval must accept too (one-way
+            // implication; see header docstring).
+            let trace = match circuit.trace(witness) {
+                Ok(t) => t.into_output(),
+                Err(_) => panic!(
+                    "trace::eval rejected SquareCircuit witness={witness:?} times={times} \
+                     but Simulator accepted — driver disagreement"
+                ),
+            };
+
+            if alphas_distinct {
+                check_alpha_injection(registry, &trace, alpha_a, alpha_b);
+            }
+        }
+
+        CircuitChoice::Simple {
+            a_seed,
+            b_seed,
+            use_special_a,
+            derive_b_from_a,
+        } => {
+            let a: Fp = match use_special_a {
+                Some(idx) => special_value(idx),
+                None => Fp::from(a_seed),
+            };
+            let b: Fp = if derive_b_from_a {
+                match derive_satisfying_b(a) {
+                    Some(v) => v,
+                    None => return, // a^5 is a non-residue; skip
+                }
+            } else {
+                Fp::from(b_seed)
+            };
+
+            let registry = match SIMPLE_REGISTRY.as_ref() {
+                Some(r) => r,
+                None => return,
+            };
+            let circuit = MySimpleCircuit;
+            let expected = simple_native(a, b); // None iff a^5 != b^2
+
+            let mut sim_value: Option<(Fp, Fp)> = None;
+            let sim_result = Simulator::<Fp>::simulate((a, b), |dr, w_just| {
+                let cw = circuit.witness(dr, w_just)?;
+                let (c_elem, d_elem) = cw.into_output();
+                sim_value = Some((*c_elem.value().take(), *d_elem.value().take()));
+                Ok(())
+            });
+
+            // Simulator is the constraint checker. Its accept/reject must
+            // match the native prediction (`expected.is_some()`).
+            match (expected, sim_result.is_ok()) {
+                (None, true) => panic!(
+                    "MySimpleCircuit: Simulator accepted unsatisfying witness \
+                     a={a:?}, b={b:?} (a^5 != b^2)"
+                ),
+                (Some(_), false) => panic!(
+                    "MySimpleCircuit: Simulator rejected satisfying witness \
+                     a={a:?}, b={b:?}"
+                ),
+                _ => {}
+            }
+
+            // trace::eval is a pure recorder; it accepts any witness that
+            // can be evaluated, satisfying or not. The required implication
+            // is one-way: Simulator accept ⇒ trace accept.
+            let trace_result = circuit.trace((a, b));
+            if sim_result.is_ok() && trace_result.is_err() {
+                panic!(
+                    "MySimpleCircuit: Simulator accepted but trace::eval rejected \
+                     for a={a:?}, b={b:?} — driver disagreement"
+                );
+            }
+
+            // Output-value check requires a satisfying witness (Simulator
+            // accepted). For unsatisfying witnesses we skip the output check
+            // but still exercise assembly if trace::eval recorded values.
+            if let Some((expected_c, expected_d)) = expected {
+                let (sim_c, sim_d) = sim_value.expect("Simulator Ok without writing value");
+                assert_eq!(
+                    sim_c, expected_c,
+                    "MySimpleCircuit: c output != a+b for a={a:?}, b={b:?}"
+                );
+                assert_eq!(
+                    sim_d, expected_d,
+                    "MySimpleCircuit: d output != a-b for a={a:?}, b={b:?}"
+                );
+            }
+
+            // assemble_with_alpha is a property of the assembly function,
+            // independent of whether the underlying witness is satisfying,
+            // so we run it on any trace::eval success.
+            if let Ok(trace) = trace_result {
+                let trace = trace.into_output();
+                if alphas_distinct {
+                    check_alpha_injection(registry, &trace, alpha_a, alpha_b);
+                }
+            }
+        }
+    }
 });

--- a/qa/fuzz/fuzz_targets/fuzz_circuit_witness.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_circuit_witness.rs
@@ -85,9 +85,9 @@ use ff::PrimeField;
 use ff::WithSmallOrderMulGroup;
 use group::Curve;
 use group::prime::PrimeCurveAffine;
+use pasta_curves::arithmetic::CurveAffine;
 use libfuzzer_sys::fuzz_target;
 use pasta_curves::Fp;
-use pasta_curves::arithmetic::CurveAffine;
 use ragu_arithmetic::Coeff;
 use ragu_circuits::{
     Circuit, CircuitExt, WithAux,
@@ -355,7 +355,7 @@ fn point_native(base: EpAffine) -> Option<EpAffine> {
     let coords = base.coordinates().into_option()?;
     let endo_x = *coords.x() * Fp::ZETA;
     let endo_p = EpAffine::from_xy(endo_x, *coords.y()).into_option()?;
-    Some((-endo_p.to_curve()).to_affine())
+    Some((-PrimeCurveAffine::to_curve(&endo_p)).to_affine())
 }
 
 // ---------------------------------------------------------------------------
@@ -692,7 +692,8 @@ fuzz_target!(|input: Input| {
             if scalar_seed == 0 {
                 return;
             }
-            let base = (EpAffine::generator() * Fq::from(scalar_seed)).to_affine();
+            let base = (<EpAffine as PrimeCurveAffine>::generator() * Fq::from(scalar_seed))
+                .to_affine();
             let registry = match POINT_REGISTRY.as_ref() {
                 Some(r) => r,
                 None => return,

--- a/qa/fuzz/fuzz_targets/fuzz_driver_metamorphic.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_driver_metamorphic.rs
@@ -43,7 +43,7 @@
 //! - Bugs in the trace-polynomial assembly, constraint polynomial emission
 //!   (`WiringObject`), or downstream prover/verifier components.
 //! - Soundness gaps in the constraint system itself
-//!   (`fuzz_soundness_cheat`'s lane).
+//!   (`fuzz_witness_cheat`'s lane).
 
 #![no_main]
 
@@ -142,7 +142,7 @@ fn build_seeds(input: &Input) -> Vec<Fp> {
 ///
 /// Runs the input's `Vec<Op>` against the supplied driver and witness,
 /// returning the final stack snapshot. Identical dispatch logic to
-/// `fuzz_element_ops` and `fuzz_soundness_cheat`, so the same gadget
+/// `fuzz_element_ops` and `fuzz_witness_cheat`, so the same gadget
 /// API surface is exercised in all three targets.
 fn run_ops<'dr, D>(
     dr: &mut D,

--- a/qa/fuzz/fuzz_targets/fuzz_soundness_cheat.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_soundness_cheat.rs
@@ -365,6 +365,16 @@ fn op_pushes(op: &Op) -> usize {
 /// (`if let Ok(_)` in `run_path`). `op_pushes` is an upper bound for these
 /// — actual `run_path` execution may push zero. Used by `is_dead_cheat` to
 /// refuse predicting through unpredictable stack growth.
+///
+/// Note: ops that use `?` to propagate errors (e.g., `Op::AllocSpecial`,
+/// `Op::BoolAlloc`, the `Element::alloc` inside `Op::Fold`) are
+/// intentionally excluded here. They fail *symmetrically* in the honest
+/// and cheat paths because pre-cheat ops execute identically through
+/// both invocations of `run_path`, so a `?`-propagated failure causes
+/// both paths to return `None` and the harness exits before the
+/// soundness assertion — there is no false-positive surface to guard
+/// against. Only `if let Ok(_)`-style fallible pushes can shift the
+/// effective stack length between paths and need conservative bail-out.
 fn op_can_fail_push(op: &Op) -> bool {
     matches!(
         op,

--- a/qa/fuzz/fuzz_targets/fuzz_staging.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_staging.rs
@@ -78,6 +78,24 @@
 //! compensating reversal inside another stage's — because each stage is
 //! checked against its own mask in isolation, not against an aggregate.
 //!
+//! ## final_mask check
+//!
+//! One additional structural check layers on top of Invariant A:
+//!
+//! - **`final_mask` zero check** (mirrors production proving at
+//!   `crates/ragu_pcd/src/internal/endoscalar.rs:470`): the *assembled
+//!   `MultiStage` trace polynomial* (before adding any stage `rx_i`) must
+//!   revdot to zero against the last stage's `final_mask()`. The
+//!   `final_mask` is constructed from `StageMask::new_final(skip+num)`
+//!   (`staging/mask.rs:121`) and carves out `[last_stage_end, R::n())` —
+//!   the post-stage gate range, where the assembled trace holds its only
+//!   non-zero values. Stage-wire positions in the assembled trace are
+//!   already zero because `StageBuilder::configure_stage` allocates them
+//!   as `Coeff::Zero` (`staging/builder.rs:221`); the SYSTEM gate
+//!   contributes nothing because `global_project` zeros it. Distinct
+//!   code path from regular `mask()`, so a regression in `new_final` that
+//!   doesn't affect `new` surfaces here.
+//!
 //! ## Circuit menu
 //!
 //! Three `MultiStageCircuit` variants, all using `TestRank` for ~2-5k
@@ -457,6 +475,29 @@ static MASK_REGISTRY_W4_CHILD: LazyLock<Option<Registry<'static, Fp, TestRank>>>
     build_mask_registry(mask)
 });
 
+// Final-mask registries — one per stage type, built from
+// `StageExt::final_mask()` instead of `mask()`. `final_mask` covers
+// `[skip_gates, R::n())` (every gate after the stage's skip), whereas
+// `mask` covers only the stage's own `[skip, skip+num)` slots. Used
+// only for the LAST stage in a variant's chain.
+static MASK_REGISTRY_W2_FINAL: LazyLock<Option<Registry<'static, Fp, TestRank>>> = LazyLock::new(|| {
+    let mask: BondingObject<'static, Fp, TestRank> =
+        <StageW2 as StageExt<Fp, TestRank>>::final_mask().ok()?;
+    build_mask_registry(mask)
+});
+
+static MASK_REGISTRY_W4_FINAL: LazyLock<Option<Registry<'static, Fp, TestRank>>> = LazyLock::new(|| {
+    let mask: BondingObject<'static, Fp, TestRank> =
+        <StageW4 as StageExt<Fp, TestRank>>::final_mask().ok()?;
+    build_mask_registry(mask)
+});
+
+static MASK_REGISTRY_W4_CHILD_FINAL: LazyLock<Option<Registry<'static, Fp, TestRank>>> = LazyLock::new(|| {
+    let mask: BondingObject<'static, Fp, TestRank> =
+        <StageW4Child as StageExt<Fp, TestRank>>::final_mask().ok()?;
+    build_mask_registry(mask)
+});
+
 // ---------------------------------------------------------------------------
 // Input shape — one variant per MultiStageCircuit. Same `Arbitrary` style
 // as fuzz_circuit_revdot_identity.
@@ -578,19 +619,23 @@ fn check_stage_isolation(
     );
 }
 
-/// Run the Invariant B oracle. The `stage_rx_sum` argument is the sum of
-/// per-stage `StageExt::rx(0, ...)` polynomials for the variant's stages;
-/// adding it to `MultiStage::trace` reconstructs the full $r(X)$ that the
-/// algebraic identity is about. See module docstring for derivation.
+/// Run the Invariant B oracle and the bare-MultiStage-trace `final_mask`
+/// check together. `stage_rx_sum` is added to the assembled trace before
+/// the algebraic identity is checked (per the canonical derivation), but
+/// the bare assembled trace alone is checked against `final_mask_registry`
+/// first — this mirrors production proving at
+/// `crates/ragu_pcd/src/internal/endoscalar.rs:470`.
 ///
 /// Returns `(expected_ky, actual_revdot)` so the caller's panic message
-/// can show both sides.
+/// can show both sides of the Invariant B check.
 fn check_identity<C: Circuit<Fp>>(
+    label: &str,
     registry: &Registry<'_, Fp, TestRank>,
     circuit: &C,
     witness: C::Witness<'_>,
     instance: C::Instance<'_>,
     stage_rx_sum: sparse::Polynomial<Fp, TestRank>,
+    final_mask_registry: Option<&Registry<'_, Fp, TestRank>>,
     y: Fp,
     z: Fp,
 ) -> Option<(Fp, Fp)> {
@@ -600,9 +645,30 @@ fn check_identity<C: Circuit<Fp>>(
     // term — same rationale as fuzz_circuit_revdot_identity. The stage rx
     // polynomials are also computed with alpha = 0; together with the
     // trace's a[0]=0 the gate-0 SYSTEM constraint stays clean.
-    let mut r = registry
+    let multistage_trace = registry
         .assemble_with_alpha(&trace, CircuitIndex::new(0), Fp::ZERO)
         .expect("assemble_with_alpha failed on a registered MultiStage circuit");
+
+    // final_mask: the bare assembled MultiStage trace (no stage rx yet)
+    // must revdot to zero against the last stage's final_mask polynomial.
+    // The final_mask carves out [last_stage_end, R::n()); the assembled
+    // trace's post-stage gate values live in that range, so the revdot
+    // collects them weighted by zero. Stage-wire positions in the
+    // assembled trace are zero (StageBuilder allocates them as
+    // Coeff::Zero), so the SYSTEM gate and earlier gates contribute
+    // nothing either.
+    if let Some(fm_reg) = final_mask_registry {
+        let fm_sy = sy_from_mask_registry(fm_reg, y);
+        let fm_actual = multistage_trace.revdot(&fm_sy);
+        assert_eq!(
+            fm_actual,
+            Fp::ZERO,
+            "final_mask check failed for {label}: \
+             assembled_multistage_trace.revdot(final_mask) = {fm_actual:?}, expected 0 at y={y:?}"
+        );
+    }
+
+    let mut r = multistage_trace;
     r.add_assign(&stage_rx_sum);
 
     let mut b = r.clone();
@@ -649,10 +715,19 @@ fuzz_target!(|input: Input| {
             if let Some(mask_reg) = MASK_REGISTRY_W2.as_ref() {
                 check_stage_isolation("Single2W/StageW2", &stage_w2_rx, mask_reg, y);
             }
-            // Invariant B: combined revdot identity through MultiStage.
-            let Some((expected, actual)) =
-                check_identity(registry, &circuit, witness, instance, stage_w2_rx, y, z)
-            else {
+            // Invariant B (with bundled final_mask check on the bare trace):
+            // StageW2 is the last (and only) stage in this variant.
+            let Some((expected, actual)) = check_identity(
+                "Single2W",
+                registry,
+                &circuit,
+                witness,
+                instance,
+                stage_w2_rx,
+                MASK_REGISTRY_W2_FINAL.as_ref(),
+                y,
+                z,
+            ) else {
                 return;
             };
             assert_eq!(
@@ -687,9 +762,17 @@ fuzz_target!(|input: Input| {
             if let Some(mask_reg) = MASK_REGISTRY_W4.as_ref() {
                 check_stage_isolation("Single4W/StageW4", &stage_w4_rx, mask_reg, y);
             }
-            let Some((expected, actual)) =
-                check_identity(registry, &circuit, witness, instance, stage_w4_rx, y, z)
-            else {
+            let Some((expected, actual)) = check_identity(
+                "Single4W",
+                registry,
+                &circuit,
+                witness,
+                instance,
+                stage_w4_rx,
+                MASK_REGISTRY_W4_FINAL.as_ref(),
+                y,
+                z,
+            ) else {
                 return;
             };
             assert_eq!(
@@ -742,12 +825,39 @@ fuzz_target!(|input: Input| {
             if let Some(mask_reg) = MASK_REGISTRY_W4_CHILD.as_ref() {
                 check_stage_isolation("Chain/child StageW4Child", &child_rx, mask_reg, y);
             }
-            // Invariant B: combined revdot identity.
+            // Cross-mask discrimination (parent.rx vs child.mask and vice
+            // versa) is intentionally NOT asserted here. The check
+            // `rx.revdot(foreign_mask) != 0` is structurally fragile under
+            // adversarial fuzzing: it reduces to a linear equation in the
+            // witness and `y` (e.g.,
+            // `child_a*y^(2n+2) + child_c*y^(2n+3) + child_b*y^2 + child_d*y^3 = 0`),
+            // and the fuzzer readily finds (witness, y) pairs that
+            // satisfy it. The canonical test at `staging/mask.rs:489` works
+            // because it uses random witnesses where the probability of
+            // hitting a degenerate point is `≤ deg/|F| ≈ 2^-254`; under
+            // libfuzzer's coverage-guided search, that probability is
+            // effectively 1. Invariant B catches any *systematic*
+            // cross-stage indistinguishability via the algebraic identity,
+            // so this gap is not coverage-relevant — it's specifically
+            // the "this rx is structurally indistinguishable" claim that
+            // can't be made on adversarial inputs.
+            //
+            // Invariant B (with bundled final_mask check on the bare trace):
+            // StageW4Child is the chain's last stage; its final_mask covers
+            // `[child_skip + child_num, R::n())`, the post-stage gate range.
             let mut stage_rx_sum = parent_rx;
             stage_rx_sum.add_assign(&child_rx);
-            let Some((expected, actual)) =
-                check_identity(registry, &circuit, witness, instance, stage_rx_sum, y, z)
-            else {
+            let Some((expected, actual)) = check_identity(
+                "Chain2x4",
+                registry,
+                &circuit,
+                witness,
+                instance,
+                stage_rx_sum,
+                MASK_REGISTRY_W4_CHILD_FINAL.as_ref(),
+                y,
+                z,
+            ) else {
                 return;
             };
             assert_eq!(

--- a/qa/fuzz/fuzz_targets/fuzz_staging.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_staging.rs
@@ -619,6 +619,70 @@ fn check_stage_isolation(
     );
 }
 
+/// Maps a sparse-polynomial coefficient degree (Trace perspective) back
+/// to its `(wire, gate_index)`. Returns `None` for degrees outside `[0, 4n)`.
+///
+/// Mirror of `polynomials::sparse::view::Trace::map_to_blocks`:
+/// - `c[i]` → degree `i`             (range `[0, n)`)
+/// - `a[i]` → degree `2n - 1 - i`    (reversed, range `[n, 2n)`)
+/// - `b[i]` → degree `2n + i`        (range `[2n, 3n)`)
+/// - `d[i]` → degree `4n - 1 - i`    (reversed, range `[3n, 4n)`)
+fn trace_degree_to_gate(deg: usize) -> Option<usize> {
+    let n = TestRank::n();
+    if deg < n {
+        Some(deg) // c[i]
+    } else if deg < 2 * n {
+        Some(2 * n - 1 - deg) // a[i]
+    } else if deg < 3 * n {
+        Some(deg - 2 * n) // b[i]
+    } else if deg < 4 * n {
+        Some(4 * n - 1 - deg) // d[i]
+    } else {
+        None
+    }
+}
+
+/// Structural cross-stage discrimination check (robust replacement for the
+/// adversarially-fragile `rx.revdot(foreign_mask) ≠ 0` algebraic version).
+/// Asserts that every non-zero coefficient of `stage_rx` maps back (under
+/// the Trace perspective) to a gate index inside the stage's declared
+/// `[skip, skip + num)` range — or to gate 0 (the SYSTEM gate, where
+/// `rx_configured` places `alpha`).
+///
+/// Catches `rx_configured` slot-leak bugs deterministically, without
+/// going through `y`, so libfuzzer can't adversarially construct
+/// witness/y pairs that hide the bug. Stronger than Invariant A:
+/// Invariant A catches via the algebraic identity which can be
+/// adversarially zeroed; this catches via direct structural inspection.
+fn check_stage_slot_range(
+    label: &str,
+    stage_rx: &sparse::Polynomial<Fp, TestRank>,
+    own_skip: usize,
+    own_num: usize,
+) {
+    for (deg, val) in stage_rx.iter_coeffs().enumerate() {
+        if val == Fp::ZERO {
+            continue;
+        }
+        let gate = trace_degree_to_gate(deg)
+            .unwrap_or_else(|| panic!("{label}: degree {deg} out of range"));
+        // Gate 0 (SYSTEM) is allowed because `rx_configured` writes
+        // `alpha` to `a[0]`. Otherwise the non-zero must lie in the
+        // stage's declared range.
+        let in_own_range = gate == 0 || (gate >= own_skip && gate < own_skip + own_num);
+        assert!(
+            in_own_range,
+            "Structural cross-mask check failed for {label}: rx has \
+             non-zero coefficient at degree {deg} (gate {gate}), which \
+             lies outside the stage's declared range [{own_skip}, {}). \
+             This stage's rx_configured is writing to a slot it shouldn't \
+             — a value-preserving slot leak that Invariant A's algebraic \
+             check can miss under adversarial witness/y combinations.",
+            own_skip + own_num
+        );
+    }
+}
+
 /// Run the Invariant B oracle and the bare-MultiStage-trace `final_mask`
 /// check together. `stage_rx_sum` is added to the assembled trace before
 /// the algebraic identity is checked (per the canonical derivation), but
@@ -707,10 +771,22 @@ fuzz_target!(|input: Input| {
             let witness = (a, b);
             let circuit = MultiStage::<Fp, TestRank, _>::new(Single2W);
             let instance = Single2W::native_instance(witness);
+            // Pin StageW2's declared offsets against hand-coded constants.
+            // Catches symmetric `skip_gates` bugs that would shift both
+            // `rx_configured` and `StageMask::new` together — invariants
+            // A/B and final_mask all stay structurally satisfied under
+            // such a shift, but this assertion fails immediately.
+            debug_assert_eq!(<StageW2 as Stage<Fp, TestRank>>::skip_gates(), 1);
+            debug_assert_eq!(<StageW2 as StageExt<Fp, TestRank>>::num_gates(), 1);
+
             let stage_w2_rx = match StageW2::rx(Fp::ZERO, (a, b)) {
                 Ok(p) => p,
                 Err(_) => return,
             };
+            // Structural cross-mask check (robust replacement for the
+            // dropped algebraic version): assert non-zero positions land
+            // only in StageW2's declared range or the SYSTEM gate.
+            check_stage_slot_range("Single2W/StageW2", &stage_w2_rx, 1, 1);
             // Invariant A: per-stage isolation against the stage's own mask.
             if let Some(mask_reg) = MASK_REGISTRY_W2.as_ref() {
                 check_stage_isolation("Single2W/StageW2", &stage_w2_rx, mask_reg, y);
@@ -755,10 +831,15 @@ fuzz_target!(|input: Input| {
             let witness = (a, b, c, d);
             let circuit = MultiStage::<Fp, TestRank, _>::new(Single4W);
             let instance = Single4W::native_instance(witness);
+            // Pin StageW4's declared offsets (same rationale as Single2W).
+            debug_assert_eq!(<StageW4 as Stage<Fp, TestRank>>::skip_gates(), 1);
+            debug_assert_eq!(<StageW4 as StageExt<Fp, TestRank>>::num_gates(), 2);
+
             let stage_w4_rx = match StageW4::rx(Fp::ZERO, witness) {
                 Ok(p) => p,
                 Err(_) => return,
             };
+            check_stage_slot_range("Single4W/StageW4", &stage_w4_rx, 1, 2);
             if let Some(mask_reg) = MASK_REGISTRY_W4.as_ref() {
                 check_stage_isolation("Single4W/StageW4", &stage_w4_rx, mask_reg, y);
             }
@@ -807,6 +888,15 @@ fuzz_target!(|input: Input| {
             );
             let circuit = MultiStage::<Fp, TestRank, _>::new(Chain2x4);
             let instance = Chain2x4::native_instance(witness);
+
+            // Pin parent and child stage offsets. Catches symmetric
+            // `skip_gates` shifts that A/B/final_mask all stay structurally
+            // satisfied under.
+            debug_assert_eq!(<StageW2 as Stage<Fp, TestRank>>::skip_gates(), 1);
+            debug_assert_eq!(<StageW2 as StageExt<Fp, TestRank>>::num_gates(), 1);
+            debug_assert_eq!(<StageW4Child as Stage<Fp, TestRank>>::skip_gates(), 2);
+            debug_assert_eq!(<StageW4Child as StageExt<Fp, TestRank>>::num_gates(), 2);
+
             // Stages composed in order: StageW2 then StageW4Child. Sum both
             // rx polynomials so the combined `r(X)` is consistent with what
             // the verifier would see after committing each stage separately.
@@ -818,6 +908,11 @@ fuzz_target!(|input: Input| {
                 Ok(p) => p,
                 Err(_) => return,
             };
+            // Structural cross-mask: each rx must write only into its own
+            // declared range. Stronger than Invariant A; not adversarially
+            // foolable via the revdot algebraic identity.
+            check_stage_slot_range("Chain/parent StageW2", &parent_rx, 1, 1);
+            check_stage_slot_range("Chain/child StageW4Child", &child_rx, 2, 2);
             // Invariant A: each stage checked against its own mask in isolation.
             if let Some(mask_reg) = MASK_REGISTRY_W2.as_ref() {
                 check_stage_isolation("Chain/parent StageW2", &parent_rx, mask_reg, y);

--- a/qa/fuzz/fuzz_targets/fuzz_staging.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_staging.rs
@@ -1,0 +1,761 @@
+//! Fuzz the canonical revdot identity through `MultiStage`-as-`Circuit`,
+//! exercising the staging plumbing in `crates/ragu_circuits/src/staging/`.
+//!
+//! For a satisfying witness `w` of a `MultiStageCircuit`, wrapped via
+//! `MultiStage::new(_)` to implement the [`Circuit`] trait, the algebraic
+//! identity from `tests/mod.rs:158-187` must hold:
+//!
+//! ```text
+//! r.revdot(b) == ms.ky(instance, y)
+//! where b = r + r.dilate(z) + s(X, y) + t(X, z)
+//! ```
+//!
+//! `r` is the assembled trace polynomial; `s(X, y)` is derived from
+//! `Registry::wy(omega_0, y)` minus the registry key term (same trick as
+//! `fuzz_circuit_revdot_identity`, valid for a single-circuit registry
+//! whose circuit is not a mask). `ms.ky(instance, y)` is the instance
+//! polynomial evaluated at `y`.
+//!
+//! ## What this catches that the non-staged targets don't
+//!
+//! The `MultiStage`-as-`Circuit` path runs the user-supplied
+//! `MultiStageCircuit::witness` body, which receives a [`StageBuilder`]
+//! (`staging/builder.rs:73`). The builder allocates stage wires in a
+//! two-phase protocol (phase 1: reserve, phase 2: inject), then hands the
+//! injected wires to post-stage code that calls real driver ops. None of
+//! that machinery is on `fuzz_circuit_witness` / `fuzz_circuit_revdot_identity`'s
+//! path — those use plain `Circuit` impls without any stage.
+//!
+//! Specifically, this target re-runs the revdot identity under conditions
+//! that exercise:
+//!
+//! - `StageBuilder::configure_stage` (`staging/builder.rs:198-242`) — wire
+//!   counting via a wireless counter emulator, then real allocation through
+//!   the supplied driver.
+//! - `StageGuard::unenforced` / `unenforced_inner`
+//!   (`staging/builder.rs:158-186`) — wireless witness execution followed
+//!   by wire injection via `StageWireInjector` (`staging/builder.rs:99-115`).
+//!   A bug that injects the wrong wires produces a trace polynomial that
+//!   no longer satisfies the algebraic identity.
+//! - `MultiStage::witness` (`staging/mod.rs:359-368`) — the adapter that
+//!   makes `MultiStageCircuit` look like `Circuit` and threads `StageBuilder`
+//!   into the user body.
+//! - Parent-chain `skip_gates` arithmetic (`staging/mod.rs:220-222`) — one
+//!   of the registered variants (`MscChain`) stacks `StageW4Child` on top
+//!   of `StageW2`, so `skip_gates` recurses one level.
+//!
+//! `MultiStage::trace` (`mod.rs:359-368`) alone is not enough: the trace it
+//! produces has zero-valued stage wire slots (`configure_stage` allocates
+//! with `Coeff::Zero` at `staging/builder.rs:221`). The real $r(X)$ is
+//! formed by adding `MultiStage::trace`'s output and each stage's
+//! `StageExt::rx(0, witness_i)` polynomial (`staging/mod.rs:431`). In
+//! production these are committed separately and summed at verification —
+//! see `crates/ragu_pcd/src/fuse/_11_circuits.rs:63-148` for an
+//! application of this pattern.
+//!
+//! The fuzz target reconstructs the full $r(X)$ that way and runs the
+//! identity on the sum. `alpha = 0` everywhere prevents the SYSTEM gate's
+//! `a[0]` from being double-counted across the trace and the stage rx
+//! polynomials.
+//!
+//! ## Invariant A: per-stage isolation
+//!
+//! In addition to the combined-polynomial check above (Invariant B),
+//! the target also runs the per-stage zero check from
+//! `staging/mask.rs:456-491`, generalized to use only pub API: for each
+//! stage in a variant's chain,
+//!
+//! ```text
+//! StageType::rx(0, witness_i).revdot(s_mask(y)) == 0
+//! ```
+//!
+//! where `s_mask(y)` is `Registry::circuit_y(0, y)` for a registry built
+//! from a single `StageType::mask()` bonding object, minus the same
+//! `digest * y^{4n-1}` key term Invariant B subtracts.
+//!
+//! Invariant A catches sum-preserving bugs that Invariant B misses — e.g.,
+//! reversing two slots inside one stage's `rx_configured` and a
+//! compensating reversal inside another stage's — because each stage is
+//! checked against its own mask in isolation, not against an aggregate.
+//!
+//! ## Circuit menu
+//!
+//! Three `MultiStageCircuit` variants, all using `TestRank` for ~2-5k
+//! exec/s throughput parity with the other circuit-layer targets:
+//!
+//! - `Single2W`  — one `StageW2` stage, post-stage `square()` on the first wire.
+//! - `Single4W`  — one `StageW4` stage, post-stage sum-then-square pattern.
+//! - `Chain2x4`  — two stages (`StageW2` → `StageW4Child`), post-stage
+//!   combines wires from both. Parent-chain `skip_gates` recurses.
+//!
+//! Each variant's `Instance` is the publicly-visible "Output" element
+//! computed natively from the witness; the algebraic identity equates
+//! that to the revdot side.
+
+#![no_main]
+
+use arbitrary::Arbitrary;
+use core::marker::PhantomData;
+use ff::Field;
+use ff::PrimeField;
+use libfuzzer_sys::fuzz_target;
+use pasta_curves::Fp;
+use ragu_circuits::{
+    BondingObject, Circuit, CircuitExt, WithAux,
+    polynomials::{Rank, TestRank, sparse},
+    registry::{CircuitIndex, Registry, RegistryBuilder},
+    staging::{MultiStage, MultiStageCircuit, Stage, StageBuilder, StageExt},
+};
+use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue},
+    gadgets::{Bound, Gadget, Kind},
+    maybe::Maybe,
+};
+use ragu_primitives::Element;
+use std::sync::LazyLock;
+
+// ---------------------------------------------------------------------------
+// Stage definitions. Each stage allocates a fixed number of wires; the
+// post-stage `MultiStageCircuit::witness` does the gadget ops.
+//
+// `Stage::witness` runs on stub drivers (wireless during reservation,
+// wired-but-no-enforce during rx extraction). To keep behavior consistent
+// across phases, stages only do plain `Element::alloc` here — gadget ops
+// happen in the post-stage code where the real driver is in scope.
+// ---------------------------------------------------------------------------
+
+#[derive(ragu_core::gadgets::Gadget, ragu_primitives::io::Write)]
+struct TwoWires<'dr, #[ragu(driver)] D: Driver<'dr>> {
+    #[ragu(gadget)]
+    a: Element<'dr, D>,
+    #[ragu(gadget)]
+    b: Element<'dr, D>,
+}
+
+#[derive(ragu_core::gadgets::Gadget, ragu_primitives::io::Write)]
+struct FourWires<'dr, #[ragu(driver)] D: Driver<'dr>> {
+    #[ragu(gadget)]
+    a: Element<'dr, D>,
+    #[ragu(gadget)]
+    b: Element<'dr, D>,
+    #[ragu(gadget)]
+    c: Element<'dr, D>,
+    #[ragu(gadget)]
+    d: Element<'dr, D>,
+}
+
+/// 2-wire stage with parent `()`. Both wires are independent witnesses.
+#[derive(Default)]
+struct StageW2;
+
+impl Stage<Fp, TestRank> for StageW2 {
+    type Parent = ();
+    type Witness<'source> = (Fp, Fp);
+    type OutputKind =
+        <TwoWires<'static, PhantomData<Fp>> as Gadget<'static, PhantomData<Fp>>>::Kind;
+
+    fn values() -> usize {
+        2
+    }
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Self::Witness<'source>>,
+    ) -> Result<Bound<'dr, D, Self::OutputKind>>
+    where
+        Self: 'dr,
+    {
+        let a = Element::alloc(dr, &mut (), witness.as_ref().map(|w| w.0))?;
+        let b = Element::alloc(dr, &mut (), witness.as_ref().map(|w| w.1))?;
+        Ok(TwoWires { a, b })
+    }
+}
+
+/// 4-wire stage with parent `()`. All four wires are independent witnesses.
+#[derive(Default)]
+struct StageW4;
+
+impl Stage<Fp, TestRank> for StageW4 {
+    type Parent = ();
+    type Witness<'source> = (Fp, Fp, Fp, Fp);
+    type OutputKind =
+        <FourWires<'static, PhantomData<Fp>> as Gadget<'static, PhantomData<Fp>>>::Kind;
+
+    fn values() -> usize {
+        4
+    }
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Self::Witness<'source>>,
+    ) -> Result<Bound<'dr, D, Self::OutputKind>>
+    where
+        Self: 'dr,
+    {
+        let a = Element::alloc(dr, &mut (), witness.as_ref().map(|w| w.0))?;
+        let b = Element::alloc(dr, &mut (), witness.as_ref().map(|w| w.1))?;
+        let c = Element::alloc(dr, &mut (), witness.as_ref().map(|w| w.2))?;
+        let d = Element::alloc(dr, &mut (), witness.as_ref().map(|w| w.3))?;
+        Ok(FourWires { a, b, c, d })
+    }
+}
+
+/// 4-wire stage with `StageW2` as parent. Exercises `skip_gates` recursion.
+#[derive(Default)]
+struct StageW4Child;
+
+impl Stage<Fp, TestRank> for StageW4Child {
+    type Parent = StageW2;
+    type Witness<'source> = (Fp, Fp, Fp, Fp);
+    type OutputKind =
+        <FourWires<'static, PhantomData<Fp>> as Gadget<'static, PhantomData<Fp>>>::Kind;
+
+    fn values() -> usize {
+        4
+    }
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Self::Witness<'source>>,
+    ) -> Result<Bound<'dr, D, Self::OutputKind>>
+    where
+        Self: 'dr,
+    {
+        let a = Element::alloc(dr, &mut (), witness.as_ref().map(|w| w.0))?;
+        let b = Element::alloc(dr, &mut (), witness.as_ref().map(|w| w.1))?;
+        let c = Element::alloc(dr, &mut (), witness.as_ref().map(|w| w.2))?;
+        let d = Element::alloc(dr, &mut (), witness.as_ref().map(|w| w.3))?;
+        Ok(FourWires { a, b, c, d })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MultiStageCircuit definitions. Each one wires up one or more stages and
+// performs a small gadget computation on the injected wires, yielding an
+// `Element` output that the verifier sees in `k(Y)`.
+//
+// The `Instance` for each is the natively-computed Output, supplied to
+// `ms.ky(instance, y)` to form the right-hand side of the identity.
+// ---------------------------------------------------------------------------
+
+/// One `StageW2` stage. Post-stage: output = a^2.
+#[derive(Clone, Default)]
+struct Single2W;
+
+impl MultiStageCircuit<Fp, TestRank> for Single2W {
+    type Last = StageW2;
+    type Instance<'source> = Fp;
+    type Witness<'source> = (Fp, Fp);
+    type Output = Kind![Fp; Element<'_, _>];
+    type Aux<'source> = ();
+
+    fn instance<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        instance: DriverValue<D, Fp>,
+    ) -> Result<Bound<'dr, D, Self::Output>>
+    where
+        Self: 'dr,
+    {
+        Element::alloc(dr, &mut (), instance)
+    }
+
+    fn witness<'a, 'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        builder: StageBuilder<'a, 'dr, D, TestRank, (), StageW2>,
+        witness: DriverValue<D, (Fp, Fp)>,
+    ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, ()>>>
+    where
+        Self: 'dr,
+    {
+        let (guard, builder) = builder.configure_stage(StageW2)?;
+        let dr = builder.finish();
+        let TwoWires { a, b: _ } = guard.unenforced(dr, witness)?;
+        let out = a.square(dr)?;
+        Ok(WithAux::new(out, D::unit()))
+    }
+}
+
+impl Single2W {
+    /// Native: `a^2`, ignoring `b`. Matches `witness` exactly.
+    fn native_instance(witness: (Fp, Fp)) -> Fp {
+        witness.0.square()
+    }
+}
+
+/// One `StageW4` stage. Post-stage: output = (a + b) * (c + d).
+#[derive(Clone, Default)]
+struct Single4W;
+
+impl MultiStageCircuit<Fp, TestRank> for Single4W {
+    type Last = StageW4;
+    type Instance<'source> = Fp;
+    type Witness<'source> = (Fp, Fp, Fp, Fp);
+    type Output = Kind![Fp; Element<'_, _>];
+    type Aux<'source> = ();
+
+    fn instance<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        instance: DriverValue<D, Fp>,
+    ) -> Result<Bound<'dr, D, Self::Output>>
+    where
+        Self: 'dr,
+    {
+        Element::alloc(dr, &mut (), instance)
+    }
+
+    fn witness<'a, 'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        builder: StageBuilder<'a, 'dr, D, TestRank, (), StageW4>,
+        witness: DriverValue<D, (Fp, Fp, Fp, Fp)>,
+    ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, ()>>>
+    where
+        Self: 'dr,
+    {
+        let (guard, builder) = builder.configure_stage(StageW4)?;
+        let dr = builder.finish();
+        let FourWires { a, b, c, d } = guard.unenforced(dr, witness)?;
+        let lhs = a.add(dr, &b);
+        let rhs = c.add(dr, &d);
+        let out = lhs.mul(dr, &rhs)?;
+        Ok(WithAux::new(out, D::unit()))
+    }
+}
+
+impl Single4W {
+    /// Native: `(a + b) * (c + d)`.
+    fn native_instance(witness: (Fp, Fp, Fp, Fp)) -> Fp {
+        (witness.0 + witness.1) * (witness.2 + witness.3)
+    }
+}
+
+/// Two stages: `StageW2` parent, `StageW4Child` last. Post-stage: output =
+/// (parent.a + child.a) * (parent.b + child.b).
+///
+/// Exercises `skip_gates` recursion at `staging/mod.rs:220-222`.
+#[derive(Clone, Default)]
+struct Chain2x4;
+
+impl MultiStageCircuit<Fp, TestRank> for Chain2x4 {
+    type Last = StageW4Child;
+    type Instance<'source> = Fp;
+    type Witness<'source> = ((Fp, Fp), (Fp, Fp, Fp, Fp));
+    type Output = Kind![Fp; Element<'_, _>];
+    type Aux<'source> = ();
+
+    fn instance<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        instance: DriverValue<D, Fp>,
+    ) -> Result<Bound<'dr, D, Self::Output>>
+    where
+        Self: 'dr,
+    {
+        Element::alloc(dr, &mut (), instance)
+    }
+
+    fn witness<'a, 'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        builder: StageBuilder<'a, 'dr, D, TestRank, (), StageW4Child>,
+        witness: DriverValue<D, ((Fp, Fp), (Fp, Fp, Fp, Fp))>,
+    ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, ()>>>
+    where
+        Self: 'dr,
+    {
+        let (parent_guard, builder) = builder.configure_stage(StageW2)?;
+        let (child_guard, builder) = builder.configure_stage(StageW4Child)?;
+        let dr = builder.finish();
+
+        let parent_witness = witness.as_ref().map(|w| w.0);
+        let child_witness = witness.as_ref().map(|w| w.1);
+
+        let TwoWires {
+            a: parent_a,
+            b: parent_b,
+        } = parent_guard.unenforced(dr, parent_witness)?;
+        let FourWires {
+            a: child_a,
+            b: child_b,
+            c: _,
+            d: _,
+        } = child_guard.unenforced(dr, child_witness)?;
+
+        let lhs = parent_a.add(dr, &child_a);
+        let rhs = parent_b.add(dr, &child_b);
+        let out = lhs.mul(dr, &rhs)?;
+        Ok(WithAux::new(out, D::unit()))
+    }
+}
+
+impl Chain2x4 {
+    /// Native: `(parent.a + child.a) * (parent.b + child.b)`.
+    fn native_instance(witness: ((Fp, Fp), (Fp, Fp, Fp, Fp))) -> Fp {
+        let ((pa, pb), (ca, cb, _, _)) = witness;
+        (pa + ca) * (pb + cb)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-variant memoized registries. Same `LazyLock<Option<Registry<...>>>`
+// pattern as fuzz_circuit_revdot_identity's SIMPLE_REGISTRY but one slot per
+// variant.
+// ---------------------------------------------------------------------------
+
+fn build_registry<C>(circuit: C) -> Option<Registry<'static, Fp, TestRank>>
+where
+    C: Circuit<Fp> + 'static,
+{
+    RegistryBuilder::<Fp, TestRank>::new()
+        .register_circuit(circuit)
+        .and_then(|b| b.finalize())
+        .ok()
+}
+
+static SINGLE2W_REGISTRY: LazyLock<Option<Registry<'static, Fp, TestRank>>> =
+    LazyLock::new(|| build_registry(MultiStage::<Fp, TestRank, _>::new(Single2W)));
+
+static SINGLE4W_REGISTRY: LazyLock<Option<Registry<'static, Fp, TestRank>>> =
+    LazyLock::new(|| build_registry(MultiStage::<Fp, TestRank, _>::new(Single4W)));
+
+static CHAIN_REGISTRY: LazyLock<Option<Registry<'static, Fp, TestRank>>> =
+    LazyLock::new(|| build_registry(MultiStage::<Fp, TestRank, _>::new(Chain2x4)));
+
+/// Build a registry containing just one stage's `mask()` as a bonding
+/// entry. The resulting registry's `circuit_y(0, y)` is the stage's full
+/// mask polynomial (the framework's `RegistryAt::y` adds the global term
+/// for masking circuits, recovering it from the `-notch`-only `sy()` that
+/// the underlying `StageMask` returns) plus the `digest * y^{4n-1}` key
+/// term — exactly the inputs Invariant A wants for its zero check, after
+/// subtracting the key term.
+fn build_mask_registry(mask: BondingObject<'static, Fp, TestRank>) -> Option<Registry<'static, Fp, TestRank>> {
+    RegistryBuilder::<Fp, TestRank>::new()
+        .register_bonding(mask)
+        .finalize()
+        .ok()
+}
+
+static MASK_REGISTRY_W2: LazyLock<Option<Registry<'static, Fp, TestRank>>> = LazyLock::new(|| {
+    let mask: BondingObject<'static, Fp, TestRank> =
+        <StageW2 as StageExt<Fp, TestRank>>::mask().ok()?;
+    build_mask_registry(mask)
+});
+
+static MASK_REGISTRY_W4: LazyLock<Option<Registry<'static, Fp, TestRank>>> = LazyLock::new(|| {
+    let mask: BondingObject<'static, Fp, TestRank> =
+        <StageW4 as StageExt<Fp, TestRank>>::mask().ok()?;
+    build_mask_registry(mask)
+});
+
+static MASK_REGISTRY_W4_CHILD: LazyLock<Option<Registry<'static, Fp, TestRank>>> = LazyLock::new(|| {
+    let mask: BondingObject<'static, Fp, TestRank> =
+        <StageW4Child as StageExt<Fp, TestRank>>::mask().ok()?;
+    build_mask_registry(mask)
+});
+
+// ---------------------------------------------------------------------------
+// Input shape — one variant per MultiStageCircuit. Same `Arbitrary` style
+// as fuzz_circuit_revdot_identity.
+// ---------------------------------------------------------------------------
+
+#[derive(Arbitrary, Debug)]
+enum CircuitChoice {
+    Single2W {
+        a_seed: u64,
+        b_seed: u64,
+        use_special: Option<u8>,
+    },
+    Single4W {
+        a_seed: u64,
+        b_seed: u64,
+        c_seed: u64,
+        d_seed: u64,
+        use_special: Option<u8>,
+    },
+    Chain {
+        parent_a_seed: u64,
+        parent_b_seed: u64,
+        child_a_seed: u64,
+        child_b_seed: u64,
+        child_c_seed: u64,
+        child_d_seed: u64,
+        use_special: Option<u8>,
+    },
+}
+
+#[derive(Arbitrary, Debug)]
+struct Input {
+    circuit: CircuitChoice,
+    y_seed: u64,
+    z_seed: u64,
+}
+
+fn special_value(idx: u8) -> Fp {
+    match idx % 8 {
+        0 => Fp::ZERO,
+        1 => Fp::ONE,
+        2 => -Fp::ONE,
+        3 => Fp::TWO_INV,
+        4 => Fp::ROOT_OF_UNITY,
+        5 => Fp::MULTIPLICATIVE_GENERATOR,
+        6 => Fp::from(1u64 << 32),
+        _ => Fp::from(u64::MAX),
+    }
+}
+
+/// `special` overrides only the first witness slot for the variant, mirroring
+/// `fuzz_circuit_revdot_identity`'s pattern of biasing the first witness toward
+/// edge values without losing entropy in the rest.
+fn maybe_special(seed: u64, special: Option<u8>) -> Fp {
+    match special {
+        Some(idx) => special_value(idx),
+        None => Fp::from(seed),
+    }
+}
+
+/// Same trick as `fuzz_circuit_revdot_identity::sy_from_registry`:
+/// `Registry::wy(omega_0, y)` is `s(X, y)` plus the registry key term
+/// `key.value() * y^{4n-1}` at slot `c[R::n() - 1]`. Subtract it to
+/// recover the bare wiring polynomial. Valid because each MSC variant
+/// is registered alone (single-circuit registry, non-mask).
+fn sy_from_registry(
+    registry: &Registry<'_, Fp, TestRank>,
+    y: Fp,
+) -> sparse::Polynomial<Fp, TestRank> {
+    let omega_0 = CircuitIndex::new(0).omega_j::<Fp>();
+    let mut wy = registry.wy(omega_0, y);
+    if y != Fp::ZERO {
+        let y_4n_minus_1 = y.pow_vartime([(4 * TestRank::n() - 1) as u64]);
+        let mut key_view = sparse::View::<_, TestRank, _>::wiring();
+        key_view.c.push(registry.digest() * y_4n_minus_1);
+        let key_term = key_view.build();
+        wy.sub_assign(&key_term);
+    }
+    wy
+}
+
+/// Same key-term subtraction as `sy_from_registry`, applied to a
+/// mask-only registry. The mask-only registry's `circuit_y(0, y)` is the
+/// stage's full mask polynomial plus the `digest * y^{4n-1}` key term;
+/// subtracting the latter gives the bare mask polynomial that Invariant
+/// A revdots against.
+fn sy_from_mask_registry(
+    mask_registry: &Registry<'_, Fp, TestRank>,
+    y: Fp,
+) -> sparse::Polynomial<Fp, TestRank> {
+    let mut wy = mask_registry.circuit_y(CircuitIndex::new(0), y);
+    if y != Fp::ZERO {
+        let y_4n_minus_1 = y.pow_vartime([(4 * TestRank::n() - 1) as u64]);
+        let mut key_view = sparse::View::<_, TestRank, _>::wiring();
+        key_view.c.push(mask_registry.digest() * y_4n_minus_1);
+        let key_term = key_view.build();
+        wy.sub_assign(&key_term);
+    }
+    wy
+}
+
+/// Invariant A: assert that a single stage's `rx` polynomial revdots to
+/// zero against its own mask polynomial. Per-stage discrimination —
+/// catches bugs that Invariant B's combined-polynomial check would miss
+/// when one stage's error is cancelled by another's. Panics with both
+/// sides on failure.
+fn check_stage_isolation(
+    label: &str,
+    stage_rx: &sparse::Polynomial<Fp, TestRank>,
+    mask_registry: &Registry<'_, Fp, TestRank>,
+    y: Fp,
+) {
+    let sy = sy_from_mask_registry(mask_registry, y);
+    let actual = stage_rx.revdot(&sy);
+    assert_eq!(
+        actual,
+        Fp::ZERO,
+        "Invariant A violated for {label}: rx.revdot(mask) = {actual:?}, expected 0 at y={y:?}"
+    );
+}
+
+/// Run the Invariant B oracle. The `stage_rx_sum` argument is the sum of
+/// per-stage `StageExt::rx(0, ...)` polynomials for the variant's stages;
+/// adding it to `MultiStage::trace` reconstructs the full $r(X)$ that the
+/// algebraic identity is about. See module docstring for derivation.
+///
+/// Returns `(expected_ky, actual_revdot)` so the caller's panic message
+/// can show both sides.
+fn check_identity<C: Circuit<Fp>>(
+    registry: &Registry<'_, Fp, TestRank>,
+    circuit: &C,
+    witness: C::Witness<'_>,
+    instance: C::Instance<'_>,
+    stage_rx_sum: sparse::Polynomial<Fp, TestRank>,
+    y: Fp,
+    z: Fp,
+) -> Option<(Fp, Fp)> {
+    let trace = circuit.trace(witness).ok()?.into_output();
+
+    // alpha = 0 so the algebraic identity holds without an extra revdot
+    // term — same rationale as fuzz_circuit_revdot_identity. The stage rx
+    // polynomials are also computed with alpha = 0; together with the
+    // trace's a[0]=0 the gate-0 SYSTEM constraint stays clean.
+    let mut r = registry
+        .assemble_with_alpha(&trace, CircuitIndex::new(0), Fp::ZERO)
+        .expect("assemble_with_alpha failed on a registered MultiStage circuit");
+    r.add_assign(&stage_rx_sum);
+
+    let mut b = r.clone();
+    b.dilate(z);
+    b.add_assign(&sy_from_registry(registry, y));
+    b.add_assign(&TestRank::tz(z));
+
+    let expected_ky = circuit
+        .ky(instance, y)
+        .expect("ky should not fail on a MultiStage Fp instance");
+    let actual = r.revdot(&b);
+    Some((expected_ky, actual))
+}
+
+fuzz_target!(|input: Input| {
+    if std::env::var("DEBUG_INPUT").is_ok() {
+        eprintln!("{:#?}", input);
+        return;
+    }
+
+    let y = Fp::from(input.y_seed);
+    let z = Fp::from(input.z_seed);
+
+    match input.circuit {
+        CircuitChoice::Single2W {
+            a_seed,
+            b_seed,
+            use_special,
+        } => {
+            let registry = match SINGLE2W_REGISTRY.as_ref() {
+                Some(r) => r,
+                None => return,
+            };
+            let a = maybe_special(a_seed, use_special);
+            let b = Fp::from(b_seed);
+            let witness = (a, b);
+            let circuit = MultiStage::<Fp, TestRank, _>::new(Single2W);
+            let instance = Single2W::native_instance(witness);
+            let stage_w2_rx = match StageW2::rx(Fp::ZERO, (a, b)) {
+                Ok(p) => p,
+                Err(_) => return,
+            };
+            // Invariant A: per-stage isolation against the stage's own mask.
+            if let Some(mask_reg) = MASK_REGISTRY_W2.as_ref() {
+                check_stage_isolation("Single2W/StageW2", &stage_w2_rx, mask_reg, y);
+            }
+            // Invariant B: combined revdot identity through MultiStage.
+            let Some((expected, actual)) =
+                check_identity(registry, &circuit, witness, instance, stage_w2_rx, y, z)
+            else {
+                return;
+            };
+            assert_eq!(
+                expected, actual,
+                "Single2W staging identity violated: \
+                 witness={witness:?}, instance={instance:?}, y={y:?}, z={z:?}, \
+                 expected_ky={expected:?}, actual_revdot={actual:?}"
+            );
+        }
+        CircuitChoice::Single4W {
+            a_seed,
+            b_seed,
+            c_seed,
+            d_seed,
+            use_special,
+        } => {
+            let registry = match SINGLE4W_REGISTRY.as_ref() {
+                Some(r) => r,
+                None => return,
+            };
+            let a = maybe_special(a_seed, use_special);
+            let b = Fp::from(b_seed);
+            let c = Fp::from(c_seed);
+            let d = Fp::from(d_seed);
+            let witness = (a, b, c, d);
+            let circuit = MultiStage::<Fp, TestRank, _>::new(Single4W);
+            let instance = Single4W::native_instance(witness);
+            let stage_w4_rx = match StageW4::rx(Fp::ZERO, witness) {
+                Ok(p) => p,
+                Err(_) => return,
+            };
+            if let Some(mask_reg) = MASK_REGISTRY_W4.as_ref() {
+                check_stage_isolation("Single4W/StageW4", &stage_w4_rx, mask_reg, y);
+            }
+            let Some((expected, actual)) =
+                check_identity(registry, &circuit, witness, instance, stage_w4_rx, y, z)
+            else {
+                return;
+            };
+            assert_eq!(
+                expected, actual,
+                "Single4W staging identity violated: \
+                 witness={witness:?}, instance={instance:?}, y={y:?}, z={z:?}, \
+                 expected_ky={expected:?}, actual_revdot={actual:?}"
+            );
+        }
+        CircuitChoice::Chain {
+            parent_a_seed,
+            parent_b_seed,
+            child_a_seed,
+            child_b_seed,
+            child_c_seed,
+            child_d_seed,
+            use_special,
+        } => {
+            let registry = match CHAIN_REGISTRY.as_ref() {
+                Some(r) => r,
+                None => return,
+            };
+            let parent_a = maybe_special(parent_a_seed, use_special);
+            let parent_b = Fp::from(parent_b_seed);
+            let child_a = Fp::from(child_a_seed);
+            let child_b = Fp::from(child_b_seed);
+            let child_c = Fp::from(child_c_seed);
+            let child_d = Fp::from(child_d_seed);
+            let witness = (
+                (parent_a, parent_b),
+                (child_a, child_b, child_c, child_d),
+            );
+            let circuit = MultiStage::<Fp, TestRank, _>::new(Chain2x4);
+            let instance = Chain2x4::native_instance(witness);
+            // Stages composed in order: StageW2 then StageW4Child. Sum both
+            // rx polynomials so the combined `r(X)` is consistent with what
+            // the verifier would see after committing each stage separately.
+            let parent_rx = match StageW2::rx(Fp::ZERO, (parent_a, parent_b)) {
+                Ok(p) => p,
+                Err(_) => return,
+            };
+            let child_rx = match StageW4Child::rx(Fp::ZERO, (child_a, child_b, child_c, child_d)) {
+                Ok(p) => p,
+                Err(_) => return,
+            };
+            // Invariant A: each stage checked against its own mask in isolation.
+            if let Some(mask_reg) = MASK_REGISTRY_W2.as_ref() {
+                check_stage_isolation("Chain/parent StageW2", &parent_rx, mask_reg, y);
+            }
+            if let Some(mask_reg) = MASK_REGISTRY_W4_CHILD.as_ref() {
+                check_stage_isolation("Chain/child StageW4Child", &child_rx, mask_reg, y);
+            }
+            // Invariant B: combined revdot identity.
+            let mut stage_rx_sum = parent_rx;
+            stage_rx_sum.add_assign(&child_rx);
+            let Some((expected, actual)) =
+                check_identity(registry, &circuit, witness, instance, stage_rx_sum, y, z)
+            else {
+                return;
+            };
+            assert_eq!(
+                expected, actual,
+                "Chain2x4 staging identity violated: \
+                 witness={witness:?}, instance={instance:?}, y={y:?}, z={z:?}, \
+                 expected_ky={expected:?}, actual_revdot={actual:?}"
+            );
+        }
+    }
+});

--- a/qa/fuzz/fuzz_targets/fuzz_sxy_agreement.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_sxy_agreement.rs
@@ -67,8 +67,10 @@ fuzz_target!(|input: Input| {
         eprintln!("{:#?}", input);
         return;
     }
-    // Clamp times to stay within TestRank bounds.
-    let times = ((input.times as usize) % 120).max(1);
+    // Map u8 to `times ∈ [1, 120]` so every slot in the 120-entry cache is
+    // reachable. `% 120` alone would yield `[0, 119]` (and the `.max(1)`
+    // floor used previously left slot 119 unreachable).
+    let times = ((input.times as usize) % 120) + 1;
 
     let registry = match registry_for(times) {
         Some(r) => r,

--- a/qa/fuzz/fuzz_targets/fuzz_verify_reject.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_verify_reject.rs
@@ -21,10 +21,18 @@ type C = Pasta;
 type R = ProductionRank;
 const HEADER_SIZE: usize = 4;
 
-/// Wrapper to satisfy `Sync` for `Application` (which contains `OnceCell`).
-/// Safe because libfuzzer is single-threaded.
+/// Wrapper to satisfy `Sync` for `Application` (which contains a
+/// `OnceCell` field — `seeded_trivial` — for memoizing the trivial-proof
+/// fixture, breaking auto-`Sync`).
 struct SyncApp(ragu_pcd::Application<'static, C, R, HEADER_SIZE>);
-// SAFETY: libfuzzer runs the fuzz target on a single thread.
+// SAFETY: this fuzz body invokes `Application` exclusively through
+// `app.test_trivial_proof()` (which only reads from the application,
+// initializing `seeded_trivial` on the first call and reading it
+// thereafter) and `verify(&proof)` (which takes `&Application` and never
+// touches `seeded_trivial`). libfuzzer drives `fuzz_target!` on a single
+// thread, so even the `OnceCell` initialization on the very first call
+// is uncontended. If this target ever grows to spawn worker threads or
+// to mutate `Application` state, the assumption must be revisited.
 unsafe impl Sync for SyncApp {}
 
 static APP: LazyLock<SyncApp> = LazyLock::new(|| {

--- a/qa/fuzz/fuzz_targets/fuzz_witness_cheat.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_witness_cheat.rs
@@ -1,10 +1,42 @@
-//! Soundness fuzz target via mid-stream witness cheating.
+//! Mid-stream witness cheating fuzz target.
 //!
 //! Runs the same instruction stream twice through the `Simulator`: an
 //! honest path and a cheat path that, at a fuzzer-chosen point, replaces
 //! one element on the stack with a fresh allocation whose value differs
 //! from the honest one. After both runs complete, the final element and
 //! boolean values are compared.
+//!
+//! # Current effective behavior
+//!
+//! As implemented, this target functions primarily as a Simulator
+//! robustness fuzzer rather than a soundness oracle. The cheated slot is
+//! included in the comparison fingerprint, and the cheat value is filtered
+//! to differ from the original, so `honest != cheat` is tautologically
+//! true regardless of whether downstream constraints actually catch the
+//! cheat. The signals the target reliably surfaces today are panics, OOB
+//! indexing, and arithmetic faults in the gadget API when fed adversarial
+//! inputs — not under-constrained gadgets.
+//!
+//! # Intended behavior (post-patcher)
+//!
+//! Becoming a true under-constrained-gadget oracle requires two changes,
+//! both tracked in the patcher follow-up issue:
+//!
+//! 1. A patcher pass that, after the cheat is injected, walks the
+//!    recorded constraint graph forward from the cheated slot and adjusts
+//!    other downstream witness slots so the constraint system stays
+//!    satisfied. Without this, the cheat is either rejected by the first
+//!    downstream constraint that compares it against a honest-derived
+//!    value, or it propagates only through gates that self-satisfy
+//!    (`c = a*b` recomputed from the cheat).
+//!
+//! 2. Excluding the cheated slot from the comparison fingerprint, so the
+//!    `honest != cheat` check reflects downstream observable behavior
+//!    rather than the cheat injection itself.
+//!
+//! With both in place, the assertion becomes: "the Simulator accepted two
+//! genuinely different witnesses producing the same observable behavior"
+//! — the canonical under-constrained-gadget signal.
 //!
 //! # Why this is the witness-mutation pattern, adapted to Ragu
 //!
@@ -555,7 +587,7 @@ fuzz_target!(|input: Input| {
         } else {
             eprintln!(
                 "\nVERDICT: LIVE CHEAT — cheated slot was read {} times \
-                 downstream. If `cargo +nightly fuzz run fuzz_soundness_cheat \
+                 downstream. If `cargo +nightly fuzz run fuzz_witness_cheat \
                  <file>` confirms the panic, the gadget on that read path \
                  is plausibly under-constrained.",
                 downstream_reads,


### PR DESCRIPTION
References  https://github.com/tachyon-zcash/ragu/issues/709 and stacks on https://github.com/tachyon-zcash/ragu/pull/724. This extends fuzzing to other targets like (1) circuit impls (through trace and registry assembly), and (2) the staging system with random witness values and asserting witness-dependent algebraic identities.

https://github.com/tachyon-zcash/ragu/issues/728 (this one is especially interesting!) and https://github.com/tachyon-zcash/ragu/issues/726 will be follow-up work. 