### PR TITLE
chore(ci): cargo vet workflow

### DIFF
--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -16,37 +16,10 @@ permissions:
   contents: read
 
 jobs:
-  # Detect whether anything that could affect vet/audit changed. The downstream
-  # jobs always evaluate (so branch-protection required-check semantics work)
-  # but short-circuit when nothing relevant changed.
-  changes:
-    name: detect changes
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      lockfile: ${{ steps.filter.outputs.lockfile }}
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
-        id: filter
-        with:
-          filters: |
-            lockfile:
-              - '**/Cargo.lock'
-              - '**/Cargo.toml'
-              - 'qa/supply-chain/**'
-              - '.github/workflows/vet.yml'
-
   vet:
     name: cargo vet
-    needs: changes
-    if: needs.changes.outputs.lockfile == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # cargo-vet only reads manifests; it doesn't compile our crates. Bypass
     # the workspace's rust-toolchain.toml (which pins 1.90.0 + clippy) so we
     # use the runner's preinstalled stable and avoid rustup component-install
@@ -74,9 +47,8 @@ jobs:
 
   audit:
     name: cargo audit
-    needs: changes
-    if: needs.changes.outputs.lockfile == 'true' || github.event_name == 'push' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       RUSTUP_TOOLCHAIN: stable
     steps:

--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -1,0 +1,56 @@
+name: Supply chain
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/Cargo.lock'
+      - 'qa/supply-chain/**'
+      - '.github/workflows/vet.yml'
+  pull_request:
+    paths:
+      - '**/Cargo.lock'
+      - 'qa/supply-chain/**'
+      - '.github/workflows/vet.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  vet:
+    name: cargo vet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain (from rust-toolchain.toml)
+        uses: dtolnay/rust-toolchain@b18f7037bce1ea84c086f4d5e9493f853c0ce412 # 1.90.0 branch HEAD @ 2026-05-23
+
+      - name: Cache cargo registry
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-vet-${{ hashFiles('Cargo.lock', 'qa/supply-chain/**') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-vet-
+
+      - name: Install cargo-vet
+        uses: taiki-e/install-action@6c1f7cf125e42770ff087ea443901b487cc5471a # v2.79.5
+        with:
+          tool: cargo-vet@0.10.3
+
+      # cargo-vet expects `supply-chain/` adjacent to the workspace Cargo.toml.
+      # Our config lives at `qa/supply-chain/`, so stage a symlink for CI.
+      - name: Stage supply-chain symlink
+        run: ln -s qa/supply-chain supply-chain
+
+      - name: Run cargo vet
+        run: cargo vet --locked

--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -70,7 +70,7 @@ jobs:
         run: cargo install --locked cargo-vet@0.10.2
 
       - name: Run cargo vet
-        run: cargo vet --frozen --locked --store-path ./qa/supply-chain/
+        run: cargo vet --locked --store-path ./qa/supply-chain/
 
   audit:
     name: cargo audit

--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Audit on a weekly cadence so new RustSec advisories published against
+  # already-pinned deps surface even without a lockfile change.
+  schedule:
+    - cron: '0 6 * * 1'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -12,9 +16,9 @@ permissions:
   contents: read
 
 jobs:
-  # Detect whether anything that could affect the vet result changed. The vet
-  # job always runs (so branch-protection required-check semantics work) but
-  # short-circuits when nothing relevant changed.
+  # Detect whether anything that could affect vet/audit changed. The downstream
+  # jobs always evaluate (so branch-protection required-check semantics work)
+  # but short-circuit when nothing relevant changed.
   changes:
     name: detect changes
     runs-on: ubuntu-latest
@@ -22,7 +26,7 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      vet: ${{ steps.filter.outputs.vet }}
+      lockfile: ${{ steps.filter.outputs.lockfile }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -32,7 +36,7 @@ jobs:
         id: filter
         with:
           filters: |
-            vet:
+            lockfile:
               - '**/Cargo.lock'
               - '**/Cargo.toml'
               - 'qa/supply-chain/**'
@@ -41,7 +45,7 @@ jobs:
   vet:
     name: cargo vet
     needs: changes
-    if: needs.changes.outputs.vet == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.lockfile == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
     # cargo-vet only reads manifests; it doesn't compile our crates. Bypass
     # the workspace's rust-toolchain.toml (which pins 1.90.0 + clippy) so we
@@ -67,3 +71,29 @@ jobs:
 
       - name: Run cargo vet
         run: cargo vet --frozen --locked --store-path ./qa/supply-chain/
+
+  audit:
+    name: cargo audit
+    needs: changes
+    if: needs.changes.outputs.lockfile == 'true' || github.event_name == 'push' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: stable
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Cache cargo-audit binary
+        id: cache-audit
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: ${{ runner.os }}-cargo-audit-bin-0.22.1
+
+      - name: Install cargo-audit
+        if: steps.cache-audit.outputs.cache-hit != 'true'
+        run: cargo install --locked cargo-audit@0.22.1
+
+      - name: Run cargo audit
+        run: cargo audit

--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -23,29 +23,27 @@ jobs:
   vet:
     name: cargo vet
     runs-on: ubuntu-latest
+    # cargo-vet only reads manifests; it doesn't compile our crates. Bypass
+    # the workspace's rust-toolchain.toml (which pins 1.90.0 + clippy) so we
+    # use the runner's preinstalled stable and avoid rustup component-install
+    # conflicts when cargo runs inside the workspace.
+    env:
+      RUSTUP_TOOLCHAIN: stable
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
-      - name: Install Rust toolchain (from rust-toolchain.toml)
-        uses: dtolnay/rust-toolchain@b18f7037bce1ea84c086f4d5e9493f853c0ce412 # 1.90.0 branch HEAD @ 2026-05-23
-
-      - name: Cache cargo registry
+      - name: Cache cargo-vet binary
+        id: cache-vet
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-          key: ${{ runner.os }}-cargo-vet-${{ hashFiles('Cargo.lock', 'qa/supply-chain/**') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-vet-
+          path: ~/.cargo/bin/cargo-vet
+          key: ${{ runner.os }}-cargo-vet-bin-0.10.2
 
       - name: Install cargo-vet
-        uses: taiki-e/install-action@6c1f7cf125e42770ff087ea443901b487cc5471a # v2.79.5
-        with:
-          tool: cargo-vet@0.10.0
+        if: steps.cache-vet.outputs.cache-hit != 'true'
+        run: cargo install --locked cargo-vet@0.10.2
 
       - name: Run cargo vet
         run: cargo vet --locked --store-path ./qa/supply-chain/

--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -2,15 +2,7 @@ name: Supply chain
 on:
   push:
     branches: [main]
-    paths:
-      - '**/Cargo.lock'
-      - 'qa/supply-chain/**'
-      - '.github/workflows/vet.yml'
   pull_request:
-    paths:
-      - '**/Cargo.lock'
-      - 'qa/supply-chain/**'
-      - '.github/workflows/vet.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -20,8 +12,36 @@ permissions:
   contents: read
 
 jobs:
+  # Detect whether anything that could affect the vet result changed. The vet
+  # job always runs (so branch-protection required-check semantics work) but
+  # short-circuits when nothing relevant changed.
+  changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      vet: ${{ steps.filter.outputs.vet }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        id: filter
+        with:
+          filters: |
+            vet:
+              - '**/Cargo.lock'
+              - '**/Cargo.toml'
+              - 'qa/supply-chain/**'
+              - '.github/workflows/vet.yml'
+
   vet:
     name: cargo vet
+    needs: changes
+    if: needs.changes.outputs.vet == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
     # cargo-vet only reads manifests; it doesn't compile our crates. Bypass
     # the workspace's rust-toolchain.toml (which pins 1.90.0 + clippy) so we
@@ -46,4 +66,4 @@ jobs:
         run: cargo install --locked cargo-vet@0.10.2
 
       - name: Run cargo vet
-        run: cargo vet --locked --store-path ./qa/supply-chain/
+        run: cargo vet --frozen --locked --store-path ./qa/supply-chain/

--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -45,12 +45,7 @@ jobs:
       - name: Install cargo-vet
         uses: taiki-e/install-action@6c1f7cf125e42770ff087ea443901b487cc5471a # v2.79.5
         with:
-          tool: cargo-vet@0.10.3
-
-      # cargo-vet expects `supply-chain/` adjacent to the workspace Cargo.toml.
-      # Our config lives at `qa/supply-chain/`, so stage a symlink for CI.
-      - name: Stage supply-chain symlink
-        run: ln -s qa/supply-chain supply-chain
+          tool: cargo-vet@0.10.0
 
       - name: Run cargo vet
-        run: cargo vet --locked
+        run: cargo vet --locked --store-path ./qa/supply-chain/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ group = { version = "0.14.0-pre.1", default-features = false }
 pasta_curves = { version = "0.5.1", features = ["deferred"] }
 rand = "0.10"
 lazy_static = "1.5.0"
-proptest = "1.7.0"
+proptest = "1.11.0"
 gungraun = "0.17.0"
 blake2b_simd = "1.0"
 maybe-rayon = { version = "0.1.1", default-features = false }

--- a/qa/supply-chain/audits.toml
+++ b/qa/supply-chain/audits.toml
@@ -6,6 +6,12 @@ who = "Sean Bowe <ewillbefull@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.4.1 -> 0.3.4"
 
+[[audits.pasta_curves]]
+who = "Sean Bowe <ewillbefull@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.5.1 -> 0.5.1@git:4b2c768ec4b14b2c7fa0f6e527e453cde97805aa"
+importable = false
+
 [[trusted.addchain]]
 criteria = "safe-to-deploy"
 user-id = 6289 # Jack Grigg (str4d)

--- a/qa/supply-chain/config.toml
+++ b/qa/supply-chain/config.toml
@@ -37,6 +37,7 @@ audit-as-crates-io = true
 
 [policy.ragu_testing]
 audit-as-crates-io = true
+criteria = "safe-to-run"
 
 [[exemptions.bincode]]
 version = "1.3.3"
@@ -106,16 +107,12 @@ criteria = "safe-to-run"
 version = "0.5.2"
 criteria = "safe-to-run"
 
-[[exemptions.pasta_curves]]
-version = "0.5.1@git:ad4c7a24d9b0829f9da5f305aab6b4ab97a97900"
-criteria = "safe-to-deploy"
-
 [[exemptions.proc-macro-crate]]
 version = "3.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.proptest]]
-version = "1.10.0"
+version = "1.11.0"
 criteria = "safe-to-run"
 
 [[exemptions.r-efi]]
@@ -125,10 +122,6 @@ criteria = "safe-to-deploy"
 [[exemptions.radium]]
 version = "0.7.0"
 criteria = "safe-to-deploy"
-
-[[exemptions.rand_xorshift]]
-version = "0.4.0"
-criteria = "safe-to-run"
 
 [[exemptions.rusty-fork]]
 version = "0.3.1"
@@ -140,10 +133,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tempfile]]
 version = "3.24.0"
-criteria = "safe-to-run"
-
-[[exemptions.unarray]]
-version = "0.1.4"
 criteria = "safe-to-run"
 
 [[exemptions.wyz]]

--- a/qa/supply-chain/imports.lock
+++ b/qa/supply-chain/imports.lock
@@ -201,6 +201,13 @@ user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
+[[publisher.pasta_curves]]
+version = "0.5.1"
+when = "2023-03-02"
+user-id = 6289
+user-login = "str4d"
+user-name = "Jack Grigg"
+
 [[publisher.prettyplease]]
 version = "0.2.37"
 when = "2025-08-19"


### PR DESCRIPTION
stacks on https://github.com/tachyon-zcash/ragu/pull/731/. 

`cargo vet` expects its config directory to live in workspace root, so had to create an ephemeral symlink inside the CI job that points to `qa/supply-chain/`. also configures `Supply chain / cargo vet` status checks in branch protections so any version drift blocks merge. 

**update:** https://mozilla.github.io/cargo-vet/commands.html#--store-path-store_path for path override instead of using a symlink.