### PR TITLE
ci: collapse duplicated Rust toolchain pins into single sources of truth

### DIFF
--- a/.github/actions/rust-nightly-setup/action.yml
+++ b/.github/actions/rust-nightly-setup/action.yml
@@ -1,0 +1,22 @@
+name: Rust nightly setup
+description: Install the project-pinned nightly Rust toolchain via dtolnay/rust-toolchain
+inputs:
+  components:
+    description: Optional Rust components to install (comma-separated)
+    required: false
+    default: ""
+outputs:
+  toolchain:
+    description: Rustup name of the installed nightly toolchain; route to RUSTUP_TOOLCHAIN at the call site
+    value: ${{ steps.toolchain.outputs.name }}
+runs:
+  using: composite
+  steps:
+    # Sole source of truth for the pinned nightly date. Audit this composite
+    # and `rust-setup/action.yml` together when rotating the dtolnay SHA.
+    - name: Install pinned nightly toolchain
+      id: toolchain
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master @ 2026-05-23
+      with:
+        toolchain: nightly-2026-04-11
+        components: ${{ inputs.components }}

--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -35,11 +35,58 @@ runs:
         # shellcheck disable=SC2086
         sudo apt-get install -y $APT_PACKAGES
 
-    - name: Install Rust toolchain (from rust-toolchain.toml)
-      uses: dtolnay/rust-toolchain@b18f7037bce1ea84c086f4d5e9493f853c0ce412 # 1.90.0 branch HEAD @ 2026-05-23
+    # Read channel/components/targets from rust-toolchain.toml and merge with
+    # the composite's own inputs. dtolnay's master action does not read
+    # rust-toolchain.toml itself (only the version-named branches do, via
+    # a hardcoded `env: toolchain:` in their own action.yml), so we extract
+    # the channel here and pass it explicitly. Audit this composite and
+    # `rust-nightly-setup/action.yml` together when rotating the dtolnay SHA.
+    - name: Read rust-toolchain.toml
+      id: toolchain-config
+      shell: bash
+      env:
+        EXTRA_COMPONENTS: ${{ inputs.components }}
+        EXTRA_TARGETS: ${{ inputs.targets }}
+      run: |
+        python3 - <<'PY'
+        import os
+        import sys
+        import tomllib
+
+        with open("rust-toolchain.toml", "rb") as f:
+            cfg = tomllib.load(f).get("toolchain", {})
+
+        channel = cfg.get("channel")
+        if not channel:
+            print("::error file=rust-toolchain.toml::missing toolchain.channel", file=sys.stderr)
+            sys.exit(1)
+
+        def merge(file_vals, env_var):
+            extra = os.environ.get(env_var, "").split(",")
+            seen = set()
+            out = []
+            for raw in list(file_vals or []) + extra:
+                v = raw.strip()
+                if v and v not in seen:
+                    seen.add(v)
+                    out.append(v)
+            return ",".join(out)
+
+        components = merge(cfg.get("components"), "EXTRA_COMPONENTS")
+        targets = merge(cfg.get("targets"), "EXTRA_TARGETS")
+
+        with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8", newline="\n") as out:
+            out.write(f"channel={channel}\n")
+            out.write(f"components={components}\n")
+            out.write(f"targets={targets}\n")
+        PY
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master @ 2026-05-23
       with:
-        components: ${{ inputs.components }}
-        targets: ${{ inputs.targets }}
+        toolchain: ${{ steps.toolchain-config.outputs.channel }}
+        components: ${{ steps.toolchain-config.outputs.components }}
+        targets: ${{ steps.toolchain-config.outputs.targets }}
 
     # Cache cargo registry and git separately (shared across all jobs)
     - name: Cache cargo registry

--- a/.github/workflows/fuzz-cron.yml
+++ b/.github/workflows/fuzz-cron.yml
@@ -71,10 +71,8 @@ jobs:
           persist-credentials: false
 
       - name: Install pinned nightly toolchain
-        id: toolchain
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master @ 2026-05-23
-        with:
-          toolchain: nightly-2026-04-11
+        id: nightly
+        uses: ./.github/actions/rust-nightly-setup
 
       - name: Cache fuzz build artifacts
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -107,7 +105,7 @@ jobs:
           # Route the toolchain through env (rustup picks it up
           # automatically) rather than `cargo +TOOLCHAIN`, so the
           # action output stays out of shell-interpolated text.
-          RUSTUP_TOOLCHAIN: ${{ steps.toolchain.outputs.name }}
+          RUSTUP_TOOLCHAIN: ${{ steps.nightly.outputs.toolchain }}
           FUZZ_TARGET: ${{ matrix.target }}
         run: |
           set -euo pipefail

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,15 +56,14 @@ jobs:
           persist-credentials: false
 
       - name: Install pinned nightly rustfmt
-        id: toolchain
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master @ 2026-05-23
+        id: nightly
+        uses: ./.github/actions/rust-nightly-setup
         with:
-          toolchain: nightly-2026-04-11
           components: rustfmt
 
       - name: Check formatting
         env:
-          RUSTUP_TOOLCHAIN: ${{ steps.toolchain.outputs.name }}
+          RUSTUP_TOOLCHAIN: ${{ steps.nightly.outputs.toolchain }}
         run: cargo fmt --all -- --config-path rustfmt.nightly.toml --check
 
   clippy:
@@ -166,10 +165,8 @@ jobs:
           persist-credentials: false
 
       - name: Install pinned nightly toolchain
-        id: toolchain
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master @ 2026-05-23
-        with:
-          toolchain: nightly-2026-04-11
+        id: nightly
+        uses: ./.github/actions/rust-nightly-setup
 
       - name: Cache fuzz target directory
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -182,7 +179,7 @@ jobs:
       - name: cargo check fuzz harness
         working-directory: qa/fuzz
         env:
-          RUSTUP_TOOLCHAIN: ${{ steps.toolchain.outputs.name }}
+          RUSTUP_TOOLCHAIN: ${{ steps.nightly.outputs.toolchain }}
         run: cargo check --bins
 
   docs:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,6 +4,5 @@ components = ["clippy"]
 
 # Bumping MSRV
 # * update `toolchain.channel` key in `rust-toolchain.toml` (this file)
-# * update toolchain in `.github/actions/rust-setup/action.yml`
 # * update `book/src/guide/requirements.md`
 # * update `workspace.package.rust-version` key in root `Cargo.toml`


### PR DESCRIPTION
`rust-setup` now pins `dtolnay/rust-toolchain` on current master and reads `channel`/`components`/`targets` from `rust-toolchain.toml` (via `tomllib`), so bumping stable Rust is a one-line edit. New `rust-nightly-setup` composite bakes the pinned nightly date in one place and feeds the three nightly call sites (`fmt`, `fuzz-check`, `fuzz cron`).