### PR TITLE
book: expand polynomials implementation chapter

### DIFF
--- a/book/src/implementation/polynomials.md
+++ b/book/src/implementation/polynomials.md
@@ -1,5 +1,12 @@
 # Polynomial Management
 
+Ragu's prover works primarily with polynomials: constructing them from
+circuit descriptions, multiplying them via FFTs, and decomposing their
+products into forms the verifier can check. This chapter covers the
+wiring polynomial that encodes an arithmetic circuit, the synthesis
+process that builds it incrementally, and the low-level polynomial
+utilities in [`ragu_arithmetic`] that support these operations.
+
 ## Wiring Polynomials
 
 Individual arithmetic circuits are defined by the
@@ -11,9 +18,10 @@ This vector is the coefficient vector of a special polynomial
 
 $$
 s(X, Y) = \sum\limits_{j=0}^{4n - 1} Y^j \Big(
-      \sum_{i = 0}^{n - 1} (\v{u})_{i,j} X^{2n - 1 - i}
-    + \sum_{i = 0}^{n - 1} (\v{v})_{i,j} X^{2n + i}
-    + \sum_{i = 0}^{n - 1} (\v{w})_{i,j} X^{4n - 1 - i}
+      \sum_{i = 0}^{n - 1} (\v{u})_{j,i} X^{2n - 1 - i}
+    + \sum_{i = 0}^{n - 1} (\v{v})_{j,i} X^{2n + i}
+    + \sum_{i = 0}^{n - 1} (\v{w})_{j,i} X^{4n - 1 - i}
+    + \sum_{i = 0}^{n - 1} (\v{d})_{j,i} X^{i}
 \Big)
 $$
 
@@ -32,7 +40,7 @@ polynomial:
 * `mul` creates new wires $(a, b, c)$ that must satisfy a
   [gate]
   $ab = c$. This allocates (or assigns) the corresponding powers
-  $(X^{2n + i}, X^{2n - 1 - i}, X^i)$ for some unused $i$.
+  $(X^{2n + i}, X^{2n - 1 - i}, X^{4n - 1 - i})$ for some unused $i$.
 
 **Importantly, this synthesis process is procedural.** Any contiguous
 sequence of `enforce_zero` and `mul` operations is defined by the
@@ -53,3 +61,76 @@ $X^i Y^j$.
 
 [gate]: ../protocol/core/arithmetization.md#gates
 
+## Polynomial Arithmetic
+
+The synthesis machinery above relies on standard polynomial operations
+provided by the [`ragu_arithmetic`] crate. These operate on coefficient
+vectors in ascending
+degree order: the slice $[c_0, c_1, \ldots, c_n]$ represents the
+polynomial
+$c_0 + c_1 X + \cdots + c_n X^n$.
+
+### Evaluation and Inner Products
+
+[`eval`] evaluates a polynomial at a point using Horner's method.
+[`dot`] computes the inner product $\langle \v{a}, \v{b} \rangle$ of
+two equal-length coefficient vectors. These helpers provide the scalar
+operations underlying polynomial evaluation and inner-product checks.
+
+### Polynomial Multiplication
+
+[`poly_mul`] computes the coefficient convolution of two polynomials,
+implemented using FFTs. Given polynomials $a(X)$ of degree $d_a$ and
+$b(X)$ of degree $d_b$, it produces $c(X) = a(X) \cdot b(X)$ of degree
+$d_a + d_b$. Internally, both inputs are zero-padded to a power-of-two
+length, transformed into evaluation form via [`Domain::fft`], multiplied
+pointwise, and transformed back via [`Domain::ifft`].
+
+The output is written into a caller-supplied `&mut Vec<F>` so that
+repeated multiplications can reuse a single allocation.
+
+### Decomposition
+
+The [NARK protocol](../protocol/core/nark.md#the-decomposition-trick)
+reduces a revdot claim $\revdot{\v{a}}{\v{b}} = c$ to polynomial
+evaluation queries by decomposing the product $a(X) \cdot b(X)$. The
+[structured vectors chapter](../protocol/prelim/structured_vectors.md#reduction-to-polynomial-queries)
+gives the general construction: for equal-length vectors
+$\v{a}, \v{b} \in \F^n$, the product polynomial
+$c(X) = a(X) \cdot b(X)$ of degree $2n - 2$ can be written as
+
+$$
+c(X) = X^{n-1}\, p(X^{-1}) + X^n\, q(X)
+$$
+
+where $p$ is formed by reversing the lower $n$ coefficients of $c$ and
+$q$ collects the upper $n - 1$ coefficients. The key property is that
+$p(0) = c_{n-1} = \revdot{\v{a}}{\v{b}}$, turning a coefficient
+extraction into a constant-term query.
+
+[`decomp_product_poly`] implements this step. It calls [`poly_mul`] to
+obtain $c$, splits off the upper half as $q$, and reverses the lower
+half in place to form $p$. The returned pair $(p, q)$ has lengths $n$
+and $n - 1$ respectively (for $n \geq 1$; empty inputs return two
+empty vectors).
+
+### Root Polynomials
+
+[`poly_with_roots`] constructs the monic polynomial
+$\prod_{i} (X - r_i)$ from a list of roots, using a pairwise tree of
+FFT-based multiplications. This is useful for constructing vanishing
+polynomials over explicit root sets.
+
+Together, these primitives support the prover's polynomial workflow:
+the wiring polynomial is synthesized incrementally from circuit
+operations, and products are multiplied and decomposed to reduce
+revdot claims to polynomial queries.
+
+[`ragu_arithmetic`]: https://docs.rs/ragu_arithmetic/latest/ragu_arithmetic/
+[`eval`]: https://docs.rs/ragu_arithmetic/latest/ragu_arithmetic/fn.eval.html
+[`dot`]: https://docs.rs/ragu_arithmetic/latest/ragu_arithmetic/fn.dot.html
+[`poly_mul`]: https://docs.rs/ragu_arithmetic/latest/ragu_arithmetic/fn.poly_mul.html
+[`decomp_product_poly`]: https://docs.rs/ragu_arithmetic/latest/ragu_arithmetic/fn.decomp_product_poly.html
+[`poly_with_roots`]: https://docs.rs/ragu_arithmetic/latest/ragu_arithmetic/fn.poly_with_roots.html
+[`Domain::fft`]: https://docs.rs/ragu_arithmetic/latest/ragu_arithmetic/struct.Domain.html#method.fft
+[`Domain::ifft`]: https://docs.rs/ragu_arithmetic/latest/ragu_arithmetic/struct.Domain.html#method.ifft

--- a/book/src/protocol/core/arithmetization.md
+++ b/book/src/protocol/core/arithmetization.md
@@ -43,8 +43,8 @@ $$
 $$
 
 for some (sparse) public input vector $\v{k} \in \F^{4n}$ and fixed matrices
-$\v{u}, \v{v}, \v{w} \in \F^{n \times 4n}$, where
-$\v{u_{j}}, \v{v_{j}}, \v{w_{j}} \in \F^{4n}$ denote the _j-th row_ of those
+$\v{u}, \v{v}, \v{w} \in \F^{4n \times n}$, where
+$\v{u_{j}}, \v{v_{j}}, \v{w_{j}} \in \F^{n}$ denote the _j-th row_ of those
 matrices. Because $n$ is fixed, individual circuits vary only by these matrices
 after this reduction.
 
@@ -52,7 +52,7 @@ Bootle16 CS is practically identical to the more commonly known R1CS, as they
 are linear-time interreducible, thus equivalent for all practical purposes.
 See [appendix](../../appendix/cs.md) for a more detailed comparison.
 
-## Gates
+## Gates {#gates}
 
 The gates over the witness can be rewritten as $\v{a} \circ
 \v{b} = \v{c}$. It is possible to _probabilistically_ reduce this to a dot

--- a/book/src/protocol/core/nark.md
+++ b/book/src/protocol/core/nark.md
@@ -38,7 +38,7 @@ costs roughly twice as much as degree-$4n$ polynomials. And we only care about
 one coefficient (the $c_{4n-1}$ term), so paying double for the whole thing
 seems wasteful.
 
-### The Decomposition Trick
+### The Decomposition Trick {#the-decomposition-trick}
 
 Instead of committing to the full product, we decompose it into two smaller pieces:
 

--- a/book/src/protocol/prelim/structured_vectors.md
+++ b/book/src/protocol/prelim/structured_vectors.md
@@ -62,7 +62,7 @@ $$
 \end{array}
 $$
 
-### Reduction to Polynomial Queries
+### Reduction to Polynomial Queries {#reduction-to-polynomial-queries}
 
 Given a claim $(\v{a}, \v{b}, c)$ where $a, b \in \F[X]$ are polynomials
 described by the respective coefficient vectors $\v{a}, \v{b} \in \F^{n}$, the


### PR DESCRIPTION
- adds Polynomial Arithmetic section covering eval, dot, poly_mul, decomp_product_poly, and poly_with_roots from ragu_arithmetic.

- fixes c-wire power `(X^i -> X^{4n-1-i})`, adds d-wire term to wiring polynomial formula, correct matrix dimensions `(F^{4n xn})` in protocol/core/arithmetization.md, and adds explicit {#slug} attributes to anchor targets in arithmetization.md, nark.md, and structured_vectors.md.