### PR TITLE
chore(ci): manual dispatch trigger for bench workflows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      base_sha:
+        description: 'Baseline commit SHA for regression comparison (defaults to latest main)'
+        required: false
+        default: ''
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,6 +24,7 @@ env:
 jobs:
   changes:
     name: detect changes
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
@@ -38,9 +45,29 @@ jobs:
               - '.github/workflows/bench.yml'
               - '.github/actions/**'
 
-  bench:
+  # PR path: compile benchmarks only (no execution)
+  build:
     needs: changes
-    if: needs.changes.outputs.rust == 'true' || github.event_name == 'push'
+    if: github.event_name == 'pull_request' && needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: ./.github/actions/rust-setup
+        with:
+          cache-suffix: bench
+
+      - name: Build benchmarks
+        run: cargo bench --workspace --all-features --locked --bench arithmetic --bench circuits --bench pcd --bench primitives --no-run
+
+  # Push-to-main: full run + save baseline for future comparisons
+  # Manual dispatch: full run + regression summary against a chosen baseline
+  bench:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -55,18 +82,25 @@ jobs:
           cargo-tools: gungraun-runner@0.17.0
           apt-packages: valgrind
 
-      - name: Load baseline
-        if: github.event_name == 'pull_request'
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Resolve baseline SHA
+        if: github.event_name == 'workflow_dispatch'
+        id: baseline
         env:
-          # SHAs are hex-only and not attacker-controllable, but route
-          # through `env:` to match the discipline applied elsewhere and
-          # avoid tripping zizmor's template-injection rule.
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          INPUT_BASE_SHA: ${{ inputs.base_sha }}
+        run: |
+          if [ -n "$INPUT_BASE_SHA" ]; then
+            echo "sha=$INPUT_BASE_SHA" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=$(git rev-parse origin/main)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Load baseline
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: target/gungraun
           key: never-${{ github.sha }}-${{ github.run_id }}
-          restore-keys: bench-${{ env.BASE_SHA }}
+          restore-keys: bench-${{ steps.baseline.outputs.sha }}
 
       - name: Clean benchmark summaries
         run: |
@@ -77,7 +111,7 @@ jobs:
         run: cargo bench --workspace --all-features --locked --bench arithmetic --bench circuits --bench pcd --bench primitives -- --save-summary=json
 
       - name: Summarize benchmark regressions
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'workflow_dispatch'
         env:
           ALERT_THRESHOLD: '1.5'
         run: |
@@ -99,7 +133,7 @@ jobs:
           fi
 
       - name: Upload benchmark results artifact
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: gungraun-results

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -91,6 +91,7 @@ jobs:
           if [ -n "$INPUT_BASE_SHA" ]; then
             echo "sha=$INPUT_BASE_SHA" >> "$GITHUB_OUTPUT"
           else
+            git fetch origin main --depth=1
             echo "sha=$(git rev-parse origin/main)" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
Prior to this change, benches didn't block CI on regression analysis (it's not in the status checks list) and [summaries](https://github.com/tachyon-zcash/ragu/pull/729) were moved into the CI workflow directly where they'd be inspectable. Regardless, I find myself basically ignoring _gungraun_ benchmarks as they're currently configured. Part of it is the presentation, which I don't find very useful, and the occasional noise (like [this](https://github.com/tachyon-zcash/ragu/pull/497#issuecomment-3937683913)), and it's hard to tell the significance of a measurement because it may be on a nano/millisecond scale. The regression analysis is wired to use gungraun. 

I personally use valgrind more often because gungraun has limitations around measuring wall-clock time (only measures instruction counts which are deterministic to be fair) and doesn't support multi-core workloads (reference https://github.com/tachyon-zcash/ragu/pull/510). 

Anyways, personally in favor of using a manual trigger in CI for things we know affect performance. This configures a lightweight build job for PRs (compile only, no valgrind/gungraun) and the existing bench job behind manual dispatch, so regressions only surface on manual triggers. These workloads can also be run locally. 

