### PR TITLE
Implement patcher soundness fuzzing

### DIFF
--- a/qa/fuzz/Cargo.toml
+++ b/qa/fuzz/Cargo.toml
@@ -141,9 +141,8 @@ test = false
 doc = false
 bench = false
 
-# Mid-stream witness cheating: honest vs cheat paths through the Simulator.
-# Currently a Simulator-robustness fuzzer; intended as a soundness oracle once
-# the patcher work lands (see issue tracking the patcher technique).
+# Mid-stream witness cheating: honest vs unpatched/patched cheat paths through
+# the Simulator, with downstream witness-slot repair for soundness signals.
 [[bin]]
 name = "fuzz_witness_cheat"
 path = "fuzz_targets/fuzz_witness_cheat.rs"

--- a/qa/fuzz/README.md
+++ b/qa/fuzz/README.md
@@ -41,7 +41,7 @@ All four share an essentially identical `Op` enum and dispatch — see the
 |---|---|
 | `fuzz_element_ops` | Completeness — random gadget compositions must not crash and must produce internally-consistent witnesses. The substrate. |
 | `fuzz_witness_coverage` | Same as `fuzz_element_ops` plus a post-run witness-state hash spread across coverage branches. Biases the fuzzer toward distinct internal witness states. Opt-in POC (~28% throughput cost). |
-| `fuzz_witness_cheat` | Mid-stream replaces an element on the stack with a fresh allocation of a different value, then compares fingerprints against the honest run. Currently functions as a Simulator-robustness fuzzer (the soundness assertion is structurally tautological today); becomes a true under-constrained-gadget oracle once the patcher technique lands. The mutation scaffolding is in place. |
+| `fuzz_witness_cheat` | Mid-stream replaces an element on the stack with a fresh allocation of a different value, then uses a patcher pass to repair downstream-created witness slots when local equations are solvable. Compares the patched cheat against the honest run after excluding directly patched support slots. Signals should still be validated against a real circuit/output boundary because the final stack is a proxy oracle. |
 | `fuzz_driver_metamorphic` | Differential — runs the same `Vec<Op>` through both `Simulator` and `Emulator<Wired<Fp>>`; wire values must match. Tests the model-vs-real-driver invariant. |
 
 ### Gadget-API property and identity targets
@@ -133,9 +133,11 @@ TRIAGE_CHEAT=1 cargo +nightly fuzz run fuzz_witness_cheat \
   artifacts/fuzz_witness_cheat/crash-abc123
 ```
 
-If the count is 0, the soundness signal is probably a dead-cheat false
-positive. If it's high, the cheat propagated but downstream constraints
-were insensitive to it — that's the real bug class.
+If the count is 0, the input is a dead cheat and should normally be
+discarded. If it's high, the patcher may have found a path where the
+cheat propagated and was repaired into the same observable fingerprint.
+Treat that as a candidate under-constrained-gadget signal until it is
+validated against the real public outputs for the circuit under test.
 
 ## CI
 
@@ -159,12 +161,11 @@ The four `Vec<Op>`-style targets (`fuzz_element_ops`,
 `fuzz_driver_metamorphic`) each have a copy of the same `Op` enum and
 dispatch — roughly 200 lines of mechanical duplication per file.
 
-This is deliberate. cargo-fuzz expects `[[bin]]`-style fuzz targets, and
-sharing a `src/lib.rs` between fuzz targets adds friction with the
-cargo-fuzz workflow and the patch-table mirroring this crate already
-needs. The duplication is annotated in each file (`Identical dispatch
-logic to fuzz_element_ops and fuzz_witness_cheat`) so future edits
-propagate the same change everywhere.
+This is mostly deliberate. cargo-fuzz expects `[[bin]]`-style fuzz
+targets, so the hot dispatch loops stay local to each target. The
+exception is `src/patcher.rs`, a small pure helper used by
+`fuzz_witness_cheat` so the downstream repair policy can have ordinary
+unit tests without pulling libFuzzer into the test harness.
 
 ## Patch table
 

--- a/qa/fuzz/fuzz_targets/fuzz_witness_cheat.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_witness_cheat.rs
@@ -1,42 +1,33 @@
 //! Mid-stream witness cheating fuzz target.
 //!
-//! Runs the same instruction stream twice through the `Simulator`: an
-//! honest path and a cheat path that, at a fuzzer-chosen point, replaces
-//! one element on the stack with a fresh allocation whose value differs
-//! from the honest one. After both runs complete, the final element and
-//! boolean values are compared.
+//! Runs the same instruction stream through the `Simulator` three ways:
+//! an honest path, an unpatched cheat path, and a patched cheat path. At
+//! a fuzzer-chosen point the cheat paths replace one element on the stack
+//! with a fresh allocation whose value differs from the honest one. The
+//! patcher then walks the remaining op stream and tries to repair only
+//! downstream-created witness slots so later constraints can keep holding.
 //!
-//! # Current effective behavior
+//! # Effective behavior
 //!
-//! As implemented, this target functions primarily as a Simulator
-//! robustness fuzzer rather than a soundness oracle. The cheated slot is
-//! included in the comparison fingerprint, and the cheat value is filtered
-//! to differ from the original, so `honest != cheat` is tautologically
-//! true regardless of whether downstream constraints actually catch the
-//! cheat. The signals the target reliably surfaces today are panics, OOB
-//! indexing, and arithmetic faults in the gadget API when fed adversarial
-//! inputs — not under-constrained gadgets.
+//! The target first requires the ordinary cheated execution to be accepted
+//! by `Simulator`, preserving the original robustness coverage. It then
+//! replays the cheat with a patch plan that:
 //!
-//! # Intended behavior (post-patcher)
+//! 1. records the op-stream dataflow over field values;
+//! 2. refuses to repair unrelated pre-existing inputs;
+//! 3. repairs downstream-created element slots when a local equation can
+//!    be solved; and
+//! 4. excludes the directly patched support slots from the final
+//!    fingerprint.
 //!
-//! Becoming a true under-constrained-gadget oracle requires two changes,
-//! both tracked in the patcher follow-up issue:
+//! A signal fires when the patched cheat is accepted and the observable
+//! fingerprint matches the honest run. This is intentionally conservative:
+//! the final stack is still only a proxy for public outputs, so crash
+//! artifacts should be triaged as "under-constrained gadget or insufficient
+//! oracle" until validated against the real circuit/output boundary.
 //!
-//! 1. A patcher pass that, after the cheat is injected, walks the
-//!    recorded constraint graph forward from the cheated slot and adjusts
-//!    other downstream witness slots so the constraint system stays
-//!    satisfied. Without this, the cheat is either rejected by the first
-//!    downstream constraint that compares it against a honest-derived
-//!    value, or it propagates only through gates that self-satisfy
-//!    (`c = a*b` recomputed from the cheat).
-//!
-//! 2. Excluding the cheated slot from the comparison fingerprint, so the
-//!    `honest != cheat` check reflects downstream observable behavior
-//!    rather than the cheat injection itself.
-//!
-//! With both in place, the assertion becomes: "the Simulator accepted two
-//! genuinely different witnesses producing the same observable behavior"
-//! — the canonical under-constrained-gadget signal.
+//! The patcher is scoped to this fuzz target's `Vec<Op>` abstraction. It
+//! is not yet a general Ragu constraint-graph driver for full circuits.
 //!
 //! # Why this is the witness-mutation pattern, adapted to Ragu
 //!
@@ -60,6 +51,7 @@ use pasta_curves::Fp;
 use ragu_arithmetic::Coeff;
 use ragu_core::maybe::Maybe;
 use ragu_primitives::{Boolean, Element, Simulator, allocator::Standard};
+use ragu_testing_fuzz::patcher::{PatchOp, PatchPlan, build_patch_plan};
 
 fn special_value(idx: u8) -> Fp {
     match idx % 16 {
@@ -79,6 +71,37 @@ fn special_value(idx: u8) -> Fp {
         13 => Fp::from(1u64 << 32),
         14 => Fp::from(1u64 << 48),
         _ => Fp::from(u64::MAX),
+    }
+}
+
+fn cheat_value(cheat: CheatFlavor) -> Fp {
+    match cheat {
+        CheatFlavor::Alloc(v) | CheatFlavor::Constant(v) => Fp::from(v),
+        CheatFlavor::Special(idx) => special_value(idx),
+    }
+}
+
+fn patch_op(op: &Op) -> PatchOp {
+    match *op {
+        Op::Add(a, b) => PatchOp::Add(a, b),
+        Op::Sub(a, b) => PatchOp::Sub(a, b),
+        Op::Mul(a, b) => PatchOp::Mul(a, b),
+        Op::Square(a) => PatchOp::Square(a),
+        Op::Double(a) => PatchOp::Double(a),
+        Op::Negate(a) => PatchOp::Negate(a),
+        Op::Invert(a) => PatchOp::Invert(a),
+        Op::IsZero(a) => PatchOp::IsZero(a),
+        Op::DivNonzero(a, b) => PatchOp::DivNonzero(a, b),
+        Op::Scale(a, c) => PatchOp::Scale(a, Fp::from(c)),
+        Op::Fold(a, b, s) => PatchOp::Fold(a, b, Fp::from(s)),
+        Op::AllocConst(v) => PatchOp::AllocConst(Fp::from(v)),
+        Op::AllocSpecial(idx) => PatchOp::AllocWitness(special_value(idx)),
+        Op::AllocSquare(v) => PatchOp::AllocSquare(Fp::from(v)),
+        Op::AllocRaw(bytes) => PatchOp::AllocRaw(Fp::from_repr(bytes).into()),
+        Op::BoolAlloc(v) => PatchOp::BoolAlloc(v),
+        Op::BoolNot(a) => PatchOp::BoolNot(a),
+        Op::BoolAnd(a, b) => PatchOp::BoolAnd(a, b),
+        Op::ConditionalSelect(cond, a, b) => PatchOp::ConditionalSelect(cond, a, b),
     }
 }
 
@@ -164,7 +187,12 @@ fn build_seeds(input: &Input) -> Vec<Fp> {
 /// but the chosen cheat value coincided with the slot's existing value
 /// (a degenerate input that would produce a false-positive fingerprint
 /// match).
-fn run_path(input: &Input, fes: &[Fp], apply_cheat: bool) -> Option<Fingerprint> {
+fn run_path(
+    input: &Input,
+    fes: &[Fp],
+    apply_cheat: bool,
+    patch_plan: Option<&PatchPlan>,
+) -> Option<Fingerprint> {
     let mut snapshot: Option<Fingerprint> = None;
     let mut cheat_noop = false;
 
@@ -194,11 +222,7 @@ fn run_path(input: &Input, fes: &[Fp], apply_cheat: bool) -> Option<Fingerprint>
             if apply_cheat && i == input.cheat_at as usize && !elems.is_empty() {
                 let target = (input.target_idx as usize) % elems.len().min(64);
                 let original_val: Fp = *elems[target].value().take();
-                let cheat_val = match input.cheat {
-                    CheatFlavor::Alloc(v) => Fp::from(v),
-                    CheatFlavor::Constant(v) => Fp::from(v),
-                    CheatFlavor::Special(idx) => special_value(idx),
-                };
+                let cheat_val = cheat_value(input.cheat);
                 if original_val == cheat_val {
                     // No actual cheat — the chosen replacement value
                     // happens to equal what was already there. Fingerprints
@@ -208,14 +232,21 @@ fn run_path(input: &Input, fes: &[Fp], apply_cheat: bool) -> Option<Fingerprint>
                     return Ok(());
                 }
                 let cheated = match input.cheat {
-                    CheatFlavor::Alloc(_) | CheatFlavor::Special(_) => Element::alloc(
-                        dr,
-                        allocator,
-                        witness.as_ref().map(|_| cheat_val),
-                    )?,
+                    CheatFlavor::Alloc(_) | CheatFlavor::Special(_) => {
+                        Element::alloc(dr, allocator, witness.as_ref().map(|_| cheat_val))?
+                    }
                     CheatFlavor::Constant(_) => Element::constant(dr, cheat_val),
                 };
                 elems[target] = cheated;
+            }
+
+            if let Some(plan) = patch_plan {
+                for &(slot, value) in plan.replacements.get(i).into_iter().flatten() {
+                    if slot < elems.len() {
+                        elems[slot] =
+                            Element::alloc(dr, allocator, witness.as_ref().map(|_| value))?;
+                    }
+                }
             }
 
             let elen = elems.len();
@@ -282,11 +313,8 @@ fn run_path(input: &Input, fes: &[Fp], apply_cheat: bool) -> Option<Fingerprint>
                 }
                 Op::Fold(a, b, s) => {
                     let (a, b) = (a as usize % elen, b as usize % elen);
-                    let scale = Element::alloc(
-                        dr,
-                        allocator,
-                        witness.as_ref().map(|_| Fp::from(s)),
-                    )?;
+                    let scale =
+                        Element::alloc(dr, allocator, witness.as_ref().map(|_| Fp::from(s)))?;
                     if let Ok(r) = Element::fold(dr, [&elems[a], &elems[b]], &scale) {
                         elems.push(r);
                     }
@@ -303,28 +331,21 @@ fn run_path(input: &Input, fes: &[Fp], apply_cheat: bool) -> Option<Fingerprint>
                 Op::AllocRaw(bytes) => {
                     let v: Option<Fp> = Fp::from_repr(bytes).into();
                     if let Some(fp) = v {
-                        if let Ok(r) =
-                            Element::alloc(dr, allocator, witness.as_ref().map(|_| fp))
-                        {
+                        if let Ok(r) = Element::alloc(dr, allocator, witness.as_ref().map(|_| fp)) {
                             elems.push(r);
                         }
                     }
                 }
                 Op::AllocSquare(v) => {
-                    if let Ok((root, sq)) = Element::alloc_square(
-                        dr,
-                        witness.as_ref().map(|_| Fp::from(v)),
-                    ) {
+                    if let Ok((root, sq)) =
+                        Element::alloc_square(dr, witness.as_ref().map(|_| Fp::from(v)))
+                    {
                         elems.push(root);
                         elems.push(sq);
                     }
                 }
                 Op::BoolAlloc(v) => {
-                    if let Ok(b) = Boolean::alloc(
-                        dr,
-                        allocator,
-                        witness.as_ref().map(|_| v),
-                    ) {
+                    if let Ok(b) = Boolean::alloc(dr, allocator, witness.as_ref().map(|_| v)) {
                         bools.push(b);
                     }
                 }
@@ -347,9 +368,7 @@ fn run_path(input: &Input, fes: &[Fp], apply_cheat: bool) -> Option<Fingerprint>
                     if blen > 0 {
                         let cond = cond as usize % blen;
                         let (a, b) = (a as usize % elen, b as usize % elen);
-                        if let Ok(r) = bools[cond].conditional_select(
-                            dr, &elems[a], &elems[b],
-                        ) {
+                        if let Ok(r) = bools[cond].conditional_select(dr, &elems[a], &elems[b]) {
                             elems.push(r);
                         }
                     }
@@ -428,11 +447,18 @@ fn op_reads_target(op: &Op, target: usize, elens: usize) -> bool {
     }
     let resolves = |a: u8| (a as usize) % elens == target;
     match op {
-        Op::Add(a, b) | Op::Sub(a, b) | Op::Mul(a, b) | Op::DivNonzero(a, b)
+        Op::Add(a, b)
+        | Op::Sub(a, b)
+        | Op::Mul(a, b)
+        | Op::DivNonzero(a, b)
         | Op::Fold(a, b, _) => resolves(*a) || resolves(*b),
         Op::ConditionalSelect(_, a, b) => resolves(*a) || resolves(*b),
-        Op::Scale(a, _) | Op::Square(a) | Op::Double(a) | Op::Negate(a)
-        | Op::Invert(a) | Op::IsZero(a) => resolves(*a),
+        Op::Scale(a, _)
+        | Op::Square(a)
+        | Op::Double(a)
+        | Op::Negate(a)
+        | Op::Invert(a)
+        | Op::IsZero(a) => resolves(*a),
         _ => false,
     }
 }
@@ -617,28 +643,73 @@ fuzz_target!(|input: Input| {
     }
 
     let fes = build_seeds(&input);
+    let patch_ops: Vec<PatchOp> = input.ops.iter().map(patch_op).collect();
+    let patch_plan = match build_patch_plan(
+        &fes,
+        &patch_ops,
+        input.cheat_at as usize,
+        input.target_idx,
+        cheat_value(input.cheat),
+    ) {
+        Some(plan) if plan.repaired_ops > 0 && plan.observable_len() > 0 => plan,
+        _ => return,
+    };
 
-    let honest = match run_path(&input, &fes, false) {
+    let honest = match run_path(&input, &fes, false, None) {
         Some(f) => f,
         None => return,
     };
-    let cheated = match run_path(&input, &fes, true) {
+    let unpatched_cheat = match run_path(&input, &fes, true, None) {
         Some(f) => f,
         None => return,
     };
+    let patched = match run_path(&input, &fes, true, Some(&patch_plan)) {
+        Some(f) => f,
+        None => return,
+    };
+    if patched != patch_plan.final_fingerprint() {
+        return;
+    }
 
-    // Soundness signal: cheat path accepted by Simulator AND its final
-    // state is observationally identical to the honest run.
+    if honest.0.len() != patch_plan.exclude_elems.len()
+        || honest.1.len() != patch_plan.exclude_bools.len()
+        || patched.0.len() != patch_plan.exclude_elems.len()
+        || patched.1.len() != patch_plan.exclude_bools.len()
+    {
+        return;
+    }
+
+    let honest_observable = patch_plan.observable_fingerprint(&honest);
+    let patched_observable = patch_plan.observable_fingerprint(&patched);
+
+    // Soundness signal: the normal cheat path is accepted by Simulator,
+    // the patcher found at least one downstream repair, and the patched
+    // invalid witness remains observationally identical to the honest
+    // witness after excluding directly patched support slots.
     assert!(
-        honest != cheated,
+        honest_observable != patched_observable,
         "soundness signal: cheat at op[{}] target {} flavor {:?} \
-         did not perturb the final state; \
-         every downstream constraint and observation was insensitive to \
-         the swap. Suspect an under-constrained gadget. \
+         accepted after {} downstream patch repair(s); \
+         observable fingerprint matched the honest run after excluding \
+         {} patched element slot(s) and {} patched boolean slot(s). \
+         Unpatched cheat changed final state: {}. \
+         Suspect an under-constrained gadget or an insufficient oracle. \
          Input: {:?}",
         input.cheat_at,
         input.target_idx,
         input.cheat,
+        patch_plan.repaired_ops,
+        patch_plan
+            .exclude_elems
+            .iter()
+            .filter(|exclude| **exclude)
+            .count(),
+        patch_plan
+            .exclude_bools
+            .iter()
+            .filter(|exclude| **exclude)
+            .count(),
+        honest != unpatched_cheat,
         input,
     );
 });

--- a/qa/fuzz/src/lib.rs
+++ b/qa/fuzz/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod patcher;

--- a/qa/fuzz/src/patcher.rs
+++ b/qa/fuzz/src/patcher.rs
@@ -1,0 +1,660 @@
+use ff::{Field, PrimeField};
+use pasta_curves::Fp;
+
+pub type PatchFingerprint = (Vec<Fp>, Vec<bool>);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PatchOp {
+    Add(u8, u8),
+    Sub(u8, u8),
+    Mul(u8, u8),
+    Square(u8),
+    Double(u8),
+    Negate(u8),
+    Invert(u8),
+    IsZero(u8),
+    DivNonzero(u8, u8),
+    Scale(u8, Fp),
+    Fold(u8, u8, Fp),
+    AllocConst(Fp),
+    AllocWitness(Fp),
+    AllocSquare(Fp),
+    AllocRaw(Option<Fp>),
+    BoolAlloc(bool),
+    BoolNot(u8),
+    BoolAnd(u8, u8),
+    ConditionalSelect(u8, u8, u8),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PatchPlan {
+    pub final_elems: Vec<Fp>,
+    pub final_bools: Vec<bool>,
+    pub exclude_elems: Vec<bool>,
+    pub exclude_bools: Vec<bool>,
+    pub replacements: Vec<Vec<(usize, Fp)>>,
+    pub repaired_ops: usize,
+}
+
+impl PatchPlan {
+    pub fn final_fingerprint(&self) -> PatchFingerprint {
+        (self.final_elems.clone(), self.final_bools.clone())
+    }
+
+    pub fn observable_fingerprint(&self, fingerprint: &PatchFingerprint) -> PatchFingerprint {
+        observable_fingerprint(fingerprint, &self.exclude_elems, &self.exclude_bools)
+    }
+
+    pub fn observable_len(&self) -> usize {
+        self.exclude_elems
+            .iter()
+            .filter(|exclude| !**exclude)
+            .count()
+            + self
+                .exclude_bools
+                .iter()
+                .filter(|exclude| !**exclude)
+                .count()
+    }
+}
+
+pub fn observable_fingerprint(
+    fingerprint: &PatchFingerprint,
+    exclude_elems: &[bool],
+    exclude_bools: &[bool],
+) -> PatchFingerprint {
+    let elems = fingerprint
+        .0
+        .iter()
+        .zip(exclude_elems)
+        .filter_map(|(value, exclude)| (!exclude).then_some(*value))
+        .collect();
+    let bools = fingerprint
+        .1
+        .iter()
+        .zip(exclude_bools)
+        .filter_map(|(value, exclude)| (!exclude).then_some(*value))
+        .collect();
+    (elems, bools)
+}
+
+pub fn build_patch_plan(
+    seeds: &[Fp],
+    ops: &[PatchOp],
+    cheat_at: usize,
+    target_idx: u8,
+    cheat_value: Fp,
+) -> Option<PatchPlan> {
+    if seeds.is_empty() || cheat_at >= ops.len() {
+        return None;
+    }
+
+    let mut honest = PatchState::new(seeds);
+    let mut honest_pre_states = Vec::with_capacity(ops.len());
+    for op in ops {
+        honest_pre_states.push(honest.snapshot());
+        let effect = eval_effect(op, &honest.elems, &honest.bools);
+        honest.apply(effect);
+    }
+
+    let mut patched = PatchState::new(seeds);
+    let mut replacements = vec![Vec::new(); ops.len()];
+    let mut repaired_ops = 0usize;
+    let mut direct_target = None;
+    let mut patchable_from = usize::MAX;
+
+    for (op_idx, op) in ops.iter().enumerate() {
+        if patched.elems.is_empty() {
+            return None;
+        }
+
+        if op_idx == cheat_at {
+            let target = (target_idx as usize) % patched.elems.len().min(64);
+            if patched.elems[target] == cheat_value {
+                return None;
+            }
+            patched.elems[target] = cheat_value;
+            patched.exclude_elems[target] = true;
+            direct_target = Some(target);
+            patchable_from = patched.elems.len();
+        }
+
+        if let Some(target) = direct_target {
+            let (honest_elems, honest_bools) = &honest_pre_states[op_idx];
+            if repair_op(
+                op,
+                honest_elems,
+                honest_bools,
+                &mut patched,
+                target,
+                patchable_from,
+                &mut replacements[op_idx],
+            ) {
+                repaired_ops += 1;
+            }
+        }
+
+        let effect = eval_effect(op, &patched.elems, &patched.bools);
+        if patched.apply(effect) && direct_target.is_some() {
+            patchable_from = patchable_from.min(64);
+        }
+    }
+
+    Some(PatchPlan {
+        final_elems: patched.elems,
+        final_bools: patched.bools,
+        exclude_elems: patched.exclude_elems,
+        exclude_bools: patched.exclude_bools,
+        replacements,
+        repaired_ops,
+    })
+}
+
+#[derive(Clone, Debug)]
+struct PatchState {
+    elems: Vec<Fp>,
+    bools: Vec<bool>,
+    exclude_elems: Vec<bool>,
+    exclude_bools: Vec<bool>,
+}
+
+impl PatchState {
+    fn new(seeds: &[Fp]) -> Self {
+        Self {
+            elems: seeds.to_vec(),
+            bools: Vec::new(),
+            exclude_elems: vec![false; seeds.len()],
+            exclude_bools: Vec::new(),
+        }
+    }
+
+    fn snapshot(&self) -> (Vec<Fp>, Vec<bool>) {
+        (self.elems.clone(), self.bools.clone())
+    }
+
+    fn apply(&mut self, effect: PatchEffect) -> bool {
+        self.elems.extend(effect.elems);
+        self.exclude_elems.extend(core::iter::repeat_n(
+            false,
+            self.elems.len() - self.exclude_elems.len(),
+        ));
+        self.bools.extend(effect.bools);
+        self.exclude_bools.extend(core::iter::repeat_n(
+            false,
+            self.bools.len() - self.exclude_bools.len(),
+        ));
+
+        let mut truncated = false;
+        if self.elems.len() > 128 {
+            self.elems.truncate(64);
+            self.exclude_elems.truncate(64);
+            truncated = true;
+        }
+        if self.bools.len() > 64 {
+            self.bools.truncate(32);
+            self.exclude_bools.truncate(32);
+        }
+
+        truncated
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct PatchEffect {
+    elems: Vec<Fp>,
+    bools: Vec<bool>,
+}
+
+fn elem_index(raw: u8, len: usize) -> usize {
+    raw as usize % len
+}
+
+fn bool_index(raw: u8, len: usize) -> usize {
+    raw as usize % len
+}
+
+fn eval_effect(op: &PatchOp, elems: &[Fp], bools: &[bool]) -> PatchEffect {
+    if elems.is_empty() {
+        return PatchEffect::default();
+    }
+
+    let mut effect = PatchEffect::default();
+    match *op {
+        PatchOp::Add(a, b) => {
+            let (a, b) = (elem_index(a, elems.len()), elem_index(b, elems.len()));
+            effect.elems.push(elems[a] + elems[b]);
+        }
+        PatchOp::Sub(a, b) => {
+            let (a, b) = (elem_index(a, elems.len()), elem_index(b, elems.len()));
+            effect.elems.push(elems[a] - elems[b]);
+        }
+        PatchOp::Mul(a, b) => {
+            let (a, b) = (elem_index(a, elems.len()), elem_index(b, elems.len()));
+            effect.elems.push(elems[a] * elems[b]);
+        }
+        PatchOp::Square(a) => {
+            let a = elem_index(a, elems.len());
+            effect.elems.push(elems[a].square());
+        }
+        PatchOp::Double(a) => {
+            let a = elem_index(a, elems.len());
+            effect.elems.push(elems[a].double());
+        }
+        PatchOp::Negate(a) => {
+            let a = elem_index(a, elems.len());
+            effect.elems.push(-elems[a]);
+        }
+        PatchOp::Invert(a) => {
+            let a = elem_index(a, elems.len());
+            if let Some(inv) = elems[a].invert().into_option() {
+                effect.elems.push(inv);
+            }
+        }
+        PatchOp::IsZero(a) => {
+            let a = elem_index(a, elems.len());
+            effect.bools.push(elems[a] == Fp::ZERO);
+        }
+        PatchOp::DivNonzero(a, b) => {
+            let (a, b) = (elem_index(a, elems.len()), elem_index(b, elems.len()));
+            if let Some(b_inv) = elems[b].invert().into_option() {
+                effect.elems.push(elems[a] * b_inv);
+            }
+        }
+        PatchOp::Scale(a, c) => {
+            let a = elem_index(a, elems.len());
+            effect.elems.push(elems[a] * c);
+        }
+        PatchOp::Fold(a, b, s) => {
+            let (a, b) = (elem_index(a, elems.len()), elem_index(b, elems.len()));
+            effect.elems.push(elems[a] * s + elems[b]);
+        }
+        PatchOp::AllocConst(v) | PatchOp::AllocWitness(v) => {
+            effect.elems.push(v);
+        }
+        PatchOp::AllocSquare(v) => {
+            effect.elems.push(v);
+            effect.elems.push(v.square());
+        }
+        PatchOp::AllocRaw(v) => {
+            if let Some(v) = v {
+                effect.elems.push(v);
+            }
+        }
+        PatchOp::BoolAlloc(v) => {
+            effect.bools.push(v);
+        }
+        PatchOp::BoolNot(a) => {
+            if !bools.is_empty() {
+                let a = bool_index(a, bools.len());
+                effect.bools.push(!bools[a]);
+            }
+        }
+        PatchOp::BoolAnd(a, b) => {
+            if !bools.is_empty() {
+                let (a, b) = (bool_index(a, bools.len()), bool_index(b, bools.len()));
+                effect.bools.push(bools[a] & bools[b]);
+            }
+        }
+        PatchOp::ConditionalSelect(cond, a, b) => {
+            if !bools.is_empty() {
+                let cond = bool_index(cond, bools.len());
+                let (a, b) = (elem_index(a, elems.len()), elem_index(b, elems.len()));
+                effect
+                    .elems
+                    .push(if bools[cond] { elems[b] } else { elems[a] });
+            }
+        }
+    }
+
+    effect
+}
+
+fn repair_op(
+    op: &PatchOp,
+    honest_elems: &[Fp],
+    honest_bools: &[bool],
+    state: &mut PatchState,
+    direct_target: usize,
+    patchable_from: usize,
+    replacements: &mut Vec<(usize, Fp)>,
+) -> bool {
+    let honest_effect = eval_effect(op, honest_elems, honest_bools);
+    let current_effect = eval_effect(op, &state.elems, &state.bools);
+    if current_effect == honest_effect {
+        return false;
+    }
+
+    let Some(&honest_output) = honest_effect.elems.first() else {
+        return repair_bool_op(
+            op,
+            honest_effect.bools.first().copied(),
+            state,
+            direct_target,
+            patchable_from,
+            replacements,
+        );
+    };
+
+    match *op {
+        PatchOp::Add(a, b) => {
+            let (a, b) = (
+                elem_index(a, state.elems.len()),
+                elem_index(b, state.elems.len()),
+            );
+            patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                a,
+                honest_output - state.elems[b],
+            ) || patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                b,
+                honest_output - state.elems[a],
+            )
+        }
+        PatchOp::Sub(a, b) => {
+            let (a, b) = (
+                elem_index(a, state.elems.len()),
+                elem_index(b, state.elems.len()),
+            );
+            patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                a,
+                honest_output + state.elems[b],
+            ) || patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                b,
+                state.elems[a] - honest_output,
+            )
+        }
+        PatchOp::Mul(a, b) => {
+            let (a, b) = (
+                elem_index(a, state.elems.len()),
+                elem_index(b, state.elems.len()),
+            );
+            if let Some(b_inv) = state.elems[b].invert().into_option() {
+                if patch_elem(
+                    state,
+                    direct_target,
+                    patchable_from,
+                    replacements,
+                    a,
+                    honest_output * b_inv,
+                ) {
+                    return true;
+                }
+            }
+            if let Some(a_inv) = state.elems[a].invert().into_option() {
+                if patch_elem(
+                    state,
+                    direct_target,
+                    patchable_from,
+                    replacements,
+                    b,
+                    honest_output * a_inv,
+                ) {
+                    return true;
+                }
+            }
+            false
+        }
+        PatchOp::Square(a) => {
+            let a = elem_index(a, state.elems.len());
+            patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                a,
+                honest_elems[a],
+            )
+        }
+        PatchOp::Double(a) => {
+            let a = elem_index(a, state.elems.len());
+            patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                a,
+                honest_output * Fp::TWO_INV,
+            )
+        }
+        PatchOp::Negate(a) => {
+            let a = elem_index(a, state.elems.len());
+            patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                a,
+                -honest_output,
+            )
+        }
+        PatchOp::Invert(a) => {
+            let a = elem_index(a, state.elems.len());
+            honest_output.invert().into_option().is_some_and(|input| {
+                patch_elem(state, direct_target, patchable_from, replacements, a, input)
+            })
+        }
+        PatchOp::DivNonzero(a, b) => {
+            let (a, b) = (
+                elem_index(a, state.elems.len()),
+                elem_index(b, state.elems.len()),
+            );
+            if state.elems[b] != Fp::ZERO
+                && patch_elem(
+                    state,
+                    direct_target,
+                    patchable_from,
+                    replacements,
+                    a,
+                    honest_output * state.elems[b],
+                )
+            {
+                return true;
+            }
+            if let Some(out_inv) = honest_output.invert().into_option() {
+                if patch_elem(
+                    state,
+                    direct_target,
+                    patchable_from,
+                    replacements,
+                    b,
+                    state.elems[a] * out_inv,
+                ) {
+                    return true;
+                }
+            }
+            false
+        }
+        PatchOp::Scale(a, c) => {
+            let a = elem_index(a, state.elems.len());
+            c.invert().into_option().is_some_and(|c_inv| {
+                patch_elem(
+                    state,
+                    direct_target,
+                    patchable_from,
+                    replacements,
+                    a,
+                    honest_output * c_inv,
+                )
+            })
+        }
+        PatchOp::Fold(a, b, s) => {
+            let (a, b) = (
+                elem_index(a, state.elems.len()),
+                elem_index(b, state.elems.len()),
+            );
+            if let Some(s_inv) = s.invert().into_option() {
+                if patch_elem(
+                    state,
+                    direct_target,
+                    patchable_from,
+                    replacements,
+                    a,
+                    (honest_output - state.elems[b]) * s_inv,
+                ) {
+                    return true;
+                }
+            }
+            patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                b,
+                honest_output - state.elems[a] * s,
+            )
+        }
+        PatchOp::ConditionalSelect(cond, a, b) => {
+            if state.bools.is_empty() {
+                return false;
+            }
+            let cond = bool_index(cond, state.bools.len());
+            let selected = if state.bools[cond] { b } else { a };
+            let selected = elem_index(selected, state.elems.len());
+            patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                selected,
+                honest_output,
+            )
+        }
+        _ => false,
+    }
+}
+
+fn repair_bool_op(
+    op: &PatchOp,
+    honest_output: Option<bool>,
+    state: &mut PatchState,
+    direct_target: usize,
+    patchable_from: usize,
+    replacements: &mut Vec<(usize, Fp)>,
+) -> bool {
+    let Some(honest_output) = honest_output else {
+        return false;
+    };
+
+    match *op {
+        PatchOp::IsZero(a) => {
+            let a = elem_index(a, state.elems.len());
+            let replacement = if honest_output { Fp::ZERO } else { Fp::ONE };
+            patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                a,
+                replacement,
+            )
+        }
+        _ => false,
+    }
+}
+
+fn patch_elem(
+    state: &mut PatchState,
+    direct_target: usize,
+    patchable_from: usize,
+    replacements: &mut Vec<(usize, Fp)>,
+    slot: usize,
+    value: Fp,
+) -> bool {
+    if slot == direct_target || slot < patchable_from {
+        return false;
+    }
+
+    state.elems[slot] = value;
+    state.exclude_elems[slot] = true;
+    replacements.push((slot, value));
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn visible(values: &[Fp], exclude: &[bool]) -> Vec<Fp> {
+        values
+            .iter()
+            .zip(exclude)
+            .filter_map(|(value, exclude)| (!exclude).then_some(*value))
+            .collect()
+    }
+
+    #[test]
+    fn repairs_mul_by_patching_downstream_sibling_and_preserves_output() {
+        let seeds = [Fp::from(2), Fp::from(3)];
+        let ops = [PatchOp::Add(0, 1), PatchOp::Mul(0, 2)];
+
+        let plan = build_patch_plan(&seeds, &ops, 0, 0, Fp::from(5))
+            .expect("non-degenerate cheat should produce a patch plan");
+
+        assert_eq!(plan.repaired_ops, 1);
+        assert_eq!(plan.final_elems[0], Fp::from(5));
+        assert_eq!(plan.final_elems[1], Fp::from(3));
+        assert_eq!(plan.final_elems[2] * Fp::from(5), Fp::from(10));
+        assert_eq!(plan.final_elems[3], Fp::from(10));
+        assert_eq!(plan.exclude_elems, vec![true, false, true, false]);
+        assert_eq!(
+            visible(&plan.final_elems, &plan.exclude_elems),
+            vec![Fp::from(3), Fp::from(10)]
+        );
+    }
+
+    #[test]
+    fn does_not_repair_by_patching_preexisting_sibling() {
+        let seeds = [Fp::from(2), Fp::from(3)];
+        let ops = [PatchOp::Mul(0, 1)];
+
+        let plan = build_patch_plan(&seeds, &ops, 0, 0, Fp::from(5))
+            .expect("non-degenerate cheat should produce a patch plan");
+
+        assert_eq!(plan.repaired_ops, 0);
+        assert_eq!(
+            plan.final_elems,
+            vec![Fp::from(5), Fp::from(3), Fp::from(15)]
+        );
+        assert_eq!(plan.exclude_elems, vec![true, false, false]);
+    }
+
+    #[test]
+    fn propagates_when_no_repair_is_available_for_direct_square() {
+        let seeds = [Fp::from(2)];
+        let ops = [PatchOp::Square(0)];
+
+        let plan = build_patch_plan(&seeds, &ops, 0, 0, Fp::from(3))
+            .expect("non-degenerate cheat should produce a patch plan");
+
+        assert_eq!(plan.repaired_ops, 0);
+        assert_eq!(plan.final_elems, vec![Fp::from(3), Fp::from(9)]);
+        assert_eq!(plan.exclude_elems, vec![true, false]);
+        assert_eq!(
+            visible(&plan.final_elems, &plan.exclude_elems),
+            vec![Fp::from(9)]
+        );
+    }
+
+    #[test]
+    fn rejects_noop_cheat() {
+        let seeds = [Fp::from(2)];
+        let ops = [PatchOp::Square(0)];
+
+        assert_eq!(build_patch_plan(&seeds, &ops, 0, 0, Fp::from(2)), None);
+    }
+}


### PR DESCRIPTION
## Summary
- Rework the patcher MVP to live entirely under `qa/fuzz`.
- Add a pure `qa/fuzz/src/patcher.rs` op-stream repair planner with unit coverage for downstream witness-slot repair behavior.
- Update `fuzz_witness_cheat` to run honest, unpatched-cheat, and patched-cheat `Simulator` paths, then signal only when the patched cheat preserves the observable fingerprint after excluding directly patched support slots.
- Leave the production-crate driver hooks, general circuit patcher, and recursion/PCD targets for a follow-up if the fuzz-local target proves insufficient.

Addresses #728

## Test Plan
- `cargo test --manifest-path qa/fuzz/Cargo.toml patcher`
- `cargo check --manifest-path qa/fuzz/Cargo.toml --bin fuzz_witness_cheat`
- `cargo check --manifest-path qa/fuzz/Cargo.toml --bins`
- `rustfmt --edition 2024 --check qa/fuzz/src/lib.rs qa/fuzz/src/patcher.rs qa/fuzz/fuzz_targets/fuzz_witness_cheat.rs`
- `git diff --check`
