### PR TITLE
Add floor planner fuzzing and target inventory helper

### DIFF
--- a/.github/workflows/fuzz-cron.yml
+++ b/.github/workflows/fuzz-cron.yml
@@ -32,8 +32,26 @@ permissions:
   contents: read
 
 jobs:
+  targets:
+    name: enumerate fuzz targets
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.targets.outputs.targets }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: List fuzz targets
+        id: targets
+        run: |
+          set -euo pipefail
+          targets_json="$(qa/fuzz/list-targets.sh | awk 'BEGIN { printf "[" } { printf "%s\"%s\"", sep, $0; sep = "," } END { print "]" }')"
+          echo "targets=${targets_json}" >> "$GITHUB_OUTPUT"
+
   fuzz:
     name: fuzz ${{ matrix.target }}
+    needs: targets
     runs-on: ubuntu-latest
     # GitHub-hosted runners have a 6-hour (360-minute) hard ceiling per
     # job. Setting timeout-minutes to that maximum gives the 5-hour
@@ -47,24 +65,7 @@ jobs:
       # cancellations.
       fail-fast: false
       matrix:
-        target:
-          - fuzz_element_ops
-          - fuzz_witness_coverage
-          - fuzz_witness_cheat
-          - fuzz_driver_metamorphic
-          - fuzz_algebraic_identities
-          - fuzz_element_assertions
-          - fuzz_multipack
-          - fuzz_point_identities
-          - fuzz_consistent
-          - fuzz_io_roundtrip
-          - fuzz_poseidon_sponge
-          - fuzz_poseidon_differential
-          - fuzz_endoscalar
-          - fuzz_revdot
-          - fuzz_fold_revdot
-          - fuzz_sxy_agreement
-          - fuzz_verify_reject
+        target: ${{ fromJSON(needs.targets.outputs.targets) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/crates/ragu_circuits/src/floor_planner.rs
+++ b/crates/ragu_circuits/src/floor_planner.rs
@@ -40,7 +40,13 @@
 
 use alloc::vec::Vec;
 
-use super::metrics::SegmentRecord;
+use ff::FromUniformBytes;
+use ragu_core::Result;
+
+use super::{
+    Circuit,
+    metrics::{self, SegmentRecord},
+};
 
 /// A segment's placement in a constraint system.
 ///
@@ -62,6 +68,7 @@ use super::metrics::SegmentRecord;
 /// the current implementation does not.
 ///
 /// [`Routine`]: ragu_core::routines::Routine
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ConstraintSegment {
     /// Gate index where this segment's gates begin.
     pub(crate) gate_start: usize,
@@ -71,6 +78,28 @@ pub struct ConstraintSegment {
     pub(crate) num_gates: usize,
     /// Number of constraints in this segment.
     pub(crate) num_constraints: usize,
+}
+
+impl ConstraintSegment {
+    /// Returns the first gate index assigned to this segment.
+    pub fn gate_start(&self) -> usize {
+        self.gate_start
+    }
+
+    /// Returns the first Y-power constraint index assigned to this segment.
+    pub fn constraint_start(&self) -> usize {
+        self.constraint_start
+    }
+
+    /// Returns the number of gates assigned to this segment.
+    pub fn num_gates(&self) -> usize {
+        self.num_gates
+    }
+
+    /// Returns the number of constraints assigned to this segment.
+    pub fn num_constraints(&self) -> usize {
+        self.num_constraints
+    }
 }
 
 /// Computes a floor plan from per-segment constraint records.
@@ -100,4 +129,33 @@ pub fn floor_plan(segment_records: &[SegmentRecord]) -> Vec<ConstraintSegment> {
     );
 
     result
+}
+
+/// Computes a floor plan directly from a circuit implementation.
+///
+/// This is the public entry point for tooling that wants to exercise the
+/// planner over real circuit topologies without going through
+/// [`RegistryBuilder`](crate::registry::RegistryBuilder). It first runs the
+/// same metrics pass that registry construction uses, then delegates to
+/// [`floor_plan`] with the collected segment records.
+pub fn floor_plan_for<F, C>(circuit: &C) -> Result<Vec<ConstraintSegment>>
+where
+    F: FromUniformBytes<64>,
+    C: Circuit<F>,
+{
+    let segment_records = segment_records_for::<F, C>(circuit)?;
+    Ok(floor_plan(&segment_records))
+}
+
+/// Collects the segment records that feed the floor planner for a circuit.
+///
+/// The returned records are in DFS synthesis order. This is primarily useful
+/// for fuzzing and diagnostics that need to compare a planned layout against
+/// the segment sizes observed by the metrics pass.
+pub fn segment_records_for<F, C>(circuit: &C) -> Result<Vec<SegmentRecord>>
+where
+    F: FromUniformBytes<64>,
+    C: Circuit<F>,
+{
+    Ok(metrics::eval(circuit)?.segments)
 }

--- a/qa/fuzz/Cargo.toml
+++ b/qa/fuzz/Cargo.toml
@@ -125,6 +125,15 @@ test = false
 doc = false
 bench = false
 
+# Floor planner: real circuit segment layouts preserve root pinning, segment
+# sizes, and non-overlap across routine-heavy topologies.
+[[bin]]
+name = "fuzz_floor_planner"
+path = "fuzz_targets/fuzz_floor_planner.rs"
+test = false
+doc = false
+bench = false
+
 # Poseidon differential: circuit sponge vs native reference implementation
 [[bin]]
 name = "fuzz_poseidon_differential"

--- a/qa/fuzz/README.md
+++ b/qa/fuzz/README.md
@@ -1,6 +1,6 @@
 # `ragu_testing-fuzz`
 
-cargo-fuzz harness for the Ragu project. 20 fuzz targets + 1 auxiliary
+cargo-fuzz harness for the Ragu project. 21 fuzz targets + 1 auxiliary
 dictionary-extractor tool. Standalone workspace (the `[workspace]` table in
 `Cargo.toml` makes this crate its own root) so nightly + libfuzzer flags
 don't leak into the rest of the repo.
@@ -65,6 +65,7 @@ All four share an essentially identical `Op` enum and dispatch — see the
 | `fuzz_revdot` | Reverse-dot-product primitive. |
 | `fuzz_fold_revdot` | RevDot folding. |
 | `fuzz_sxy_agreement` | `s(X, Y)` registry consistency. Caught `Key::new(0)` divide-by-zero. |
+| `fuzz_floor_planner` | Floor-plan structural invariants over real circuit topologies: root pinning, segment-size preservation, and non-overlap across routine-heavy layouts. |
 
 ### Verifier robustness
 
@@ -147,10 +148,16 @@ Two workflows in `.github/workflows/`:
   and `bin/**/*.rs`.
 
 - **`fuzz-cron.yml`** runs every target via matrix-parallel for 5 hours
-  each, weekly on Sundays at 00:00 UTC. Corpus persists across runs via
-  `actions/cache`. Crashes upload as workflow artifacts with 30-day
-  retention. Manual trigger via the Actions tab `workflow_dispatch`
-  with override knobs for `duration` and `use_dict`.
+  each, twice weekly on Sundays and Wednesdays at 00:00 UTC. Corpus
+  persists across runs via `actions/cache`. Crashes upload as workflow
+  artifacts with 30-day retention. Manual trigger via the Actions tab
+  `workflow_dispatch` with override knobs for `duration` and `use_dict`.
+
+The local `fuzz.sh` helper and the scheduled workflow both derive their
+target list from `Cargo.toml` via `list-targets.sh`. This keeps new
+`fuzz_*` bins in the local runner and continuous fuzzing without a
+second hand-maintained target list, while excluding auxiliary bins such
+as `extract_dict`.
 
 ## Why several targets duplicate the same `Op` enum
 

--- a/qa/fuzz/fuzz.sh
+++ b/qa/fuzz/fuzz.sh
@@ -92,28 +92,10 @@ if [[ -n "$ASAN" ]]; then
   SAN_FLAG=""
 fi
 
-TARGETS=(
-  fuzz_poseidon_sponge
-  fuzz_endoscalar
-  fuzz_element_ops
-  fuzz_circuit_witness
-  fuzz_circuit_revdot_identity
-  fuzz_staging
-  fuzz_revdot
-  fuzz_fold_revdot
-  fuzz_sxy_agreement
-  fuzz_poseidon_differential
-  fuzz_verify_reject
-  fuzz_witness_cheat
-  fuzz_driver_metamorphic
-  fuzz_witness_coverage
-  fuzz_algebraic_identities
-  fuzz_element_assertions
-  fuzz_multipack
-  fuzz_point_identities
-  fuzz_consistent
-  fuzz_io_roundtrip
-)
+TARGETS=()
+while IFS= read -r target; do
+  TARGETS+=("$target")
+done < <(./list-targets.sh)
 
 run_target() {
   local target="$1"

--- a/qa/fuzz/fuzz_targets/fuzz_floor_planner.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_floor_planner.rs
@@ -1,0 +1,263 @@
+//! Fuzz floor-planner invariants over real circuit topologies.
+//!
+//! The current planner is a prefix sum, but consumers already depend on a
+//! stronger public contract that should survive future reordering planners:
+//! segment 0 is pinned at the polynomial origin, every planned segment keeps
+//! the size observed during synthesis, and planned gate/constraint ranges do
+//! not overlap. This target drives the planner through ordinary `Circuit`
+//! implementations instead of synthetic `SegmentRecord` values so routine
+//! boundaries and nested-routine DFS order stay covered.
+
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use pasta_curves::Fp;
+use ragu_arithmetic::Coeff;
+use ragu_circuits::{
+    Circuit, SegmentRecord, WithAux,
+    floor_planner::{self, ConstraintSegment},
+};
+use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue, LinearExpression},
+    gadgets::{Bound, Kind},
+    maybe::Maybe,
+    routines::{Prediction, Routine},
+};
+use ragu_primitives::{Element, allocator::Standard};
+use ragu_testing::circuits::{MySimpleCircuit, SquareCircuit};
+
+#[derive(Arbitrary, Debug)]
+enum CircuitChoice {
+    Square { times: u8 },
+    Simple,
+    Routine,
+    NestedRoutine,
+}
+
+#[derive(Arbitrary, Debug)]
+struct Input {
+    circuit: CircuitChoice,
+}
+
+fn check_non_overlapping_ranges(
+    label: &str,
+    ranges: &mut [(usize, usize, usize)],
+    segments: &[ConstraintSegment],
+) {
+    ranges.sort_by_key(|(start, _, idx)| (*start, *idx));
+    for pair in ranges.windows(2) {
+        let (prev_start, prev_end, prev_idx) = pair[0];
+        let (start, end, idx) = pair[1];
+        assert!(
+            prev_end <= start,
+            "{label} ranges overlap: segment {prev_idx} [{prev_start}, {prev_end}) \
+             intersects segment {idx} [{start}, {end}); plan={segments:?}"
+        );
+    }
+}
+
+fn check_plan(records: &[SegmentRecord], segments: &[ConstraintSegment]) {
+    assert!(!segments.is_empty(), "floor plan must include root segment");
+    assert_eq!(
+        records.len(),
+        segments.len(),
+        "floor plan and segment records disagree on segment count"
+    );
+    assert_eq!(
+        segments[0].gate_start(),
+        0,
+        "root segment gate offset must be pinned at zero: {segments:?}"
+    );
+    assert_eq!(
+        segments[0].constraint_start(),
+        0,
+        "root segment constraint offset must be pinned at zero: {segments:?}"
+    );
+
+    let mut gate_ranges = Vec::new();
+    let mut constraint_ranges = Vec::new();
+    for (idx, (record, segment)) in records.iter().zip(segments.iter()).enumerate() {
+        assert_eq!(
+            segment.num_gates(),
+            record.num_gates(),
+            "segment {idx} gate count changed during planning"
+        );
+        assert_eq!(
+            segment.num_constraints(),
+            record.num_constraints(),
+            "segment {idx} constraint count changed during planning"
+        );
+
+        let gate_end = segment
+            .gate_start()
+            .checked_add(segment.num_gates())
+            .expect("gate range overflow");
+        let constraint_end = segment
+            .constraint_start()
+            .checked_add(segment.num_constraints())
+            .expect("constraint range overflow");
+
+        if segment.num_gates() > 0 {
+            gate_ranges.push((segment.gate_start(), gate_end, idx));
+        }
+        if segment.num_constraints() > 0 {
+            constraint_ranges.push((segment.constraint_start(), constraint_end, idx));
+        }
+    }
+
+    check_non_overlapping_ranges("gate", &mut gate_ranges, segments);
+    check_non_overlapping_ranges("constraint", &mut constraint_ranges, segments);
+}
+
+fn check_circuit<C: Circuit<Fp>>(circuit: &C) {
+    let records = floor_planner::segment_records_for::<Fp, _>(circuit)
+        .expect("metrics collection should succeed");
+    let plan = floor_planner::floor_plan(&records);
+    check_plan(&records, &plan);
+}
+
+#[derive(Clone)]
+struct ScaleByThree;
+
+impl Routine<Fp> for ScaleByThree {
+    type Input = Kind![Fp; Element<'_, _>];
+    type Output = Kind![Fp; Element<'_, _>];
+    type Aux<'dr> = Fp;
+
+    fn execute<'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        input: Bound<'dr, D, Self::Input>,
+        aux: DriverValue<D, Self::Aux<'dr>>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        let allocator = &mut Standard::new();
+        let output = Element::alloc(dr, allocator, aux)?;
+        let three_input = input.scale(dr, Coeff::Arbitrary(Fp::from(3u64)));
+        dr.enforce_zero(|lc| lc.add(three_input.wire()).sub(output.wire()))?;
+        Ok(output)
+    }
+
+    fn predict<'dr, D: Driver<'dr, F = Fp, Wire = ()>>(
+        &self,
+        _dr: &mut D,
+        input: &Bound<'dr, D, Self::Input>,
+    ) -> Result<Prediction<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'dr>>>> {
+        let aux = input.value().map(|v| *v * Fp::from(3u64));
+        Ok(Prediction::Unknown(aux))
+    }
+}
+
+#[derive(Clone)]
+struct DoubleAfterNestedTriple;
+
+impl Routine<Fp> for DoubleAfterNestedTriple {
+    type Input = Kind![Fp; Element<'_, _>];
+    type Output = Kind![Fp; Element<'_, _>];
+    type Aux<'dr> = Fp;
+
+    fn execute<'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        input: Bound<'dr, D, Self::Input>,
+        aux: DriverValue<D, Self::Aux<'dr>>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        let tripled = dr.routine(ScaleByThree, input)?;
+        let allocator = &mut Standard::new();
+        let output = Element::alloc(dr, allocator, aux)?;
+        let doubled_tripled = tripled.double(dr);
+        dr.enforce_zero(|lc| lc.add(doubled_tripled.wire()).sub(output.wire()))?;
+        Ok(output)
+    }
+
+    fn predict<'dr, D: Driver<'dr, F = Fp, Wire = ()>>(
+        &self,
+        _dr: &mut D,
+        input: &Bound<'dr, D, Self::Input>,
+    ) -> Result<Prediction<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'dr>>>> {
+        let aux = input.value().map(|v| *v * Fp::from(6u64));
+        Ok(Prediction::Unknown(aux))
+    }
+}
+
+struct RoutineCircuit;
+
+impl Circuit<Fp> for RoutineCircuit {
+    type Instance<'instance> = Fp;
+    type Output = Kind![Fp; Element<'_, _>];
+    type Witness<'witness> = Fp;
+    type Aux<'witness> = ();
+
+    fn instance<'dr, 'instance: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        instance: DriverValue<D, Self::Instance<'instance>>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        let allocator = &mut Standard::new();
+        Element::alloc(dr, allocator, instance)
+    }
+
+    fn witness<'dr, 'witness: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Self::Witness<'witness>>,
+    ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'witness>>>>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let x = Element::alloc(dr, allocator, witness)?;
+        let result = dr.routine(ScaleByThree, x)?;
+        Ok(WithAux::new(result, D::unit()))
+    }
+}
+
+struct NestedRoutineCircuit;
+
+impl Circuit<Fp> for NestedRoutineCircuit {
+    type Instance<'instance> = Fp;
+    type Output = Kind![Fp; Element<'_, _>];
+    type Witness<'witness> = Fp;
+    type Aux<'witness> = ();
+
+    fn instance<'dr, 'instance: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        instance: DriverValue<D, Self::Instance<'instance>>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        let allocator = &mut Standard::new();
+        Element::alloc(dr, allocator, instance)
+    }
+
+    fn witness<'dr, 'witness: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Self::Witness<'witness>>,
+    ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'witness>>>>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let x = Element::alloc(dr, allocator, witness)?;
+        let result = dr.routine(DoubleAfterNestedTriple, x)?;
+        Ok(WithAux::new(result, D::unit()))
+    }
+}
+
+fuzz_target!(|input: Input| {
+    if std::env::var("DEBUG_INPUT").is_ok() {
+        eprintln!("{:#?}", input);
+        return;
+    }
+
+    match input.circuit {
+        CircuitChoice::Square { times } => {
+            let times = ((times as usize) % 120) + 1;
+            check_circuit(&SquareCircuit { times });
+        }
+        CircuitChoice::Simple => check_circuit(&MySimpleCircuit),
+        CircuitChoice::Routine => check_circuit(&RoutineCircuit),
+        CircuitChoice::NestedRoutine => check_circuit(&NestedRoutineCircuit),
+    }
+});

--- a/qa/fuzz/list-targets.sh
+++ b/qa/fuzz/list-targets.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Print fuzz target names declared in Cargo.toml, one per line.
+#
+# cargo-fuzz stores each target as a `[[bin]]`. Auxiliary tools live in the
+# same manifest, so this script includes only bin names with the `fuzz_`
+# prefix.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+awk '
+  /^\[\[bin\]\]/ {
+    in_bin = 1
+    next
+  }
+
+  /^\[/ {
+    in_bin = 0
+    next
+  }
+
+  in_bin && /^[[:space:]]*name[[:space:]]*=/ {
+    name = $0
+    sub(/^[^=]*=[[:space:]]*"/, "", name)
+    sub(/".*/, "", name)
+    if (name ~ /^fuzz_/) {
+      print name
+    }
+    in_bin = 0
+  }
+' Cargo.toml


### PR DESCRIPTION
## Summary
- add public floor-planner inspection helpers and a new `fuzz_floor_planner` target over real circuit topologies, including nested routines
- derive local and scheduled fuzz target inventories from `qa/fuzz/Cargo.toml` via `list-targets.sh`
- update fuzz README target count and CI notes

Closes #726.
Partially addresses #558 by removing target-list drift between `Cargo.toml`, `fuzz.sh`, and continuous fuzzing.

## Verification
- `cargo check --manifest-path qa/fuzz/Cargo.toml --bins`
- `cargo test -p ragu_circuits`
- `rustfmt --edition 2024 --check crates/ragu_circuits/src/floor_planner.rs qa/fuzz/fuzz_targets/fuzz_floor_planner.rs`
- `bash -n qa/fuzz/fuzz.sh qa/fuzz/list-targets.sh`
- `git diff --check`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p ragu_circuits --document-private-items`
