### PR TITLE
Add fuzz-local circuit patcher target

### DIFF
--- a/qa/fuzz/Cargo.toml
+++ b/qa/fuzz/Cargo.toml
@@ -150,6 +150,15 @@ test = false
 doc = false
 bench = false
 
+# Fuzz-local dummy Circuit patcher oracle: same op-stream patcher policy as
+# fuzz_witness_cheat, but checked at a selected circuit public output.
+[[bin]]
+name = "fuzz_circuit_patcher"
+path = "fuzz_targets/fuzz_circuit_patcher.rs"
+test = false
+doc = false
+bench = false
+
 # Driver-vs-driver metamorphic: same Vec<Op> through Simulator and
 # Emulator<Wired>. Both should produce identical wire values; disagreement is
 # a model-vs-real driver divergence.

--- a/qa/fuzz/Cargo.toml
+++ b/qa/fuzz/Cargo.toml
@@ -141,9 +141,8 @@ test = false
 doc = false
 bench = false
 
-# Mid-stream witness cheating: honest vs cheat paths through the Simulator.
-# Currently a Simulator-robustness fuzzer; intended as a soundness oracle once
-# the patcher work lands (see issue tracking the patcher technique).
+# Mid-stream witness cheating: honest vs unpatched/patched cheat paths through
+# the Simulator, with downstream witness-slot repair for soundness signals.
 [[bin]]
 name = "fuzz_witness_cheat"
 path = "fuzz_targets/fuzz_witness_cheat.rs"

--- a/qa/fuzz/README.md
+++ b/qa/fuzz/README.md
@@ -41,7 +41,7 @@ All four share an essentially identical `Op` enum and dispatch — see the
 |---|---|
 | `fuzz_element_ops` | Completeness — random gadget compositions must not crash and must produce internally-consistent witnesses. The substrate. |
 | `fuzz_witness_coverage` | Same as `fuzz_element_ops` plus a post-run witness-state hash spread across coverage branches. Biases the fuzzer toward distinct internal witness states. Opt-in POC (~28% throughput cost). |
-| `fuzz_witness_cheat` | Mid-stream replaces an element on the stack with a fresh allocation of a different value, then compares fingerprints against the honest run. Currently functions as a Simulator-robustness fuzzer (the soundness assertion is structurally tautological today); becomes a true under-constrained-gadget oracle once the patcher technique lands. The mutation scaffolding is in place. |
+| `fuzz_witness_cheat` | Mid-stream replaces an element on the stack with a fresh allocation of a different value, then uses a patcher pass to repair downstream-created witness slots when local equations are solvable. Compares the patched cheat against the honest run after excluding directly patched support slots. Signals should still be validated against a real circuit/output boundary because the final stack is a proxy oracle. |
 | `fuzz_driver_metamorphic` | Differential — runs the same `Vec<Op>` through both `Simulator` and `Emulator<Wired<Fp>>`; wire values must match. Tests the model-vs-real-driver invariant. |
 
 ### Gadget-API property and identity targets
@@ -133,9 +133,11 @@ TRIAGE_CHEAT=1 cargo +nightly fuzz run fuzz_witness_cheat \
   artifacts/fuzz_witness_cheat/crash-abc123
 ```
 
-If the count is 0, the soundness signal is probably a dead-cheat false
-positive. If it's high, the cheat propagated but downstream constraints
-were insensitive to it — that's the real bug class.
+If the count is 0, the input is a dead cheat and should normally be
+discarded. If it's high, the patcher may have found a path where the
+cheat propagated and was repaired into the same observable fingerprint.
+Treat that as a candidate under-constrained-gadget signal until it is
+validated against the real public outputs for the circuit under test.
 
 ## CI
 
@@ -159,12 +161,11 @@ The four `Vec<Op>`-style targets (`fuzz_element_ops`,
 `fuzz_driver_metamorphic`) each have a copy of the same `Op` enum and
 dispatch — roughly 200 lines of mechanical duplication per file.
 
-This is deliberate. cargo-fuzz expects `[[bin]]`-style fuzz targets, and
-sharing a `src/lib.rs` between fuzz targets adds friction with the
-cargo-fuzz workflow and the patch-table mirroring this crate already
-needs. The duplication is annotated in each file (`Identical dispatch
-logic to fuzz_element_ops and fuzz_witness_cheat`) so future edits
-propagate the same change everywhere.
+This is mostly deliberate. cargo-fuzz expects `[[bin]]`-style fuzz
+targets, so the hot dispatch loops stay local to each target. The
+exception is `src/patcher.rs`, a small pure helper used by
+`fuzz_witness_cheat` so the downstream repair policy can have ordinary
+unit tests without pulling libFuzzer into the test harness.
 
 ## Patch table
 

--- a/qa/fuzz/README.md
+++ b/qa/fuzz/README.md
@@ -1,6 +1,6 @@
 # `ragu_testing-fuzz`
 
-cargo-fuzz harness for the Ragu project. 20 fuzz targets + 1 auxiliary
+cargo-fuzz harness for the Ragu project. 21 fuzz targets + 1 auxiliary
 dictionary-extractor tool. Standalone workspace (the `[workspace]` table in
 `Cargo.toml` makes this crate its own root) so nightly + libfuzzer flags
 don't leak into the rest of the repo.
@@ -34,7 +34,7 @@ cargo +nightly fuzz run fuzz_element_ops -- -max_total_time=60
 ### Vec\<Op\>-style instruction-vector targets
 
 Generate random `Vec<Op>` sequences of `Element`/`Boolean` gadget calls.
-All four share an essentially identical `Op` enum and dispatch — see the
+All five share an essentially identical `Op` enum and dispatch — see the
 "why duplicated" note at the bottom.
 
 | Target | What it catches |
@@ -42,6 +42,7 @@ All four share an essentially identical `Op` enum and dispatch — see the
 | `fuzz_element_ops` | Completeness — random gadget compositions must not crash and must produce internally-consistent witnesses. The substrate. |
 | `fuzz_witness_coverage` | Same as `fuzz_element_ops` plus a post-run witness-state hash spread across coverage branches. Biases the fuzzer toward distinct internal witness states. Opt-in POC (~28% throughput cost). |
 | `fuzz_witness_cheat` | Mid-stream replaces an element on the stack with a fresh allocation of a different value, then uses a patcher pass to repair downstream-created witness slots when local equations are solvable. Compares the patched cheat against the honest run after excluding directly patched support slots. Signals should still be validated against a real circuit/output boundary because the final stack is a proxy oracle. |
+| `fuzz_circuit_patcher` | Runs the same patcher policy through a fuzz-local dummy `Circuit` and compares a selected public output element. Keeps the circuit-boundary experiment in `qa/fuzz` without production driver hooks. |
 | `fuzz_driver_metamorphic` | Differential — runs the same `Vec<Op>` through both `Simulator` and `Emulator<Wired<Fp>>`; wire values must match. Tests the model-vs-real-driver invariant. |
 
 ### Gadget-API property and identity targets
@@ -156,16 +157,17 @@ Two workflows in `.github/workflows/`:
 
 ## Why several targets duplicate the same `Op` enum
 
-The four `Vec<Op>`-style targets (`fuzz_element_ops`,
+The five `Vec<Op>`-style targets (`fuzz_element_ops`,
 `fuzz_witness_coverage`, `fuzz_witness_cheat`,
-`fuzz_driver_metamorphic`) each have a copy of the same `Op` enum and
-dispatch — roughly 200 lines of mechanical duplication per file.
+`fuzz_circuit_patcher`, `fuzz_driver_metamorphic`) each have a copy of
+the same `Op` enum and dispatch — roughly 200 lines of mechanical
+duplication per file.
 
 This is mostly deliberate. cargo-fuzz expects `[[bin]]`-style fuzz
 targets, so the hot dispatch loops stay local to each target. The
-exception is `src/patcher.rs`, a small pure helper used by
-`fuzz_witness_cheat` so the downstream repair policy can have ordinary
-unit tests without pulling libFuzzer into the test harness.
+exception is `src/patcher.rs`, a small pure helper used by the patcher
+targets so the downstream repair policy can have ordinary unit tests
+without pulling libFuzzer into the test harness.
 
 ## Patch table
 

--- a/qa/fuzz/fuzz_targets/fuzz_circuit_patcher.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_circuit_patcher.rs
@@ -1,0 +1,451 @@
+//! Fuzz-local circuit/output-boundary patcher target.
+//!
+//! This is the narrower follow-up to `fuzz_witness_cheat`: keep the
+//! patcher policy in `qa/fuzz`, but run the repaired witness through a
+//! real `Circuit::witness` implementation and compare a chosen public
+//! output element rather than the whole final op stack.
+//!
+//! The circuit here is intentionally a dummy circuit local to this fuzz
+//! target. It translates the same `Vec<Op>` abstraction used by
+//! `fuzz_witness_cheat` into `Element` and `Boolean` gadget calls. The
+//! fuzzer then runs three circuit witnesses:
+//!
+//! 1. honest witness;
+//! 2. unpatched cheated witness;
+//! 3. patched cheated witness.
+//!
+//! A signal fires only when the patched cheated witness is accepted and
+//! produces the same selected public output as the honest witness, while
+//! the unpatched cheat either rejects or produces a different output.
+
+#![no_main]
+
+use arbitrary::Arbitrary;
+use ff::{Field, PrimeField};
+use libfuzzer_sys::fuzz_target;
+use pasta_curves::Fp;
+use ragu_arithmetic::Coeff;
+use ragu_circuits::{Circuit, CircuitExt, WithAux};
+use ragu_core::{
+    Error, Result,
+    drivers::{Driver, DriverValue},
+    gadgets::{Bound, Kind},
+    maybe::Maybe,
+};
+use ragu_primitives::{Boolean, Element, Simulator, allocator::Standard};
+use ragu_testing_fuzz::patcher::{PatchOp, build_patch_plan};
+
+fn special_value(idx: u8) -> Fp {
+    match idx % 16 {
+        0 => Fp::ZERO,
+        1 => Fp::ONE,
+        2 => -Fp::ONE,
+        3 => -Fp::from(2),
+        4 => Fp::TWO_INV,
+        5 => Fp::from(2),
+        6 => Fp::from(3),
+        7 => Fp::from(7),
+        8 => Fp::ROOT_OF_UNITY,
+        9 => Fp::ROOT_OF_UNITY.square(),
+        10 => Fp::ROOT_OF_UNITY.pow_vartime([4u64]),
+        11 => Fp::MULTIPLICATIVE_GENERATOR,
+        12 => Fp::MULTIPLICATIVE_GENERATOR.square(),
+        13 => Fp::from(1u64 << 32),
+        14 => Fp::from(1u64 << 48),
+        _ => Fp::from(u64::MAX),
+    }
+}
+
+#[derive(Arbitrary, Debug, Clone, Copy)]
+enum Op {
+    Add(u8, u8),
+    Sub(u8, u8),
+    Mul(u8, u8),
+    Square(u8),
+    Double(u8),
+    Negate(u8),
+    Invert(u8),
+    IsZero(u8),
+    DivNonzero(u8, u8),
+    Scale(u8, u64),
+    Fold(u8, u8, u64),
+    AllocConst(u64),
+    AllocSpecial(u8),
+    AllocSquare(u64),
+    AllocRaw([u8; 32]),
+    BoolAlloc(bool),
+    BoolNot(u8),
+    BoolAnd(u8, u8),
+    ConditionalSelect(u8, u8, u8),
+}
+
+#[derive(Arbitrary, Debug, Clone, Copy)]
+enum CheatFlavor {
+    Alloc(u64),
+    Constant(u64),
+    Special(u8),
+}
+
+#[derive(Arbitrary, Debug)]
+struct Input {
+    seeds: [u64; 4],
+    large_seeds: [[u64; 4]; 2],
+    special_seeds: [u8; 2],
+    ops: Vec<Op>,
+    cheat_at: u16,
+    target_idx: u8,
+    output_idx: u8,
+    cheat: CheatFlavor,
+}
+
+fn cheat_value(cheat: CheatFlavor) -> Fp {
+    match cheat {
+        CheatFlavor::Alloc(v) | CheatFlavor::Constant(v) => Fp::from(v),
+        CheatFlavor::Special(idx) => special_value(idx),
+    }
+}
+
+fn patch_op(op: &Op) -> PatchOp {
+    match *op {
+        Op::Add(a, b) => PatchOp::Add(a, b),
+        Op::Sub(a, b) => PatchOp::Sub(a, b),
+        Op::Mul(a, b) => PatchOp::Mul(a, b),
+        Op::Square(a) => PatchOp::Square(a),
+        Op::Double(a) => PatchOp::Double(a),
+        Op::Negate(a) => PatchOp::Negate(a),
+        Op::Invert(a) => PatchOp::Invert(a),
+        Op::IsZero(a) => PatchOp::IsZero(a),
+        Op::DivNonzero(a, b) => PatchOp::DivNonzero(a, b),
+        Op::Scale(a, c) => PatchOp::Scale(a, Fp::from(c)),
+        Op::Fold(a, b, s) => PatchOp::Fold(a, b, Fp::from(s)),
+        Op::AllocConst(v) => PatchOp::AllocConst(Fp::from(v)),
+        Op::AllocSpecial(idx) => PatchOp::AllocWitness(special_value(idx)),
+        Op::AllocSquare(v) => PatchOp::AllocSquare(Fp::from(v)),
+        Op::AllocRaw(bytes) => PatchOp::AllocRaw(Fp::from_repr(bytes).into()),
+        Op::BoolAlloc(v) => PatchOp::BoolAlloc(v),
+        Op::BoolNot(a) => PatchOp::BoolNot(a),
+        Op::BoolAnd(a, b) => PatchOp::BoolAnd(a, b),
+        Op::ConditionalSelect(cond, a, b) => PatchOp::ConditionalSelect(cond, a, b),
+    }
+}
+
+fn build_seeds(input: &Input) -> Vec<Fp> {
+    let mut fes: Vec<Fp> = input.seeds.iter().map(|v| Fp::from(*v)).collect();
+    for ls in &input.large_seeds {
+        let val = Fp::from(ls[0])
+            + Fp::from(ls[1]) * Fp::from(1u64 << 32)
+            + Fp::from(ls[2]) * Fp::from(1u64 << 48)
+            + Fp::from(ls[3]) * Fp::from(1u64 << 56);
+        fes.push(val);
+    }
+    for ss in &input.special_seeds {
+        fes.push(special_value(*ss));
+    }
+    fes
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RunMode {
+    Honest,
+    Cheat,
+    Patched,
+}
+
+#[derive(Clone, Debug)]
+struct PatchCircuit {
+    seed_len: usize,
+    ops: Vec<Op>,
+    mode: RunMode,
+    cheat_at: usize,
+    target_idx: u8,
+    cheat: CheatFlavor,
+    cheat_value: Fp,
+    replacements: Vec<Vec<(usize, Fp)>>,
+    output_idx: usize,
+}
+
+impl PatchCircuit {
+    fn with_mode(&self, mode: RunMode) -> Self {
+        Self {
+            mode,
+            ..self.clone()
+        }
+    }
+}
+
+impl Circuit<Fp> for PatchCircuit {
+    type Instance<'source> = Fp;
+    type Witness<'source> = Vec<Fp>;
+    type Output = Kind![Fp; Element<'_, _>];
+    type Aux<'source> = ();
+
+    fn instance<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        instance: DriverValue<D, Self::Instance<'source>>,
+    ) -> Result<Bound<'dr, D, Self::Output>> {
+        Element::alloc(dr, &mut Standard::new(), instance)
+    }
+
+    fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>>(
+        &self,
+        dr: &mut D,
+        witness: DriverValue<D, Self::Witness<'source>>,
+    ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'source>>>>
+    where
+        Self: 'dr,
+    {
+        let allocator = &mut Standard::new();
+        let mut elems: Vec<Element<'_, _>> = (0..self.seed_len)
+            .map(|seed_idx| Element::alloc(dr, allocator, witness.as_ref().map(|v| v[seed_idx])))
+            .collect::<Result<_>>()?;
+        let mut bools: Vec<Boolean<'_, _>> = Vec::new();
+
+        for (op_idx, op) in self.ops.iter().enumerate() {
+            if self.mode != RunMode::Honest && op_idx == self.cheat_at && !elems.is_empty() {
+                let target = (self.target_idx as usize) % elems.len().min(64);
+                let cheated = match self.cheat {
+                    CheatFlavor::Alloc(_) | CheatFlavor::Special(_) => {
+                        Element::alloc(dr, allocator, witness.as_ref().map(|_| self.cheat_value))?
+                    }
+                    CheatFlavor::Constant(_) => Element::constant(dr, self.cheat_value),
+                };
+                elems[target] = cheated;
+            }
+
+            if self.mode == RunMode::Patched {
+                for &(slot, value) in self.replacements.get(op_idx).into_iter().flatten() {
+                    if slot < elems.len() {
+                        elems[slot] =
+                            Element::alloc(dr, allocator, witness.as_ref().map(|_| value))?;
+                    }
+                }
+            }
+
+            let elen = elems.len();
+            let blen = bools.len();
+            if elen == 0 {
+                break;
+            }
+
+            match *op {
+                Op::Add(a, b) => {
+                    let (a, b) = (a as usize % elen, b as usize % elen);
+                    let r = elems[a].add(dr, &elems[b]);
+                    elems.push(r);
+                }
+                Op::Sub(a, b) => {
+                    let (a, b) = (a as usize % elen, b as usize % elen);
+                    let r = elems[a].sub(dr, &elems[b]);
+                    elems.push(r);
+                }
+                Op::Mul(a, b) => {
+                    let (a, b) = (a as usize % elen, b as usize % elen);
+                    if let Ok(r) = elems[a].mul(dr, &elems[b]) {
+                        elems.push(r);
+                    }
+                }
+                Op::Square(a) => {
+                    let a = a as usize % elen;
+                    if let Ok(r) = elems[a].square(dr) {
+                        elems.push(r);
+                    }
+                }
+                Op::Double(a) => {
+                    let a = a as usize % elen;
+                    let r = elems[a].double(dr);
+                    elems.push(r);
+                }
+                Op::Negate(a) => {
+                    let a = a as usize % elen;
+                    let r = elems[a].negate(dr);
+                    elems.push(r);
+                }
+                Op::Invert(a) => {
+                    let a = a as usize % elen;
+                    if let Ok(r) = elems[a].invert(dr) {
+                        elems.push(r);
+                    }
+                }
+                Op::IsZero(a) => {
+                    let a = a as usize % elen;
+                    if let Ok(b) = elems[a].is_zero(dr, allocator) {
+                        bools.push(b);
+                    }
+                }
+                Op::DivNonzero(a, b) => {
+                    let (a, b) = (a as usize % elen, b as usize % elen);
+                    if let Ok(r) = elems[a].div_nonzero(dr, &elems[b]) {
+                        elems.push(r);
+                    }
+                }
+                Op::Scale(a, c) => {
+                    let a = a as usize % elen;
+                    let r = elems[a].scale(dr, Coeff::Arbitrary(Fp::from(c)));
+                    elems.push(r);
+                }
+                Op::Fold(a, b, s) => {
+                    let (a, b) = (a as usize % elen, b as usize % elen);
+                    let scale =
+                        Element::alloc(dr, allocator, witness.as_ref().map(|_| Fp::from(s)))?;
+                    if let Ok(r) = Element::fold(dr, [&elems[a], &elems[b]], &scale) {
+                        elems.push(r);
+                    }
+                }
+                Op::AllocConst(v) => {
+                    let r = Element::constant(dr, Fp::from(v));
+                    elems.push(r);
+                }
+                Op::AllocSpecial(idx) => {
+                    let v = special_value(idx);
+                    let r = Element::alloc(dr, allocator, witness.as_ref().map(|_| v))?;
+                    elems.push(r);
+                }
+                Op::AllocRaw(bytes) => {
+                    let v: Option<Fp> = Fp::from_repr(bytes).into();
+                    if let Some(fp) = v {
+                        if let Ok(r) = Element::alloc(dr, allocator, witness.as_ref().map(|_| fp)) {
+                            elems.push(r);
+                        }
+                    }
+                }
+                Op::AllocSquare(v) => {
+                    if let Ok((root, sq)) =
+                        Element::alloc_square(dr, witness.as_ref().map(|_| Fp::from(v)))
+                    {
+                        elems.push(root);
+                        elems.push(sq);
+                    }
+                }
+                Op::BoolAlloc(v) => {
+                    if let Ok(b) = Boolean::alloc(dr, allocator, witness.as_ref().map(|_| v)) {
+                        bools.push(b);
+                    }
+                }
+                Op::BoolNot(a) => {
+                    if blen > 0 {
+                        let a = a as usize % blen;
+                        let r = bools[a].not(dr);
+                        bools.push(r);
+                    }
+                }
+                Op::BoolAnd(a, b) => {
+                    if blen > 0 {
+                        let (a, b) = (a as usize % blen, b as usize % blen);
+                        if let Ok(r) = bools[a].and(dr, &bools[b]) {
+                            bools.push(r);
+                        }
+                    }
+                }
+                Op::ConditionalSelect(cond, a, b) => {
+                    if blen > 0 {
+                        let cond = cond as usize % blen;
+                        let (a, b) = (a as usize % elen, b as usize % elen);
+                        if let Ok(r) = bools[cond].conditional_select(dr, &elems[a], &elems[b]) {
+                            elems.push(r);
+                        }
+                    }
+                }
+            }
+
+            if elems.len() > 128 {
+                elems.truncate(64);
+            }
+            if bools.len() > 64 {
+                bools.truncate(32);
+            }
+        }
+
+        let output = elems
+            .get(self.output_idx)
+            .cloned()
+            .ok_or_else(|| Error::InvalidWitness("selected output slot missing".into()))?;
+        Ok(WithAux::new(output, D::unit()))
+    }
+}
+
+fn run_circuit(circuit: PatchCircuit, seeds: &[Fp]) -> Option<Fp> {
+    let mut output = None;
+    Simulator::<Fp>::simulate(seeds.to_vec(), |dr, witness| {
+        let circuit_output = circuit.clone().witness(dr, witness)?.into_output();
+        output = Some(*circuit_output.value().take());
+        Ok(())
+    })
+    .ok()?;
+
+    circuit.trace(seeds.to_vec()).ok()?;
+    output
+}
+
+fuzz_target!(|input: Input| {
+    if std::env::var("DEBUG_INPUT").is_ok() {
+        eprintln!("{:#?}", input);
+        return;
+    }
+    if input.ops.is_empty() || input.ops.len() > 48 {
+        return;
+    }
+
+    let seeds = build_seeds(&input);
+    let patch_ops: Vec<PatchOp> = input.ops.iter().map(patch_op).collect();
+    let cheat_value = cheat_value(input.cheat);
+    let patch_plan = match build_patch_plan(
+        &seeds,
+        &patch_ops,
+        input.cheat_at as usize,
+        input.target_idx,
+        cheat_value,
+    ) {
+        Some(plan) if plan.repaired_ops > 0 => plan,
+        _ => return,
+    };
+
+    let observable_elems = patch_plan.observable_elem_indices();
+    if observable_elems.is_empty() {
+        return;
+    }
+    let output_idx = observable_elems[input.output_idx as usize % observable_elems.len()];
+
+    let base = PatchCircuit {
+        seed_len: seeds.len(),
+        ops: input.ops.clone(),
+        mode: RunMode::Honest,
+        cheat_at: input.cheat_at as usize,
+        target_idx: input.target_idx,
+        cheat: input.cheat,
+        cheat_value,
+        replacements: patch_plan.replacements.clone(),
+        output_idx,
+    };
+
+    let honest_output = match run_circuit(base.with_mode(RunMode::Honest), &seeds) {
+        Some(output) => output,
+        None => return,
+    };
+    let unpatched_output = run_circuit(base.with_mode(RunMode::Cheat), &seeds);
+    let patched_output = match run_circuit(base.with_mode(RunMode::Patched), &seeds) {
+        Some(output) => output,
+        None => return,
+    };
+
+    if patched_output != patch_plan.final_elems[output_idx] {
+        return;
+    }
+    if unpatched_output == Some(honest_output) {
+        return;
+    }
+
+    assert_ne!(
+        honest_output,
+        patched_output,
+        "circuit patcher signal: op[{}] target {} output slot {} flavor {:?} \
+         accepted after {} downstream repair(s); unpatched output {:?}; input: {:?}",
+        input.cheat_at,
+        input.target_idx,
+        output_idx,
+        input.cheat,
+        patch_plan.repaired_ops,
+        unpatched_output,
+        input,
+    );
+});

--- a/qa/fuzz/fuzz_targets/fuzz_witness_cheat.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_witness_cheat.rs
@@ -1,42 +1,33 @@
 //! Mid-stream witness cheating fuzz target.
 //!
-//! Runs the same instruction stream twice through the `Simulator`: an
-//! honest path and a cheat path that, at a fuzzer-chosen point, replaces
-//! one element on the stack with a fresh allocation whose value differs
-//! from the honest one. After both runs complete, the final element and
-//! boolean values are compared.
+//! Runs the same instruction stream through the `Simulator` three ways:
+//! an honest path, an unpatched cheat path, and a patched cheat path. At
+//! a fuzzer-chosen point the cheat paths replace one element on the stack
+//! with a fresh allocation whose value differs from the honest one. The
+//! patcher then walks the remaining op stream and tries to repair only
+//! downstream-created witness slots so later constraints can keep holding.
 //!
-//! # Current effective behavior
+//! # Effective behavior
 //!
-//! As implemented, this target functions primarily as a Simulator
-//! robustness fuzzer rather than a soundness oracle. The cheated slot is
-//! included in the comparison fingerprint, and the cheat value is filtered
-//! to differ from the original, so `honest != cheat` is tautologically
-//! true regardless of whether downstream constraints actually catch the
-//! cheat. The signals the target reliably surfaces today are panics, OOB
-//! indexing, and arithmetic faults in the gadget API when fed adversarial
-//! inputs — not under-constrained gadgets.
+//! The target first requires the ordinary cheated execution to be accepted
+//! by `Simulator`, preserving the original robustness coverage. It then
+//! replays the cheat with a patch plan that:
 //!
-//! # Intended behavior (post-patcher)
+//! 1. records the op-stream dataflow over field values;
+//! 2. refuses to repair unrelated pre-existing inputs;
+//! 3. repairs downstream-created element slots when a local equation can
+//!    be solved; and
+//! 4. excludes the directly patched support slots from the final
+//!    fingerprint.
 //!
-//! Becoming a true under-constrained-gadget oracle requires two changes,
-//! both tracked in the patcher follow-up issue:
+//! A signal fires when the patched cheat is accepted and the observable
+//! fingerprint matches the honest run. This is intentionally conservative:
+//! the final stack is still only a proxy for public outputs, so crash
+//! artifacts should be triaged as "under-constrained gadget or insufficient
+//! oracle" until validated against the real circuit/output boundary.
 //!
-//! 1. A patcher pass that, after the cheat is injected, walks the
-//!    recorded constraint graph forward from the cheated slot and adjusts
-//!    other downstream witness slots so the constraint system stays
-//!    satisfied. Without this, the cheat is either rejected by the first
-//!    downstream constraint that compares it against a honest-derived
-//!    value, or it propagates only through gates that self-satisfy
-//!    (`c = a*b` recomputed from the cheat).
-//!
-//! 2. Excluding the cheated slot from the comparison fingerprint, so the
-//!    `honest != cheat` check reflects downstream observable behavior
-//!    rather than the cheat injection itself.
-//!
-//! With both in place, the assertion becomes: "the Simulator accepted two
-//! genuinely different witnesses producing the same observable behavior"
-//! — the canonical under-constrained-gadget signal.
+//! The patcher is scoped to this fuzz target's `Vec<Op>` abstraction. It
+//! is not yet a general Ragu constraint-graph driver for full circuits.
 //!
 //! # Why this is the witness-mutation pattern, adapted to Ragu
 //!
@@ -60,6 +51,7 @@ use pasta_curves::Fp;
 use ragu_arithmetic::Coeff;
 use ragu_core::maybe::Maybe;
 use ragu_primitives::{Boolean, Element, Simulator, allocator::Standard};
+use ragu_testing_fuzz::patcher::{PatchOp, PatchPlan, build_patch_plan};
 
 fn special_value(idx: u8) -> Fp {
     match idx % 16 {
@@ -79,6 +71,37 @@ fn special_value(idx: u8) -> Fp {
         13 => Fp::from(1u64 << 32),
         14 => Fp::from(1u64 << 48),
         _ => Fp::from(u64::MAX),
+    }
+}
+
+fn cheat_value(cheat: CheatFlavor) -> Fp {
+    match cheat {
+        CheatFlavor::Alloc(v) | CheatFlavor::Constant(v) => Fp::from(v),
+        CheatFlavor::Special(idx) => special_value(idx),
+    }
+}
+
+fn patch_op(op: &Op) -> PatchOp {
+    match *op {
+        Op::Add(a, b) => PatchOp::Add(a, b),
+        Op::Sub(a, b) => PatchOp::Sub(a, b),
+        Op::Mul(a, b) => PatchOp::Mul(a, b),
+        Op::Square(a) => PatchOp::Square(a),
+        Op::Double(a) => PatchOp::Double(a),
+        Op::Negate(a) => PatchOp::Negate(a),
+        Op::Invert(a) => PatchOp::Invert(a),
+        Op::IsZero(a) => PatchOp::IsZero(a),
+        Op::DivNonzero(a, b) => PatchOp::DivNonzero(a, b),
+        Op::Scale(a, c) => PatchOp::Scale(a, Fp::from(c)),
+        Op::Fold(a, b, s) => PatchOp::Fold(a, b, Fp::from(s)),
+        Op::AllocConst(v) => PatchOp::AllocConst(Fp::from(v)),
+        Op::AllocSpecial(idx) => PatchOp::AllocWitness(special_value(idx)),
+        Op::AllocSquare(v) => PatchOp::AllocSquare(Fp::from(v)),
+        Op::AllocRaw(bytes) => PatchOp::AllocRaw(Fp::from_repr(bytes).into()),
+        Op::BoolAlloc(v) => PatchOp::BoolAlloc(v),
+        Op::BoolNot(a) => PatchOp::BoolNot(a),
+        Op::BoolAnd(a, b) => PatchOp::BoolAnd(a, b),
+        Op::ConditionalSelect(cond, a, b) => PatchOp::ConditionalSelect(cond, a, b),
     }
 }
 
@@ -164,7 +187,12 @@ fn build_seeds(input: &Input) -> Vec<Fp> {
 /// but the chosen cheat value coincided with the slot's existing value
 /// (a degenerate input that would produce a false-positive fingerprint
 /// match).
-fn run_path(input: &Input, fes: &[Fp], apply_cheat: bool) -> Option<Fingerprint> {
+fn run_path(
+    input: &Input,
+    fes: &[Fp],
+    apply_cheat: bool,
+    patch_plan: Option<&PatchPlan>,
+) -> Option<Fingerprint> {
     let mut snapshot: Option<Fingerprint> = None;
     let mut cheat_noop = false;
 
@@ -194,11 +222,7 @@ fn run_path(input: &Input, fes: &[Fp], apply_cheat: bool) -> Option<Fingerprint>
             if apply_cheat && i == input.cheat_at as usize && !elems.is_empty() {
                 let target = (input.target_idx as usize) % elems.len().min(64);
                 let original_val: Fp = *elems[target].value().take();
-                let cheat_val = match input.cheat {
-                    CheatFlavor::Alloc(v) => Fp::from(v),
-                    CheatFlavor::Constant(v) => Fp::from(v),
-                    CheatFlavor::Special(idx) => special_value(idx),
-                };
+                let cheat_val = cheat_value(input.cheat);
                 if original_val == cheat_val {
                     // No actual cheat — the chosen replacement value
                     // happens to equal what was already there. Fingerprints
@@ -208,14 +232,21 @@ fn run_path(input: &Input, fes: &[Fp], apply_cheat: bool) -> Option<Fingerprint>
                     return Ok(());
                 }
                 let cheated = match input.cheat {
-                    CheatFlavor::Alloc(_) | CheatFlavor::Special(_) => Element::alloc(
-                        dr,
-                        allocator,
-                        witness.as_ref().map(|_| cheat_val),
-                    )?,
+                    CheatFlavor::Alloc(_) | CheatFlavor::Special(_) => {
+                        Element::alloc(dr, allocator, witness.as_ref().map(|_| cheat_val))?
+                    }
                     CheatFlavor::Constant(_) => Element::constant(dr, cheat_val),
                 };
                 elems[target] = cheated;
+            }
+
+            if let Some(plan) = patch_plan {
+                for &(slot, value) in plan.replacements.get(i).into_iter().flatten() {
+                    if slot < elems.len() {
+                        elems[slot] =
+                            Element::alloc(dr, allocator, witness.as_ref().map(|_| value))?;
+                    }
+                }
             }
 
             let elen = elems.len();
@@ -282,11 +313,8 @@ fn run_path(input: &Input, fes: &[Fp], apply_cheat: bool) -> Option<Fingerprint>
                 }
                 Op::Fold(a, b, s) => {
                     let (a, b) = (a as usize % elen, b as usize % elen);
-                    let scale = Element::alloc(
-                        dr,
-                        allocator,
-                        witness.as_ref().map(|_| Fp::from(s)),
-                    )?;
+                    let scale =
+                        Element::alloc(dr, allocator, witness.as_ref().map(|_| Fp::from(s)))?;
                     if let Ok(r) = Element::fold(dr, [&elems[a], &elems[b]], &scale) {
                         elems.push(r);
                     }
@@ -303,28 +331,21 @@ fn run_path(input: &Input, fes: &[Fp], apply_cheat: bool) -> Option<Fingerprint>
                 Op::AllocRaw(bytes) => {
                     let v: Option<Fp> = Fp::from_repr(bytes).into();
                     if let Some(fp) = v {
-                        if let Ok(r) =
-                            Element::alloc(dr, allocator, witness.as_ref().map(|_| fp))
-                        {
+                        if let Ok(r) = Element::alloc(dr, allocator, witness.as_ref().map(|_| fp)) {
                             elems.push(r);
                         }
                     }
                 }
                 Op::AllocSquare(v) => {
-                    if let Ok((root, sq)) = Element::alloc_square(
-                        dr,
-                        witness.as_ref().map(|_| Fp::from(v)),
-                    ) {
+                    if let Ok((root, sq)) =
+                        Element::alloc_square(dr, witness.as_ref().map(|_| Fp::from(v)))
+                    {
                         elems.push(root);
                         elems.push(sq);
                     }
                 }
                 Op::BoolAlloc(v) => {
-                    if let Ok(b) = Boolean::alloc(
-                        dr,
-                        allocator,
-                        witness.as_ref().map(|_| v),
-                    ) {
+                    if let Ok(b) = Boolean::alloc(dr, allocator, witness.as_ref().map(|_| v)) {
                         bools.push(b);
                     }
                 }
@@ -347,9 +368,7 @@ fn run_path(input: &Input, fes: &[Fp], apply_cheat: bool) -> Option<Fingerprint>
                     if blen > 0 {
                         let cond = cond as usize % blen;
                         let (a, b) = (a as usize % elen, b as usize % elen);
-                        if let Ok(r) = bools[cond].conditional_select(
-                            dr, &elems[a], &elems[b],
-                        ) {
+                        if let Ok(r) = bools[cond].conditional_select(dr, &elems[a], &elems[b]) {
                             elems.push(r);
                         }
                     }
@@ -428,11 +447,18 @@ fn op_reads_target(op: &Op, target: usize, elens: usize) -> bool {
     }
     let resolves = |a: u8| (a as usize) % elens == target;
     match op {
-        Op::Add(a, b) | Op::Sub(a, b) | Op::Mul(a, b) | Op::DivNonzero(a, b)
+        Op::Add(a, b)
+        | Op::Sub(a, b)
+        | Op::Mul(a, b)
+        | Op::DivNonzero(a, b)
         | Op::Fold(a, b, _) => resolves(*a) || resolves(*b),
         Op::ConditionalSelect(_, a, b) => resolves(*a) || resolves(*b),
-        Op::Scale(a, _) | Op::Square(a) | Op::Double(a) | Op::Negate(a)
-        | Op::Invert(a) | Op::IsZero(a) => resolves(*a),
+        Op::Scale(a, _)
+        | Op::Square(a)
+        | Op::Double(a)
+        | Op::Negate(a)
+        | Op::Invert(a)
+        | Op::IsZero(a) => resolves(*a),
         _ => false,
     }
 }
@@ -617,28 +643,73 @@ fuzz_target!(|input: Input| {
     }
 
     let fes = build_seeds(&input);
+    let patch_ops: Vec<PatchOp> = input.ops.iter().map(patch_op).collect();
+    let patch_plan = match build_patch_plan(
+        &fes,
+        &patch_ops,
+        input.cheat_at as usize,
+        input.target_idx,
+        cheat_value(input.cheat),
+    ) {
+        Some(plan) if plan.repaired_ops > 0 && plan.observable_len() > 0 => plan,
+        _ => return,
+    };
 
-    let honest = match run_path(&input, &fes, false) {
+    let honest = match run_path(&input, &fes, false, None) {
         Some(f) => f,
         None => return,
     };
-    let cheated = match run_path(&input, &fes, true) {
+    let unpatched_cheat = match run_path(&input, &fes, true, None) {
         Some(f) => f,
         None => return,
     };
+    let patched = match run_path(&input, &fes, true, Some(&patch_plan)) {
+        Some(f) => f,
+        None => return,
+    };
+    if patched != patch_plan.final_fingerprint() {
+        return;
+    }
 
-    // Soundness signal: cheat path accepted by Simulator AND its final
-    // state is observationally identical to the honest run.
+    if honest.0.len() != patch_plan.exclude_elems.len()
+        || honest.1.len() != patch_plan.exclude_bools.len()
+        || patched.0.len() != patch_plan.exclude_elems.len()
+        || patched.1.len() != patch_plan.exclude_bools.len()
+    {
+        return;
+    }
+
+    let honest_observable = patch_plan.observable_fingerprint(&honest);
+    let patched_observable = patch_plan.observable_fingerprint(&patched);
+
+    // Soundness signal: the normal cheat path is accepted by Simulator,
+    // the patcher found at least one downstream repair, and the patched
+    // invalid witness remains observationally identical to the honest
+    // witness after excluding directly patched support slots.
     assert!(
-        honest != cheated,
+        honest_observable != patched_observable,
         "soundness signal: cheat at op[{}] target {} flavor {:?} \
-         did not perturb the final state; \
-         every downstream constraint and observation was insensitive to \
-         the swap. Suspect an under-constrained gadget. \
+         accepted after {} downstream patch repair(s); \
+         observable fingerprint matched the honest run after excluding \
+         {} patched element slot(s) and {} patched boolean slot(s). \
+         Unpatched cheat changed final state: {}. \
+         Suspect an under-constrained gadget or an insufficient oracle. \
          Input: {:?}",
         input.cheat_at,
         input.target_idx,
         input.cheat,
+        patch_plan.repaired_ops,
+        patch_plan
+            .exclude_elems
+            .iter()
+            .filter(|exclude| **exclude)
+            .count(),
+        patch_plan
+            .exclude_bools
+            .iter()
+            .filter(|exclude| **exclude)
+            .count(),
+        honest != unpatched_cheat,
         input,
     );
 });

--- a/qa/fuzz/src/lib.rs
+++ b/qa/fuzz/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod patcher;

--- a/qa/fuzz/src/patcher.rs
+++ b/qa/fuzz/src/patcher.rs
@@ -56,6 +56,14 @@ impl PatchPlan {
                 .filter(|exclude| !**exclude)
                 .count()
     }
+
+    pub fn observable_elem_indices(&self) -> Vec<usize> {
+        self.exclude_elems
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, exclude)| (!exclude).then_some(idx))
+            .collect()
+    }
 }
 
 pub fn observable_fingerprint(
@@ -656,5 +664,19 @@ mod tests {
         let ops = [PatchOp::Square(0)];
 
         assert_eq!(build_patch_plan(&seeds, &ops, 0, 0, Fp::from(2)), None);
+    }
+
+    #[test]
+    fn reports_observable_element_slots() {
+        let plan = PatchPlan {
+            final_elems: vec![Fp::from(1), Fp::from(2), Fp::from(3)],
+            final_bools: vec![true],
+            exclude_elems: vec![true, false, false],
+            exclude_bools: vec![false],
+            replacements: Vec::new(),
+            repaired_ops: 0,
+        };
+
+        assert_eq!(plan.observable_elem_indices(), vec![1, 2]);
     }
 }

--- a/qa/fuzz/src/patcher.rs
+++ b/qa/fuzz/src/patcher.rs
@@ -1,0 +1,660 @@
+use ff::{Field, PrimeField};
+use pasta_curves::Fp;
+
+pub type PatchFingerprint = (Vec<Fp>, Vec<bool>);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PatchOp {
+    Add(u8, u8),
+    Sub(u8, u8),
+    Mul(u8, u8),
+    Square(u8),
+    Double(u8),
+    Negate(u8),
+    Invert(u8),
+    IsZero(u8),
+    DivNonzero(u8, u8),
+    Scale(u8, Fp),
+    Fold(u8, u8, Fp),
+    AllocConst(Fp),
+    AllocWitness(Fp),
+    AllocSquare(Fp),
+    AllocRaw(Option<Fp>),
+    BoolAlloc(bool),
+    BoolNot(u8),
+    BoolAnd(u8, u8),
+    ConditionalSelect(u8, u8, u8),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PatchPlan {
+    pub final_elems: Vec<Fp>,
+    pub final_bools: Vec<bool>,
+    pub exclude_elems: Vec<bool>,
+    pub exclude_bools: Vec<bool>,
+    pub replacements: Vec<Vec<(usize, Fp)>>,
+    pub repaired_ops: usize,
+}
+
+impl PatchPlan {
+    pub fn final_fingerprint(&self) -> PatchFingerprint {
+        (self.final_elems.clone(), self.final_bools.clone())
+    }
+
+    pub fn observable_fingerprint(&self, fingerprint: &PatchFingerprint) -> PatchFingerprint {
+        observable_fingerprint(fingerprint, &self.exclude_elems, &self.exclude_bools)
+    }
+
+    pub fn observable_len(&self) -> usize {
+        self.exclude_elems
+            .iter()
+            .filter(|exclude| !**exclude)
+            .count()
+            + self
+                .exclude_bools
+                .iter()
+                .filter(|exclude| !**exclude)
+                .count()
+    }
+}
+
+pub fn observable_fingerprint(
+    fingerprint: &PatchFingerprint,
+    exclude_elems: &[bool],
+    exclude_bools: &[bool],
+) -> PatchFingerprint {
+    let elems = fingerprint
+        .0
+        .iter()
+        .zip(exclude_elems)
+        .filter_map(|(value, exclude)| (!exclude).then_some(*value))
+        .collect();
+    let bools = fingerprint
+        .1
+        .iter()
+        .zip(exclude_bools)
+        .filter_map(|(value, exclude)| (!exclude).then_some(*value))
+        .collect();
+    (elems, bools)
+}
+
+pub fn build_patch_plan(
+    seeds: &[Fp],
+    ops: &[PatchOp],
+    cheat_at: usize,
+    target_idx: u8,
+    cheat_value: Fp,
+) -> Option<PatchPlan> {
+    if seeds.is_empty() || cheat_at >= ops.len() {
+        return None;
+    }
+
+    let mut honest = PatchState::new(seeds);
+    let mut honest_pre_states = Vec::with_capacity(ops.len());
+    for op in ops {
+        honest_pre_states.push(honest.snapshot());
+        let effect = eval_effect(op, &honest.elems, &honest.bools);
+        honest.apply(effect);
+    }
+
+    let mut patched = PatchState::new(seeds);
+    let mut replacements = vec![Vec::new(); ops.len()];
+    let mut repaired_ops = 0usize;
+    let mut direct_target = None;
+    let mut patchable_from = usize::MAX;
+
+    for (op_idx, op) in ops.iter().enumerate() {
+        if patched.elems.is_empty() {
+            return None;
+        }
+
+        if op_idx == cheat_at {
+            let target = (target_idx as usize) % patched.elems.len().min(64);
+            if patched.elems[target] == cheat_value {
+                return None;
+            }
+            patched.elems[target] = cheat_value;
+            patched.exclude_elems[target] = true;
+            direct_target = Some(target);
+            patchable_from = patched.elems.len();
+        }
+
+        if let Some(target) = direct_target {
+            let (honest_elems, honest_bools) = &honest_pre_states[op_idx];
+            if repair_op(
+                op,
+                honest_elems,
+                honest_bools,
+                &mut patched,
+                target,
+                patchable_from,
+                &mut replacements[op_idx],
+            ) {
+                repaired_ops += 1;
+            }
+        }
+
+        let effect = eval_effect(op, &patched.elems, &patched.bools);
+        if patched.apply(effect) && direct_target.is_some() {
+            patchable_from = patchable_from.min(64);
+        }
+    }
+
+    Some(PatchPlan {
+        final_elems: patched.elems,
+        final_bools: patched.bools,
+        exclude_elems: patched.exclude_elems,
+        exclude_bools: patched.exclude_bools,
+        replacements,
+        repaired_ops,
+    })
+}
+
+#[derive(Clone, Debug)]
+struct PatchState {
+    elems: Vec<Fp>,
+    bools: Vec<bool>,
+    exclude_elems: Vec<bool>,
+    exclude_bools: Vec<bool>,
+}
+
+impl PatchState {
+    fn new(seeds: &[Fp]) -> Self {
+        Self {
+            elems: seeds.to_vec(),
+            bools: Vec::new(),
+            exclude_elems: vec![false; seeds.len()],
+            exclude_bools: Vec::new(),
+        }
+    }
+
+    fn snapshot(&self) -> (Vec<Fp>, Vec<bool>) {
+        (self.elems.clone(), self.bools.clone())
+    }
+
+    fn apply(&mut self, effect: PatchEffect) -> bool {
+        self.elems.extend(effect.elems);
+        self.exclude_elems.extend(core::iter::repeat_n(
+            false,
+            self.elems.len() - self.exclude_elems.len(),
+        ));
+        self.bools.extend(effect.bools);
+        self.exclude_bools.extend(core::iter::repeat_n(
+            false,
+            self.bools.len() - self.exclude_bools.len(),
+        ));
+
+        let mut truncated = false;
+        if self.elems.len() > 128 {
+            self.elems.truncate(64);
+            self.exclude_elems.truncate(64);
+            truncated = true;
+        }
+        if self.bools.len() > 64 {
+            self.bools.truncate(32);
+            self.exclude_bools.truncate(32);
+        }
+
+        truncated
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct PatchEffect {
+    elems: Vec<Fp>,
+    bools: Vec<bool>,
+}
+
+fn elem_index(raw: u8, len: usize) -> usize {
+    raw as usize % len
+}
+
+fn bool_index(raw: u8, len: usize) -> usize {
+    raw as usize % len
+}
+
+fn eval_effect(op: &PatchOp, elems: &[Fp], bools: &[bool]) -> PatchEffect {
+    if elems.is_empty() {
+        return PatchEffect::default();
+    }
+
+    let mut effect = PatchEffect::default();
+    match *op {
+        PatchOp::Add(a, b) => {
+            let (a, b) = (elem_index(a, elems.len()), elem_index(b, elems.len()));
+            effect.elems.push(elems[a] + elems[b]);
+        }
+        PatchOp::Sub(a, b) => {
+            let (a, b) = (elem_index(a, elems.len()), elem_index(b, elems.len()));
+            effect.elems.push(elems[a] - elems[b]);
+        }
+        PatchOp::Mul(a, b) => {
+            let (a, b) = (elem_index(a, elems.len()), elem_index(b, elems.len()));
+            effect.elems.push(elems[a] * elems[b]);
+        }
+        PatchOp::Square(a) => {
+            let a = elem_index(a, elems.len());
+            effect.elems.push(elems[a].square());
+        }
+        PatchOp::Double(a) => {
+            let a = elem_index(a, elems.len());
+            effect.elems.push(elems[a].double());
+        }
+        PatchOp::Negate(a) => {
+            let a = elem_index(a, elems.len());
+            effect.elems.push(-elems[a]);
+        }
+        PatchOp::Invert(a) => {
+            let a = elem_index(a, elems.len());
+            if let Some(inv) = elems[a].invert().into_option() {
+                effect.elems.push(inv);
+            }
+        }
+        PatchOp::IsZero(a) => {
+            let a = elem_index(a, elems.len());
+            effect.bools.push(elems[a] == Fp::ZERO);
+        }
+        PatchOp::DivNonzero(a, b) => {
+            let (a, b) = (elem_index(a, elems.len()), elem_index(b, elems.len()));
+            if let Some(b_inv) = elems[b].invert().into_option() {
+                effect.elems.push(elems[a] * b_inv);
+            }
+        }
+        PatchOp::Scale(a, c) => {
+            let a = elem_index(a, elems.len());
+            effect.elems.push(elems[a] * c);
+        }
+        PatchOp::Fold(a, b, s) => {
+            let (a, b) = (elem_index(a, elems.len()), elem_index(b, elems.len()));
+            effect.elems.push(elems[a] * s + elems[b]);
+        }
+        PatchOp::AllocConst(v) | PatchOp::AllocWitness(v) => {
+            effect.elems.push(v);
+        }
+        PatchOp::AllocSquare(v) => {
+            effect.elems.push(v);
+            effect.elems.push(v.square());
+        }
+        PatchOp::AllocRaw(v) => {
+            if let Some(v) = v {
+                effect.elems.push(v);
+            }
+        }
+        PatchOp::BoolAlloc(v) => {
+            effect.bools.push(v);
+        }
+        PatchOp::BoolNot(a) => {
+            if !bools.is_empty() {
+                let a = bool_index(a, bools.len());
+                effect.bools.push(!bools[a]);
+            }
+        }
+        PatchOp::BoolAnd(a, b) => {
+            if !bools.is_empty() {
+                let (a, b) = (bool_index(a, bools.len()), bool_index(b, bools.len()));
+                effect.bools.push(bools[a] & bools[b]);
+            }
+        }
+        PatchOp::ConditionalSelect(cond, a, b) => {
+            if !bools.is_empty() {
+                let cond = bool_index(cond, bools.len());
+                let (a, b) = (elem_index(a, elems.len()), elem_index(b, elems.len()));
+                effect
+                    .elems
+                    .push(if bools[cond] { elems[b] } else { elems[a] });
+            }
+        }
+    }
+
+    effect
+}
+
+fn repair_op(
+    op: &PatchOp,
+    honest_elems: &[Fp],
+    honest_bools: &[bool],
+    state: &mut PatchState,
+    direct_target: usize,
+    patchable_from: usize,
+    replacements: &mut Vec<(usize, Fp)>,
+) -> bool {
+    let honest_effect = eval_effect(op, honest_elems, honest_bools);
+    let current_effect = eval_effect(op, &state.elems, &state.bools);
+    if current_effect == honest_effect {
+        return false;
+    }
+
+    let Some(&honest_output) = honest_effect.elems.first() else {
+        return repair_bool_op(
+            op,
+            honest_effect.bools.first().copied(),
+            state,
+            direct_target,
+            patchable_from,
+            replacements,
+        );
+    };
+
+    match *op {
+        PatchOp::Add(a, b) => {
+            let (a, b) = (
+                elem_index(a, state.elems.len()),
+                elem_index(b, state.elems.len()),
+            );
+            patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                a,
+                honest_output - state.elems[b],
+            ) || patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                b,
+                honest_output - state.elems[a],
+            )
+        }
+        PatchOp::Sub(a, b) => {
+            let (a, b) = (
+                elem_index(a, state.elems.len()),
+                elem_index(b, state.elems.len()),
+            );
+            patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                a,
+                honest_output + state.elems[b],
+            ) || patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                b,
+                state.elems[a] - honest_output,
+            )
+        }
+        PatchOp::Mul(a, b) => {
+            let (a, b) = (
+                elem_index(a, state.elems.len()),
+                elem_index(b, state.elems.len()),
+            );
+            if let Some(b_inv) = state.elems[b].invert().into_option() {
+                if patch_elem(
+                    state,
+                    direct_target,
+                    patchable_from,
+                    replacements,
+                    a,
+                    honest_output * b_inv,
+                ) {
+                    return true;
+                }
+            }
+            if let Some(a_inv) = state.elems[a].invert().into_option() {
+                if patch_elem(
+                    state,
+                    direct_target,
+                    patchable_from,
+                    replacements,
+                    b,
+                    honest_output * a_inv,
+                ) {
+                    return true;
+                }
+            }
+            false
+        }
+        PatchOp::Square(a) => {
+            let a = elem_index(a, state.elems.len());
+            patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                a,
+                honest_elems[a],
+            )
+        }
+        PatchOp::Double(a) => {
+            let a = elem_index(a, state.elems.len());
+            patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                a,
+                honest_output * Fp::TWO_INV,
+            )
+        }
+        PatchOp::Negate(a) => {
+            let a = elem_index(a, state.elems.len());
+            patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                a,
+                -honest_output,
+            )
+        }
+        PatchOp::Invert(a) => {
+            let a = elem_index(a, state.elems.len());
+            honest_output.invert().into_option().is_some_and(|input| {
+                patch_elem(state, direct_target, patchable_from, replacements, a, input)
+            })
+        }
+        PatchOp::DivNonzero(a, b) => {
+            let (a, b) = (
+                elem_index(a, state.elems.len()),
+                elem_index(b, state.elems.len()),
+            );
+            if state.elems[b] != Fp::ZERO
+                && patch_elem(
+                    state,
+                    direct_target,
+                    patchable_from,
+                    replacements,
+                    a,
+                    honest_output * state.elems[b],
+                )
+            {
+                return true;
+            }
+            if let Some(out_inv) = honest_output.invert().into_option() {
+                if patch_elem(
+                    state,
+                    direct_target,
+                    patchable_from,
+                    replacements,
+                    b,
+                    state.elems[a] * out_inv,
+                ) {
+                    return true;
+                }
+            }
+            false
+        }
+        PatchOp::Scale(a, c) => {
+            let a = elem_index(a, state.elems.len());
+            c.invert().into_option().is_some_and(|c_inv| {
+                patch_elem(
+                    state,
+                    direct_target,
+                    patchable_from,
+                    replacements,
+                    a,
+                    honest_output * c_inv,
+                )
+            })
+        }
+        PatchOp::Fold(a, b, s) => {
+            let (a, b) = (
+                elem_index(a, state.elems.len()),
+                elem_index(b, state.elems.len()),
+            );
+            if let Some(s_inv) = s.invert().into_option() {
+                if patch_elem(
+                    state,
+                    direct_target,
+                    patchable_from,
+                    replacements,
+                    a,
+                    (honest_output - state.elems[b]) * s_inv,
+                ) {
+                    return true;
+                }
+            }
+            patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                b,
+                honest_output - state.elems[a] * s,
+            )
+        }
+        PatchOp::ConditionalSelect(cond, a, b) => {
+            if state.bools.is_empty() {
+                return false;
+            }
+            let cond = bool_index(cond, state.bools.len());
+            let selected = if state.bools[cond] { b } else { a };
+            let selected = elem_index(selected, state.elems.len());
+            patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                selected,
+                honest_output,
+            )
+        }
+        _ => false,
+    }
+}
+
+fn repair_bool_op(
+    op: &PatchOp,
+    honest_output: Option<bool>,
+    state: &mut PatchState,
+    direct_target: usize,
+    patchable_from: usize,
+    replacements: &mut Vec<(usize, Fp)>,
+) -> bool {
+    let Some(honest_output) = honest_output else {
+        return false;
+    };
+
+    match *op {
+        PatchOp::IsZero(a) => {
+            let a = elem_index(a, state.elems.len());
+            let replacement = if honest_output { Fp::ZERO } else { Fp::ONE };
+            patch_elem(
+                state,
+                direct_target,
+                patchable_from,
+                replacements,
+                a,
+                replacement,
+            )
+        }
+        _ => false,
+    }
+}
+
+fn patch_elem(
+    state: &mut PatchState,
+    direct_target: usize,
+    patchable_from: usize,
+    replacements: &mut Vec<(usize, Fp)>,
+    slot: usize,
+    value: Fp,
+) -> bool {
+    if slot == direct_target || slot < patchable_from {
+        return false;
+    }
+
+    state.elems[slot] = value;
+    state.exclude_elems[slot] = true;
+    replacements.push((slot, value));
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn visible(values: &[Fp], exclude: &[bool]) -> Vec<Fp> {
+        values
+            .iter()
+            .zip(exclude)
+            .filter_map(|(value, exclude)| (!exclude).then_some(*value))
+            .collect()
+    }
+
+    #[test]
+    fn repairs_mul_by_patching_downstream_sibling_and_preserves_output() {
+        let seeds = [Fp::from(2), Fp::from(3)];
+        let ops = [PatchOp::Add(0, 1), PatchOp::Mul(0, 2)];
+
+        let plan = build_patch_plan(&seeds, &ops, 0, 0, Fp::from(5))
+            .expect("non-degenerate cheat should produce a patch plan");
+
+        assert_eq!(plan.repaired_ops, 1);
+        assert_eq!(plan.final_elems[0], Fp::from(5));
+        assert_eq!(plan.final_elems[1], Fp::from(3));
+        assert_eq!(plan.final_elems[2] * Fp::from(5), Fp::from(10));
+        assert_eq!(plan.final_elems[3], Fp::from(10));
+        assert_eq!(plan.exclude_elems, vec![true, false, true, false]);
+        assert_eq!(
+            visible(&plan.final_elems, &plan.exclude_elems),
+            vec![Fp::from(3), Fp::from(10)]
+        );
+    }
+
+    #[test]
+    fn does_not_repair_by_patching_preexisting_sibling() {
+        let seeds = [Fp::from(2), Fp::from(3)];
+        let ops = [PatchOp::Mul(0, 1)];
+
+        let plan = build_patch_plan(&seeds, &ops, 0, 0, Fp::from(5))
+            .expect("non-degenerate cheat should produce a patch plan");
+
+        assert_eq!(plan.repaired_ops, 0);
+        assert_eq!(
+            plan.final_elems,
+            vec![Fp::from(5), Fp::from(3), Fp::from(15)]
+        );
+        assert_eq!(plan.exclude_elems, vec![true, false, false]);
+    }
+
+    #[test]
+    fn propagates_when_no_repair_is_available_for_direct_square() {
+        let seeds = [Fp::from(2)];
+        let ops = [PatchOp::Square(0)];
+
+        let plan = build_patch_plan(&seeds, &ops, 0, 0, Fp::from(3))
+            .expect("non-degenerate cheat should produce a patch plan");
+
+        assert_eq!(plan.repaired_ops, 0);
+        assert_eq!(plan.final_elems, vec![Fp::from(3), Fp::from(9)]);
+        assert_eq!(plan.exclude_elems, vec![true, false]);
+        assert_eq!(
+            visible(&plan.final_elems, &plan.exclude_elems),
+            vec![Fp::from(9)]
+        );
+    }
+
+    #[test]
+    fn rejects_noop_cheat() {
+        let seeds = [Fp::from(2)];
+        let ops = [PatchOp::Square(0)];
+
+        assert_eq!(build_patch_plan(&seeds, &ops, 0, 0, Fp::from(2)), None);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `fuzz_circuit_patcher`, a fuzz-local dummy `Circuit` target that reuses the #737 op-stream patcher policy but checks a selected public output element instead of the whole final stack.
- Keep the circuit-boundary experiment entirely under `qa/fuzz`; no production crate driver hooks or public API changes.
- Add a small `PatchPlan::observable_elem_indices()` helper so fuzz targets can select observable public-output slots directly.

Stacked on #737. The intended review delta for this follow-up is the second commit, `Add fuzz-local circuit patcher target`.

Addresses the follow-up from #737 review discussion.

## Test Plan
- `cargo test --manifest-path qa/fuzz/Cargo.toml patcher`
- `cargo check --manifest-path qa/fuzz/Cargo.toml --bin fuzz_circuit_patcher`
- `cargo check --manifest-path qa/fuzz/Cargo.toml --bins`
- `rustfmt --edition 2024 --check qa/fuzz/src/lib.rs qa/fuzz/src/patcher.rs qa/fuzz/fuzz_targets/fuzz_witness_cheat.rs qa/fuzz/fuzz_targets/fuzz_circuit_patcher.rs`
- `git diff --check`
