### PR TITLE
perf: hoist duplicate x_inv exponentiation in sx/sxy routine entry

### DIFF
--- a/crates/ragu_circuits/src/wiring/sx.rs
+++ b/crates/ragu_circuits/src/wiring/sx.rs
@@ -277,10 +277,12 @@ impl<'dr, F: Field, R: Rank> Driver<'dr> for Evaluator<'_, F, R> {
 
         // Jump to this routine's absolute position in the polynomial;
         // see "Polynomial Encoding and Scope Jumps" in the `s` module doc.
+        let x_pow = self.x.pow_vartime([seg.gate_start as u64]);
+        let x_inv_pow = self.x_inv.pow_vartime([seg.gate_start as u64]);
         let init_scope = SxScope {
-            current_a_x: self.base_a_x * self.x.pow_vartime([seg.gate_start as u64]),
-            current_b_x: self.base_b_x * self.x_inv.pow_vartime([seg.gate_start as u64]),
-            current_c_x: self.base_c_x * self.x_inv.pow_vartime([seg.gate_start as u64]),
+            current_a_x: self.base_a_x * x_pow,
+            current_b_x: self.base_b_x * x_inv_pow,
+            current_c_x: self.base_c_x * x_inv_pow,
             gates: seg.gate_start,
             constraints: seg.constraint_start,
         };

--- a/crates/ragu_circuits/src/wiring/sxy.rs
+++ b/crates/ragu_circuits/src/wiring/sxy.rs
@@ -249,10 +249,12 @@ impl<'dr, F: Field, R: Rank> Driver<'dr> for Evaluator<'_, F, R> {
 
         // Jump to this routine's absolute position in the polynomial;
         // see "Polynomial Encoding and Scope Jumps" in the `s` module doc.
+        let x_pow = self.x.pow_vartime([gate_start as u64]);
+        let x_inv_pow = self.x_inv.pow_vartime([gate_start as u64]);
         let init_scope = SxyScope {
-            current_a_x: self.base_a_x * self.x.pow_vartime([gate_start as u64]),
-            current_b_x: self.base_b_x * self.x_inv.pow_vartime([gate_start as u64]),
-            current_c_x: self.base_c_x * self.x_inv.pow_vartime([gate_start as u64]),
+            current_a_x: self.base_a_x * x_pow,
+            current_b_x: self.base_b_x * x_inv_pow,
+            current_c_x: self.base_c_x * x_inv_pow,
             gates: gate_start,
             constraints: constraint_start,
             result: F::ZERO,


### PR DESCRIPTION
hoist duplicate inverse gate-offset powers in `sx`/`sxy`.
both evaluators computed:
  ```rust
  self.x_inv.pow_vartime([gate_start as u64])
```
twice per routine entry, once for `current_b_x` and once for `current_c_x`. since the base and exponent are identical, this now computes the value once as `x_inv_pow` and reuses it.

basically reduces routine-boundary exponentiation work from 3 `pow_vartime` calls to 2 in each evaluator, with no behavioral change.