### PR TITLE
chore: audit finding cleanups

### DIFF
--- a/book/src/protocol/core/accumulation/wiring.md
+++ b/book/src/protocol/core/accumulation/wiring.md
@@ -77,7 +77,9 @@ m(W, X, Y) = \sum_{i=0}^{2^k-1} \ell_i(W) \cdot s_i(X, Y)
 $$
 
 where $\ell_i(W)$ is the Lagrange basis polynomials and $2^k$ is the domain size
-(namely total number of registered circuits in the registry).
+(the smallest power of two that fits all registered circuits; any unregistered
+domain points contribute the [zero wiring polynomial](../../extensions/registry.md#unregistered-domain-points),
+so the sum is unchanged).
 The $i$-th circuit is $s_i(X,Y)=m(\omega^i, X, Y)$ where $\omega$ is a $2^k$-th
 primitive root of unity that generates the entire Lagrange domain[^simplify].
 

--- a/book/src/protocol/core/accumulation/wiring.md
+++ b/book/src/protocol/core/accumulation/wiring.md
@@ -76,7 +76,9 @@ m(W, X, Y) = \sum_{i=0}^{2^k-1} \ell_i(W) \cdot s_i(X, Y)
 $$
 
 where $\ell_i(W)$ is the Lagrange basis polynomials and $2^k$ is the domain size
-(namely total number of registered circuits in the registry).
+(the smallest power of two that fits all registered circuits; any unregistered
+domain points contribute the [zero wiring polynomial](../../extensions/registry.md#unregistered-domain-points),
+so the sum is unchanged).
 The $i$-th circuit is $s_i(X,Y)=m(\omega^i, X, Y)$ where $\omega$ is a $2^k$-th
 primitive root of unity that generates the entire Lagrange domain[^simplify].
 

--- a/book/src/protocol/core/accumulation/wiring.md
+++ b/book/src/protocol/core/accumulation/wiring.md
@@ -76,7 +76,7 @@ m(W, X, Y) = \sum_{i=0}^{2^k-1} \ell_i(W) \cdot s_i(X, Y)
 $$
 
 where $\ell_i(W)$ is the Lagrange basis polynomials and $2^k$ is the domain size
-(the smallest power of two that fits all registered circuits; any unregistered
+(the smallest power of two that accommodates all registered circuits; any unregistered
 domain points contribute the [zero wiring polynomial](../../extensions/registry.md#unregistered-domain-points),
 so the sum is unchanged).
 The $i$-th circuit is $s_i(X,Y)=m(\omega^i, X, Y)$ where $\omega$ is a $2^k$-th

--- a/book/src/protocol/extensions/registry.md
+++ b/book/src/protocol/extensions/registry.md
@@ -177,3 +177,29 @@ circuits $C$. This enables incremental circuit registration during
 compilation, where each circuit independently computes its domain
 point, and the registry is finalized only after all circuits are
 known.
+
+## Unregistered Domain Points
+
+The domain size $2^k$ is the smallest power of two that holds all $C$
+registered circuits, so whenever $C$ is not itself a power of two the
+domain has $2^k - C$ points with no circuit assigned to them. These
+points are not invalid: the registry interpolates the value $0$ at
+every unassigned domain point, so each one indexes the **zero wiring
+polynomial**. Every domain point is thus a wiring polynomial — a
+registered circuit's $s_i(X, Y)$ where a circuit was assigned, and the
+zero polynomial everywhere else.
+
+The zero polynomial is a degenerate but well-formed wiring polynomial.
+Because it encodes no constraints — in particular no `ONE` constraint
+against $\v{k}_0$ — it has $s(X, 0) = 0$, exactly the property that
+distinguishes a [bonding polynomial](../local/wiring.md#bonding-polynomials)
+from a circuit wiring polynomial, which has $s(X, 0) = 1$. A verifier
+that expects a circuit fixes $\v{k}_0 = 1$, so the zero polynomial can
+never satisfy a circuit claim: an unregistered domain point cannot
+stand in for a registered circuit.
+
+This is why selecting a circuit by domain membership alone is safe. A
+circuit index that lands on an unassigned point is still in the domain,
+but it selects the harmless zero polynomial rather than escaping the
+domain — there is no "out of bounds" index to guard against, only the
+inert zero wiring polynomial.

--- a/book/src/protocol/extensions/registry.md
+++ b/book/src/protocol/extensions/registry.md
@@ -180,26 +180,32 @@ known.
 
 ## Unregistered Domain Points
 
-The domain size $2^k$ is the smallest power of two that holds all $C$
-registered circuits, so whenever $C$ is not itself a power of two the
-domain has $2^k - C$ points with no circuit assigned to them. These
-points are not invalid: the registry interpolates the value $0$ at
-every unassigned domain point, so each one indexes the **zero wiring
-polynomial**. Every domain point is thus a wiring polynomial — a
-registered circuit's $s_i(X, Y)$ where a circuit was assigned, and the
-zero polynomial everywhere else.
+Every point of the $2^k$ domain carries a wiring polynomial. Most carry
+one that was explicitly registered — a circuit, or one of the
+[bonding polynomials](../local/wiring.md#bonding-polynomials) Ragu
+registers alongside them — but $2^k$ is the smallest power of two that
+accommodates all of them, so unless that count is itself a power of two
+some domain points are left unassigned. Those points are not invalid:
+the registry interpolates the value $0$ at each of them, so each one
+carries the zero polynomial.
 
-The zero polynomial is a degenerate but well-formed wiring polynomial.
-Because it encodes no constraints — in particular no `ONE` constraint
-against $\v{k}_0$ — it has $s(X, 0) = 0$, exactly the property that
-distinguishes a [bonding polynomial](../local/wiring.md#bonding-polynomials)
-from a circuit wiring polynomial, which has $s(X, 0) = 1$. A verifier
-that expects a circuit fixes $\v{k}_0 = 1$, so the zero polynomial can
-never satisfy a circuit claim: an unregistered domain point cannot
-stand in for a registered circuit.
+The zero polynomial is not a special case. A bonding polynomial is
+precisely a wiring polynomial that omits the $0$th constraint against
+$\v{k}_0$, giving $s(X, 0) = 0$, and the zero polynomial satisfies that
+definition trivially. Unassigned domain points therefore carry bonding
+polynomials, and the domain holds just two kinds of wiring polynomial,
+told apart by $s(X, 0)$:
 
-This is why selecting a circuit by domain membership alone is safe. A
-circuit index that lands on an unassigned point is still in the domain,
-but it selects the harmless zero polynomial rather than escaping the
-domain — there is no "out of bounds" index to guard against, only the
-inert zero wiring polynomial.
+| $s(X, 0)$ | kind | occupies |
+|-----------|------|----------|
+| $1$ | circuit wiring polynomial | a point with a registered circuit |
+| $0$ | bonding polynomial | a point with a registered bonding polynomial, or any unassigned point |
+
+This is what makes it safe to let an adversary choose a domain point
+arbitrarily. A verifier that expects a circuit fixes $\v{k}_0 = 1$, and
+no bonding polynomial can satisfy such a claim — so wherever an
+arbitrary choice from the domain is permitted, that choice is already
+confined to the registered circuits by construction. Registered bonding
+polynomials and unassigned points are excluded by the same mechanism,
+and neither needs its own bounds check: within the domain there is no
+"out of bounds" index to guard against.

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -10,6 +10,45 @@
 //! s_i(X, Y)$ for some $\omega \in \mathbb{F}$ of sufficiently high $2^k$ order
 //! to encode all circuits for both PCD and for application circuits.
 //!
+//! ## Every domain point is a wiring polynomial
+//!
+//! The interpolation domain is padded to a power of two, so it usually has more
+//! points than there are explicitly registered circuits. Rather than treat the
+//! surplus points as "out of bounds", the registry treats *every* domain point
+//! as indexing a wiring polynomial: an explicitly registered circuit at
+//! $\omega^i$ contributes its $s_i(X, Y)$, and every other domain point is
+//! *implicitly registered to the zero wiring polynomial* (the interpolation is
+//! zero there). A [`CircuitIndex`] is therefore never out of bounds within the
+//! domain — if its $\omega^j$ is in the domain, it selects a wiring polynomial.
+//!
+//! The zero wiring polynomial is a genuine wiring polynomial, but because it has
+//! $s(X, 0) = 0$ it is bonding-shaped and cannot satisfy a circuit revdot claim
+//! (which fixes $k_0 = 1$). See [`BondingObject`] for how this $s(X, 0)$
+//! distinction keeps one wiring polynomial from standing in for another.
+//!
+//! Two properties of an index — whether its $\omega^j$ is in the domain, and
+//! whether a circuit is explicitly registered there — fix which wiring
+//! polynomial it selects. A registered circuit is always in the domain, so only
+//! three combinations occur:
+//!
+//! | in domain? | registered? | wiring polynomial selected   |
+//! | ---------- | ----------- | ---------------------------- |
+//! | yes        | yes         | the circuit's $s_i(X, Y)$    |
+//! | yes        | no          | the zero wiring polynomial   |
+//! | no         | —           | an off-domain interpolation  |
+//!
+//! [`circuit_in_domain`](Registry::circuit_in_domain) reports the first column;
+//! it does *not* distinguish the first two rows (both are in the domain), which
+//! is why it is a domain-membership predicate and not a registration check.
+//!
+//! The third row is just the general behavior of [`at`](Registry::at), which
+//! evaluates $m(W, X, Y)$ at an arbitrary $W$: off the domain there is no stored
+//! value, so $m$ evaluates to the Lagrange interpolation of the domain points
+//! (registered circuits, padding zero). This is the normal case for a random
+//! challenge $W$. Reaching it from a [`CircuitIndex`] requires an index past the
+//! padded domain — its $\omega^j$ then has order exceeding the domain size, so
+//! `circuit_in_domain` returns `false` for it.
+//!
 //! The [`RegistryBuilder`] structure is used to construct a new [`Registry`] by
 //! inserting circuits and performing a [`finalize`](RegistryBuilder::finalize) step
 //! to compile the added circuits into a registry polynomial representation that can
@@ -31,6 +70,10 @@ use crate::{
 };
 
 /// Represents a simple numeric index of a circuit in the registry.
+///
+/// Any value naming a domain point selects a wiring polynomial: the explicitly
+/// registered circuit's $s_i(X, Y)$ if one was registered at that index, or the
+/// zero wiring polynomial otherwise. See the [module overview](crate::registry).
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(transparent)]
 pub struct CircuitIndex(u32);
@@ -314,13 +357,20 @@ pub struct Registry<'params, F: PrimeField, R: Rank> {
 }
 
 /// Cached Lagrange state for a fixed W point.
+///
+/// Selects which wiring polynomial the W point resolves to. The three variants
+/// are the three rows of the resolution matrix in the
+/// [module overview](crate::registry): a registered circuit, the zero wiring
+/// polynomial, or an interpolation.
 enum LagrangeCache<F> {
-    /// Must interpolate across circuits (w not in domain).
+    /// `w` is not a domain point: its wiring polynomial is a Lagrange
+    /// interpolation across the registered circuits.
     Interpolate(Vec<F>),
-    /// Direct circuit lookup (w in domain).
+    /// `w` is a domain point with an explicitly registered circuit at index `i`.
     Direct(usize),
-    /// No circuit at this point.
-    Empty,
+    /// `w` is a domain point with no explicitly registered circuit; its wiring
+    /// polynomial is implicitly the zero polynomial.
+    Zero,
 }
 
 /// A registry bound to a specific W point, with cached Lagrange coefficients.
@@ -373,6 +423,11 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     /// all-zero (the ONE wire at `d[0] = 1` ensures this), but the
     /// predictable ONE slot can cancel in linear combinations of traces;
     /// a random `alpha` at `a[0]` keeps derived polynomials non-zero.
+    ///
+    /// `circuit` indexes the registered circuits directly (for the floor plan)
+    /// and **panics** if it is not a registered index. Unlike the
+    /// polynomial-evaluation methods, this is the registered-`Vec` view; there
+    /// is no implicit zero-polynomial slot here.
     pub fn assemble_with_alpha(
         &self,
         trace: &crate::trace::Trace<F>,
@@ -397,6 +452,12 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     }
 
     /// Returns the constraint counts for the given circuit.
+    ///
+    /// Like [`assemble_with_alpha`](Self::assemble_with_alpha), `circuit`
+    /// indexes the registered circuits directly and **panics** if it is not a
+    /// registered index — the registered-`Vec` view, not the
+    /// every-domain-point-is-a-wiring-polynomial view of
+    /// [`circuit_y`](Self::circuit_y) / [`circuit_xy`](Self::circuit_xy).
     pub fn constraint_counts(&self, circuit: CircuitIndex) -> (usize, usize) {
         self.circuits[usize::from(circuit)].constraint_counts()
     }
@@ -446,8 +507,8 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     /// Wraps [`Registry::at`] and [`RegistryAt::y`].
     /// See [`CircuitIndex::omega_j`] for more details.
     ///
-    /// `i` is not bounds-checked against the registry; an unregistered index
-    /// resolves to an empty or interpolated slot. See
+    /// Every domain point indexes a wiring polynomial; an index with no
+    /// explicitly registered circuit selects the zero wiring polynomial. See
     /// [`circuit_in_domain`](Self::circuit_in_domain).
     pub fn circuit_y(&self, i: CircuitIndex, y: F) -> sparse::Polynomial<F, R> {
         let w: F = i.omega_j();
@@ -458,26 +519,29 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     ///
     /// See [`CircuitIndex::omega_j`] for details on the $\omega^j$ mapping.
     ///
-    /// `i` is not bounds-checked against the registry; see
+    /// As with [`circuit_y`](Self::circuit_y), an index with no explicitly
+    /// registered circuit selects the zero wiring polynomial. See
     /// [`circuit_in_domain`](Self::circuit_in_domain).
     pub fn circuit_xy(&self, i: CircuitIndex, x: F, y: F) -> F {
         self.wxy(i.omega_j(), x, y)
     }
 
-    /// Returns true if the circuit's $\omega^j$ value lies in the registry's
-    /// (power-of-two padded) domain.
+    /// Returns true if this index's $\omega^j$ value lies in the registry's
+    /// domain.
     ///
-    /// This checks **domain membership**, not that a circuit is registered at
-    /// `i`. A non-power-of-two [`num_circuits`](Self::num_circuits) leaves
-    /// padded domain points with no circuit behind them, and `i` landing on one
-    /// of those still returns `true`.
+    /// This reports domain membership. Every domain point is a wiring
+    /// polynomial: indices with an explicitly registered circuit carry that
+    /// circuit's $s_i(X, Y)$; the remaining domain points (present when
+    /// [`num_circuits`](Self::num_circuits) is not a power of two) are implicitly
+    /// the zero wiring polynomial. Both are selected the same way by
+    /// [`circuit_y`](Self::circuit_y) / [`circuit_xy`](Self::circuit_xy), so a
+    /// `true` result means "in domain", not "explicitly registered".
     ///
-    /// Such an index is safe by construction: [`circuit_y`](Self::circuit_y) /
-    /// [`circuit_xy`](Self::circuit_xy) resolve it to an *empty slot* (only the
-    /// registry key term, $s(X, 0) = 0$), which is bonding-shaped and so cannot
-    /// pass a circuit revdot claim that fixes $k_0 = 1$ — see [`BondingObject`].
-    /// An index whose $\omega^j$ falls outside the domain (returns `false`)
-    /// would instead interpolate across all circuits.
+    /// The zero wiring polynomial has $s(X, 0) = 0$, so it is bonding-shaped and
+    /// cannot satisfy a circuit revdot claim (which fixes $k_0 = 1$); see
+    /// [`BondingObject`]. An index whose $\omega^j$ falls *outside* the domain
+    /// (returns `false`) selects a Lagrange interpolation across the registered
+    /// circuits instead.
     ///
     /// See [`CircuitIndex::omega_j`] for details on the $\omega^j$ mapping.
     pub fn circuit_in_domain(&self, i: CircuitIndex) -> bool {
@@ -527,10 +591,11 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
                     add_poly(&**circuit, &self.floor_plans[*i], F::ONE, &mut result);
                 }
             }
-            LagrangeCache::Empty => {
-                // No circuit at this domain point; circuit contribution is zero.
-                // The registry key term is added by the caller (`RegistryAt`
-                // methods), so the overall evaluation is not zero.
+            LagrangeCache::Zero => {
+                // This domain point is the zero wiring polynomial, so it
+                // contributes nothing. The registry key term is still added by
+                // the caller (`RegistryAt` methods), so the evaluation is not
+                // identically zero.
             }
         }
 
@@ -561,7 +626,7 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
                     F::ZERO
                 }
             }
-            LagrangeCache::Empty => F::ZERO,
+            LagrangeCache::Zero => F::ZERO,
         }
     }
 
@@ -577,8 +642,9 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
             // w is in the domain (omega^j) and a circuit is registered at index i.
             LagrangeCache::Direct(i)
         } else {
-            // w is in the domain but no circuit registered at that index.
-            LagrangeCache::Empty
+            // w is a domain point with no explicitly registered circuit; its
+            // wiring polynomial is implicitly the zero polynomial.
+            LagrangeCache::Zero
         };
         let mask_coeff_sum = self.mask_coeff_sum(&cache);
         RegistryAt {
@@ -1028,6 +1094,51 @@ mod tests {
                 !registry.circuit_in_domain(CircuitIndex::new(i)),
                 "Circuit {} should not be in domain",
                 i
+            );
+        }
+
+        Ok(())
+    }
+
+    /// A registry whose circuit count is not a power of two has padded domain
+    /// points with no explicitly registered circuit (row 2 of the resolution
+    /// matrix). Such an index is *in the domain* yet selects the zero wiring
+    /// polynomial: $s(X, 0) = 0$ (bonding-shaped), unlike a registered circuit
+    /// whose $s(X, 0) = 1$. This $s(X, 0)$ gap is what makes an unregistered
+    /// in-domain id safe — it cannot satisfy a circuit revdot claim.
+    #[test]
+    fn test_padded_slot_is_zero_wiring_polynomial() -> Result<()> {
+        // 3 circuits => domain size 4 (next power of two), so index 3 is a
+        // padded, in-domain, unregistered slot.
+        let registry = TestRegistryBuilder::new()
+            .register_circuit(SquareCircuit { times: 1 })?
+            .register_circuit(SquareCircuit { times: 2 })?
+            .register_circuit(SquareCircuit { times: 3 })?
+            .finalize()?;
+
+        assert_eq!(registry.num_circuits(), 3);
+
+        let registered = CircuitIndex::new(0);
+        let padded = CircuitIndex::new(3);
+
+        // The padded index is past the registered range but still in the domain.
+        assert!(usize::from(padded) >= registry.num_circuits());
+        assert!(registry.circuit_in_domain(padded));
+
+        // s(X, 0) distinguishes the two: the zero wiring polynomial has
+        // s(X, 0) = 0, whereas a registered circuit has s(X, 0) = 1.
+        let s_padded = registry.circuit_y(padded, Fp::ZERO);
+        let s_registered = registry.circuit_y(registered, Fp::ZERO);
+        for x in [Fp::from(7u64), Fp::from(11u64)] {
+            assert_eq!(
+                s_padded.eval(x),
+                Fp::ZERO,
+                "padded slot must be the zero wiring polynomial"
+            );
+            assert_eq!(
+                s_registered.eval(x),
+                Fp::ONE,
+                "registered circuit must have s(X, 0) = 1"
             );
         }
 

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -8,7 +8,9 @@
 //! Ragu's PCD construction, and so the [`Registry`] structure represents a larger
 //! polynomial $m(W, X, Y)$ that interpolates such that $m(\omega^i, X, Y) =
 //! s_i(X, Y)$ for some $\omega \in \mathbb{F}$ of sufficiently high $2^k$ order
-//! to encode all circuits for both PCD and for application circuits.
+//! to encode all circuits for both PCD and for application circuits. The book's
+//! [registry chapter] gives the full construction, including Lagrange
+//! interpolation at an arbitrary $W$ and the rolling domain extension.
 //!
 //! ## Every domain point is a wiring polynomial
 //!
@@ -19,11 +21,12 @@
 //! $\omega^i$ contributes its $s_i(X, Y)$, and every other domain point is
 //! *implicitly registered to the zero wiring polynomial* (the interpolation is
 //! zero there). A [`CircuitIndex`] is therefore never out of bounds within the
-//! domain — if its $\omega^j$ is in the domain, it selects a wiring polynomial.
+//! domain — if its $\omega^j$ (the bit-reversed exponent of its index $i$; see
+//! [`CircuitIndex::omega_j`]) is in the domain, it selects a wiring polynomial.
 //!
 //! The zero wiring polynomial is a genuine wiring polynomial, but because it has
 //! $s(X, 0) = 0$ it is bonding-shaped and cannot satisfy a circuit revdot claim
-//! (which fixes $k_0 = 1$). See [`BondingObject`] for how this $s(X, 0)$
+//! (which fixes $\mathbf{k}_0 = 1$). See [`BondingObject`] for how this $s(X, 0)$
 //! distinction keeps one wiring polynomial from standing in for another.
 //!
 //! Two properties of an index — whether its $\omega^j$ is in the domain, and
@@ -41,18 +44,19 @@
 //! it does *not* distinguish the first two rows (both are in the domain), which
 //! is why it is a domain-membership predicate and not a registration check.
 //!
-//! The third row is just the general behavior of [`at`](Registry::at), which
-//! evaluates $m(W, X, Y)$ at an arbitrary $W$: off the domain there is no stored
-//! value, so $m$ evaluates to the Lagrange interpolation of the domain points
-//! (registered circuits, padding zero). This is the normal case for a random
-//! challenge $W$. Reaching it from a [`CircuitIndex`] requires an index past the
-//! padded domain — its $\omega^j$ then has order exceeding the domain size, so
+//! The third row is the general behavior of [`at`](Registry::at): at a $W$
+//! outside the domain it returns the Lagrange interpolation of the domain points
+//! (registered circuits, padding zero), derived in the [registry chapter].
+//! Reaching this from a [`CircuitIndex`] requires an index past the padded domain
+//! — its $\omega^j$ then has order exceeding the domain size, so
 //! `circuit_in_domain` returns `false` for it.
 //!
 //! The [`RegistryBuilder`] structure is used to construct a new [`Registry`] by
 //! inserting circuits and performing a [`finalize`](RegistryBuilder::finalize) step
 //! to compile the added circuits into a registry polynomial representation that can
 //! be efficiently evaluated at different restrictions.
+//!
+//! [registry chapter]: https://tachyon.z.cash/ragu/protocol/extensions/registry.html
 
 use alloc::{boxed::Box, collections::btree_map::BTreeMap, vec::Vec};
 
@@ -538,7 +542,7 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     /// `true` result means "in domain", not "explicitly registered".
     ///
     /// The zero wiring polynomial has $s(X, 0) = 0$, so it is bonding-shaped and
-    /// cannot satisfy a circuit revdot claim (which fixes $k_0 = 1$); see
+    /// cannot satisfy a circuit revdot claim (which fixes $\mathbf{k}_0 = 1$); see
     /// [`BondingObject`]. An index whose $\omega^j$ falls *outside* the domain
     /// (returns `false`) selects a Lagrange interpolation across the registered
     /// circuits instead.

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -445,6 +445,10 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     ///
     /// Wraps [`Registry::at`] and [`RegistryAt::y`].
     /// See [`CircuitIndex::omega_j`] for more details.
+    ///
+    /// `i` is not bounds-checked against the registry; an unregistered index
+    /// resolves to an empty or interpolated slot. See
+    /// [`circuit_in_domain`](Self::circuit_in_domain).
     pub fn circuit_y(&self, i: CircuitIndex, y: F) -> sparse::Polynomial<F, R> {
         let w: F = i.omega_j();
         self.at(w).y(y)
@@ -453,11 +457,27 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     /// Evaluates $s_i(x, y)$ for circuit `i` at point $(x, y)$.
     ///
     /// See [`CircuitIndex::omega_j`] for details on the $\omega^j$ mapping.
+    ///
+    /// `i` is not bounds-checked against the registry; see
+    /// [`circuit_in_domain`](Self::circuit_in_domain).
     pub fn circuit_xy(&self, i: CircuitIndex, x: F, y: F) -> F {
         self.wxy(i.omega_j(), x, y)
     }
 
-    /// Returns true if the circuit's $\omega^j$ value is in the registry domain.
+    /// Returns true if the circuit's $\omega^j$ value lies in the registry's
+    /// (power-of-two padded) domain.
+    ///
+    /// This checks **domain membership**, not that a circuit is registered at
+    /// `i`. A non-power-of-two [`num_circuits`](Self::num_circuits) leaves
+    /// padded domain points with no circuit behind them, and `i` landing on one
+    /// of those still returns `true`.
+    ///
+    /// Such an index is safe by construction: [`circuit_y`](Self::circuit_y) /
+    /// [`circuit_xy`](Self::circuit_xy) resolve it to an *empty slot* (only the
+    /// registry key term, $s(X, 0) = 0$), which is bonding-shaped and so cannot
+    /// pass a circuit revdot claim that fixes $k_0 = 1$ — see [`BondingObject`].
+    /// An index whose $\omega^j$ falls outside the domain (returns `false`)
+    /// would instead interpolate across all circuits.
     ///
     /// See [`CircuitIndex::omega_j`] for details on the $\omega^j$ mapping.
     pub fn circuit_in_domain(&self, i: CircuitIndex) -> bool {

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -10,6 +10,45 @@
 //! s_i(X, Y)$ for some $\omega \in \mathbb{F}$ of sufficiently high $2^k$ order
 //! to encode all circuits for both PCD and for application circuits.
 //!
+//! ## Every domain point is a wiring polynomial
+//!
+//! The interpolation domain is padded to a power of two, so it usually has more
+//! points than there are explicitly registered circuits. Rather than treat the
+//! surplus points as "out of bounds", the registry treats *every* domain point
+//! as indexing a wiring polynomial: an explicitly registered circuit at
+//! $\omega^i$ contributes its $s_i(X, Y)$, and every other domain point is
+//! *implicitly registered to the zero wiring polynomial* (the interpolation is
+//! zero there). A [`CircuitIndex`] is therefore never out of bounds within the
+//! domain — if its $\omega^j$ is in the domain, it selects a wiring polynomial.
+//!
+//! The zero wiring polynomial is a genuine wiring polynomial, but because it has
+//! $s(X, 0) = 0$ it is bonding-shaped and cannot satisfy a circuit revdot claim
+//! (which fixes $k_0 = 1$). See [`BondingObject`] for how this $s(X, 0)$
+//! distinction keeps one wiring polynomial from standing in for another.
+//!
+//! Two properties of an index — whether its $\omega^j$ is in the domain, and
+//! whether a circuit is explicitly registered there — fix which wiring
+//! polynomial it selects. A registered circuit is always in the domain, so only
+//! three combinations occur:
+//!
+//! | in domain? | registered? | wiring polynomial selected   |
+//! | ---------- | ----------- | ---------------------------- |
+//! | yes        | yes         | the circuit's $s_i(X, Y)$    |
+//! | yes        | no          | the zero wiring polynomial   |
+//! | no         | —           | an off-domain interpolation  |
+//!
+//! [`circuit_in_domain`](Registry::circuit_in_domain) reports the first column;
+//! it does *not* distinguish the first two rows (both are in the domain), which
+//! is why it is a domain-membership predicate and not a registration check.
+//!
+//! The third row is just the general behavior of [`at`](Registry::at), which
+//! evaluates $m(W, X, Y)$ at an arbitrary $W$: off the domain there is no stored
+//! value, so $m$ evaluates to the Lagrange interpolation of the domain points
+//! (registered circuits, padding zero). This is the normal case for a random
+//! challenge $W$. Reaching it from a [`CircuitIndex`] requires an index past the
+//! padded domain — its $\omega^j$ then has order exceeding the domain size, so
+//! `circuit_in_domain` returns `false` for it.
+//!
 //! The [`RegistryBuilder`] structure is used to construct a new [`Registry`] by
 //! inserting circuits and performing a [`finalize`](RegistryBuilder::finalize) step
 //! to compile the added circuits into a registry polynomial representation that can
@@ -31,6 +70,10 @@ use crate::{
 };
 
 /// Represents a simple numeric index of a circuit in the registry.
+///
+/// Any value naming a domain point selects a wiring polynomial: the explicitly
+/// registered circuit's $s_i(X, Y)$ if one was registered at that index, or the
+/// zero wiring polynomial otherwise. See the [module overview](crate::registry).
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(transparent)]
 pub struct CircuitIndex(u32);
@@ -334,13 +377,20 @@ pub struct Registry<'params, F: PrimeField, R: Rank> {
 }
 
 /// Cached Lagrange state for a fixed W point.
+///
+/// Selects which wiring polynomial the W point resolves to. The three variants
+/// are the three rows of the resolution matrix in the
+/// [module overview](crate::registry): a registered circuit, the zero wiring
+/// polynomial, or an interpolation.
 enum LagrangeCache<F> {
-    /// Must interpolate across circuits (w not in domain).
+    /// `w` is not a domain point: its wiring polynomial is a Lagrange
+    /// interpolation across the registered circuits.
     Interpolate(Vec<F>),
-    /// Direct circuit lookup (w in domain).
+    /// `w` is a domain point with an explicitly registered circuit at index `i`.
     Direct(usize),
-    /// No circuit at this point.
-    Empty,
+    /// `w` is a domain point with no explicitly registered circuit; its wiring
+    /// polynomial is implicitly the zero polynomial.
+    Zero,
 }
 
 /// A registry bound to a specific W point, with cached Lagrange coefficients.
@@ -397,6 +447,11 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     /// all-zero (the ONE wire at `d[0] = 1` ensures this), but the
     /// predictable ONE slot can cancel in linear combinations of traces;
     /// a random `alpha` at `a[0]` keeps derived polynomials non-zero.
+    ///
+    /// `circuit` indexes the registered circuits directly (for the floor plan)
+    /// and **panics** if it is not a registered index. Unlike the
+    /// polynomial-evaluation methods, this is the registered-`Vec` view; there
+    /// is no implicit zero-polynomial slot here.
     ///
     /// # Errors
     ///
@@ -470,8 +525,8 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     /// Wraps [`Registry::at`] and [`RegistryAt::y`].
     /// See [`CircuitIndex::omega_j`] for more details.
     ///
-    /// `i` is not bounds-checked against the registry; an unregistered index
-    /// resolves to an empty or interpolated slot. See
+    /// Every domain point indexes a wiring polynomial; an index with no
+    /// explicitly registered circuit selects the zero wiring polynomial. See
     /// [`circuit_in_domain`](Self::circuit_in_domain).
     pub fn circuit_y(&self, i: CircuitIndex, y: F) -> sparse::Polynomial<F, R> {
         let w: F = i.omega_j();
@@ -482,26 +537,29 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     ///
     /// See [`CircuitIndex::omega_j`] for details on the $\omega^j$ mapping.
     ///
-    /// `i` is not bounds-checked against the registry; see
+    /// As with [`circuit_y`](Self::circuit_y), an index with no explicitly
+    /// registered circuit selects the zero wiring polynomial. See
     /// [`circuit_in_domain`](Self::circuit_in_domain).
     pub fn circuit_xy(&self, i: CircuitIndex, x: F, y: F) -> F {
         self.wxy(i.omega_j(), x, y)
     }
 
-    /// Returns true if the circuit's $\omega^j$ value lies in the registry's
-    /// (power-of-two padded) domain.
+    /// Returns true if this index's $\omega^j$ value lies in the registry's
+    /// domain.
     ///
-    /// This checks **domain membership**, not that a circuit is registered at
-    /// `i`. A non-power-of-two [`num_circuits`](Self::num_circuits) leaves
-    /// padded domain points with no circuit behind them, and `i` landing on one
-    /// of those still returns `true`.
+    /// This reports domain membership. Every domain point is a wiring
+    /// polynomial: indices with an explicitly registered circuit carry that
+    /// circuit's $s_i(X, Y)$; the remaining domain points (present when
+    /// [`num_circuits`](Self::num_circuits) is not a power of two) are implicitly
+    /// the zero wiring polynomial. Both are selected the same way by
+    /// [`circuit_y`](Self::circuit_y) / [`circuit_xy`](Self::circuit_xy), so a
+    /// `true` result means "in domain", not "explicitly registered".
     ///
-    /// Such an index is safe by construction: [`circuit_y`](Self::circuit_y) /
-    /// [`circuit_xy`](Self::circuit_xy) resolve it to an *empty slot* (only the
-    /// registry key term, $s(X, 0) = 0$), which is bonding-shaped and so cannot
-    /// pass a circuit revdot claim that fixes $k_0 = 1$ — see [`BondingObject`].
-    /// An index whose $\omega^j$ falls outside the domain (returns `false`)
-    /// would instead interpolate across all circuits.
+    /// The zero wiring polynomial has $s(X, 0) = 0$, so it is bonding-shaped and
+    /// cannot satisfy a circuit revdot claim (which fixes $k_0 = 1$); see
+    /// [`BondingObject`]. An index whose $\omega^j$ falls *outside* the domain
+    /// (returns `false`) selects a Lagrange interpolation across the registered
+    /// circuits instead.
     ///
     /// See [`CircuitIndex::omega_j`] for details on the $\omega^j$ mapping.
     pub fn circuit_in_domain(&self, i: CircuitIndex) -> bool {
@@ -551,10 +609,11 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
                     add_poly(&**circuit, &self.floor_plans[*i], F::ONE, &mut result);
                 }
             }
-            LagrangeCache::Empty => {
-                // No circuit at this domain point; circuit contribution is zero.
-                // The registry key term is added by the caller (`RegistryAt`
-                // methods), so the overall evaluation is not zero.
+            LagrangeCache::Zero => {
+                // This domain point is the zero wiring polynomial, so it
+                // contributes nothing. The registry key term is still added by
+                // the caller (`RegistryAt` methods), so the evaluation is not
+                // identically zero.
             }
         }
 
@@ -585,7 +644,7 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
                     F::ZERO
                 }
             }
-            LagrangeCache::Empty => F::ZERO,
+            LagrangeCache::Zero => F::ZERO,
         }
     }
 
@@ -601,8 +660,9 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
             // w is in the domain (omega^j) and a circuit is registered at index i.
             LagrangeCache::Direct(i)
         } else {
-            // w is in the domain but no circuit registered at that index.
-            LagrangeCache::Empty
+            // w is a domain point with no explicitly registered circuit; its
+            // wiring polynomial is implicitly the zero polynomial.
+            LagrangeCache::Zero
         };
         let mask_coeff_sum = self.mask_coeff_sum(&cache);
         RegistryAt {
@@ -1052,6 +1112,51 @@ mod tests {
                 !registry.circuit_in_domain(CircuitIndex::new(i)),
                 "Circuit {} should not be in domain",
                 i
+            );
+        }
+
+        Ok(())
+    }
+
+    /// A registry whose circuit count is not a power of two has padded domain
+    /// points with no explicitly registered circuit (row 2 of the resolution
+    /// matrix). Such an index is *in the domain* yet selects the zero wiring
+    /// polynomial: $s(X, 0) = 0$ (bonding-shaped), unlike a registered circuit
+    /// whose $s(X, 0) = 1$. This $s(X, 0)$ gap is what makes an unregistered
+    /// in-domain id safe — it cannot satisfy a circuit revdot claim.
+    #[test]
+    fn test_padded_slot_is_zero_wiring_polynomial() -> Result<()> {
+        // 3 circuits => domain size 4 (next power of two), so index 3 is a
+        // padded, in-domain, unregistered slot.
+        let registry = TestRegistryBuilder::new()
+            .register_circuit(SquareCircuit { times: 1 })?
+            .register_circuit(SquareCircuit { times: 2 })?
+            .register_circuit(SquareCircuit { times: 3 })?
+            .finalize()?;
+
+        assert_eq!(registry.num_circuits(), 3);
+
+        let registered = CircuitIndex::new(0);
+        let padded = CircuitIndex::new(3);
+
+        // The padded index is past the registered range but still in the domain.
+        assert!(usize::from(padded) >= registry.num_circuits());
+        assert!(registry.circuit_in_domain(padded));
+
+        // s(X, 0) distinguishes the two: the zero wiring polynomial has
+        // s(X, 0) = 0, whereas a registered circuit has s(X, 0) = 1.
+        let s_padded = registry.circuit_y(padded, Fp::ZERO);
+        let s_registered = registry.circuit_y(registered, Fp::ZERO);
+        for x in [Fp::from(7u64), Fp::from(11u64)] {
+            assert_eq!(
+                s_padded.eval(x),
+                Fp::ZERO,
+                "padded slot must be the zero wiring polynomial"
+            );
+            assert_eq!(
+                s_registered.eval(x),
+                Fp::ONE,
+                "registered circuit must have s(X, 0) = 1"
             );
         }
 

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -469,6 +469,10 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     ///
     /// Wraps [`Registry::at`] and [`RegistryAt::y`].
     /// See [`CircuitIndex::omega_j`] for more details.
+    ///
+    /// `i` is not bounds-checked against the registry; an unregistered index
+    /// resolves to an empty or interpolated slot. See
+    /// [`circuit_in_domain`](Self::circuit_in_domain).
     pub fn circuit_y(&self, i: CircuitIndex, y: F) -> sparse::Polynomial<F, R> {
         let w: F = i.omega_j();
         self.at(w).y(y)
@@ -477,11 +481,27 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     /// Evaluates $s_i(x, y)$ for circuit `i` at point $(x, y)$.
     ///
     /// See [`CircuitIndex::omega_j`] for details on the $\omega^j$ mapping.
+    ///
+    /// `i` is not bounds-checked against the registry; see
+    /// [`circuit_in_domain`](Self::circuit_in_domain).
     pub fn circuit_xy(&self, i: CircuitIndex, x: F, y: F) -> F {
         self.wxy(i.omega_j(), x, y)
     }
 
-    /// Returns true if the circuit's $\omega^j$ value is in the registry domain.
+    /// Returns true if the circuit's $\omega^j$ value lies in the registry's
+    /// (power-of-two padded) domain.
+    ///
+    /// This checks **domain membership**, not that a circuit is registered at
+    /// `i`. A non-power-of-two [`num_circuits`](Self::num_circuits) leaves
+    /// padded domain points with no circuit behind them, and `i` landing on one
+    /// of those still returns `true`.
+    ///
+    /// Such an index is safe by construction: [`circuit_y`](Self::circuit_y) /
+    /// [`circuit_xy`](Self::circuit_xy) resolve it to an *empty slot* (only the
+    /// registry key term, $s(X, 0) = 0$), which is bonding-shaped and so cannot
+    /// pass a circuit revdot claim that fixes $k_0 = 1$ — see [`BondingObject`].
+    /// An index whose $\omega^j$ falls outside the domain (returns `false`)
+    /// would instead interpolate across all circuits.
     ///
     /// See [`CircuitIndex::omega_j`] for details on the $\omega^j$ mapping.
     pub fn circuit_in_domain(&self, i: CircuitIndex) -> bool {

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -14,42 +14,37 @@
 //!
 //! ## Every domain point is a wiring polynomial
 //!
-//! The interpolation domain is padded to a power of two, so it usually has more
-//! points than there are explicitly registered circuits. Rather than treat the
-//! surplus points as "out of bounds", the registry treats *every* domain point
-//! as indexing a wiring polynomial: an explicitly registered circuit at
-//! $\omega^i$ contributes its $s_i(X, Y)$, and every other domain point is
-//! *implicitly registered to the zero wiring polynomial* (the interpolation is
-//! zero there). A [`CircuitIndex`] is therefore never out of bounds within the
-//! domain — if its $\omega^j$ (the bit-reversed exponent of its index $i$; see
-//! [`CircuitIndex::omega_j`]) is in the domain, it selects a wiring polynomial.
+//! The domain is padded to a power of two, so it usually has more points than
+//! there are explicitly registered wiring polynomials. Rather than treat the
+//! surplus points as "out of bounds", the registry assigns a wiring polynomial
+//! to *every* domain point: an explicit registration at $\omega^i$ contributes
+//! its $s_i(X, Y)$, and every other domain point is implicitly the zero
+//! polynomial (the interpolation is zero there). A [`CircuitIndex`] is therefore
+//! never out of bounds within the domain — if its $\omega^j$ (the bit-reversed
+//! exponent of its index $i$; see [`CircuitIndex::omega_j`]) is in the domain,
+//! it selects a wiring polynomial.
 //!
-//! The zero wiring polynomial is a genuine wiring polynomial, but because it has
-//! $s(X, 0) = 0$ it is bonding-shaped and cannot satisfy a circuit revdot claim
-//! (which fixes $\mathbf{k}_0 = 1$). See [`BondingObject`] for how this $s(X, 0)$
-//! distinction keeps one wiring polynomial from standing in for another.
+//! The zero polynomial is not a special case: a bonding polynomial is precisely
+//! a wiring polynomial with $s(X, 0) = 0$, so the zero polynomial *is* one. The
+//! domain thus holds circuit wiring polynomials ($s(X, 0) = 1$) and bonding
+//! polynomials ($s(X, 0) = 0$) — the latter being both the explicitly registered
+//! ones (see [`register_bonding`](RegistryBuilder::register_bonding)) and the
+//! unassigned points. See [`BondingObject`] for how this $s(X, 0)$ distinction
+//! keeps one kind from standing in for the other.
 //!
-//! Two properties of an index — whether its $\omega^j$ is in the domain, and
-//! whether a circuit is explicitly registered there — fix which wiring
-//! polynomial it selects. A registered circuit is always in the domain, so only
-//! three combinations occur:
+//! This is why selecting by domain membership alone is safe. A verifier that
+//! expects a circuit fixes $\mathbf{k}_0 = 1$, which no bonding polynomial can
+//! satisfy, so permitting an arbitrary in-domain index already confines the
+//! selection to the registered circuits by construction — registered bonding
+//! polynomials and unassigned points are excluded by that same mechanism, not by
+//! a bounds check.
 //!
-//! | in domain? | registered? | wiring polynomial selected   |
-//! | ---------- | ----------- | ---------------------------- |
-//! | yes        | yes         | the circuit's $s_i(X, Y)$    |
-//! | yes        | no          | the zero wiring polynomial   |
-//! | no         | —           | an off-domain interpolation  |
-//!
-//! [`circuit_in_domain`](Registry::circuit_in_domain) reports the first column;
-//! it does *not* distinguish the first two rows (both are in the domain), which
-//! is why it is a domain-membership predicate and not a registration check.
-//!
-//! The third row is the general behavior of [`at`](Registry::at): at a $W$
-//! outside the domain it returns the Lagrange interpolation of the domain points
-//! (registered circuits, padding zero), derived in the [registry chapter].
-//! Reaching this from a [`CircuitIndex`] requires an index past the padded domain
-//! — its $\omega^j$ then has order exceeding the domain size, so
-//! `circuit_in_domain` returns `false` for it.
+//! [`circuit_in_domain`](Registry::circuit_in_domain) reports domain membership
+//! only; it does *not* report whether anything was explicitly registered at that
+//! point, which is why it is not a registration check. An index whose $\omega^j$
+//! falls *outside* the domain is the general case of [`at`](Registry::at): it
+//! evaluates the registry interpolation at that arbitrary point, mixing all
+//! domain points together, and is what `circuit_in_domain` returns `false` for.
 //!
 //! The [`RegistryBuilder`] structure is used to construct a new [`Registry`] by
 //! inserting circuits and performing a [`finalize`](RegistryBuilder::finalize) step
@@ -75,9 +70,9 @@ use crate::{
 
 /// Represents a simple numeric index of a circuit in the registry.
 ///
-/// Any value naming a domain point selects a wiring polynomial: the explicitly
-/// registered circuit's $s_i(X, Y)$ if one was registered at that index, or the
-/// zero wiring polynomial otherwise. See the [module overview](crate::registry).
+/// Any value naming a domain point selects a wiring polynomial: the $s_i(X, Y)$
+/// explicitly registered at that index, or the zero polynomial if nothing was.
+/// See the [module overview](crate::registry).
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(transparent)]
 pub struct CircuitIndex(u32);
@@ -382,17 +377,17 @@ pub struct Registry<'params, F: PrimeField, R: Rank> {
 
 /// Cached Lagrange state for a fixed W point.
 ///
-/// Selects which wiring polynomial the W point resolves to. The three variants
-/// are the three rows of the resolution matrix in the
-/// [module overview](crate::registry): a registered circuit, the zero wiring
-/// polynomial, or an interpolation.
+/// Distinguishes the kind of point the registry interpolation is being
+/// evaluated at; see the [module overview](crate::registry).
 enum LagrangeCache<F> {
-    /// `w` is not a domain point: its wiring polynomial is a Lagrange
-    /// interpolation across the registered circuits.
-    Interpolate(Vec<F>),
-    /// `w` is a domain point with an explicitly registered circuit at index `i`.
-    Direct(usize),
-    /// `w` is a domain point with no explicitly registered circuit; its wiring
+    /// `w` is an arbitrary point, not one of the domain points the registry
+    /// assigns wiring polynomials to. Holds the Lagrange coefficients used to
+    /// evaluate the interpolation there.
+    Arbitrary(Vec<F>),
+    /// `w` is a domain point with a wiring polynomial explicitly registered at
+    /// index `i`.
+    Assigned(usize),
+    /// `w` is a domain point with nothing explicitly registered; its wiring
     /// polynomial is implicitly the zero polynomial.
     Zero,
 }
@@ -529,8 +524,8 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     /// Wraps [`Registry::at`] and [`RegistryAt::y`].
     /// See [`CircuitIndex::omega_j`] for more details.
     ///
-    /// Every domain point indexes a wiring polynomial; an index with no
-    /// explicitly registered circuit selects the zero wiring polynomial. See
+    /// Every domain point carries a wiring polynomial; an index with nothing
+    /// explicitly registered carries the zero polynomial. See
     /// [`circuit_in_domain`](Self::circuit_in_domain).
     pub fn circuit_y(&self, i: CircuitIndex, y: F) -> sparse::Polynomial<F, R> {
         let w: F = i.omega_j();
@@ -541,8 +536,8 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     ///
     /// See [`CircuitIndex::omega_j`] for details on the $\omega^j$ mapping.
     ///
-    /// As with [`circuit_y`](Self::circuit_y), an index with no explicitly
-    /// registered circuit selects the zero wiring polynomial. See
+    /// As with [`circuit_y`](Self::circuit_y), an index with nothing explicitly
+    /// registered carries the zero polynomial. See
     /// [`circuit_in_domain`](Self::circuit_in_domain).
     pub fn circuit_xy(&self, i: CircuitIndex, x: F, y: F) -> F {
         self.wxy(i.omega_j(), x, y)
@@ -551,19 +546,21 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     /// Returns true if this index's $\omega^j$ value lies in the registry's
     /// domain.
     ///
-    /// This reports domain membership. Every domain point is a wiring
-    /// polynomial: indices with an explicitly registered circuit carry that
-    /// circuit's $s_i(X, Y)$; the remaining domain points (present when
-    /// [`num_circuits`](Self::num_circuits) is not a power of two) are implicitly
-    /// the zero wiring polynomial. Both are selected the same way by
-    /// [`circuit_y`](Self::circuit_y) / [`circuit_xy`](Self::circuit_xy), so a
-    /// `true` result means "in domain", not "explicitly registered".
+    /// This reports domain membership, and nothing more. Every domain point is a
+    /// wiring polynomial — a registered circuit, a registered bonding
+    /// polynomial, or (at points left over when
+    /// [`num_circuits`](Self::num_circuits) is not a power of two) the zero
+    /// polynomial, which is itself a bonding polynomial. All are selected the
+    /// same way by [`circuit_y`](Self::circuit_y) /
+    /// [`circuit_xy`](Self::circuit_xy), so a `true` result means "in domain",
+    /// not "a circuit is registered here".
     ///
-    /// The zero wiring polynomial has $s(X, 0) = 0$, so it is bonding-shaped and
-    /// cannot satisfy a circuit revdot claim (which fixes $\mathbf{k}_0 = 1$); see
-    /// [`BondingObject`]. An index whose $\omega^j$ falls *outside* the domain
-    /// (returns `false`) selects a Lagrange interpolation across the registered
-    /// circuits instead.
+    /// A caller expecting a circuit does not need it to mean more than that: it
+    /// fixes $\mathbf{k}_0 = 1$, and no bonding polynomial ($s(X, 0) = 0$) can
+    /// satisfy such a claim; see [`BondingObject`]. An index whose $\omega^j$
+    /// falls *outside* the domain (returns `false`) escapes that argument — it
+    /// evaluates the registry interpolation at an arbitrary point, mixing all
+    /// domain points together.
     ///
     /// See [`CircuitIndex::omega_j`] for details on the $\omega^j$ mapping.
     pub fn circuit_in_domain(&self, i: CircuitIndex) -> bool {
@@ -597,7 +594,7 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
         let mut result = init();
 
         match cache {
-            LagrangeCache::Interpolate(coeffs) => {
+            LagrangeCache::Arbitrary(coeffs) => {
                 // The provided `w` was not in the domain, and `coeffs` are the
                 // coefficients we need to use to separate each (partial) circuit
                 // evaluation.
@@ -608,13 +605,13 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
                     }
                 }
             }
-            LagrangeCache::Direct(i) => {
+            LagrangeCache::Assigned(i) => {
                 if let Some(circuit) = self.circuits.get(*i) {
                     add_poly(&**circuit, &self.floor_plans[*i], F::ONE, &mut result);
                 }
             }
             LagrangeCache::Zero => {
-                // This domain point is the zero wiring polynomial, so it
+                // This domain point carries the zero polynomial, so it
                 // contributes nothing. The registry key term is still added by
                 // the caller (`RegistryAt` methods), so the evaluation is not
                 // identically zero.
@@ -629,7 +626,7 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     /// Only circuits where [`WiringObject::is_mask`] returns `true` contribute.
     fn mask_coeff_sum(&self, cache: &LagrangeCache<F>) -> F {
         match cache {
-            LagrangeCache::Interpolate(coeffs) => {
+            LagrangeCache::Arbitrary(coeffs) => {
                 let mut sum = F::ZERO;
                 for (i, circuit) in self.circuits.iter().enumerate() {
                     if circuit.is_mask() {
@@ -639,7 +636,7 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
                 }
                 sum
             }
-            LagrangeCache::Direct(i) => {
+            LagrangeCache::Assigned(i) => {
                 // W is exactly omega^bitreverse(i), so the Lagrange
                 // coefficient for circuit i is ONE and all others are ZERO.
                 if self.circuits[*i].is_mask() {
@@ -658,14 +655,16 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     /// polynomial at multiple $X$/$Y$ points without recomputing the W-restriction.
     pub fn at(&self, w: F) -> RegistryAt<'_, F, R> {
         let cache = if let Some(coeffs) = self.domain.ell(w, self.domain.n()) {
-            // w is not in the domain; use Lagrange coefficients to interpolate.
-            LagrangeCache::Interpolate(coeffs)
+            // w is not a domain point; the Lagrange coefficients evaluate the
+            // registry interpolation there.
+            LagrangeCache::Arbitrary(coeffs)
         } else if let Some(&i) = self.omega_lookup.get(&OmegaKey::from(w)) {
-            // w is in the domain (omega^j) and a circuit is registered at index i.
-            LagrangeCache::Direct(i)
+            // w is a domain point (omega^j) with a wiring polynomial registered
+            // at index i.
+            LagrangeCache::Assigned(i)
         } else {
-            // w is a domain point with no explicitly registered circuit; its
-            // wiring polynomial is implicitly the zero polynomial.
+            // w is a domain point with nothing explicitly registered; its wiring
+            // polynomial is implicitly the zero polynomial.
             LagrangeCache::Zero
         };
         let mask_coeff_sum = self.mask_coeff_sum(&cache);
@@ -1123,11 +1122,12 @@ mod tests {
     }
 
     /// A registry whose circuit count is not a power of two has padded domain
-    /// points with no explicitly registered circuit (row 2 of the resolution
-    /// matrix). Such an index is *in the domain* yet selects the zero wiring
-    /// polynomial: $s(X, 0) = 0$ (bonding-shaped), unlike a registered circuit
-    /// whose $s(X, 0) = 1$. This $s(X, 0)$ gap is what makes an unregistered
-    /// in-domain id safe — it cannot satisfy a circuit revdot claim.
+    /// points with nothing explicitly registered. Such an index is *in the
+    /// domain* yet carries the zero polynomial, which has $s(X, 0) = 0$ and is
+    /// therefore a bonding polynomial, unlike a registered circuit whose
+    /// $s(X, 0) = 1$. That is what makes an unregistered in-domain id safe: a
+    /// verifier expecting a circuit fixes $\mathbf{k}_0 = 1$, which no bonding
+    /// polynomial can satisfy.
     #[test]
     fn test_padded_slot_is_zero_wiring_polynomial() -> Result<()> {
         // 3 circuits => domain size 4 (next power of two), so index 3 is a
@@ -1147,15 +1147,15 @@ mod tests {
         assert!(usize::from(padded) >= registry.num_circuits());
         assert!(registry.circuit_in_domain(padded));
 
-        // s(X, 0) distinguishes the two: the zero wiring polynomial has
-        // s(X, 0) = 0, whereas a registered circuit has s(X, 0) = 1.
+        // s(X, 0) distinguishes the two: a bonding polynomial has s(X, 0) = 0,
+        // whereas a circuit wiring polynomial has s(X, 0) = 1.
         let s_padded = registry.circuit_y(padded, Fp::ZERO);
         let s_registered = registry.circuit_y(registered, Fp::ZERO);
         for x in [Fp::from(7u64), Fp::from(11u64)] {
             assert_eq!(
                 s_padded.eval(x),
                 Fp::ZERO,
-                "padded slot must be the zero wiring polynomial"
+                "padded slot must carry the zero polynomial"
             );
             assert_eq!(
                 s_registered.eval(x),

--- a/crates/ragu_circuits/src/registry.rs
+++ b/crates/ragu_circuits/src/registry.rs
@@ -8,7 +8,9 @@
 //! Ragu's PCD construction, and so the [`Registry`] structure represents a larger
 //! polynomial $m(W, X, Y)$ that interpolates such that $m(\omega^i, X, Y) =
 //! s_i(X, Y)$ for some $\omega \in \mathbb{F}$ of sufficiently high $2^k$ order
-//! to encode all circuits for both PCD and for application circuits.
+//! to encode all circuits for both PCD and for application circuits. The book's
+//! [registry chapter] gives the full construction, including Lagrange
+//! interpolation at an arbitrary $W$ and the rolling domain extension.
 //!
 //! ## Every domain point is a wiring polynomial
 //!
@@ -19,11 +21,12 @@
 //! $\omega^i$ contributes its $s_i(X, Y)$, and every other domain point is
 //! *implicitly registered to the zero wiring polynomial* (the interpolation is
 //! zero there). A [`CircuitIndex`] is therefore never out of bounds within the
-//! domain — if its $\omega^j$ is in the domain, it selects a wiring polynomial.
+//! domain — if its $\omega^j$ (the bit-reversed exponent of its index $i$; see
+//! [`CircuitIndex::omega_j`]) is in the domain, it selects a wiring polynomial.
 //!
 //! The zero wiring polynomial is a genuine wiring polynomial, but because it has
 //! $s(X, 0) = 0$ it is bonding-shaped and cannot satisfy a circuit revdot claim
-//! (which fixes $k_0 = 1$). See [`BondingObject`] for how this $s(X, 0)$
+//! (which fixes $\mathbf{k}_0 = 1$). See [`BondingObject`] for how this $s(X, 0)$
 //! distinction keeps one wiring polynomial from standing in for another.
 //!
 //! Two properties of an index — whether its $\omega^j$ is in the domain, and
@@ -41,18 +44,19 @@
 //! it does *not* distinguish the first two rows (both are in the domain), which
 //! is why it is a domain-membership predicate and not a registration check.
 //!
-//! The third row is just the general behavior of [`at`](Registry::at), which
-//! evaluates $m(W, X, Y)$ at an arbitrary $W$: off the domain there is no stored
-//! value, so $m$ evaluates to the Lagrange interpolation of the domain points
-//! (registered circuits, padding zero). This is the normal case for a random
-//! challenge $W$. Reaching it from a [`CircuitIndex`] requires an index past the
-//! padded domain — its $\omega^j$ then has order exceeding the domain size, so
+//! The third row is the general behavior of [`at`](Registry::at): at a $W$
+//! outside the domain it returns the Lagrange interpolation of the domain points
+//! (registered circuits, padding zero), derived in the [registry chapter].
+//! Reaching this from a [`CircuitIndex`] requires an index past the padded domain
+//! — its $\omega^j$ then has order exceeding the domain size, so
 //! `circuit_in_domain` returns `false` for it.
 //!
 //! The [`RegistryBuilder`] structure is used to construct a new [`Registry`] by
 //! inserting circuits and performing a [`finalize`](RegistryBuilder::finalize) step
 //! to compile the added circuits into a registry polynomial representation that can
 //! be efficiently evaluated at different restrictions.
+//!
+//! [registry chapter]: https://tachyon.z.cash/ragu/protocol/extensions/registry.html
 
 use alloc::{boxed::Box, collections::btree_map::BTreeMap, vec::Vec};
 
@@ -556,7 +560,7 @@ impl<F: PrimeField, R: Rank> Registry<'_, F, R> {
     /// `true` result means "in domain", not "explicitly registered".
     ///
     /// The zero wiring polynomial has $s(X, 0) = 0$, so it is bonding-shaped and
-    /// cannot satisfy a circuit revdot claim (which fixes $k_0 = 1$); see
+    /// cannot satisfy a circuit revdot claim (which fixes $\mathbf{k}_0 = 1$); see
     /// [`BondingObject`]. An index whose $\omega^j$ falls *outside* the domain
     /// (returns `false`) selects a Lagrange interpolation across the registered
     /// circuits instead.

--- a/crates/ragu_pcd/src/verify.rs
+++ b/crates/ragu_pcd/src/verify.rs
@@ -37,7 +37,12 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         let y = C::CircuitField::random(&mut rng);
         let z = C::CircuitField::random(&mut rng);
 
-        // Validate that the application circuit_id is within the registry domain.
+        // The proof's circuit_id selects which wiring polynomial the verifier
+        // checks against. Every domain point is a wiring polynomial, so any
+        // in-domain id is well defined: it is either a registered circuit or the
+        // zero wiring polynomial (bonding-shaped, so it cannot satisfy a circuit
+        // revdot claim). Rejecting out-of-domain ids confines the selection to
+        // those slots rather than a Lagrange interpolation across circuits.
         // (Internal circuit IDs are constants and don't need this check.)
         if !self
             .native_registry

--- a/crates/ragu_pcd/src/verify.rs
+++ b/crates/ragu_pcd/src/verify.rs
@@ -38,11 +38,15 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         let z = C::CircuitField::random(&mut rng);
 
         // The proof's circuit_id selects which wiring polynomial the verifier
-        // checks against. Every domain point is a wiring polynomial, so any
-        // in-domain id is well defined: it is either a registered circuit or the
-        // zero wiring polynomial (bonding-shaped, so it cannot satisfy a circuit
-        // revdot claim). Rejecting out-of-domain ids confines the selection to
-        // those slots rather than a Lagrange interpolation across circuits.
+        // checks against, and every domain point carries one, so an in-domain id
+        // is always well defined. It need not name a circuit: the domain also
+        // holds registered bonding polynomials and, at unassigned points, the
+        // zero polynomial, which is itself a bonding polynomial. Letting the
+        // prover choose freely among them is safe because this check expects a
+        // circuit and so fixes k_0 = 1, which no bonding polynomial (s(X, 0) =
+        // 0) can satisfy. Rejecting out-of-domain ids keeps the selection inside
+        // that argument, rather than an evaluation of the registry interpolation
+        // at an arbitrary point.
         // (Internal circuit IDs are constants and don't need this check.)
         if !self
             .native_registry

--- a/crates/ragu_primitives/src/poseidon.rs
+++ b/crates/ragu_primitives/src/poseidon.rs
@@ -77,6 +77,12 @@ impl<'dr, D: Driver<'dr>, P: ragu_arithmetic::PoseidonPermutation<D::F>> Clone f
 }
 
 /// The [Poseidon](https://eprint.iacr.org/2019/458) sponge function.
+///
+/// Intended for fixed-length inputs only. The sponge never records how many
+/// elements it absorbed, so absorbing a trailing zero looks identical to
+/// absorbing nothing: feeding it `[x]` and `[x, 0]` produces the same output.
+/// Only use it where the number of absorbed elements is fixed by the protocol;
+/// to absorb variable-length data, absorb its length first.
 pub struct Sponge<'dr, D: Driver<'dr>, P: ragu_arithmetic::PoseidonPermutation<D::F>> {
     mode: Mode<'dr, D, P>,
     params: &'dr P,


### PR DESCRIPTION
Cross-linking to audit findings [here](https://zkao.io/projects/cmpvhafwe001u01jr5wejqxni/findings?finding=cmpvtk8wj0027o2jzj81x35p9) and [here](https://zkao.io/projects/cmpvhafwe001u01jr5wejqxni/findings?finding=cmpvoyc560012o4jvvoiely1f). Resolves a few internal audit triage items: documents behaviors more explicitly that are already safe by construction.