### PR TITLE
perf(pcd): replace O(n²) dedup in fuse AB commitment with BTreeMap ac…

### DIFF
--- a/crates/ragu_pcd/src/fuse/_06_ab.rs
+++ b/crates/ragu_pcd/src/fuse/_06_ab.rs
@@ -27,7 +27,7 @@
 //! evaluations that $B(x)$ already needs, eliminating separate
 //! $r\_i(x)$ queries.
 
-use alloc::vec::Vec;
+use alloc::{collections::BTreeMap, vec::Vec};
 
 use ragu_arithmetic::{Cycle, ff::Field};
 use ragu_circuits::polynomials::{Rank, sparse};
@@ -93,15 +93,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         // full polynomial-degree MSM.
         let a_commitment_proj = {
             // Deduplicate terms by key, summing coefficients.
-            // TODO: O(n²) linear scan; switch to HashMap or sort-based dedup
-            // if the number of terms grows beyond current M×N ≈ 108.
-            let mut entries: Vec<(FoldKey, C::CircuitField)> = Vec::new();
+            let mut entries = BTreeMap::<FoldKey, C::CircuitField>::new();
             for &(key, coeff) in &a_decomp.terms {
-                if let Some(entry) = entries.iter_mut().find(|(k, _)| *k == key) {
-                    entry.1 += coeff;
-                } else {
-                    entries.push((key, coeff));
-                }
+                *entries.entry(key).or_insert(C::CircuitField::ZERO) += coeff;
             }
 
             let mut msm: Vec<(C::CircuitField, C::HostCurve)> = Vec::with_capacity(entries.len());

--- a/crates/ragu_pcd/src/internal/mod.rs
+++ b/crates/ragu_pcd/src/internal/mod.rs
@@ -29,7 +29,7 @@ pub mod nested;
 pub mod transcript;
 
 /// Identifies which of the two child proofs a component came from.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Side {
     Left,
     Right,

--- a/crates/ragu_pcd/src/internal/native/mod.rs
+++ b/crates/ragu_pcd/src/internal/native/mod.rs
@@ -191,7 +191,7 @@ impl<T> InternalCircuitValues<T> {
 }
 
 /// Enum identifying which rx polynomial component to index within [`RxValues`].
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RxIndex {
     // Circuits
     Application,
@@ -312,7 +312,7 @@ impl<T> RxValues<T> {
 /// Identifies a native-field polynomial within a proof — either one of the
 /// two AB polynomials (which are not rx polynomials) or one of the 11 rx
 /// polynomials addressed by [`RxIndex`].
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RxComponent {
     /// The `a` polynomial from the AB proof (revdot claim).
     AbA,


### PR DESCRIPTION
replace O(n²) linear-scan dedup in fuse AB commitment reconstruction with BTreeMap-based accumulation.                               
                                                                  
the fold decomposition terms in `_06_ab.rs` are deduplicated by `FoldKey` before the MSM.
                                                                  
~also adds `PartialOrd, Ord` derives to `Side`, `RxIndex`, and `RxComponent` to support the ordered map key requirement.       
                                                                  
no API or behavioural changes...