### PR TITLE
fix(ragu): Use `legacy-deps` in mock

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,10 +81,6 @@ jobs:
           components: clippy
       - name: Run clippy
         run: cargo clippy --workspace --lib --tests --benches --locked -- -D warnings
-      # The `mock` feature is off by default, so the workspace run above does not
-      # lint the mock surface. Lint it explicitly.
-      - name: Run clippy (mock)
-        run: cargo clippy -p ragu --features mock --lib --tests --locked -- -D warnings
 
   legacy-check:
     name: legacy dependency check
@@ -103,6 +99,29 @@ jobs:
         run: cargo check -p ragu_arithmetic -p ragu_pasta -p ragu_core -p ragu_primitives -p ragu_circuits -p ragu_pcd --lib --locked --no-default-features --features "alloc legacy-deps"
       - name: Check root crate with legacy dependencies
         run: cargo check -p ragu --lib --locked --no-default-features --features legacy-deps
+
+  # The `mock` feature is off by default and requires the legacy crypto stack
+  # (it is incompatible with the default `modern-deps`, enforced by a
+  # compile_error in src/lib.rs). It therefore gets its own job rather than
+  # sharing the modern-stack `clippy`/`test` runs.
+  mock:
+    name: mock (legacy stack)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Setup Rust
+        uses: ./.github/actions/rust-setup
+        with:
+          components: clippy
+          cache-suffix: mock
+      - name: Run clippy (mock)
+        run: cargo clippy -p ragu --no-default-features --features "mock legacy-deps" --lib --tests --locked -- -D warnings
+      - name: Run tests (mock)
+        run: cargo test --release -p ragu --no-default-features --features "mock legacy-deps" --locked
 
   proptests-fast:
     name: proptests (fast)
@@ -141,10 +160,6 @@ jobs:
           cache-suffix: release
       - name: Run tests
         run: cargo test --release --all --locked
-      # The `mock` feature is off by default, so the run above does not build the
-      # mock or its tests. Exercise them explicitly.
-      - name: Run tests (mock)
-        run: cargo test --release -p ragu --features mock --locked
 
   test-32-bit:
     name: test (i686-unknown-linux-gnu)
@@ -257,6 +272,7 @@ jobs:
       - changes
       - fmt
       - clippy
+      - mock
       - proptests-fast
       - test
       - test-32-bit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,16 +867,16 @@ name = "ragu"
 version = "0.0.0"
 dependencies = [
  "blake2b_simd",
- "ff 0.14.0",
+ "ff 0.13.1",
  "lazy_static",
- "pasta_curves 0.5.1 (git+https://github.com/ebfull/pasta_curves?rev=5a84fc0d13f738f54c43fb1f9e28ecf1d358dcf5)",
+ "pasta_curves 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ragu_arithmetic",
  "ragu_circuits",
  "ragu_core",
  "ragu_pcd",
  "ragu_primitives",
- "rand 0.10.1",
- "rand_core 0.10.0",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,15 @@ keywords = []
 [package.metadata.docs.rs]
 rustdoc-args = ["--html-in-header", "katex-header.html"]
 no-default-features = true
-features = ["modern-deps", "multicore", "mock"]
+features = ["legacy-deps", "multicore", "mock"]
 
 [features]
 default = ["modern-deps", "multicore"]
 # Opt-in API-level mock of `ragu_pcd` (see the crate docs). Off by default:
 # without it the crate exposes no API and pulls none of the mock-only deps
-# below. The mock is built against the modern crypto stack (the default), and is
-# guarded against `legacy-deps` (compile_error in lib.rs) so legacy builds stay
-# legacy-pure.
+# below. The mock is built against the legacy crypto stack, so it requires
+# `legacy-deps` and is guarded against the default `modern-deps`
+# (compile_error in lib.rs).
 mock = [
   "dep:blake2b_simd",
   "dep:ff",
@@ -65,15 +65,19 @@ ragu_arithmetic = { path = "crates/ragu_arithmetic", version = "0.0.0", default-
 ragu_primitives = { path = "crates/ragu_primitives", version = "0.0.0", default-features = false, features = ["alloc"] }
 ragu_pcd = { path = "crates/ragu_pcd", version = "0.0.0", default-features = false, features = ["alloc"] }
 
-# mock dependencies (pulled in only by the `mock` feature)
+# mock dependencies (pulled in only by the `mock` feature; legacy crypto stack).
+# `ff`/`pasta_curves`/`rand_core` are pinned to the legacy versions directly
+# (mirroring the `*_legacy` aliases in `[workspace.dependencies]`) so the mock's
+# unaliased `use ff::…` / `use pasta_curves::…` / `use rand_core::…` resolve to
+# the legacy stack without routing through the workspace crates.
 blake2b_simd = { workspace = true, optional = true }
-ff = { workspace = true, optional = true }
+ff = { package = "ff", version = "0.13", default-features = false, optional = true }
 lazy_static = { workspace = true, optional = true }
-pasta_curves = { workspace = true, optional = true }
-rand_core = { workspace = true, optional = true }
+pasta_curves = { package = "pasta_curves", version = "0.5.1", optional = true }
+rand_core = { package = "rand_core", version = "0.6", default-features = false, optional = true }
 
 [dev-dependencies]
-rand = { workspace = true }
+rand = { package = "rand", version = "0.8" }
 
 [workspace]
 members = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,9 @@
 //! the `mock` feature to instead expose an API-level mock of `ragu_pcd`
 //! (re-exported at the crate root), used to integrate downstream consumers
 //! (e.g. Zebra) against the eventual interface ahead of the real
-//! implementation. The mock is built against the modern crypto stack (enabled
-//! by default) and cannot be combined with `legacy-deps`. See the
+//! implementation. The mock is built against the legacy crypto stack, so it
+//! requires `legacy-deps` and cannot be combined with the default
+//! `modern-deps`. See the
 //! [Ragu Book](https://tachyon.z.cash/ragu/) for more information.
 // The lints below apply to the `mock` surface, which mirrors an external API.
 #![no_std]
@@ -37,11 +38,13 @@
     )
 )]
 
-// The mock uses the modern crypto stack (ff 0.14 / ebfull pasta_curves /
-// rand_core 0.10) unconditionally, so it cannot be built against `legacy-deps`.
-#[cfg(all(feature = "mock", feature = "legacy-deps"))]
+// The mock uses the legacy crypto stack (ff 0.13 / pasta_curves 0.5 /
+// rand_core 0.6) unconditionally, so it requires `legacy-deps` and cannot be
+// built against the default `modern-deps`.
+#[cfg(all(feature = "mock", not(feature = "legacy-deps")))]
 compile_error!(
-    "the `mock` feature requires the modern crypto stack and is incompatible with `legacy-deps`"
+    "the `mock` feature requires the legacy crypto stack; build with \
+     `--no-default-features --features \"mock legacy-deps\"`"
 );
 
 #[cfg(feature = "std")]

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -4,8 +4,8 @@
 //! so downstream consumers (e.g. Zebra) can integrate against it ahead of the
 //! real implementation. The contents are re-exported at the crate root.
 //!
-//! The mock is built against the modern crypto stack only and is incompatible
-//! with `legacy-deps`.
+//! The mock is built against the legacy crypto stack only and is incompatible
+//! with `modern-deps`.
 
 pub use application::{Application, ApplicationBuilder};
 pub use ctx::StepCtx;

--- a/src/mock/proof.rs
+++ b/src/mock/proof.rs
@@ -48,6 +48,23 @@ impl<H: Header> Pcd<H> {
     pub fn data(&self) -> &H::Data {
         &self.data
     }
+
+    /// Returns a reference to the recursive proof.
+    ///
+    /// Mirrors `ragu_pcd::Pcd::proof`.
+    #[must_use]
+    pub fn proof(&self) -> &Proof {
+        &self.proof
+    }
+
+    /// Consumes the proof-carrying data and returns the proof and data
+    /// separately.
+    ///
+    /// Mirrors `ragu_pcd::Pcd::into_parts`.
+    #[must_use]
+    pub fn into_parts(self) -> (Proof, H::Data) {
+        (self.proof, self.data)
+    }
 }
 
 impl<H: Header> Clone for Pcd<H> {

--- a/src/mock/tests/application.rs
+++ b/src/mock/tests/application.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use rand::rng;
+use rand::thread_rng as rng;
 
 use crate::{
     application::*,


### PR DESCRIPTION
The mock was wired to `modern-deps` and guarded against `legacy-deps`. Consumers still remain on the legacy deps, so this PR flips the feature configuration.

## Changes

- **`Cargo.toml`** — repoint the mock's crypto deps to legacy versions (`ff` →
  0.13, `pasta_curves` → 0.5.1, `rand_core` → 0.6; dev-dep `rand` → 0.8 to match
  the `rand_core` 0.6 `CryptoRng` bound); docs.rs metadata → `legacy-deps`.
- **`src/lib.rs`** — flip the guard to require `legacy-deps`
  (`cfg(all(feature = "mock", not(feature = "legacy-deps")))`), catching both
  `mock`+`modern-deps` and `mock` with no stack; update docs.
- **`src/mock/tests/application.rs`** — `use rand::rng` →
  `use rand::thread_rng as rng` (the rand 0.8 spelling).
- **`src/mock/proof.rs`** — expose `Pcd::proof()` and `Pcd::into_parts()`,
  mirroring `ragu_pcd::Pcd`.
- **CI** — extract the mock lint/test out of the modern `clippy`/`test` jobs into
  a dedicated legacy-stack `mock` job; added to the `ci-required` gate. (Mock
  tests are now ubuntu-only.)

## Verification

- `cargo check -p ragu --no-default-features --features "mock legacy-deps"` ✅
- `cargo check -p ragu --no-default-features --features legacy-deps` ✅
- `cargo build --features mock` fails fast with the new `compile_error!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)