### PR TITLE
fix: prevent application suffix wrapping

### DIFF
--- a/crates/ragu_pcd/src/header.rs
+++ b/crates/ragu_pcd/src/header.rs
@@ -38,7 +38,18 @@ pub struct Suffix {
 
 impl Suffix {
     /// Creates a new application-defined [`Header`] suffix.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `value` is large enough that adding the internal suffix
+    /// offset would overflow `usize`, which would alias reserved internal
+    /// suffixes.
     pub const fn new(value: usize) -> Self {
+        assert!(
+            value <= usize::MAX - NUM_INTERNAL_SUFFIXES as usize,
+            "application suffix too large; would alias internal suffixes",
+        );
+
         Suffix {
             suffix: HeaderSuffix::Application(value),
         }
@@ -73,6 +84,19 @@ fn test_suffix_map() {
     assert_eq!(Suffix::internal(1).get(), 1);
     assert_eq!(Suffix::new(0).get(), 2);
     assert_eq!(Suffix::new(1).get(), 3);
+}
+
+#[test]
+fn test_suffix_max_application_value() {
+    let max = usize::MAX - NUM_INTERNAL_SUFFIXES as usize;
+    let suffix = Suffix::new(max);
+    assert_eq!(suffix.get(), usize::MAX as u64);
+}
+
+#[test]
+#[should_panic(expected = "would alias internal suffixes")]
+fn test_suffix_wrapping_panics() {
+    let _ = Suffix::new(usize::MAX - NUM_INTERNAL_SUFFIXES as usize + 1);
 }
 
 /// Headers are succinct representations of data, essentially used as public

--- a/src/mock/header.rs
+++ b/src/mock/header.rs
@@ -28,8 +28,20 @@ pub struct Suffix {
 }
 
 impl Suffix {
+    /// Creates a new application-defined [`Header`] suffix.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `value` is large enough that adding the internal suffix
+    /// offset would overflow `usize`, which would alias reserved internal
+    /// suffixes.
     #[must_use]
     pub const fn new(value: usize) -> Self {
+        assert!(
+            value <= usize::MAX - NUM_INTERNAL_SUFFIXES,
+            "application suffix too large; would alias internal suffixes",
+        );
+
         Self {
             suffix: HeaderSuffix::Application(value),
         }
@@ -59,6 +71,19 @@ impl Suffix {
         };
         u64::try_from(value_usize).expect("suffix value fits in u64")
     }
+}
+
+#[test]
+fn test_suffix_max_application_value() {
+    let max = usize::MAX - NUM_INTERNAL_SUFFIXES;
+    let suffix = Suffix::new(max);
+    assert_eq!(suffix.get(), usize::MAX as u64);
+}
+
+#[test]
+#[should_panic(expected = "would alias internal suffixes")]
+fn test_suffix_wrapping_panics() {
+    let _ = Suffix::new(usize::MAX - NUM_INTERNAL_SUFFIXES + 1);
 }
 
 /// Mirrors `ragu_pcd::Header`.


### PR DESCRIPTION
fixes #776 

guards `Suffix::new()` against application suffix values that would overflow when the reserved internal suffix offset is added.

- changes

- Add a const-compatible assertion to `Suffix::new()`
- Document the panic condition
- Test the maximum valid application suffix
- Test that an overflowing suffix is rejected