### PR TITLE
chore(ci): fix weekly automated fuzzing workflow

### DIFF
--- a/.github/workflows/fuzz-cron.yml
+++ b/.github/workflows/fuzz-cron.yml
@@ -95,7 +95,12 @@ jobs:
             ${{ runner.os }}-fuzz-corpus-${{ matrix.target }}-
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+        # Pinned version + --locked: an unlocked install re-resolves
+        # transitive deps, whose MSRV can drift past the pinned nightly
+        # (cargo-fuzz 0.13.2 pulls cargo-platform 0.3.3, which wants
+        # rustc >= 1.91). Revisit this pin when rotating the nightly in
+        # .github/actions/rust-nightly-setup.
+        run: cargo install --locked cargo-fuzz@0.13.1
 
       - name: Run fuzz target
         working-directory: qa/fuzz

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,7 @@ jobs:
       pull-requests: read
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
+      fuzz: ${{ steps.filter.outputs.fuzz }}
       book: ${{ steps.filter.outputs.book }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -42,6 +43,10 @@ jobs:
               - 'rust-toolchain.toml'
               - '.github/workflows/rust.yml'
               - '.github/actions/**'
+            fuzz:
+              - 'qa/fuzz/**'
+              - '.github/workflows/fuzz-cron.yml'
+              - '.github/workflows/fuzz-coverage.yml'
             book:
               - 'book/**'
 
@@ -198,7 +203,7 @@ jobs:
   fuzz-check:
     name: fuzz harness check (nightly)
     needs: changes
-    if: needs.changes.outputs.rust == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.fuzz == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/qa/fuzz/.gitignore
+++ b/qa/fuzz/.gitignore
@@ -2,3 +2,4 @@ target
 corpus
 artifacts
 coverage
+seeds


### PR DESCRIPTION
References action failure in https://github.com/tachyon-zcash/ragu/actions/runs/27245117745.

After this lands on main, need to manually trigger `workflow_dispatch` to rerun job and fix our continuous fuzzing workflow.