### PR TITLE
chore(fuzz): cron coverage fixes and crash regression infra

### DIFF
--- a/.github/workflows/fuzz-coverage.yml
+++ b/.github/workflows/fuzz-coverage.yml
@@ -1,0 +1,124 @@
+name: Fuzz coverage
+
+# Weekly per-target coverage reports over the cron-accumulated corpora.
+# Replays each target's cached corpus under a coverage-instrumented
+# build and uploads an llvm-cov per-file report, so coverage drift is
+# visible over time without running anything locally. The union ("which
+# code does fuzzing reach at all") view is generated locally via
+# `./fuzz.sh coverage`; this workflow tracks the per-target trend.
+
+on:
+  # Mondays 06:00 UTC, after the Sunday 00:00 UTC fuzz run has extended
+  # and saved each target's corpus cache.
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    name: coverage ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - fuzz_element_ops
+          - fuzz_witness_coverage
+          - fuzz_witness_cheat
+          - fuzz_driver_metamorphic
+          - fuzz_algebraic_identities
+          - fuzz_element_assertions
+          - fuzz_multipack
+          - fuzz_point_identities
+          - fuzz_consistent
+          - fuzz_io_roundtrip
+          - fuzz_poseidon_sponge
+          - fuzz_poseidon_differential
+          - fuzz_endoscalar
+          - fuzz_revdot
+          - fuzz_fold_revdot
+          - fuzz_sxy_agreement
+          - fuzz_circuit_witness
+          - fuzz_circuit_revdot_identity
+          - fuzz_staging
+          - fuzz_verify_reject
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Install pinned nightly toolchain
+        id: nightly
+        uses: ./.github/actions/rust-nightly-setup
+        with:
+          components: llvm-tools-preview
+
+      # Separate cache family from fuzz-cron: the coverage profile is a
+      # distinct build flavor, and sharing the cron's cache would evict
+      # its hot fuzz build artifacts.
+      - name: Cache coverage build artifacts
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: qa/fuzz/target
+          key: ${{ runner.os }}-fuzz-coverage-target-${{ hashFiles('qa/fuzz/Cargo.toml') }}-${{ hashFiles('qa/fuzz/fuzz_targets/**/*.rs') }}-${{ hashFiles('qa/fuzz/bin/**/*.rs') }}
+          restore-keys: |
+            ${{ runner.os }}-fuzz-coverage-target-
+
+      # Read-only consumer of the corpus the fuzz cron accumulates; the
+      # run-id key never matches, so restore-keys pulls the most recent
+      # entry. No save step — this workflow never modifies the corpus.
+      - name: Restore fuzz corpus
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: qa/fuzz/corpus/${{ matrix.target }}
+          key: ${{ runner.os }}-fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-fuzz-corpus-${{ matrix.target }}-
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+
+      - name: Generate coverage report
+        working-directory: qa/fuzz
+        env:
+          RUSTUP_TOOLCHAIN: ${{ steps.nightly.outputs.toolchain }}
+          FUZZ_TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          REPORT="coverage-report-${FUZZ_TARGET}.txt"
+          if [ ! -d "corpus/${FUZZ_TARGET}" ] || [ -z "$(ls -A "corpus/${FUZZ_TARGET}" 2>/dev/null)" ]; then
+            # First run for a target predates any cron corpus; surface
+            # that in the artifact rather than failing the matrix.
+            echo "No corpus restored for ${FUZZ_TARGET}; skipping coverage." | tee "$REPORT"
+            exit 0
+          fi
+          HOST=$(rustc -vV | sed -n 's/^host: //p')
+          TOOLS="$(rustc --print sysroot)/lib/rustlib/${HOST}/bin"
+          cargo fuzz coverage --fuzz-dir . -s none "$FUZZ_TARGET" "corpus/${FUZZ_TARGET}"
+          # Keep the report focused on workspace code: drop registry
+          # deps, the rust std sources, and the fuzz harness itself.
+          "$TOOLS/llvm-cov" report \
+            --instr-profile="coverage/${FUZZ_TARGET}/coverage.profdata" \
+            "target/${HOST}/coverage/${HOST}/release/${FUZZ_TARGET}" \
+            --ignore-filename-regex='(/\.cargo/|/rustc/|/\.rustup/|qa/fuzz/)' \
+            > "$REPORT"
+          {
+            echo "## coverage ${FUZZ_TARGET}"
+            echo '```'
+            head -2 "$REPORT"
+            tail -1 "$REPORT"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-${{ matrix.target }}
+          path: qa/fuzz/coverage-report-${{ matrix.target }}.txt
+          retention-days: 90
+          if-no-files-found: warn

--- a/.github/workflows/fuzz-coverage.yml
+++ b/.github/workflows/fuzz-coverage.yml
@@ -1,11 +1,12 @@
 name: Fuzz coverage
 
 # Weekly per-target coverage reports over the cron-accumulated corpora.
-# Replays each target's cached corpus under a coverage-instrumented
-# build and uploads an llvm-cov per-file report, so coverage drift is
-# visible over time without running anything locally. The union ("which
-# code does fuzzing reach at all") view is generated locally via
-# `./fuzz.sh coverage`; this workflow tracks the per-target trend.
+# Replays each target's cached corpus and committed seeds under a
+# coverage-instrumented build and uploads an llvm-cov per-file report,
+# so coverage drift is visible over time without running anything
+# locally. The union ("which code does fuzzing reach at all") view is
+# generated locally via `./fuzz.sh coverage`; this workflow tracks the
+# per-target trend.
 
 on:
   # Mondays 06:00 UTC, after the Sunday 00:00 UTC fuzz run has extended
@@ -80,7 +81,10 @@ jobs:
             ${{ runner.os }}-fuzz-corpus-${{ matrix.target }}-
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+        # Keep this pin in sync with fuzz-cron.yml. An unlocked install
+        # currently resolves cargo-platform 0.3.3, which requires Rust 1.91,
+        # while this step runs under the repository's Rust 1.90 toolchain.
+        run: cargo install --locked cargo-fuzz@0.13.1
 
       - name: Generate coverage report
         working-directory: qa/fuzz
@@ -90,15 +94,27 @@ jobs:
         run: |
           set -euo pipefail
           REPORT="coverage-report-${FUZZ_TARGET}.txt"
-          if [ ! -d "corpus/${FUZZ_TARGET}" ] || [ -z "$(ls -A "corpus/${FUZZ_TARGET}" 2>/dev/null)" ]; then
-            # First run for a target predates any cron corpus; surface
-            # that in the artifact rather than failing the matrix.
-            echo "No corpus restored for ${FUZZ_TARGET}; skipping coverage." | tee "$REPORT"
+          has_input_files() {
+            local dir="$1"
+            [ -d "$dir" ] && [ -n "$(find "$dir" -type f -print -quit)" ]
+          }
+          INPUT_DIRS=()
+          if has_input_files "corpus/${FUZZ_TARGET}"; then
+            INPUT_DIRS+=("corpus/${FUZZ_TARGET}")
+          fi
+          if has_input_files "seeds/${FUZZ_TARGET}"; then
+            INPUT_DIRS+=("seeds/${FUZZ_TARGET}")
+          fi
+          if [ "${#INPUT_DIRS[@]}" -eq 0 ]; then
+            # A target can predate both a cron corpus and committed seeds;
+            # surface that in the artifact rather than failing the matrix.
+            echo "No corpus or seed inputs found for ${FUZZ_TARGET}; skipping coverage." \
+              | tee "$REPORT"
             exit 0
           fi
           HOST=$(rustc -vV | sed -n 's/^host: //p')
           TOOLS="$(rustc --print sysroot)/lib/rustlib/${HOST}/bin"
-          cargo fuzz coverage --fuzz-dir . -s none "$FUZZ_TARGET" "corpus/${FUZZ_TARGET}"
+          cargo fuzz coverage --fuzz-dir . -s none "$FUZZ_TARGET" "${INPUT_DIRS[@]}"
           # Keep the report focused on workspace code: drop registry
           # deps, the rust std sources, and the fuzz harness itself.
           "$TOOLS/llvm-cov" report \

--- a/.github/workflows/fuzz-cron.yml
+++ b/.github/workflows/fuzz-cron.yml
@@ -64,6 +64,9 @@ jobs:
           - fuzz_revdot
           - fuzz_fold_revdot
           - fuzz_sxy_agreement
+          - fuzz_circuit_witness
+          - fuzz_circuit_revdot_identity
+          - fuzz_staging
           - fuzz_verify_reject
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -82,12 +85,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-fuzz-cron-target-
 
-      # Per-target corpus: each run extends the corpus for its target, then
-      # uploads the new state via the actions/cache "always-save" semantics
-      # (key includes the run id, so every run produces a fresh cache entry;
-      # restore-keys then pulls the most recent prior entry on the next run).
+      # Per-target corpus: the run-id key never matches an existing entry,
+      # so restore-keys' prefix match pulls the most recent prior corpus;
+      # the run extends it, and the explicit save step below uploads it as
+      # a fresh entry. Split restore/save (rather than the combined cache
+      # action) so the save still happens when the job fails — a
+      # crash-finding run is exactly the one whose corpus progress we
+      # most want to keep.
       - name: Restore fuzz corpus
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: qa/fuzz/corpus/${{ matrix.target }}
           key: ${{ runner.os }}-fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
@@ -96,6 +102,22 @@ jobs:
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
+
+      # Replay committed crash reproducers (one execution per file, no
+      # fuzzing) before spending the long fuzz budget. A regression here
+      # fails the job immediately.
+      - name: Replay regression inputs
+        working-directory: qa/fuzz
+        env:
+          RUSTUP_TOOLCHAIN: ${{ steps.nightly.outputs.toolchain }}
+          FUZZ_TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          if compgen -G "regressions/${FUZZ_TARGET}/*" > /dev/null; then
+            cargo fuzz run --fuzz-dir . "$FUZZ_TARGET" regressions/"${FUZZ_TARGET}"/*
+          else
+            echo "No regression inputs for ${FUZZ_TARGET}; skipping."
+          fi
 
       - name: Run fuzz target
         working-directory: qa/fuzz
@@ -120,12 +142,30 @@ jobs:
             cargo run --release --bin extract_dict > dict.txt
             DICT_FLAG="-dict=dict.txt"
           fi
+          # Corpus layout: corpus/<target> (cache-restored, receives new
+          # units) plus seeds/<target> (committed read-only seed inputs)
+          # when present, so cold-cache runs don't start from an empty
+          # corpus.
+          mkdir -p "corpus/${FUZZ_TARGET}"
+          CORPUS_DIRS="corpus/${FUZZ_TARGET}"
+          if [ -d "seeds/${FUZZ_TARGET}" ]; then
+            CORPUS_DIRS="${CORPUS_DIRS} seeds/${FUZZ_TARGET}"
+          fi
           # Tee output so we can extract stats after the run regardless
           # of whether the fuzz target crashed.
-          cargo fuzz run --fuzz-dir . "$FUZZ_TARGET" -- \
+          cargo fuzz run --fuzz-dir . "$FUZZ_TARGET" $CORPUS_DIRS -- \
             $DICT_FLAG \
             -max_len=1024 \
             -max_total_time="$DURATION" 2>&1 | tee fuzz-run.log
+
+      - name: Save fuzz corpus
+        # always() so the corpus extension survives crash-finding (failed)
+        # runs; the combined cache action only saves on job success.
+        if: always()
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: qa/fuzz/corpus/${{ matrix.target }}
+          key: ${{ runner.os }}-fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
 
       - name: Extract run stats
         # Run even if the fuzz step crashed — we want stats artifacts

--- a/.github/workflows/fuzz-cron.yml
+++ b/.github/workflows/fuzz-cron.yml
@@ -7,14 +7,15 @@ name: Continuous fuzzing
 # crash as a failed job + uploaded artifact.
 
 on:
-  # Twice-weekly: Sundays and Wednesdays at 00:00 UTC. Spreading the runs
-  # gives libFuzzer fresh mutation randomness on each fire (while still
-  # accumulating the corpus across runs via cache), which empirically
-  # outperforms single long runs for shallow-bug discovery. Catches
-  # regressions ~3 days faster than once-weekly.
+  # Three times weekly: Sundays, Wednesdays, and Fridays at 00:00 UTC.
+  # Spreading the runs gives libFuzzer fresh mutation randomness on each
+  # fire (while still accumulating the corpus across runs via cache),
+  # which empirically outperforms single long runs for shallow-bug
+  # discovery and bounds the gap between campaigns to three days.
   schedule:
     - cron: '0 0 * * 0'
     - cron: '0 0 * * 3'
+    - cron: '0 0 * * 5'
   # Ad-hoc trigger from the Actions tab.
   workflow_dispatch:
     inputs:

--- a/.github/workflows/fuzz-cron.yml
+++ b/.github/workflows/fuzz-cron.yml
@@ -101,7 +101,10 @@ jobs:
             ${{ runner.os }}-fuzz-corpus-${{ matrix.target }}-
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+        # Keep this pin in sync with fuzz-coverage.yml. An unlocked install
+        # currently resolves cargo-platform 0.3.3, which requires Rust 1.91,
+        # while this step runs under the repository's Rust 1.90 toolchain.
+        run: cargo install --locked cargo-fuzz@0.13.1
 
       # Replay committed crash reproducers (one execution per file, no
       # fuzzing) before spending the long fuzz budget. A regression here

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,7 @@ jobs:
       pull-requests: read
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
+      fuzz: ${{ steps.filter.outputs.fuzz }}
       book: ${{ steps.filter.outputs.book }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -42,6 +43,10 @@ jobs:
               - 'rust-toolchain.toml'
               - '.github/workflows/rust.yml'
               - '.github/actions/**'
+            fuzz:
+              - 'qa/fuzz/**'
+              - '.github/workflows/fuzz-cron.yml'
+              - '.github/workflows/fuzz-coverage.yml'
             book:
               - 'book/**'
 
@@ -198,7 +203,7 @@ jobs:
   fuzz-check:
     name: fuzz harness check (nightly)
     needs: changes
-    if: needs.changes.outputs.rust == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.fuzz == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -282,6 +282,7 @@ jobs:
       - test
       - test-32-bit
       - bitrot
+      - fuzz-check
       - docs
       - book
     runs-on: ubuntu-latest

--- a/qa/fuzz/.gitignore
+++ b/qa/fuzz/.gitignore
@@ -2,3 +2,4 @@ target
 corpus
 artifacts
 coverage
+seeds

--- a/qa/fuzz/.gitignore
+++ b/qa/fuzz/.gitignore
@@ -2,4 +2,3 @@ target
 corpus
 artifacts
 coverage
-seeds

--- a/qa/fuzz/README.md
+++ b/qa/fuzz/README.md
@@ -156,10 +156,10 @@ Three workflows in `.github/workflows/`:
   and `bin/**/*.rs`.
 
 - **`fuzz-cron.yml`** runs every target via matrix-parallel for 5 hours
-  each on Sundays and Wednesdays at 00:00 UTC. Each target restores its
-  latest corpus, replays committed crash regressions, extends the corpus,
-  and saves it even when fuzzing finds a crash. Crash artifacts have
-  30-day retention. Manual runs can override `duration` and `use_dict`.
+  each on Sundays, Wednesdays, and Fridays at 00:00 UTC. Each target
+  restores its latest corpus, replays committed crash regressions, extends
+  the corpus, and saves it even when fuzzing finds a crash. Crash artifacts
+  have 30-day retention. Manual runs can override `duration` and `use_dict`.
 
 - **`fuzz-coverage.yml`** runs every Monday at 06:00 UTC, after the Sunday
   fuzz run. Each matrix job restores its target's latest accumulated corpus,

--- a/qa/fuzz/README.md
+++ b/qa/fuzz/README.md
@@ -27,6 +27,15 @@ ASAN=1 ./fuzz.sh
 
 # Run a single target directly.
 cargo +nightly fuzz run fuzz_element_ops -- -max_total_time=60
+
+# Replay all committed crash regressions once each.
+./fuzz.sh regress
+
+# Minimize each accumulated corpus in place.
+./fuzz.sh cmin
+
+# Generate per-target reports and a union coverage report locally.
+./fuzz.sh coverage
 ```
 
 ## Targets
@@ -139,7 +148,7 @@ were insensitive to it — that's the real bug class.
 
 ## CI
 
-Two workflows in `.github/workflows/`:
+Three workflows in `.github/workflows/`:
 
 - **`rust.yml`** runs `cargo +nightly check --bins` from this directory
   on every PR. Catches bitrot in the fuzz crate without actually running
@@ -147,10 +156,16 @@ Two workflows in `.github/workflows/`:
   and `bin/**/*.rs`.
 
 - **`fuzz-cron.yml`** runs every target via matrix-parallel for 5 hours
-  each, weekly on Sundays at 00:00 UTC. Corpus persists across runs via
-  `actions/cache`. Crashes upload as workflow artifacts with 30-day
-  retention. Manual trigger via the Actions tab `workflow_dispatch`
-  with override knobs for `duration` and `use_dict`.
+  each on Sundays and Wednesdays at 00:00 UTC. Each target restores its
+  latest corpus, replays committed crash regressions, extends the corpus,
+  and saves it even when fuzzing finds a crash. Crash artifacts have
+  30-day retention. Manual runs can override `duration` and `use_dict`.
+
+- **`fuzz-coverage.yml`** runs every Monday at 06:00 UTC, after the Sunday
+  fuzz run. Each matrix job restores its target's latest accumulated corpus,
+  includes any committed seeds, generates an `llvm-cov` per-file report,
+  writes the headline totals to the job summary, and uploads the full report
+  with 90-day retention.
 
 ## Why several targets duplicate the same `Op` enum
 

--- a/qa/fuzz/fuzz.sh
+++ b/qa/fuzz/fuzz.sh
@@ -11,6 +11,7 @@
 #   ./fuzz.sh triage <file>                   # Triage a fuzz_witness_cheat crash
 #   ./fuzz.sh cmin [target]                   # Minimize corpora in place (all targets if omitted)
 #   ./fuzz.sh regress [target]                # Replay committed crash reproducers once each
+#   ./fuzz.sh coverage [target]               # Corpus coverage report (union report if all targets)
 #
 # Crash-regression inputs: when a fuzz run finds a real bug, commit the
 # minimized reproducer to regressions/<target>/ (tracked in git, unlike
@@ -156,6 +157,67 @@ if [[ "${1:-}" == "regress" ]]; then
     cargo +nightly fuzz run --fuzz-dir . $REG_SAN_FLAG "$target" "${files[@]}"
   done
   echo "=== regressions OK ==="
+  exit
+fi
+
+# `coverage` subcommand: replay each target's corpus under a
+# coverage-instrumented build (cargo fuzz coverage), then emit an
+# llvm-cov per-file report to coverage/<target>/report.txt. When at
+# least two targets are covered, also merges the profiles into a single
+# union report at coverage/union-report.txt — the "which code does
+# fuzzing reach at all" view. Requires llvm-tools-preview:
+#   rustup component add llvm-tools-preview --toolchain nightly
+if [[ "${1:-}" == "coverage" ]]; then
+  HOST=$(rustc +nightly -vV | sed -n 's/^host: //p')
+  TOOLS="$(rustc +nightly --print sysroot)/lib/rustlib/${HOST}/bin"
+  if [[ ! -x "$TOOLS/llvm-cov" ]]; then
+    echo "llvm-cov not found under $TOOLS" >&2
+    echo "Install it with: rustup component add llvm-tools-preview --toolchain nightly" >&2
+    exit 1
+  fi
+  # Keep the report focused on workspace code: drop registry deps, the
+  # rust std sources, and the fuzz harness itself.
+  IGNORE='(/\.cargo/|/rustc/|/\.rustup/|qa/fuzz/)'
+  if [[ -n "${2:-}" ]]; then
+    COV_TARGETS=("$2")
+  else
+    COV_TARGETS=("${TARGETS[@]}")
+  fi
+  FIRST_BIN=""
+  PROFS=()
+  OBJS=()
+  for target in "${COV_TARGETS[@]}"; do
+    if [[ ! -d "corpus/$target" ]]; then
+      echo "=== $target: no corpus, skipping ==="
+      continue
+    fi
+    dirs=("corpus/$target")
+    if [[ -d "seeds/$target" ]]; then
+      dirs+=("seeds/$target")
+    fi
+    echo "=== coverage $target ==="
+    cargo +nightly fuzz coverage --fuzz-dir . -s none "$target" "${dirs[@]}"
+    BIN="target/${HOST}/coverage/${HOST}/release/$target"
+    PROF="coverage/$target/coverage.profdata"
+    "$TOOLS/llvm-cov" report --instr-profile="$PROF" "$BIN" \
+      --ignore-filename-regex="$IGNORE" > "coverage/$target/report.txt"
+    tail -1 "coverage/$target/report.txt"
+    PROFS+=("$PROF")
+    if [[ -z "$FIRST_BIN" ]]; then
+      FIRST_BIN="$BIN"
+    else
+      OBJS+=(-object "$BIN")
+    fi
+  done
+  if [[ ${#PROFS[@]} -ge 2 ]]; then
+    "$TOOLS/llvm-profdata" merge -sparse "${PROFS[@]}" -o coverage/union.profdata
+    "$TOOLS/llvm-cov" report --instr-profile=coverage/union.profdata \
+      "$FIRST_BIN" "${OBJS[@]}" \
+      --ignore-filename-regex="$IGNORE" > coverage/union-report.txt
+    echo "=== union (${#PROFS[@]} targets) ==="
+    tail -1 coverage/union-report.txt
+    echo "Union report: coverage/union-report.txt"
+  fi
   exit
 fi
 

--- a/qa/fuzz/fuzz.sh
+++ b/qa/fuzz/fuzz.sh
@@ -9,6 +9,14 @@
 #   ASAN=1 ./fuzz.sh                          # Re-enable AddressSanitizer
 #   ./fuzz.sh summarize <target> <file>       # Decode a corpus/crash input
 #   ./fuzz.sh triage <file>                   # Triage a fuzz_witness_cheat crash
+#   ./fuzz.sh cmin [target]                   # Minimize corpora in place (all targets if omitted)
+#   ./fuzz.sh regress [target]                # Replay committed crash reproducers once each
+#
+# Crash-regression inputs: when a fuzz run finds a real bug, commit the
+# minimized reproducer to regressions/<target>/ (tracked in git, unlike
+# corpus/ and seeds/). `./fuzz.sh regress` replays every committed
+# reproducer once and fails on any crash; the cron does the same before
+# each fuzz run.
 #
 # The DICT=1 path passes -dict=dict.txt to libFuzzer. Empirical comparison
 # (60s on fuzz_element_ops): roughly flat coverage with a small features
@@ -43,6 +51,29 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
+TARGETS=(
+  fuzz_poseidon_sponge
+  fuzz_endoscalar
+  fuzz_element_ops
+  fuzz_circuit_witness
+  fuzz_circuit_revdot_identity
+  fuzz_staging
+  fuzz_revdot
+  fuzz_fold_revdot
+  fuzz_sxy_agreement
+  fuzz_poseidon_differential
+  fuzz_verify_reject
+  fuzz_witness_cheat
+  fuzz_driver_metamorphic
+  fuzz_witness_coverage
+  fuzz_algebraic_identities
+  fuzz_element_assertions
+  fuzz_multipack
+  fuzz_point_identities
+  fuzz_consistent
+  fuzz_io_roundtrip
+)
+
 # `summarize` subcommand: decode a single corpus/crash input via DEBUG_INPUT.
 if [[ "${1:-}" == "summarize" ]]; then
   if [[ -z "${2:-}" || -z "${3:-}" ]]; then
@@ -75,6 +106,59 @@ if [[ "${1:-}" == "triage" ]]; then
   exit
 fi
 
+# `cmin` subcommand: coverage-preserving corpus minimization, in place.
+# Minimizes one target's corpus, or every target's when none is given.
+# Uses `-s none` to reuse the default build cache; set ASAN=1 to match a
+# sanitizer-enabled build instead.
+if [[ "${1:-}" == "cmin" ]]; then
+  CMIN_SAN_FLAG="-s none"
+  if [[ -n "${ASAN:-}" ]]; then
+    CMIN_SAN_FLAG=""
+  fi
+  if [[ -n "${2:-}" ]]; then
+    CMIN_TARGETS=("$2")
+  else
+    CMIN_TARGETS=("${TARGETS[@]}")
+  fi
+  for target in "${CMIN_TARGETS[@]}"; do
+    if [[ ! -d "corpus/$target" ]]; then
+      echo "=== $target: no corpus, skipping ==="
+      continue
+    fi
+    BEFORE=$(find "corpus/$target" -type f | wc -l | tr -d ' ')
+    echo "=== cmin $target ($BEFORE inputs) ==="
+    cargo +nightly fuzz cmin --fuzz-dir . $CMIN_SAN_FLAG "$target"
+    AFTER=$(find "corpus/$target" -type f | wc -l | tr -d ' ')
+    echo "=== $target: $BEFORE -> $AFTER inputs ==="
+  done
+  exit
+fi
+
+# `regress` subcommand: replay committed crash reproducers (one
+# execution per file, no fuzzing) for one target or all targets.
+# Any crash fails the run.
+if [[ "${1:-}" == "regress" ]]; then
+  REG_SAN_FLAG="-s none"
+  if [[ -n "${ASAN:-}" ]]; then
+    REG_SAN_FLAG=""
+  fi
+  if [[ -n "${2:-}" ]]; then
+    REG_TARGETS=("$2")
+  else
+    REG_TARGETS=("${TARGETS[@]}")
+  fi
+  for target in "${REG_TARGETS[@]}"; do
+    files=("regressions/$target"/*)
+    if [[ ! -e "${files[0]:-}" ]]; then
+      continue
+    fi
+    echo "=== regress $target (${#files[@]} inputs) ==="
+    cargo +nightly fuzz run --fuzz-dir . $REG_SAN_FLAG "$target" "${files[@]}"
+  done
+  echo "=== regressions OK ==="
+  exit
+fi
+
 DURATION="${1:-30}"
 PARALLEL="${2:-}"
 DICT="${DICT:-}"
@@ -92,33 +176,18 @@ if [[ -n "$ASAN" ]]; then
   SAN_FLAG=""
 fi
 
-TARGETS=(
-  fuzz_poseidon_sponge
-  fuzz_endoscalar
-  fuzz_element_ops
-  fuzz_circuit_witness
-  fuzz_circuit_revdot_identity
-  fuzz_staging
-  fuzz_revdot
-  fuzz_fold_revdot
-  fuzz_sxy_agreement
-  fuzz_poseidon_differential
-  fuzz_verify_reject
-  fuzz_witness_cheat
-  fuzz_driver_metamorphic
-  fuzz_witness_coverage
-  fuzz_algebraic_identities
-  fuzz_element_assertions
-  fuzz_multipack
-  fuzz_point_identities
-  fuzz_consistent
-  fuzz_io_roundtrip
-)
-
 run_target() {
   local target="$1"
   echo "=== $target (${DURATION}s) ==="
-  cargo +nightly fuzz run --fuzz-dir . $SAN_FLAG "$target" -- \
+  # First dir receives new units; seeds/<target> (when present) is a
+  # committed, read-only seed set merged in at startup so cold starts
+  # never begin from an empty corpus.
+  local dirs=("corpus/$target")
+  if [[ -d "seeds/$target" ]]; then
+    dirs+=("seeds/$target")
+  fi
+  mkdir -p "corpus/$target"
+  cargo +nightly fuzz run --fuzz-dir . $SAN_FLAG "$target" "${dirs[@]}" -- \
     $DICT_FLAG \
     -max_len=1024 \
     -max_total_time="$DURATION" \

--- a/qa/fuzz/fuzz.sh
+++ b/qa/fuzz/fuzz.sh
@@ -29,7 +29,7 @@
 # — measured ~70% on fuzz_witness_cheat (50k → 84k exec/s), ~30% on
 # fuzz_poseidon_sponge, ~10% on fuzz_element_ops. ASAN catches memory
 # bugs (UAF, OOB on unwise unsafe, leaks across `Simulator::simulate`
-# closures); to opt back in, set ASAN=1. The weekly cron in
+# closures); to opt back in, set ASAN=1. The scheduled cron in
 # `.github/workflows/fuzz-cron.yml` invokes `cargo +nightly fuzz run`
 # directly and keeps ASAN regardless of this script's default. Crash
 # artifacts found here should be reproduced under ASAN=1 before triaging
@@ -175,6 +175,10 @@ if [[ "${1:-}" == "coverage" ]]; then
     echo "Install it with: rustup component add llvm-tools-preview --toolchain nightly" >&2
     exit 1
   fi
+  has_input_files() {
+    local dir="$1"
+    [[ -d "$dir" ]] && [[ -n "$(find "$dir" -type f -print -quit)" ]]
+  }
   # Keep the report focused on workspace code: drop registry deps, the
   # rust std sources, and the fuzz harness itself.
   IGNORE='(/\.cargo/|/rustc/|/\.rustup/|qa/fuzz/)'
@@ -187,13 +191,16 @@ if [[ "${1:-}" == "coverage" ]]; then
   PROFS=()
   OBJS=()
   for target in "${COV_TARGETS[@]}"; do
-    if [[ ! -d "corpus/$target" ]]; then
-      echo "=== $target: no corpus, skipping ==="
-      continue
+    dirs=()
+    if has_input_files "corpus/$target"; then
+      dirs+=("corpus/$target")
     fi
-    dirs=("corpus/$target")
-    if [[ -d "seeds/$target" ]]; then
+    if has_input_files "seeds/$target"; then
       dirs+=("seeds/$target")
+    fi
+    if [[ ${#dirs[@]} -eq 0 ]]; then
+      echo "=== $target: no corpus or seed inputs, skipping ==="
+      continue
     fi
     echo "=== coverage $target ==="
     cargo +nightly fuzz coverage --fuzz-dir . -s none "$target" "${dirs[@]}"


### PR DESCRIPTION
There were some fuzzing targets missing from the CI matrix, which this adds. Also splits the corpus cache into restore/save so it can load interesting crash inputs for future workloads.

We run these automated workflows three times a week. It already runs, `fuzz-cron.yml` which looks for bugs and mutates inputs to find crashes and grow the corpus. After this lands, it'll also run `fuzz-coverage.yml` which produces a coverage report (it replays the corpus once and reports which code / lines the fuzzers are actually reaching, so we have some stats even when the fuzzing didn't find anything!). Before this coverage report, we only collected crash artifacts when a bug was found, saved that in the corpus as memory, and then next run picks up from it.