### PR TITLE
docs(primitives): document gadget preconditions/contracts

### DIFF
--- a/crates/ragu_primitives/src/boolean.rs
+++ b/crates/ragu_primitives/src/boolean.rs
@@ -28,8 +28,16 @@ use crate::{
     util::InternalMaybe,
 };
 
-/// Represents a wire that is constrained to be zero or one, along with its
-/// corresponding [`bool`] value.
+/// Represents a wire constrained to encode a [`bool`].
+///
+/// # Contract
+///
+/// A valid [`Boolean`] carries a wire whose assignment is either `0` or `1`,
+/// together with a witness value matching that assignment. All public
+/// constructors maintain this invariant. Internal promotion paths that rebuild a
+/// [`Boolean`] from an existing wire must only be used when the caller already
+/// knows that the wire was produced by, or remains equal to, a boolean
+/// constraint.
 #[derive(Gadget, GadgetEquals)]
 pub struct Boolean<'dr, D: Driver<'dr>> {
     /// The wire constrained to hold either `0` or `1` in the scalar field.
@@ -43,6 +51,11 @@ pub struct Boolean<'dr, D: Driver<'dr>> {
 
 impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
     /// Allocates a boolean with the provided witness value.
+    ///
+    /// # Contract
+    ///
+    /// The returned wire is constrained to be either `0` or `1` and to agree
+    /// with `value`.
     ///
     /// This costs one gate and two constraints.
     pub fn alloc<A: crate::allocator::Allocator<'dr, D>>(
@@ -68,6 +81,11 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
     }
 
     /// Computes the NOT of this boolean. This is "free" in the circuit model.
+    ///
+    /// # Contract
+    ///
+    /// The input must already satisfy the [`Boolean`] invariant. The returned
+    /// value is boolean because its wire is the affine expression `1 - self`.
     pub fn not(&self, dr: &mut D) -> Self {
         // The wire w is transformed into 1 - w, its logical NOT.
         let wire = dr.add(|lc| lc.add(&D::ONE).sub(self.wire()));
@@ -75,8 +93,14 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
         Boolean { wire, value }
     }
 
-    /// Computes the AND of two booleans. This costs one gate and two
-    /// constraints.
+    /// Computes the AND of two booleans.
+    ///
+    /// # Contract
+    ///
+    /// Both inputs must already satisfy the [`Boolean`] invariant. The returned
+    /// wire is then constrained to equal their product, which is again boolean.
+    ///
+    /// This costs one gate and two constraints.
     pub fn and(&self, dr: &mut D, other: &Self) -> Result<Self> {
         let result = D::just(|| self.value.snag() & other.value.snag());
         let (a, b, c) = dr.mul(|| {
@@ -98,6 +122,12 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
     /// Selects between two elements based on this boolean's value.
     /// Returns `a` when false, `b` when true.
     ///
+    /// # Contract
+    ///
+    /// `self` must already satisfy the [`Boolean`] invariant. If it does, the
+    /// returned element is constrained to `a + self * (b - a)`, which equals
+    /// `a` for `false` and `b` for `true`.
+    ///
     /// This costs one gate and two constraints.
     pub fn conditional_select(
         &self,
@@ -113,6 +143,12 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
 
     /// Conditionally enforces that two elements are equal.
     /// When this boolean is true, enforces `a == b`; when false, no constraint.
+    ///
+    /// # Contract
+    ///
+    /// `self` must already satisfy the [`Boolean`] invariant. Under that
+    /// precondition, the emitted constraint is equivalent to
+    /// `self * (a - b) = 0`.
     ///
     /// This costs one gate and three constraints.
     pub fn conditional_enforce_equal(
@@ -157,6 +193,10 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
     }
 
     /// Converts this boolean into an [`Element`].
+    ///
+    /// The returned element carries the same wire and witness value, represented
+    /// as `0` or `1` in the field. It relies on this [`Boolean`]'s existing
+    /// boolean constraint; no new constraint is emitted.
     pub fn element(&self) -> Element<'dr, D> {
         Element::promote(self.wire.clone(), self.value().fe())
     }
@@ -165,6 +205,12 @@ impl<'dr, D: Driver<'dr>> Boolean<'dr, D> {
 /// Returns a boolean indicating whether the element is zero.
 ///
 /// Uses the standard inverse trick for zero checking in arithmetic circuits.
+///
+/// # Contract
+///
+/// The returned [`Boolean`] is constrained to be `1` exactly when `x = 0`, and
+/// `0` exactly when `x != 0`. The auxiliary inverse witness is unconstrained
+/// when `x = 0` and must be `x^{-1}` when `x != 0`.
 pub(crate) fn is_zero<'dr, D: Driver<'dr>>(
     dr: &mut D,
     allocator: &mut impl Allocator<'dr, D>,
@@ -235,6 +281,9 @@ impl<F: Field> Promotion<F> for Kind![F; @Boolean<'_, _>] {
         demoted: &Demoted<'dr, D, Boolean<'dr, D>>,
         witness: DriverValue<D, bool>,
     ) -> Boolean<'dr, D> {
+        // Soundness: a demoted Boolean carries a wire that was already
+        // constrained by the original Boolean gadget. Promotion only restores
+        // the erased witness value.
         Boolean {
             wire: demoted.wire.clone(),
             value: witness,
@@ -245,6 +294,12 @@ impl<F: Field> Promotion<F> for Kind![F; @Boolean<'_, _>] {
 /// Packs boolean slices into field elements using little-endian bit order.
 ///
 /// The first bit in each chunk is the least significant bit.
+///
+/// # Contract
+///
+/// Every input must already satisfy the [`Boolean`] invariant. The returned
+/// elements are linear combinations of those boolean wires; this function does
+/// not re-enforce booleanity.
 pub fn multipack<'dr, D: Driver<'dr, F: ragu_arithmetic::ff::PrimeField>>(
     dr: &mut D,
     bits: &[Boolean<'dr, D>],

--- a/crates/ragu_primitives/src/invertible.rs
+++ b/crates/ragu_primitives/src/invertible.rs
@@ -18,6 +18,14 @@ use crate::{
 
 /// An [`Element`] that has been constrained nonzero in the constraint system.
 ///
+/// # Contract
+///
+/// A valid [`Nonzero`] carries an [`Element`] whose assignment cannot be zero in
+/// any satisfying circuit assignment. Public constructors and methods preserve
+/// this invariant. Internal unchecked constructors may only be used after the
+/// caller has already emitted equivalent constraints or has a structural
+/// argument that the element is nonzero.
+///
 /// See [`Element::enforce_nonzero`].
 ///
 /// [`Nonzero`] dereferences to the underlying [`Element`], so all of
@@ -31,7 +39,8 @@ impl<'dr, D: Driver<'dr>> Nonzero<'dr, D> {
     /// Wraps `element` without checking the nonzero invariant.
     ///
     /// The caller is responsible for having emitted constraints that prove
-    /// `element` is nonzero.
+    /// `element` is nonzero, or for relying on a structural argument that makes
+    /// zero impossible.
     pub(crate) fn new_unchecked(element: Element<'dr, D>) -> Self {
         Self { element }
     }
@@ -116,6 +125,12 @@ impl<'dr, D: Driver<'dr>> Consistent<'dr, D> for Nonzero<'dr, D> {
 /// [`inverse`](Self::inverse).
 ///
 /// Inversion is free, since the inverse is located within the gadget.
+///
+/// # Contract
+///
+/// A valid [`Invertible`] carries two [`Nonzero`] elements `x` and `x^{-1}` and
+/// constrains their product to `1`. This proves both that `x` is nonzero and
+/// that the stored inverse is canonical in any satisfying assignment.
 #[derive(Gadget)]
 pub struct Invertible<'dr, D: Driver<'dr>> {
     element: Nonzero<'dr, D>,
@@ -125,7 +140,10 @@ pub struct Invertible<'dr, D: Driver<'dr>> {
 impl<'dr, D: Driver<'dr>> Invertible<'dr, D> {
     /// Allocate an [`Invertible`] field element.
     ///
-    /// This will be unsatisfied (and fail to synthesize) if `value` is zero.
+    /// # Precondition
+    ///
+    /// `value` must be nonzero. A zero witness is rejected while computing the
+    /// inverse witness.
     ///
     /// Computing the inverse witness costs a field inversion. If the inverse is
     /// already known, prefer
@@ -145,8 +163,11 @@ impl<'dr, D: Driver<'dr>> Invertible<'dr, D> {
 
     /// Allocate an [`Invertible`] field element given its inverse as advice.
     ///
-    /// This will be unsatisfied if `value` is zero or if `inverse_value` is not
-    /// really its multiplicative inverse.
+    /// # Precondition
+    ///
+    /// `value` must be nonzero and `inverse_value` must be its multiplicative
+    /// inverse. If not, the emitted `value * inverse_value = 1` constraint is
+    /// unsatisfied.
     ///
     /// This costs one gate and one constraint.
     pub fn alloc_with_advice(
@@ -237,6 +258,8 @@ impl<F: Field> Write<F> for Kind![F; @Invertible<'_, _>] {
 /// Batches deferred nonzero proofs so several factors can share one final
 /// nonzero check.
 ///
+/// # Contract
+///
 /// Folding an element into the bank multiplies it into a running product and
 /// trusts it nonzero; when the scope closes, the product is constrained
 /// nonzero, retroactively validating every factor.
@@ -262,6 +285,9 @@ impl<'dr, D: Driver<'dr>> NonzeroBank<'dr, D> {
     /// Constructs a bank that asserts every fold is nonzero by external
     /// argument. No constraints are emitted by `fold` or by dropping the
     /// bank. Internal use only.
+    ///
+    /// Callers must have a structural proof that every folded element is
+    /// nonzero.
     pub(crate) fn new_unchecked() -> Self {
         Self { product: None }
     }
@@ -271,6 +297,9 @@ impl<'dr, D: Driver<'dr>> NonzeroBank<'dr, D> {
     /// In discharging mode, the nonzero proof is deferred until the enclosing
     /// [`scope`](Self::scope) succeeds. Errors from that scope must be
     /// propagated.
+    ///
+    /// In unchecked mode, this method emits no constraints; callers of the
+    /// unchecked constructor are responsible for the nonzero argument.
     ///
     /// This costs one gate and two constraints in discharging mode, and zero
     /// gates and zero constraints in unchecked mode.

--- a/crates/ragu_primitives/src/point.rs
+++ b/crates/ragu_primitives/src/point.rs
@@ -41,9 +41,11 @@ pub struct Point<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
 }
 
 impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
-    /// Creates a new `Point` from the given coordinates without checking that
-    /// the provided $x, y$ satisfy the curve equation. The caller is
-    /// responsible for ensuring this.
+    /// Creates a new `Point` from the given coordinates without checking the
+    /// curve equation.
+    ///
+    /// The caller is responsible for ensuring that `x` and `y` are nonzero and
+    /// satisfy the supported curve equation documented on [`Point`].
     fn new_unchecked(x: Nonzero<'dr, D>, y: Nonzero<'dr, D>) -> Self {
         Point {
             x,
@@ -56,7 +58,9 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
     /// point is at infinity.
     ///
     /// This method uses [`Element::alloc_square`] to allocate coordinates and
-    /// then enforces the curve equation.
+    /// then enforces the supported curve equation documented on [`Point`].
+    /// Under those curve assumptions, every affine point has nonzero
+    /// coordinates.
     pub fn alloc(dr: &mut D, p: DriverValue<D, C>) -> Result<Self> {
         let coordinates = D::try_just(|| {
             let coordinates = p.take().coordinates().into_option();
@@ -84,6 +88,9 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
 
     /// Obtain a constant point in the circuit. Fails if the point is the
     /// identity.
+    ///
+    /// The supported curve assumptions documented on [`Point`] imply that every
+    /// non-identity affine point has nonzero coordinates.
     pub fn constant(dr: &mut D, p: C) -> Result<Self> {
         if let Some(coordinates) = p.coordinates().into_option() {
             let x = Element::constant(dr, *coordinates.x());
@@ -101,6 +108,11 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
     }
 
     /// Returns the point represented by this gadget.
+    ///
+    /// This relies on the [`Point`] invariant that its coordinates satisfy the
+    /// supported curve equation. Public constructors enforce this; internal
+    /// unchecked constructors must only be used when the caller has already
+    /// established it.
     pub fn value(&self) -> DriverValue<D, C> {
         D::just(|| {
             let x = *self.x.value().take();
@@ -110,6 +122,9 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
     }
 
     /// Applies the endomorphism to this point.
+    ///
+    /// This relies on the nontrivial cube root of unity required by the
+    /// supported curve assumptions documented on [`Point`].
     pub fn endo(&self, dr: &mut D) -> Self {
         let endo_x = self.x.scale(dr, Coeff::Arbitrary(C::Base::ZETA));
         Point::new_unchecked(Nonzero::new_unchecked(endo_x), self.y.clone())
@@ -125,6 +140,9 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
     }
 
     /// Apply the endomorphism iff the provided condition is true.
+    ///
+    /// The `condition` argument is a [`Boolean`], so its bitness is enforced by
+    /// the boolean gadget invariant.
     pub fn conditional_endo(&self, dr: &mut D, condition: &Boolean<'dr, D>) -> Result<Self> {
         let endo_x = self.x.scale(dr, Coeff::Arbitrary(D::F::ZETA));
         let x = condition.conditional_select(dr, &self.x, &endo_x)?;
@@ -135,6 +153,9 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
     }
 
     /// Apply the negation map iff the provided condition is true.
+    ///
+    /// The `condition` argument is a [`Boolean`], so its bitness is enforced by
+    /// the boolean gadget invariant.
     pub fn conditional_negate(&self, dr: &mut D, condition: &Boolean<'dr, D>) -> Result<Self> {
         let neg_y = self.y.negate(dr);
         let y = condition.conditional_select(dr, &self.y, &neg_y)?;
@@ -144,8 +165,13 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
         ))
     }
 
-    /// Doubles this point. Ragu does not support curves with points of order
-    /// two, and thus all affine points have affine doubles.
+    /// Doubles this point.
+    ///
+    /// # Precondition
+    ///
+    /// This relies on the supported curve assumptions documented on [`Point`]:
+    /// Ragu does not support curves with points of order two, so every affine
+    /// point has nonzero `y` coordinate and therefore an affine double.
     pub fn double(&self, dr: &mut D) -> Result<Self> {
         // delta = 3x^2 / 2y
         let double_y = self.y.double(dr);


### PR DESCRIPTION
Work on #762 — rigorously documenting gadget preconditions/contracts as Rust-side hygiene.

**Status: WIP / parked.** Opening as a draft to park progress; Not ready for review.

### Covered so far
- `boolean.rs` — `Boolean` invariant + `alloc`/`not`/`and`/`conditional_select`/`conditional_enforce_equal`/`element`/`is_zero`/promotion/`multipack`
- `invertible.rs` — `Nonzero`, `new_unchecked`, `Invertible`, `alloc`
- `point.rs` — partial

### Still to do
- `element.rs` (the bulk: `promote` contract, arithmetic ops, `enforce_root_of_unity` comment)
- Reconcile heading convention against #760 (circuit code documentation policy) before finalizing
- Rebase onto current `main` (`invertible.rs` doc comments moved since this draft)

### Out of scope (deliberately)
- **Endoscalar** — held while #765 / #767 / #711 / #761 are in flight
- Non-doc findings (`enforce_root_of_unity` mismatch, `promote` hardening per #245, `scope` error-propagation per #467) to be filed separately, not folded in here
