### PR TITLE
refactor(mock): polys and identity commits

### DIFF
--- a/src/mock/application.rs
+++ b/src/mock/application.rs
@@ -96,6 +96,9 @@ impl Application {
         let left_proof = left.proof;
         let right_proof = right.proof;
 
+        proof::compute_header_hash(S::Left::SUFFIX, &S::Left::encode(&left.data))?;
+        proof::compute_header_hash(S::Right::SUFFIX, &S::Right::encode(&right.data))?;
+
         let mut hooks = FrameworkHooks::new();
         let mut ctx = StepCtx::new(&mut hooks);
         let (output_data, aux) = step.witness(&mut ctx, witness, left.data, right.data)?;
@@ -111,7 +114,7 @@ impl Application {
         witness_data.extend_from_slice(left_bytes.as_ref());
         witness_data.extend_from_slice(right_bytes.as_ref());
 
-        let proof_value = Proof::new(S::Output::SUFFIX, S::INDEX, &encoded, &witness_data);
+        let proof_value = Proof::new(S::Output::SUFFIX, S::INDEX, &encoded, &witness_data)?;
         Ok((proof_value.carry::<S::Output>(output_data), aux))
     }
 
@@ -122,7 +125,7 @@ impl Application {
         }
 
         let encoded = H::encode(&pcd.data);
-        let expected_header_hash = proof::compute_header_hash(H::SUFFIX, &encoded);
+        let expected_header_hash = proof::compute_header_hash(H::SUFFIX, &encoded)?;
         if expected_header_hash != pcd.proof.header_hash {
             return Ok(false);
         }

--- a/src/mock/constraint.rs
+++ b/src/mock/constraint.rs
@@ -73,11 +73,14 @@ pub fn conditional_enforce_equal<F: Field>(
 /// equal); returns `Err(Error::InvalidWitness(err))` where those constraints
 /// would be unsatisfiable (`a != b`).
 ///
-/// Note: the real `Point` gadget cannot represent the identity —
-/// `Point::alloc` and `Point::constant` reject points at infinity — so while
-/// this mock accepts `identity == identity`, callers using it as a `Point`
-/// mock must only pass non-identity points.
+/// An identity input errors instead, since real ragu cannot witness it as a
+/// `Point`.
 pub fn enforce_equal_point<C: Group>(a: C, b: C, err: &'static str) -> Result<()> {
+    if bool::from(a.is_identity()) || bool::from(b.is_identity()) {
+        return Err(Error::InvalidWitness(
+            "point at infinity cannot be witnessed".into(),
+        ));
+    }
     if a == b {
         Ok(())
     } else {

--- a/src/mock/ctx.rs
+++ b/src/mock/ctx.rs
@@ -8,8 +8,11 @@
 //! polynomial-query opening claims and deriving Fiat-Shamir challenges.
 
 use blake2b_simd::Params;
-use ragu_arithmetic::{ff::FromUniformBytes as _, group::GroupEncoding as _};
-use ragu_core::Result;
+use ragu_arithmetic::{
+    ff::FromUniformBytes as _,
+    group::{Group as _, GroupEncoding as _},
+};
+use ragu_core::{Error, Result};
 use ragu_pasta::{Eq, Fp};
 
 use crate::hooks::FrameworkHooks;
@@ -27,11 +30,23 @@ impl<'a> StepCtx<'a> {
         Self { hooks }
     }
 
+    /// Records a polynomial-query opening claim. Errors if `com` is the
+    /// identity, which real ragu cannot witness as a commitment `Point`.
     pub fn enforce_poly_query(&mut self, com: Eq, x: Fp, y: Fp) -> Result<()> {
         self.hooks.enforce_polynomial_query(com, x, y)
     }
 
+    /// Derives a Fiat-Shamir challenge from `commitments`. Errors on an
+    /// identity commitment, which real ragu could not have absorbed as a
+    /// `Point`.
     pub fn derive_challenge(&mut self, commitments: &[Eq]) -> Result<Fp> {
+        for com in commitments {
+            if bool::from(com.is_identity()) {
+                return Err(Error::InvalidWitness(
+                    "point at infinity cannot be witnessed".into(),
+                ));
+            }
+        }
         let mut state = Params::new()
             .hash_length(CHALLENGE_LEN)
             .personal(b"MkRagu_Challng_\0")

--- a/src/mock/header.rs
+++ b/src/mock/header.rs
@@ -2,6 +2,8 @@
 
 use alloc::vec::Vec;
 
+use ragu_pasta::{Ep, Eq, Fp, Fq};
+
 /// Number of internal header suffixes reserved by mock_ragu.
 ///
 /// Mirrors real ragu's `InternalStepIndex` layout:
@@ -63,7 +65,12 @@ impl Suffix {
 pub trait Header: Send + Sync + 'static {
     const SUFFIX: Suffix;
     type Data: Send + Clone;
-    fn encode(data: &Self::Data) -> Vec<u8>;
+
+    /// Decomposes header data into the in-circuit values it would carry, as
+    /// `(Fp elements, Fq elements, Pallas points, Vesta points)`. Pass points
+    /// as points, not coordinates: like real ragu's in-circuit `encode`, the
+    /// identity is rejected when these are hashed.
+    fn encode(data: &Self::Data) -> (Vec<Fp>, Vec<Fq>, Vec<Ep>, Vec<Eq>);
 }
 
 /// Trivial header for seed steps.
@@ -72,7 +79,7 @@ impl Header for () {
 
     const SUFFIX: Suffix = Suffix::internal(1);
 
-    fn encode(_data: &()) -> Vec<u8> {
-        Vec::new()
+    fn encode(_data: &()) -> (Vec<Fp>, Vec<Fq>, Vec<Ep>, Vec<Eq>) {
+        (Vec::new(), Vec::new(), Vec::new(), Vec::new())
     }
 }

--- a/src/mock/hooks.rs
+++ b/src/mock/hooks.rs
@@ -7,7 +7,8 @@
 
 use alloc::vec::Vec;
 
-use ragu_core::Result;
+use ragu_arithmetic::group::Group as _;
+use ragu_core::{Error, Result};
 use ragu_pasta::{Eq, Fp};
 
 pub type PolyQueryClaim = (Eq, Fp, Fp);
@@ -27,7 +28,14 @@ impl FrameworkHooks {
         }
     }
 
+    /// Records a polynomial-query opening claim. Errors if `com` is the
+    /// identity, which real ragu cannot witness as a commitment `Point`.
     pub fn enforce_polynomial_query(&mut self, com: Eq, x: Fp, y: Fp) -> Result<()> {
+        if bool::from(com.is_identity()) {
+            return Err(Error::InvalidWitness(
+                "point at infinity cannot be witnessed".into(),
+            ));
+        }
         self.poly_query_claims.push((com, x, y));
         Ok(())
     }

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -12,7 +12,7 @@ pub use ctx::StepCtx;
 pub use domain::Domain;
 pub use header::{Header, Suffix};
 pub use hooks::FrameworkHooks;
-pub use polynomial::Polynomial;
+pub use polynomial::{Polynomial, poly_with_roots};
 pub use proof::{Pcd, Proof};
 pub use ragu_arithmetic::{Cycle, FixedGenerators};
 pub use ragu_core::{Error, Result};

--- a/src/mock/polynomial.rs
+++ b/src/mock/polynomial.rs
@@ -1,69 +1,132 @@
-//! Polynomial commitments — mirrors Ragu's polynomial commitment scheme.
-//!
-//! Real Pedersen crypto on Vesta, against the real Ragu generators. A commitment
-//! is just the curve point (`Eq`) that `ragu_arithmetic::mul` returns — exactly
-//! what real ragu's `Polynomial::commit` produces (`C::Curve`), with no
-//! mock-specific wrapper — and the generators are the real
-//! [`ragu_pasta::VestaGenerators`]. Only the proof system is mocked.
-
 use alloc::vec::Vec;
+use core::borrow::Borrow;
 
-use ragu_arithmetic::{Cycle as _, FixedGenerators as _, ff::Field as _};
-use ragu_circuits::polynomials::{ProductionRank, Rank};
-use ragu_pasta::{Eq, Fp, Pasta};
+pub use ragu_arithmetic::poly_with_roots;
+use ragu_arithmetic::{CryptoRngCore, Cycle};
+use ragu_circuits::polynomials::{ProductionRank, Rank, sparse};
+use ragu_pasta::{Eq, EqAffine, Fp, Pasta};
 
-/// Mirrors `ragu_circuits::polynomials::unstructured::Polynomial`.
-#[derive(Clone, Debug)]
-pub struct Polynomial(Vec<Fp>);
+/// Mirrors [`ragu_circuits::polynomials::sparse::Polynomial`], concrete over the
+/// Pasta scalar field [`Fp`] and the [`ProductionRank`].
+#[derive(Clone, Debug, Default)]
+pub struct Polynomial(sparse::Polynomial<Fp, ProductionRank>);
 
 impl Polynomial {
-    pub const MAX: usize = 1 << <ProductionRank as Rank>::RANK;
+    /// The rank: coefficient capacity is `2^R`.
+    pub const R: u32 = <ProductionRank as Rank>::RANK;
 
+    /// Creates a new empty (zero) polynomial.
     #[must_use]
-    pub fn from_coeffs(coeffs: &[Fp]) -> Self {
-        Self(coeffs.to_vec())
+    pub fn new() -> Self {
+        Self(sparse::Polynomial::new())
     }
 
+    /// Compresses a dense coefficient vector into sparse form.
+    ///
+    /// Panics if `coeffs.len()` exceeds the capacity `2^R`.
     #[must_use]
-    pub fn from_roots(roots: &[Fp]) -> Self {
-        Self::from_coeffs(&ragu_arithmetic::poly_with_roots(roots))
+    pub fn from_coeffs(coeffs: Vec<Fp>) -> Self {
+        Self(sparse::Polynomial::from_coeffs(coeffs))
     }
 
+    /// Creates a polynomial with random coefficients filling all slots.
     #[must_use]
-    pub fn multiply(&self, other: &Self) -> Self {
-        let mut result = Vec::new();
-        ragu_arithmetic::poly_mul(&self.0, &other.0, &mut result);
-        Self::from_coeffs(&result)
+    pub fn random<RNG: CryptoRngCore>(rng: &mut RNG) -> Self {
+        Self(sparse::Polynomial::random(rng))
     }
 
-    #[must_use]
-    pub fn coefficients(&self) -> &[Fp] {
-        &self.0
+    /// Iterates over the coefficients in ascending degree order, yielding
+    /// [`Fp::ZERO`](ragu_arithmetic::ff::Field::ZERO) for gaps.
+    pub fn iter_coeffs(&self) -> impl DoubleEndedIterator<Item = Fp> + ExactSizeIterator + '_ {
+        self.0.iter_coeffs()
     }
 
-    /// Evaluate at `x` via the real `ragu_arithmetic::eval` (Horner's method).
-    #[must_use]
-    pub fn eval(&self, x: Fp) -> Fp {
-        ragu_arithmetic::eval(&self.0, x)
+    /// Multiplies all coefficients by `by`.
+    pub fn scale(&mut self, by: Fp) {
+        self.0.scale(by);
     }
 
-    /// $\text{commit}() = \sum_i c_i \cdot g_i$ -- the unblinded coefficient
-    /// commitment, the Vesta point `ragu_arithmetic::mul` returns.
+    /// Adds the coefficients of `other` to `self`.
+    pub fn add_assign(&mut self, other: &Self) {
+        self.0.add_assign(&other.0);
+    }
+
+    /// Subtracts the coefficients of `other` from `self`.
+    pub fn sub_assign(&mut self, other: &Self) {
+        self.0.sub_assign(&other.0);
+    }
+
+    /// Negates all coefficients.
+    pub fn negate(&mut self) {
+        self.0.negate();
+    }
+
+    /// Horner-style weighted sum of polynomials by powers of `scale_factor`.
+    #[must_use]
+    pub fn fold<E: Borrow<Self>>(polys: impl IntoIterator<Item = E>, scale_factor: Fp) -> Self {
+        polys.into_iter().fold(Self::new(), |mut acc, poly| {
+            acc.scale(scale_factor);
+            acc.add_assign(poly.borrow());
+            acc
+        })
+    }
+
+    /// Evaluates this polynomial at `z`.
+    #[must_use]
+    pub fn eval(&self, z: Fp) -> Fp {
+        self.0.eval(z)
+    }
+
+    /// Transforms `p(X)` into `p(zX)`.
+    pub fn dilate(&mut self, z: Fp) {
+        self.0.dilate(z);
+    }
+
+    /// Inner product of `self` with the coefficient-reversed `other`.
+    #[must_use]
+    pub fn revdot(&self, other: &Self) -> Fp {
+        self.0.revdot(&other.0)
+    }
+
+    /// Commits to this polynomial against the host generators, returning the
+    /// Vesta point in projective form.
     #[must_use]
     pub fn commit(&self) -> Eq {
-        let g = Pasta::host_generators(Pasta::baked()).g();
-        assert!(
-            self.0.len() <= g.len(),
-            "polynomial degree {} exceeds max generators {}",
-            self.0.len() - 1,
-            g.len() - 1
-        );
-        ragu_arithmetic::mul(self.0.iter(), g[..self.0.len()].iter())
+        self.0.commit(Pasta::host_generators(Pasta::baked()))
+    }
+
+    /// Commits to this polynomial against the host generators, returning the
+    /// Vesta point normalized to affine.
+    #[must_use]
+    pub fn commit_to_affine(&self) -> EqAffine {
+        self.0
+            .commit_to_affine(Pasta::host_generators(Pasta::baked()))
     }
 }
 
-impl Default for Polynomial {
-    fn default() -> Self {
-        Self::from_coeffs(&[Fp::ONE])
+impl core::ops::AddAssign<&Self> for Polynomial {
+    fn add_assign(&mut self, rhs: &Self) {
+        Polynomial::add_assign(self, rhs);
+    }
+}
+
+impl core::ops::SubAssign<&Self> for Polynomial {
+    fn sub_assign(&mut self, rhs: &Self) {
+        Polynomial::sub_assign(self, rhs);
+    }
+}
+
+impl ragu_arithmetic::Ring for Polynomial {
+    type R = Self;
+    type F = Fp;
+
+    fn scale_assign(r: &mut Self, by: Fp) {
+        r.scale(by);
+    }
+    fn add_assign(r: &mut Self, other: &Self) {
+        Polynomial::add_assign(r, other);
+    }
+    fn sub_assign(r: &mut Self, other: &Self) {
+        Polynomial::sub_assign(r, other);
     }
 }

--- a/src/mock/proof.rs
+++ b/src/mock/proof.rs
@@ -11,7 +11,11 @@
 //! | 104..136    | 32   | rerandomization tag                                |
 //! | 136..23000  | …    | zero padding                                       |
 
-use alloc::{boxed::Box, vec};
+use alloc::{boxed::Box, vec, vec::Vec};
+
+use ragu_arithmetic::{CurveAffine as _, ff::PrimeField as _, group::Curve as _};
+use ragu_core::{Error, Result};
+use ragu_pasta::{Ep, Eq, Fp, Fq};
 
 use crate::{
     header::{Header, Suffix},
@@ -79,26 +83,31 @@ impl<H: Header> Clone for Pcd<H> {
 impl Proof {
     #[must_use]
     pub fn trivial() -> Self {
-        Self::new(<() as Header>::SUFFIX, Index::internal(1), &[], &[])
+        Self::new(
+            <() as Header>::SUFFIX,
+            Index::internal(1),
+            &(Vec::new(), Vec::new(), Vec::new(), Vec::new()),
+            &[],
+        )
+        .expect("empty header cannot fail to hash")
     }
 
-    #[must_use]
     pub(crate) fn new(
         suffix: Suffix,
         step_index: Index,
-        encoded_header: &[u8],
+        encoded_header: &(Vec<Fp>, Vec<Fq>, Vec<Ep>, Vec<Eq>),
         witness_data: &[u8],
-    ) -> Self {
-        let header_hash = compute_header_hash(suffix, encoded_header);
+    ) -> Result<Self> {
+        let header_hash = compute_header_hash(suffix, encoded_header)?;
         let witness_hash = compute_witness_hash(witness_data);
         let binding = compute_binding(step_index, &header_hash, &witness_hash);
-        Self {
+        Ok(Self {
             step_index,
             header_hash,
             witness_hash,
             binding,
             rerand_tag: [0u8; HASH_SIZE],
-        }
+        })
     }
 
     /// Mirrors `ragu_pcd::Proof::carry`.
@@ -149,9 +158,7 @@ impl From<Proof> for [u8; PROOF_SIZE_COMPRESSED] {
 impl TryFrom<&[u8; PROOF_SIZE_COMPRESSED]> for Proof {
     type Error = ragu_core::Error;
 
-    fn try_from(bytes: &[u8; PROOF_SIZE_COMPRESSED]) -> Result<Self, Self::Error> {
-        use ragu_core::Error;
-
+    fn try_from(bytes: &[u8; PROOF_SIZE_COMPRESSED]) -> Result<Self> {
         let slice: &[u8] = bytes.as_slice();
         let (step_index_bytes, rest) = slice
             .split_first_chunk::<STEP_INDEX_SIZE>()
@@ -189,17 +196,72 @@ impl TryFrom<&[u8; PROOF_SIZE_COMPRESSED]> for Proof {
     }
 }
 
-pub(crate) fn compute_header_hash(suffix: Suffix, encoded: &[u8]) -> [u8; HASH_SIZE] {
-    let hash = blake2b_simd::Params::new()
+pub(crate) fn compute_header_hash(
+    suffix: Suffix,
+    encoded: &(Vec<Fp>, Vec<Fq>, Vec<Ep>, Vec<Eq>),
+) -> Result<[u8; HASH_SIZE]> {
+    let (fps, fqs, eps, eqs) = encoded;
+    let mut state = blake2b_simd::Params::new()
         .hash_length(HASH_SIZE)
         .personal(b"MkRagu_HdrHash_\0")
-        .to_state()
-        .update(&suffix.get().to_le_bytes())
-        .update(encoded)
-        .finalize();
+        .to_state();
+
+    {
+        state.update(b"Suffix");
+        state.update(&suffix.get().to_le_bytes());
+    }
+
+    {
+        state.update(b"Fp");
+        state.update(&(fps.len() as u64).to_le_bytes());
+        for element in fps {
+            state.update(element.to_repr().as_ref());
+        }
+    }
+
+    {
+        state.update(b"Fq");
+        state.update(&(fqs.len() as u64).to_le_bytes());
+        for element in fqs {
+            state.update(element.to_repr().as_ref());
+        }
+    }
+
+    {
+        state.update(b"Ep");
+        state.update(&(eps.len() as u64).to_le_bytes());
+        for point in eps {
+            let coordinates = point
+                .to_affine()
+                .coordinates()
+                .into_option()
+                .ok_or_else(|| {
+                    Error::InvalidWitness("point at infinity cannot be witnessed".into())
+                })?;
+            state.update(coordinates.x().to_repr().as_ref());
+            state.update(coordinates.y().to_repr().as_ref());
+        }
+    }
+
+    {
+        state.update(b"Eq");
+        state.update(&(eqs.len() as u64).to_le_bytes());
+        for point in eqs {
+            let coordinates = point
+                .to_affine()
+                .coordinates()
+                .into_option()
+                .ok_or_else(|| {
+                    Error::InvalidWitness("point at infinity cannot be witnessed".into())
+                })?;
+            state.update(coordinates.x().to_repr().as_ref());
+            state.update(coordinates.y().to_repr().as_ref());
+        }
+    }
+
     let mut out = [0u8; HASH_SIZE];
-    out.copy_from_slice(hash.as_bytes());
-    out
+    out.copy_from_slice(state.finalize().as_bytes());
+    Ok(out)
 }
 
 pub(crate) fn compute_witness_hash(witness_bytes: &[u8]) -> [u8; HASH_SIZE] {

--- a/src/mock/tests/application.rs
+++ b/src/mock/tests/application.rs
@@ -1,7 +1,11 @@
 use alloc::vec::Vec;
 
-use ragu_arithmetic::rand::{SeedableRng as _, rngs::StdRng};
-use ragu_core::Result;
+use ragu_arithmetic::{
+    group::Group as _,
+    rand::{SeedableRng as _, rngs::StdRng},
+};
+use ragu_core::{Error, Result};
+use ragu_pasta::{Ep, Eq, Fp, Fq};
 
 use crate::{
     application::*,
@@ -23,9 +27,13 @@ impl Header for TestHeader {
 
     const SUFFIX: Suffix = Suffix::new(0);
 
-    fn encode(data: &Self::Data) -> Vec<u8> {
-        let bytes = data.value.to_le_bytes();
-        bytes.to_vec()
+    fn encode(data: &Self::Data) -> (Vec<Fp>, Vec<Fq>, Vec<Ep>, Vec<Eq>) {
+        (
+            alloc::vec![Fp::from(data.value)],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
     }
 }
 
@@ -438,8 +446,13 @@ impl Header for ConflictingHeader {
 
     const SUFFIX: Suffix = Suffix::new(0);
 
-    fn encode(data: &Self::Data) -> Vec<u8> {
-        data.value.to_le_bytes().to_vec()
+    fn encode(data: &Self::Data) -> (Vec<Fp>, Vec<Fq>, Vec<Ep>, Vec<Eq>) {
+        (
+            alloc::vec![Fp::from(data.value)],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
     }
 }
 
@@ -577,7 +590,8 @@ fn verify_rejects_unregistered_step_index() {
         Index::new(999),
         &encoded,
         b"unused-witness",
-    );
+    )
+    .expect("header without points hashes without error");
     let forged_pcd: Pcd<TestHeader> =
         forged_proof.carry::<TestHeader>(TestHeaderData { value: 42 });
 
@@ -598,8 +612,13 @@ fn verify_rejects_swapped_header_type() {
 
         const SUFFIX: Suffix = Suffix::new(99);
 
-        fn encode(data: &Self::Data) -> Vec<u8> {
-            data.value.to_le_bytes().to_vec()
+        fn encode(data: &Self::Data) -> (Vec<Fp>, Vec<Fq>, Vec<Ep>, Vec<Eq>) {
+            (
+                alloc::vec![Fp::from(data.value)],
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            )
         }
     }
 
@@ -625,4 +644,157 @@ fn verify_rejects_swapped_header_type() {
         !valid,
         "proof bound to a different Header SUFFIX must fail verify"
     );
+}
+
+/// Header carrying a Vesta commitment point.
+struct PointHeader;
+
+#[derive(Clone, Debug)]
+struct PointHeaderData {
+    commitment: Eq,
+}
+
+impl Header for PointHeader {
+    type Data = PointHeaderData;
+
+    const SUFFIX: Suffix = Suffix::new(1);
+
+    fn encode(data: &Self::Data) -> (Vec<Fp>, Vec<Fq>, Vec<Ep>, Vec<Eq>) {
+        (
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            alloc::vec![data.commitment],
+        )
+    }
+}
+
+/// Seed step whose output header carries the witness point.
+struct PointSeedStep;
+
+impl Step for PointSeedStep {
+    type Aux<'source> = ();
+    type Left = ();
+    type Output = PointHeader;
+    type Right = ();
+    type Witness<'source> = Eq;
+
+    const INDEX: Index = Index::new(0);
+
+    fn witness<'source>(
+        &self,
+        _ctx: &mut StepCtx<'_>,
+        witness: Self::Witness<'source>,
+        _left: <Self::Left as Header>::Data,
+        _right: <Self::Right as Header>::Data,
+    ) -> Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
+        Ok((
+            PointHeaderData {
+                commitment: witness,
+            },
+            (),
+        ))
+    }
+}
+
+/// Step consuming a [`PointHeader`] as its left input.
+struct PointConsumeStep;
+
+impl Step for PointConsumeStep {
+    type Aux<'source> = ();
+    type Left = PointHeader;
+    type Output = TestHeader;
+    type Right = ();
+    type Witness<'source> = ();
+
+    const INDEX: Index = Index::new(1);
+
+    fn witness<'source>(
+        &self,
+        _ctx: &mut StepCtx<'_>,
+        _witness: Self::Witness<'source>,
+        _left: <Self::Left as Header>::Data,
+        _right: <Self::Right as Header>::Data,
+    ) -> Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
+        Ok((TestHeaderData { value: 1 }, ()))
+    }
+}
+
+/// Application with [`PointSeedStep`] registered.
+fn point_app() -> Application {
+    ApplicationBuilder::new()
+        .register(PointSeedStep)
+        .expect("register")
+        .finalize()
+        .expect("finalize")
+}
+
+#[test]
+fn header_with_point_round_trips() {
+    let mut rng = StdRng::seed_from_u64(0);
+    let app = point_app();
+
+    let (pcd, ()) = app
+        .seed(&mut rng, PointSeedStep, Eq::generator())
+        .expect("seed with a non-identity point");
+    assert!(app.verify(&pcd, &mut rng).expect("verify"));
+}
+
+#[test]
+fn identity_point_in_output_header_fails_fuse() {
+    let mut rng = StdRng::seed_from_u64(0);
+    let app = point_app();
+
+    assert!(
+        matches!(
+            app.seed(&mut rng, PointSeedStep, Eq::identity()),
+            Err(Error::InvalidWitness(_))
+        ),
+        "identity point in output header must fail"
+    );
+}
+
+#[test]
+fn identity_point_in_input_header_fails_fuse() {
+    let mut rng = StdRng::seed_from_u64(0);
+    let app = ApplicationBuilder::new()
+        .register(PointSeedStep)
+        .expect("register")
+        .register(PointConsumeStep)
+        .expect("register")
+        .finalize()
+        .expect("finalize");
+
+    let bad_left = Proof::trivial().carry::<PointHeader>(PointHeaderData {
+        commitment: Eq::identity(),
+    });
+    let right = Proof::trivial().carry::<()>(());
+
+    assert!(
+        matches!(
+            app.fuse(&mut rng, PointConsumeStep, (), bad_left, right),
+            Err(Error::InvalidWitness(_))
+        ),
+        "identity point in input header must fail"
+    );
+}
+
+#[test]
+fn identity_point_in_carried_data_errors_verify() {
+    let mut rng = StdRng::seed_from_u64(0);
+    let app = point_app();
+
+    let (pcd, ()) = app
+        .seed(&mut rng, PointSeedStep, Eq::generator())
+        .expect("seed with a non-identity point");
+    let bad_pcd = pcd.proof.carry::<PointHeader>(PointHeaderData {
+        commitment: Eq::identity(),
+    });
+
+    // Errs rather than returning `Ok(false)`: re-encoding such a header
+    // fails synthesis in real ragu, it does not merely mismatch.
+    assert!(matches!(
+        app.verify(&bad_pcd, &mut rng),
+        Err(Error::InvalidWitness(_))
+    ));
 }

--- a/src/mock/tests/constraint.rs
+++ b/src/mock/tests/constraint.rs
@@ -1,4 +1,7 @@
+use alloc::string::ToString as _;
+
 use ragu_arithmetic::{ff::Field as _, group::Group as _};
+use ragu_core::Error;
 use ragu_pasta::{Eq, Fp};
 
 use crate::constraint::*;
@@ -63,5 +66,15 @@ fn enforce_equal_point_rejects_distinct_points() {
     let g = Eq::generator();
     assert!(enforce_equal_point(g, g, "points must match").is_ok());
     assert!(enforce_equal_point(g, g.double(), "points must match").is_err());
-    assert!(enforce_equal_point(g, Eq::identity(), "points must match").is_err());
+}
+
+#[test]
+fn enforce_equal_point_rejects_identity() {
+    let err = enforce_equal_point(Eq::generator(), Eq::identity(), "points must match")
+        .expect_err("identity must be rejected");
+    assert!(matches!(err, Error::InvalidWitness(_)));
+    assert!(err.to_string().contains("point at infinity"));
+
+    // Not even `identity == identity`: the real gadget cannot witness it.
+    assert!(enforce_equal_point(Eq::identity(), Eq::identity(), "points must match").is_err());
 }

--- a/src/mock/tests/ctx.rs
+++ b/src/mock/tests/ctx.rs
@@ -1,4 +1,4 @@
-use alloc::string::ToString as _;
+use alloc::{string::ToString as _, vec};
 
 use ragu_arithmetic::{ff::Field as _, group::Group as _};
 use ragu_core::Error;
@@ -39,7 +39,7 @@ fn derive_challenge_rejects_identity() {
 #[test]
 fn zero_polynomial_commits_to_identity_but_cannot_be_witnessed() {
     // Commit is permissive, exactly like real ragu's unblinded MSM…
-    let com = Polynomial::from_coeffs(&[Fp::ZERO]).commit();
+    let com = Polynomial::from_coeffs(vec![Fp::ZERO]).commit();
     assert!(bool::from(com.is_identity()));
 
     // …the failure happens where the commitment enters the proof system,

--- a/src/mock/tests/ctx.rs
+++ b/src/mock/tests/ctx.rs
@@ -1,0 +1,50 @@
+use alloc::string::ToString as _;
+
+use ragu_arithmetic::{ff::Field as _, group::Group as _};
+use ragu_core::Error;
+use ragu_pasta::{Eq, Fp};
+
+use crate::{ctx::StepCtx, hooks::FrameworkHooks, polynomial::Polynomial};
+
+#[test]
+fn enforce_poly_query_rejects_identity() {
+    let mut hooks = FrameworkHooks::new();
+    let mut ctx = StepCtx::new(&mut hooks);
+
+    assert!(
+        ctx.enforce_poly_query(Eq::generator(), Fp::ONE, Fp::ONE)
+            .is_ok()
+    );
+
+    let err = ctx
+        .enforce_poly_query(Eq::identity(), Fp::ONE, Fp::ONE)
+        .expect_err("identity commitment must be rejected");
+    assert!(matches!(err, Error::InvalidWitness(_)));
+    assert!(err.to_string().contains("point at infinity"));
+}
+
+#[test]
+fn derive_challenge_rejects_identity() {
+    let mut hooks = FrameworkHooks::new();
+    let mut ctx = StepCtx::new(&mut hooks);
+
+    assert!(ctx.derive_challenge(&[Eq::generator()]).is_ok());
+
+    let err = ctx
+        .derive_challenge(&[Eq::generator(), Eq::identity()])
+        .expect_err("identity commitment must be rejected");
+    assert!(matches!(err, Error::InvalidWitness(_)));
+}
+
+#[test]
+fn zero_polynomial_commits_to_identity_but_cannot_be_witnessed() {
+    // Commit is permissive, exactly like real ragu's unblinded MSM…
+    let com = Polynomial::from_coeffs(&[Fp::ZERO]).commit();
+    assert!(bool::from(com.is_identity()));
+
+    // …the failure happens where the commitment enters the proof system,
+    // mirroring `Point::alloc` at the real pcd boundary.
+    let mut hooks = FrameworkHooks::new();
+    let mut ctx = StepCtx::new(&mut hooks);
+    assert!(ctx.enforce_poly_query(com, Fp::ONE, Fp::ZERO).is_err());
+}

--- a/src/mock/tests/mod.rs
+++ b/src/mock/tests/mod.rs
@@ -1,4 +1,5 @@
 mod application;
 mod constraint;
+mod ctx;
 mod proof;
 mod sponge;

--- a/src/mock/tests/proof.rs
+++ b/src/mock/tests/proof.rs
@@ -1,24 +1,85 @@
+use alloc::vec::Vec;
+
+use ragu_arithmetic::rand::{SeedableRng as _, rngs::StdRng};
+use ragu_core::Result;
+use ragu_pasta::{Ep, Eq, Fp, Fq};
+
 use crate::{
-    header::Suffix,
+    application::{Application, ApplicationBuilder},
+    ctx::StepCtx,
+    header::{Header, Suffix},
     proof::{PROOF_SIZE_COMPRESSED, Pcd, Proof},
-    step::Index,
+    step::{Index, Step},
 };
 
-const TEST_SUFFIX: Suffix = Suffix::new(0);
-const TEST_INDEX: Index = Index::new(0);
+/// Header carrying one field element, as an application header would.
+struct ValueHeader;
+
+impl Header for ValueHeader {
+    type Data = u64;
+
+    const SUFFIX: Suffix = Suffix::new(0);
+
+    fn encode(data: &Self::Data) -> (Vec<Fp>, Vec<Fq>, Vec<Ep>, Vec<Eq>) {
+        (
+            alloc::vec![Fp::from(*data)],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+    }
+}
+
+/// Seed step producing a [`ValueHeader`].
+struct ValueSeedStep;
+
+impl Step for ValueSeedStep {
+    type Aux<'source> = ();
+    type Left = ();
+    type Output = ValueHeader;
+    type Right = ();
+    type Witness<'source> = u64;
+
+    const INDEX: Index = Index::new(0);
+
+    fn witness<'source>(
+        &self,
+        _ctx: &mut StepCtx<'_>,
+        witness: Self::Witness<'source>,
+        _left: <Self::Left as Header>::Data,
+        _right: <Self::Right as Header>::Data,
+    ) -> Result<(<Self::Output as Header>::Data, Self::Aux<'source>)> {
+        Ok((witness, ()))
+    }
+}
+
+/// Application with [`ValueSeedStep`] registered.
+fn value_app() -> Application {
+    ApplicationBuilder::new()
+        .register(ValueSeedStep)
+        .expect("register")
+        .finalize()
+        .expect("finalize")
+}
 
 #[test]
 fn round_trip() {
-    let proof = Proof::new(TEST_SUFFIX, TEST_INDEX, b"header", b"witness");
-    let bytes: [u8; PROOF_SIZE_COMPRESSED] = proof.clone().into();
+    let mut rng = StdRng::seed_from_u64(0);
+    let app = value_app();
+    let (pcd, ()) = app.seed(&mut rng, ValueSeedStep, 7u64).expect("seed");
+
+    let bytes: [u8; PROOF_SIZE_COMPRESSED] = pcd.proof().clone().into();
     let recovered = Proof::try_from(&bytes).expect("round trip should succeed");
-    assert_eq!(proof.serialize(), recovered.serialize());
+    assert_eq!(pcd.proof().serialize(), recovered.serialize());
 }
 
 #[test]
 fn tampered_fails() {
-    let proof = Proof::new(TEST_SUFFIX, TEST_INDEX, b"header", b"witness");
-    let mut bytes: [u8; PROOF_SIZE_COMPRESSED] = proof.into();
+    let mut rng = StdRng::seed_from_u64(0);
+    let app = value_app();
+    let (pcd, ()) = app.seed(&mut rng, ValueSeedStep, 7u64).expect("seed");
+
+    let mut bytes: [u8; PROOF_SIZE_COMPRESSED] = pcd.proof().clone().into();
     bytes[0] ^= 0xFFu8;
     assert!(
         Proof::try_from(&bytes).is_err(),
@@ -28,31 +89,44 @@ fn tampered_fails() {
 
 #[test]
 fn carry_creates_pcd() {
-    let proof = Proof::new(TEST_SUFFIX, TEST_INDEX, b"header", b"witness");
+    let mut rng = StdRng::seed_from_u64(0);
+    let app = value_app();
+    let (pcd, ()) = app.seed(&mut rng, ValueSeedStep, 7u64).expect("seed");
+
+    let (proof, _data) = pcd.into_parts();
     let expected = proof.clone();
-    let pcd: Pcd<()> = proof.carry(());
-    assert_eq!(pcd.proof.serialize(), expected.serialize());
+    let carried: Pcd<()> = proof.carry(());
+    assert_eq!(carried.proof().serialize(), expected.serialize());
 }
 
 #[test]
 fn rerandomize() {
-    let proof = Proof::new(TEST_SUFFIX, TEST_INDEX, b"header", b"witness");
-    assert_eq!(proof.rerand_tag, [0u8; 32]);
+    let mut rng = StdRng::seed_from_u64(0);
+    let app = value_app();
+    let (pcd, ()) = app.seed(&mut rng, ValueSeedStep, 7u64).expect("seed");
 
-    let once = proof.rerandomize();
+    let original = pcd.proof().clone();
+    assert_eq!(original.rerand_tag, [0u8; 32]);
 
-    assert_eq!(proof.header_hash, once.header_hash);
-    assert_eq!(proof.witness_hash, once.witness_hash);
-    assert_eq!(proof.binding, once.binding);
-    assert_ne!(proof.serialize(), once.serialize());
+    let once_pcd = app.rerandomize(pcd, &mut rng).expect("rerandomize once");
+    let once = once_pcd.proof().clone();
 
-    let twice = once.rerandomize();
-    assert_eq!(proof.header_hash, twice.header_hash);
-    assert_eq!(proof.witness_hash, twice.witness_hash);
-    assert_eq!(proof.binding, twice.binding);
+    assert_eq!(original.header_hash, once.header_hash);
+    assert_eq!(original.witness_hash, once.witness_hash);
+    assert_eq!(original.binding, once.binding);
+    assert_ne!(original.serialize(), once.serialize());
+
+    let twice_pcd = app
+        .rerandomize(once_pcd, &mut rng)
+        .expect("rerandomize twice");
+    let twice = twice_pcd.proof().clone();
+
+    assert_eq!(original.header_hash, twice.header_hash);
+    assert_eq!(original.witness_hash, twice.witness_hash);
+    assert_eq!(original.binding, twice.binding);
     assert_ne!(once.serialize(), twice.serialize());
 
-    assert_ne!(proof.rerand_tag, once.rerand_tag);
-    assert_ne!(proof.rerand_tag, twice.rerand_tag);
+    assert_ne!(original.rerand_tag, once.rerand_tag);
+    assert_ne!(original.rerand_tag, twice.rerand_tag);
     assert_ne!(once.rerand_tag, twice.rerand_tag);
 }


### PR DESCRIPTION
Ragu can't witness or handle the identity point. The mock accepted it everywhere, letting consumers depend on behavior real ragu forbids. <https://github.com/tachyon-zcash/ragu/pull/802#discussion_r3461366870>

## Changes

- `enforce_equal_point`, the poly-query claim sink, and `derive_challenge` return `InvalidWitness` on an identity point.
- `Header::encode` now diverges to return typed values instead of opaque bytes, so the mock system can reject identity points carried in header data.
- `Polynomial::commit` stays permissive: an empty polynomial still commits to the identity, as is permitted in ragu.
- The mock `Polynomial` now wraps `ragu_circuits::polynomials::sparse::Polynomial` instead of a bare `Vec<Fp>`, so it mirrors the real type (sparse API, `Ring` impl) rather than reimplementing things.
