### PR TITLE
chore: CI check for thumbv7em-none-eabihf no_std

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -180,6 +180,28 @@ jobs:
       - name: Run 32-bit tests
         run: cargo test --release --all --locked --target i686-unknown-linux-gnu
 
+  # Ensure the mock API stays `no_std`-buildable on a bare-metal target. This is
+  # the configuration downstream consumers (e.g. `zcash_tachyon`) compile for
+  # `no_std`, so a regression here breaks their embedded builds. The other jobs
+  # only exercise targets that have `std`, which is how past `no_std` breakage
+  # (a std-only transitive dep sneaking in via default features) went unnoticed.
+  build-nostd:
+    name: build (thumbv7em-none-eabihf, no_std)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Setup Rust
+        uses: ./.github/actions/rust-setup
+        with:
+          targets: thumbv7em-none-eabihf
+          cache-suffix: nostd
+      - name: Build the mock API for a bare-metal no_std target
+        run: cargo build -p ragu --lib --locked --no-default-features --features "mock legacy-deps" --target thumbv7em-none-eabihf
+
   bitrot:
     name: bitrot check
     needs: changes
@@ -277,6 +299,7 @@ jobs:
       - proptests-fast
       - test
       - test-32-bit
+      - build-nostd
       - bitrot
       - docs
       - book


### PR DESCRIPTION
closes https://github.com/tachyon-zcash/ragu/issues/808

after https://github.com/tachyon-zcash/ragu/pull/809

it should pass after 809