### PR TITLE
feat(primitives): add Element::batch_invert

### DIFF
--- a/crates/ragu_pcd/src/internal/native/circuits/compute_v.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/compute_v.rs
@@ -43,10 +43,10 @@
 //! [$\mu'$]: unified::Output::mu_prime
 //! [$\nu'$]: unified::Output::nu_prime
 
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 
-use ragu_arithmetic::{Cycle, ff::Field};
+use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     WithAux,
     horner::Horner,
@@ -689,34 +689,12 @@ impl<'dr, D: Driver<'dr, F: ragu_arithmetic::ff::PrimeField>> Inverter<'dr, D> {
     /// Performs batch inversion on all accumulated differences.
     ///
     /// Consumes the inverter and returns a vector of inverted [`Element`]s.
-    /// Each difference [`Element`] is inverted using [`Element::invert_with`]
-    /// with the batch-inverted field value as advice.
     ///
-    /// During proving, this function batch inverts the accumulated field values
-    /// using Montgomery's trick and uses them as advice for constraint
-    /// generation. During verification, the field values are not available, but
-    /// the inversion constraints are still enforced through the [`Element`]
-    /// wiring.
+    /// Delegates to [`Element::batch_invert`], so during proving the
+    /// differences are inverted with a single field inversion via Montgomery's
+    /// trick. During verification, the field values are not available, but the
+    /// inversion constraints are still enforced through the [`Element`] wiring.
     fn invert(self, dr: &mut D) -> Result<Vec<Element<'dr, D>>> {
-        let mut advice = D::just(|| {
-            let mut differences = self
-                .differences
-                .iter()
-                .map(|diff| **diff.value().snag())
-                .collect::<Vec<_>>();
-
-            let mut scratch = vec![D::F::ZERO; differences.len()];
-            ragu_arithmetic::ff::BatchInverter::invert_with_external_scratch(
-                &mut differences,
-                &mut scratch,
-            );
-
-            differences.into_iter()
-        });
-
-        self.differences
-            .into_iter()
-            .map(|e| e.invert_with(dr, advice.as_mut().map(|e| e.next().unwrap())))
-            .collect()
+        Element::batch_invert(dr, &self.differences)
     }
 }

--- a/crates/ragu_primitives/src/element.rs
+++ b/crates/ragu_primitives/src/element.rs
@@ -303,6 +303,48 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
             .map(|inv| inv.into_inverse().into_inner())
     }
 
+    /// Returns the multiplicative inverses of `elements`.
+    ///
+    /// Equivalent to calling [`Self::invert`] on each element, but during
+    /// proving the witness values are obtained with Montgomery's trick, which
+    /// needs a single field inversion for the whole batch instead of one per
+    /// element. The batch-inverted values are then supplied to
+    /// [`Self::invert_with`] as advice.
+    ///
+    /// During verification the field values are unavailable, but the inversion
+    /// constraints are still emitted for every element.
+    ///
+    /// This does not change the circuit: as with [`Self::invert`], each element
+    /// costs one gate and two constraints. Only the prover's witness
+    /// computation gets cheaper.
+    ///
+    /// This will be unsatisfied (and fail to synthesize) if any element is
+    /// zero. Zero elements are left as zero by the batch inversion, so the
+    /// per-element constraint rejects them exactly as [`Self::invert`] would.
+    pub fn batch_invert(dr: &mut D, elements: &[Self]) -> Result<Vec<Self>> {
+        let mut advice = D::just(|| {
+            let mut values = elements
+                .iter()
+                .map(|element| **element.value().snag())
+                .collect::<Vec<_>>();
+
+            let mut scratch = alloc::vec![D::F::ZERO; values.len()];
+            ragu_arithmetic::ff::BatchInverter::invert_with_external_scratch(
+                &mut values,
+                &mut scratch,
+            );
+
+            values.into_iter()
+        });
+
+        elements
+            .iter()
+            .map(|element| {
+                element.invert_with(dr, advice.as_mut().map(|values| values.next().unwrap()))
+            })
+            .collect()
+    }
+
     /// Divides this element by `divisor` and returns the quotient.
     ///
     /// This costs one gate and two constraints.
@@ -687,6 +729,58 @@ mod tests {
 
         inv(F::from(4578u64))?;
         assert!(inv(F::ZERO).is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_batch_invert() -> Result<()> {
+        type F = ragu_pasta::Fp;
+        type Simulator = crate::Simulator<F>;
+
+        let batch = |values: &[F]| {
+            let count = values.len();
+            let sim = Simulator::simulate((), |dr, _| {
+                let allocator = &mut Standard::new();
+                let elements = values
+                    .iter()
+                    .map(|value| {
+                        let value = *value;
+                        Element::alloc(dr, allocator, Simulator::just(move || value))
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                dr.reset();
+
+                let inverses = Element::batch_invert(dr, &elements)?;
+                assert_eq!(inverses.len(), count);
+
+                for (element, inverse) in elements.iter().zip(inverses.iter()) {
+                    assert_eq!(
+                        *inverse.value().take(),
+                        element.value().take().invert().unwrap()
+                    );
+                }
+
+                Ok(())
+            })?;
+
+            // Batching changes only how the prover computes the witness, so the
+            // circuit is the same as calling `invert` once per element.
+            assert_eq!(sim.num_gates(), count);
+            assert_eq!(sim.num_constraints(), 2 * count);
+            Ok(())
+        };
+
+        batch(&[F::from(4578u64)])?;
+        batch(&[F::from(3u64), F::from(372u64), F::from(4578u64), F::ONE])?;
+
+        // An empty batch imposes nothing.
+        batch(&[])?;
+
+        // A zero anywhere in the batch is left as zero by Montgomery's trick,
+        // so the per-element constraint rejects it just as `invert` would.
+        assert!(batch(&[F::ZERO]).is_err());
+        assert!(batch(&[F::from(3u64), F::ZERO, F::from(7u64)]).is_err());
 
         Ok(())
     }


### PR DESCRIPTION
Closes #292.

`compute_v` already had a private `Inverter` that batch inverted its `(u - x_i)` differences with Montgomery's trick and passed the results to `invert_with` as advice. Since #292 asks for exactly that as a general API, this lifts the logic onto `Element` and points the existing caller at it, so `Inverter::invert` becomes a one-line delegation.

The issue also mentions the related need to override inversion when the caller already has the inverse from somewhere else. I think `invert_with` already covers that case, so I left it alone and built the batch API on top of it rather than duplicating the advice plumbing.

### On cost

Worth being precise, since it would be easy to read this as a circuit improvement and it isn't one. Each element still costs one gate and two constraints, exactly as `invert` does. The saving is entirely in the prover's witness computation, which goes from n field inversions to one inversion plus the batch multiplications. The doc comment and the test both say so explicitly.

### On zeros

`BatchInverter::invert_with_external_scratch` skips zero elements via `conditional_select` and leaves them as zero, so the accumulator only ever multiplies nonzero values and its `invert().unwrap()` cannot panic. A zero therefore gets zero as its advice, and the existing per-element constraint is what rejects it. Net behaviour matches `invert`: the batch fails to synthesize. `test_batch_invert` pins this for a zero in first and middle position, and covers the empty batch too.

### Checks

`cargo test --workspace` passes, including the `ragu_pcd` circuit tests that exercise the refactored `compute_v` path. `cargo clippy --workspace --lib --tests --benches -- -D warnings` and the pinned nightly `fmt --check` are both clean.

One judgement call I'd happily change: I kept the `next().unwrap()` idiom from the original code, since the iterator and the slice are built from the same source and are always the same length. If you'd rather it returned an error there, say the word.