### PR TITLE
ci(fuzz): build cargo-fuzz on the pinned nightly (continuous fuzzing has been down since June 10)

### DIFF
--- a/.github/workflows/fuzz-cron.yml
+++ b/.github/workflows/fuzz-cron.yml
@@ -95,7 +95,15 @@ jobs:
             ${{ runner.os }}-fuzz-corpus-${{ matrix.target }}-
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+        # Build cargo-fuzz with the same pinned nightly the targets run on.
+        # Without this the step falls back to the repo's pinned stable from
+        # rust-toolchain.toml, which cargo-fuzz's dependency tree no longer
+        # supports. Routed through env for the same reason as the run step
+        # below. `--locked` keeps the install reproducible, matching the
+        # cargo-vet and cargo-audit installs in vet.yml.
+        env:
+          RUSTUP_TOOLCHAIN: ${{ steps.nightly.outputs.toolchain }}
+        run: cargo install --locked cargo-fuzz
 
       - name: Run fuzz target
         working-directory: qa/fuzz


### PR DESCRIPTION
The `Continuous fuzzing` workflow has failed on **every scheduled run since 2026-06-10**, 16 in a row. The last green run was 2026-06-07. I went looking at the logs because a red fuzz cron seemed worth understanding, and it turns out no fuzzing has actually happened in about eight weeks. All 17 targets fail identically, during setup, before libFuzzer is ever invoked:

```
error: failed to compile `cargo-fuzz v0.13.2`
Caused by:
  rustc 1.90.0 is not supported by the following package:
    cargo-platform@0.3.3 requires rustc 1.91
```

I checked the 2026-06-10 run and today's: same error, same package, so this is one cause the whole way through and not a series of unrelated breakages.

### Cause

The job resolves a pinned nightly via `rust-nightly-setup`, and the `Run fuzz target` step picks it up through `RUSTUP_TOOLCHAIN`. The `Install cargo-fuzz` step never got the same treatment, so it builds on whatever the default toolchain is, which is the pinned stable **1.90.0** from `rust-toolchain.toml`. That was fine until `cargo-platform 0.3.3` raised its MSRV to 1.91 and landed in cargo-fuzz's tree.

So the fuzzing toolchain was right all along. Only the step that builds the tool was missing it.

### On cargo's suggestion

Cargo's own hint here is ``Try re-running `cargo install` with `--locked` ``, which is the obvious first thing to reach for. I tried it and **it does not fix this**, because cargo-fuzz 0.13.2's own lockfile already pins `cargo-platform 0.3.3`. Flagging that in case anyone else takes a run at this and follows the hint.

I reproduced all three cases locally on the repo's pinned toolchains:

| install command | toolchain | result |
| --- | --- | --- |
| `cargo install cargo-fuzz` | 1.90.0 | fails, identical error to CI |
| `cargo install --locked cargo-fuzz` | 1.90.0 | fails, same error |
| `cargo install --locked cargo-fuzz` | nightly-2026-04-11 | installs cleanly |

### The change

Give the install step the same `RUSTUP_TOOLCHAIN` the run step already uses. I also added `--locked` so the install is reproducible and a future transitive bump cannot quietly do this again, matching how `vet.yml` already installs `cargo-vet` and `cargo-audit`. The toolchain is the actual fix; `--locked` is hygiene, and the table above is the evidence for both.

### What this PR cannot show

Being upfront: `fuzz-cron.yml` only fires on schedule and `workflow_dispatch`, so nothing on this PR exercises it. The local reproduction above is the strongest evidence I can produce from outside. A manual dispatch on the branch would confirm it end to end if you'd like one before merging.

Worth noting the failure mode was quiet in a specific way: the summary step does `tail -20 fuzz-run.log` inside a `|| true` block, so a run where fuzzing never started still uploads an empty stats artifact and reports "No files were found" for crashes, which reads a lot like a clean run. Happy to open a separate issue about making setup failure louder, if that seems useful.