### PR TITLE
docs: note that circuits are compile-time and cannot be serialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,14 @@
 * The minimum supported [Rust](https://rust-lang.org/) version is currently **1.90.0**.
 * Ragu requires minimal dependencies and currently strives to avoid using dependencies that are not already used in [Zebra](https://github.com/ZcashFoundation/zebra).
 * Ragu's library crates are [`no_std`]-compatible and only need a global allocator; the default `multicore` crate feature uses [`maybe-rayon`] and pulls in `std`. See the [book][book-no-std] for details.
+* Circuits are defined at compile time and are built into your binary. Ragu does not support serializing circuits or verifying keys to disk, the same limitation [halo2] has. See the [book][book-compile-time] for details.
 
 [Zebra]: https://github.com/ZcashFoundation/zebra
+[halo2]: https://github.com/zcash/halo2
 [`no_std`]: https://doc.rust-lang.org/reference/names/preludes.html#the-no_std-attribute
 [`maybe-rayon`]: https://crates.io/crates/maybe-rayon
 [book-no-std]: https://tachyon.z.cash/ragu/guide/requirements.html#no-std
+[book-compile-time]: https://tachyon.z.cash/ragu/guide/requirements.html#compile-time-circuits
 
 ## License
 

--- a/book/src/guide/requirements.md
+++ b/book/src/guide/requirements.md
@@ -6,6 +6,24 @@
   dependencies that are not already used in
   [Zebra](https://github.com/ZcashFoundation/zebra).
 
+## Circuits Are Defined at Compile Time {#compile-time-circuits}
+
+Ragu circuits are described in Rust and are built during `cargo build`,
+so they end up inside your binary rather than in a data file alongside
+it.
+
+```admonish warning
+There is no serialization path for circuits. Ragu does not support
+writing a circuit to a file or reading one back, and it does not
+provide serializable verifying keys.
+```
+
+The practical consequence is that the binary carries the circuit. A
+verifier has to be built from the same circuit definitions as the
+prover, rather than loading a key file at startup.
+
+[halo2] works this way too, for the same reason.
+
 ## `no_std` Support {#no-std}
 
 None of Ragu's library code requires the standard library. Every
@@ -21,4 +39,5 @@ via [maybe-rayon] for multi-threaded parallelism. Build with
 `--no-default-features` to drop it.
 
 [`alloc`]: https://doc.rust-lang.org/alloc/
+[halo2]: https://github.com/zcash/halo2
 [maybe-rayon]: https://crates.io/crates/maybe-rayon


### PR DESCRIPTION
Closes #118.

Two places, as the issue asked:

- **README**, a bullet under Requirements, next to the existing `no_std` note, since that section is already doing the job of "things to know before you use this".
- **The user guide**, a new section at the top of `guide/requirements.md`, above `no_std` so it is the first thing on the page after the version requirements. The core sentence is in an `admonish warning` block, matching how the introduction and the `GadgetKind` page flag their caveats.

I linked the two together with a `#compile-time-circuits` anchor, the same way the README already points at `#no-std`.

Beyond restating the issue, I added one sentence about the practical consequence: the binary carries the circuit, so a verifier has to be built from the same circuit definitions as the prover rather than loading a key file at startup. That is the part that actually bites if you have come from a proving system that ships verifying keys as data, and it seemed worth saying out loud. Happy to cut it if you would rather the docs stay closer to a plain statement of the limitation.

Also noted that halo2 has the same limitation, as the issue mentions.

Markdown only, no code touched.