### PR TITLE
feat(pcd): an application declares hook layout, a step witnesses polynomials

### DIFF
--- a/crates/ragu_pcd/benches/criterion/fuse.rs
+++ b/crates/ragu_pcd/benches/criterion/fuse.rs
@@ -10,12 +10,12 @@ fn fuse_bench(c: &mut Criterion) {
     let pasta = Pasta::baked();
     let poseidon_params = Pasta::circuit_poseidon(pasta);
 
-    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new(pasta)
         .register(nontrivial::WitnessLeaf { poseidon_params })
         .unwrap()
         .register(nontrivial::Hash2 { poseidon_params })
         .unwrap()
-        .finalize(pasta)
+        .finalize()
         .unwrap();
 
     let mut rng = StdRng::seed_from_u64(1234);

--- a/crates/ragu_pcd/benches/criterion/registry.rs
+++ b/crates/ragu_pcd/benches/criterion/registry.rs
@@ -13,7 +13,7 @@ fn registry_bench(c: &mut Criterion) {
 
     // Time finalize separately: build the ApplicationBuilder, then bench only finalize.
     let make_builder = || {
-        ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+        ApplicationBuilder::<Pasta, ProductionRank, 4>::new(pasta)
             .register(nontrivial::WitnessLeaf { poseidon_params })
             .unwrap()
             .register(nontrivial::Hash2 { poseidon_params })
@@ -23,13 +23,13 @@ fn registry_bench(c: &mut Criterion) {
     c.bench_function("registry::finalize", |b| {
         b.iter_batched(
             make_builder,
-            |builder| builder.finalize(pasta).unwrap(),
+            |builder| builder.finalize().unwrap(),
             criterion::BatchSize::PerIteration,
         );
     });
 
     // Build the finalized app once for evaluation benchmarks.
-    let app = make_builder().finalize(pasta).unwrap();
+    let app = make_builder().finalize().unwrap();
     let registry = app.native_registry();
 
     // Use deterministic "random" field elements.

--- a/crates/ragu_pcd/benches/pcd.rs
+++ b/crates/ragu_pcd/benches/pcd.rs
@@ -24,7 +24,7 @@ fn register(
     ),
 ) {
     black_box(
-        ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+        ApplicationBuilder::<Pasta, ProductionRank, 4>::new(Pasta::baked())
             .register(leaf)
             .unwrap()
             .register(hash)
@@ -35,12 +35,12 @@ fn register(
 #[library_benchmark(setup = setup_finalize)]
 #[bench::finalize()]
 fn finalize(
-    (app, pasta): (
+    (app, _pasta): (
         ApplicationBuilder<'static, Pasta, ProductionRank, 4>,
         &'static <Pasta as Cycle>::Params,
     ),
 ) {
-    black_box(app.finalize(pasta)).unwrap();
+    black_box(app.finalize()).unwrap();
 }
 
 library_benchmark_group!(

--- a/crates/ragu_pcd/benches/setup/mod.rs
+++ b/crates/ragu_pcd/benches/setup/mod.rs
@@ -23,7 +23,7 @@ pub fn setup_finalize() -> (
 ) {
     let pasta = Pasta::baked();
     let poseidon_params = Pasta::circuit_poseidon(pasta);
-    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new(pasta)
         .register(nontrivial::WitnessLeaf { poseidon_params })
         .unwrap()
         .register(nontrivial::Hash2 { poseidon_params })
@@ -38,12 +38,12 @@ pub fn setup_seed() -> (
 ) {
     let pasta = Pasta::baked();
     let poseidon_params = Pasta::circuit_poseidon(pasta);
-    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new(pasta)
         .register(nontrivial::WitnessLeaf { poseidon_params })
         .unwrap()
         .register(nontrivial::Hash2 { poseidon_params })
         .unwrap()
-        .finalize(pasta)
+        .finalize()
         .unwrap();
     (app, poseidon_params, StdRng::seed_from_u64(1234))
 }

--- a/crates/ragu_pcd/src/framework_hooks.rs
+++ b/crates/ragu_pcd/src/framework_hooks.rs
@@ -1,0 +1,165 @@
+//! Framework-side state behind the hooks a step reaches through
+//! [`StepCtx`](crate::step::StepCtx).
+//!
+//! Nothing a hook produces is enforced here. It lands in the application
+//! circuit's instance, padded to the [`HookLayout`], and the parent fuse — or
+//! [`Application::verify`](crate::Application::verify), for a proof that is
+//! never fused — discharges it.
+
+use alloc::{vec, vec::Vec};
+
+use ragu_arithmetic::{Cycle, eval, ff::Field};
+use ragu_circuits::polynomials::{Rank, sparse};
+use ragu_core::{
+    Error, Result,
+    drivers::{Driver, DriverValue},
+    maybe::Maybe,
+};
+use ragu_primitives::vec::Len;
+
+use crate::poly_commitment::{HANDLE_WIRES, PolyHandle};
+
+/// A polynomial a step witnessed: the handle it was handed back, the commitment
+/// that handle encodes, and the coefficients the fuse folds.
+struct Witnessed<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>> {
+    handle: PolyHandle<'dr, D, C>,
+    commitment: DriverValue<D, C::HostCurve>,
+    coefficients: DriverValue<D, Vec<C::CircuitField>>,
+}
+
+/// Accumulates hook wires during one [`Step::witness`](crate::step::Step::witness)
+/// run; the adapter drains it into a [`FrameworkAux`].
+pub(crate) struct FrameworkHooks<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>> {
+    witnessed_polys: Vec<Witnessed<'dr, D, C>>,
+    hook_layout: HookLayout,
+    params: &'dr C::Params,
+}
+
+/// Every hook's output as plain values, for the fuse. Every list is in call
+/// order and padded to the application's [`HookLayout`].
+pub(crate) struct FrameworkAux<C: Cycle> {
+    /// Coefficient vectors; the commitments are not here, the builder derives
+    /// those from these.
+    pub witness_polys: Vec<Vec<C::CircuitField>>,
+}
+
+/// An application's [`HookLayout`] as type-level lengths on a marker type;
+/// usually written as [`crate::AppHooks`].
+pub trait HookConfig: Send + Sync + 'static {
+    /// Polynomial witnesses committed per step.
+    type PolyWitnesses: Len;
+
+    /// These lengths as the value the circuits are built from.
+    fn layout() -> HookLayout {
+        HookLayout {
+            witness_polys: Self::PolyWitnesses::len(),
+        }
+    }
+}
+
+/// A [`HookConfig`]'s lengths as a value.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct HookLayout {
+    /// [`witness_polynomial`](crate::step::StepCtx::witness_polynomial) calls.
+    pub witness_polys: usize,
+}
+
+impl HookLayout {
+    /// Instance elements the handles occupy.
+    pub const fn poly_query_instance_len(&self) -> usize {
+        self.witness_polys * HANDLE_WIRES
+    }
+}
+
+impl<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>> FrameworkHooks<'dr, D, C> {
+    pub(crate) fn witnessed_polys(&self) -> impl Iterator<Item = &PolyHandle<'dr, D, C>> {
+        self.witnessed_polys.iter().map(|w| &w.handle)
+    }
+
+    /// Reads each hook's wires back out as plain values, for the fuse.
+    /// [`pad_to_layout`](Self::pad_to_layout) filled each list to the layout.
+    pub(crate) fn into_values(self) -> Result<DriverValue<D, FrameworkAux<C>>> {
+        D::try_just(move || {
+            Ok(FrameworkAux {
+                witness_polys: self
+                    .witnessed_polys
+                    .into_iter()
+                    .map(|w| w.coefficients.take())
+                    .collect(),
+            })
+        })
+    }
+
+    pub(crate) fn new(hook_layout: HookLayout, params: &'dr C::Params) -> Self {
+        Self {
+            witnessed_polys: Vec::new(),
+            hook_layout,
+            params,
+        }
+    }
+
+    pub(crate) fn witness_polynomial<R: Rank>(
+        &mut self,
+        dr: &mut D,
+        polynomial: DriverValue<D, sparse::Polynomial<C::CircuitField, R>>,
+    ) -> Result<PolyHandle<'dr, D, C>> {
+        let (handle, commitment) = PolyHandle::new(dr, self.params, &polynomial)?;
+        // The rank goes no further. What a *proof* carries the coefficients at
+        // is the application's rank, which the fuse applies.
+        self.witnessed_polys.push(Witnessed {
+            handle: handle.clone(),
+            commitment,
+            coefficients: polynomial.map(|p| p.iter_coeffs().collect()),
+        });
+        Ok(handle)
+    }
+
+    pub(crate) fn evaluate(
+        &self,
+        handle: &PolyHandle<'dr, D, C>,
+        x: DriverValue<D, C::CircuitField>,
+    ) -> Result<DriverValue<D, C::CircuitField>> {
+        let found = self.witnessed_of(handle)?;
+        D::try_just(move || {
+            let (_, coefficients) = found.take();
+            Ok(eval(&coefficients, x.take()))
+        })
+    }
+
+    /// The commitment and coefficients behind `handle`.
+    fn witnessed_of(
+        &self,
+        handle: &PolyHandle<'dr, D, C>,
+    ) -> Result<DriverValue<D, (C::HostCurve, Vec<C::CircuitField>)>> {
+        D::try_just(|| {
+            let sought = handle.value().take();
+            self.witnessed_polys
+                .iter()
+                .find(|w| w.handle.value().take() == sought)
+                .map(|w| {
+                    (
+                        *w.commitment.as_ref().take(),
+                        w.coefficients.as_ref().take().clone(),
+                    )
+                })
+                .ok_or_else(|| {
+                    Error::InvalidWitness(
+                        "evaluation rejected: the handle names no polynomial this step witnessed"
+                            .into(),
+                    )
+                })
+        })
+    }
+
+    /// Fills whatever the body left unused up to the [`HookLayout`].
+    pub(crate) fn pad_to_layout<R: Rank>(&mut self, dr: &mut D) -> Result<()> {
+        // The constant $1$, whose commitment is `g[0]` — which is what the
+        // builder derives for every padded polynomial.
+        let pad_poly = D::just(|| sparse::Polynomial::<_, R>::from_coeffs(vec![D::F::ONE]));
+        while self.witnessed_polys.len() < self.hook_layout.witness_polys {
+            self.witness_polynomial(dr, pad_poly.clone())?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/ragu_pcd/src/fuse/_01_application.rs
+++ b/crates/ragu_pcd/src/fuse/_01_application.rs
@@ -57,10 +57,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
             right_header,
             output_data,
             step_aux,
-            framework:
-                FrameworkAux {
-                    witness_polys: witnessed,
-                },
+            framework: FrameworkAux {
+                witness_polys: witnessed,
+            },
         } = aux;
 
         let witness_polys = witnessed

--- a/crates/ragu_pcd/src/fuse/_01_application.rs
+++ b/crates/ragu_pcd/src/fuse/_01_application.rs
@@ -3,18 +3,30 @@
 //! This creates a witness for the step circuit given the two input [`Pcd`]s and
 //! the step witness. This sets the application fields on the [`ProofBuilder`]
 //! and returns the child proofs along with the output data from the step circuit.
+//!
+//! This is where the hooks' coefficient vectors become polynomials at the
+//! application's rank, that being the first place the rank is in scope.
 
 use ragu_arithmetic::{CryptoRngCore, Cycle};
-use ragu_circuits::{CircuitExt, polynomials::Rank};
+use ragu_circuits::{
+    CircuitExt,
+    polynomials::{Rank, sparse},
+};
 use ragu_core::Result;
 
 use crate::{
     Application, Header, Pcd, Proof,
+    framework_hooks::{FrameworkAux, HookConfig},
     proof::ProofBuilder,
-    step::{Step, internal::adapter::Adapter},
+    step::{
+        Step,
+        internal::adapter::{Adapter, AdapterAux},
+    },
 };
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    Application<'_, C, R, HEADER_SIZE, J>
+{
     pub(super) fn compute_application_proof<'source, RNG: CryptoRngCore, S: Step<C>>(
         &self,
         rng: &mut RNG,
@@ -22,7 +34,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         witness: S::Witness<'source>,
         left: Pcd<C, R, S::Left>,
         right: Pcd<C, R, S::Right>,
-        builder: &mut ProofBuilder<'_, C, R>,
+        builder: &mut ProofBuilder<'_, C, R, J>,
     ) -> Result<(
         Proof<C, R>,
         Proof<C, R>,
@@ -31,7 +43,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
     )> {
         let (left_proof, left_data) = left.into_parts();
         let (right_proof, right_data) = right.into_parts();
-        let (trace, aux) = Adapter::<C, S, R, HEADER_SIZE>::new(step)
+        let (trace, aux) = Adapter::<C, S, R, HEADER_SIZE, J>::new(step, self.params)
             .trace((left_data, right_data, witness))?
             .into_parts();
         let rx = self.native_registry.assemble(
@@ -40,12 +52,28 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             &mut *rng,
         )?;
 
-        let ((left_header, right_header), output_data, step_aux) = aux;
+        let AdapterAux {
+            left_header,
+            right_header,
+            output_data,
+            step_aux,
+            framework:
+                FrameworkAux {
+                    witness_polys: witnessed,
+                },
+        } = aux;
+
+        let witness_polys = witnessed
+            .iter()
+            .map(|coefficients| sparse::Polynomial::<_, R>::from_coeffs(coefficients.to_vec()))
+            .collect();
 
         builder.set_circuit_id(S::INDEX.circuit_index(self.num_application_steps)?);
         builder.set_left_header(left_header.into_inner());
         builder.set_right_header(right_header.into_inner());
+
         builder.set_native_application_rx(rx);
+        builder.set_application_polys(witness_polys);
 
         Ok((left_proof, right_proof, output_data, step_aux))
     }

--- a/crates/ragu_pcd/src/fuse/_02_preamble.rs
+++ b/crates/ragu_pcd/src/fuse/_02_preamble.rs
@@ -9,18 +9,24 @@ use ragu_core::Result;
 
 use crate::{
     Application, Proof,
+    framework_hooks::HookConfig,
     internal::{native, nested},
     proof::ProofBuilder,
 };
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    Application<'params, C, R, HEADER_SIZE, J>
+{
     pub(super) fn compute_preamble<'a, RNG: CryptoRngCore>(
         &self,
         rng: &mut RNG,
         left: &'a Proof<C, R>,
         right: &'a Proof<C, R>,
-        builder: &mut ProofBuilder<'_, C, R>,
-    ) -> Result<native::stages::preamble::Witness<'a, C, R, HEADER_SIZE>> {
+        builder: &mut ProofBuilder<'_, C, R, J>,
+    ) -> Result<native::stages::preamble::Witness<'a, C, R, HEADER_SIZE>>
+    where
+        'params: 'a,
+    {
         let preamble_witness = self.compute_native_preamble(rng, left, right, builder)?;
         self.compute_bridge_preamble(rng, left, right, builder)?;
         Ok(preamble_witness)
@@ -31,8 +37,11 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         rng: &mut RNG,
         left: &'a Proof<C, R>,
         right: &'a Proof<C, R>,
-        builder: &mut ProofBuilder<'_, C, R>,
-    ) -> Result<native::stages::preamble::Witness<'a, C, R, HEADER_SIZE>> {
+        builder: &mut ProofBuilder<'_, C, R, J>,
+    ) -> Result<native::stages::preamble::Witness<'a, C, R, HEADER_SIZE>>
+    where
+        'params: 'a,
+    {
         let preamble_witness = native::stages::preamble::Witness::new(
             left,
             right,
@@ -40,7 +49,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             builder.right_header(),
         )?;
 
-        let rx = native::stages::preamble::Stage::<C, R, HEADER_SIZE>::rx(
+        let rx = native::stages::preamble::Stage::<C, R, HEADER_SIZE, J>::rx(
             C::CircuitField::random(&mut *rng),
             &preamble_witness,
         )?;
@@ -55,15 +64,16 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         rng: &mut RNG,
         left: &Proof<C, R>,
         right: &Proof<C, R>,
-        builder: &mut ProofBuilder<'_, C, R>,
+        builder: &mut ProofBuilder<'_, C, R, J>,
     ) -> Result<()> {
-        let bridge_rx = nested::stages::preamble::Stage::<C::HostCurve, R>::rx(
+        let witness = nested::stages::preamble::Witness {
+            native_preamble: builder.native_preamble_commitment(),
+            left: nested::stages::preamble::ChildWitness::from_proof(left)?,
+            right: nested::stages::preamble::ChildWitness::from_proof(right)?,
+        };
+        let bridge_rx = nested::stages::preamble::Stage::<C::HostCurve, R, J::PolyWitnesses>::rx(
             C::ScalarField::random(&mut *rng),
-            &nested::stages::preamble::Witness {
-                native_preamble: builder.native_preamble_commitment(),
-                left: nested::stages::preamble::ChildWitness::from_proof(left),
-                right: nested::stages::preamble::ChildWitness::from_proof(right),
-            },
+            &witness,
         )?;
         let bridge_commitment = bridge_rx.commit_to_affine(C::nested_generators(self.params));
         builder.set_bridge_preamble_rx(bridge_rx, bridge_commitment);

--- a/crates/ragu_pcd/src/fuse/_03_s_prime.rs
+++ b/crates/ragu_pcd/src/fuse/_03_s_prime.rs
@@ -8,16 +8,20 @@ use ragu_circuits::{polynomials::Rank, registry::RegistryAt, staging::StageExt};
 use ragu_core::Result;
 
 use super::NativeSPrime;
-use crate::{Application, Proof, internal::nested, proof::ProofBuilder};
+use crate::{
+    Application, Proof, framework_hooks::HookConfig, internal::nested, proof::ProofBuilder,
+};
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    Application<'_, C, R, HEADER_SIZE, J>
+{
     pub(super) fn compute_s_prime<RNG: CryptoRngCore>(
         &self,
         rng: &mut RNG,
         native_registry: &RegistryAt<'_, C::CircuitField, R>,
         left: &Proof<C, R>,
         right: &Proof<C, R>,
-        builder: &mut ProofBuilder<'_, C, R>,
+        builder: &mut ProofBuilder<'_, C, R, J>,
     ) -> Result<NativeSPrime<C, R>> {
         let native = self.compute_native_s_prime(native_registry, left, right)?;
         self.compute_bridge_s_prime(rng, &native, builder)?;
@@ -28,9 +32,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         &self,
         rng: &mut RNG,
         native: &NativeSPrime<C, R>,
-        builder: &mut ProofBuilder<'_, C, R>,
+        builder: &mut ProofBuilder<'_, C, R, J>,
     ) -> Result<()> {
-        let bridge_rx = nested::stages::s_prime::Stage::<C::HostCurve, R>::rx(
+        let bridge_rx = nested::stages::s_prime::Stage::<C::HostCurve, R, J::PolyWitnesses>::rx(
             C::ScalarField::random(&mut *rng),
             &nested::stages::s_prime::Witness {
                 registry_wx0: native.registry_wx0_commitment,

--- a/crates/ragu_pcd/src/fuse/_04_inner_error.rs
+++ b/crates/ragu_pcd/src/fuse/_04_inner_error.rs
@@ -18,11 +18,14 @@ use super::{
 };
 use crate::{
     Application,
+    framework_hooks::HookConfig,
     internal::{claims, fold_revdot, native, nested},
     proof::ProofBuilder,
 };
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    Application<'_, C, R, HEADER_SIZE, J>
+{
     pub(super) fn inner_error_terms<'dr, 'rx, D, RNG: CryptoRngCore>(
         &self,
         rng: &mut RNG,
@@ -30,7 +33,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         y: &Element<'dr, D>,
         z: &Element<'dr, D>,
         source: &FuseProofSource<'rx, C, R>,
-        builder: &mut ProofBuilder<'_, C, R>,
+        builder: &mut ProofBuilder<'_, C, R, J>,
     ) -> Result<(
         native::stages::inner_error::Witness<C, native::RevdotParameters>,
         FuseBuilder<'_, 'rx, C::CircuitField, R>,
@@ -49,15 +52,16 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         &self,
         rng: &mut RNG,
         registry_wy: &RegistryWy<C, R>,
-        builder: &mut ProofBuilder<'_, C, R>,
+        builder: &mut ProofBuilder<'_, C, R, J>,
     ) -> Result<()> {
-        let bridge_rx = nested::stages::inner_error::Stage::<C::HostCurve, R>::rx(
-            C::ScalarField::random(&mut *rng),
-            &nested::stages::inner_error::Witness {
-                native_inner_error: builder.native_inner_error_commitment(),
-                registry_wy: registry_wy.commitment,
-            },
-        )?;
+        let bridge_rx =
+            nested::stages::inner_error::Stage::<C::HostCurve, R, J::PolyWitnesses>::rx(
+                C::ScalarField::random(&mut *rng),
+                &nested::stages::inner_error::Witness {
+                    native_inner_error: builder.native_inner_error_commitment(),
+                    registry_wy: registry_wy.commitment,
+                },
+            )?;
         let bridge_commitment = bridge_rx.commit_to_affine(C::nested_generators(self.params));
         builder.set_bridge_inner_error_rx(bridge_rx, bridge_commitment);
         Ok(())
@@ -70,7 +74,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         y: &Element<'dr, D>,
         z: &Element<'dr, D>,
         source: &FuseProofSource<'rx, C, R>,
-        builder: &mut ProofBuilder<'_, C, R>,
+        builder: &mut ProofBuilder<'_, C, R, J>,
     ) -> Result<(
         native::stages::inner_error::Witness<C, native::RevdotParameters>,
         FuseBuilder<'_, 'rx, C::CircuitField, R>,
@@ -82,7 +86,12 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         let y = *y.value().take();
         let z = *z.value().take();
 
-        let mut claims_builder = claims::Builder::new(&self.native_registry, y, z);
+        let mut claims_builder = claims::Builder::new(
+            &self.native_registry,
+            y,
+            z,
+            self.hook_layout().witness_polys,
+        );
         native::claims::build(source, &mut claims_builder)?;
 
         let inner_error_witness =
@@ -92,11 +101,13 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                     &claims_builder.b,
                 ),
             };
-        let native_rx =
-            native::stages::inner_error::Stage::<C, R, HEADER_SIZE, native::RevdotParameters>::rx(
-                C::CircuitField::random(&mut *rng),
-                &inner_error_witness,
-            )?;
+        let native_rx = native::stages::inner_error::Stage::<
+            C,
+            R,
+            HEADER_SIZE,
+            J,
+            native::RevdotParameters,
+        >::rx(C::CircuitField::random(&mut *rng), &inner_error_witness)?;
 
         builder.set_native_inner_error_rx(native_rx);
 

--- a/crates/ragu_pcd/src/fuse/_05_outer_error.rs
+++ b/crates/ragu_pcd/src/fuse/_05_outer_error.rs
@@ -21,6 +21,7 @@ use ragu_primitives::{Element, vec::FixedVec};
 use super::claims::{FoldKey, FuseBuilder, TrackedPoly};
 use crate::{
     Application,
+    framework_hooks::HookConfig,
     internal::{
         fold_revdot, native,
         native::stages::outer_error::{ChildKyValues, KyValues},
@@ -30,7 +31,9 @@ use crate::{
 
 type NativeNumGroups = <native::RevdotParameters as fold_revdot::Parameters>::NumGroups;
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    Application<'_, C, R, HEADER_SIZE, J>
+{
     pub(super) fn outer_error_terms<'dr, 'rx, D, RNG: CryptoRngCore>(
         &self,
         rng: &mut RNG,
@@ -44,7 +47,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             C::CircuitField,
             ragu_primitives::poseidon::PoseidonStateLen<C::CircuitField, C::CircuitPoseidon>,
         >,
-        builder: &mut ProofBuilder<'_, C, R>,
+        builder: &mut ProofBuilder<'_, C, R, J>,
     ) -> Result<(
         native::stages::outer_error::Witness<C, native::RevdotParameters>,
         FixedVec<TrackedPoly<'rx, FoldKey, C::CircuitField, R>, NativeNumGroups>,
@@ -74,7 +77,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                 let (preamble_witness, inner_error_terms, y, mu, nu) = witness.cast();
                 let allocator = &mut ();
 
-                let preamble = native::stages::preamble::Stage::<C, R, HEADER_SIZE>::default()
+                let preamble = native::stages::preamble::Stage::<C, R, HEADER_SIZE, J>::default()
                     .witness(dr, preamble_witness.as_ref().map(|w| *w))?;
 
                 let y = Element::alloc(dr, allocator, y)?;
@@ -155,13 +158,15 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         &self,
         rng: &mut RNG,
         outer_error_witness: &native::stages::outer_error::Witness<C, native::RevdotParameters>,
-        builder: &mut ProofBuilder<'_, C, R>,
+        builder: &mut ProofBuilder<'_, C, R, J>,
     ) -> Result<()> {
-        let rx =
-            native::stages::outer_error::Stage::<C, R, HEADER_SIZE, native::RevdotParameters>::rx(
-                C::CircuitField::random(&mut *rng),
-                outer_error_witness,
-            )?;
+        let rx = native::stages::outer_error::Stage::<
+            C,
+            R,
+            HEADER_SIZE,
+            J,
+            native::RevdotParameters,
+        >::rx(C::CircuitField::random(&mut *rng), outer_error_witness)?;
 
         builder.set_native_outer_error_rx(rx);
 

--- a/crates/ragu_pcd/src/fuse/_06_ab.rs
+++ b/crates/ragu_pcd/src/fuse/_06_ab.rs
@@ -37,13 +37,16 @@ use ragu_primitives::{Element, vec::FixedVec};
 use super::claims::{FoldKey, FuseProofSource, TrackedPoly};
 use crate::{
     Application,
+    framework_hooks::HookConfig,
     internal::{fold_revdot, native},
     proof::ProofBuilder,
 };
 
 type NativeNumGroups = <native::RevdotParameters as fold_revdot::Parameters>::NumGroups;
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    Application<'_, C, R, HEADER_SIZE, J>
+{
     pub(super) fn compute_ab<'dr, D>(
         &self,
         a: FixedVec<TrackedPoly<'_, FoldKey, C::CircuitField, R>, NativeNumGroups>,
@@ -51,7 +54,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         source: &FuseProofSource<'_, C, R>,
         mu_prime: &Element<'dr, D>,
         nu_prime: &Element<'dr, D>,
-        builder: &mut ProofBuilder<'_, C, R>,
+        builder: &mut ProofBuilder<'_, C, R, J>,
     ) -> Result<()>
     where
         D: Driver<'dr, F = C::CircuitField>,
@@ -68,7 +71,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         source: &FuseProofSource<'_, C, R>,
         mu_prime: &Element<'dr, D>,
         nu_prime: &Element<'dr, D>,
-        builder: &mut ProofBuilder<'_, C, R>,
+        builder: &mut ProofBuilder<'_, C, R, J>,
     ) -> Result<()>
     where
         D: Driver<'dr, F = C::CircuitField>,

--- a/crates/ragu_pcd/src/fuse/_07_query.rs
+++ b/crates/ragu_pcd/src/fuse/_07_query.rs
@@ -14,9 +14,13 @@ use ragu_core::{Result, drivers::Driver, maybe::Maybe};
 use ragu_primitives::Element;
 
 use super::RegistryWy;
-use crate::{Application, Proof, internal::native, proof::ProofBuilder};
+use crate::{
+    Application, Proof, framework_hooks::HookConfig, internal::native, proof::ProofBuilder,
+};
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    Application<'_, C, R, HEADER_SIZE, J>
+{
     pub(super) fn compute_query<'dr, D, RNG: CryptoRngCore>(
         &self,
         rng: &mut RNG,
@@ -27,7 +31,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         registry_wy: &RegistryWy<C, R>,
         left: &Proof<C, R>,
         right: &Proof<C, R>,
-        builder: &mut ProofBuilder<'_, C, R>,
+        builder: &mut ProofBuilder<'_, C, R, J>,
     ) -> Result<native::stages::query::Witness<C>>
     where
         D: Driver<'dr, F = C::CircuitField>,
@@ -64,7 +68,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             ),
         };
 
-        let rx = native::stages::query::Stage::<C, R, HEADER_SIZE>::rx(
+        let rx = native::stages::query::Stage::<C, R, HEADER_SIZE, J>::rx(
             C::CircuitField::random(&mut *rng),
             &query_witness,
         )?;

--- a/crates/ragu_pcd/src/fuse/_08_f.rs
+++ b/crates/ragu_pcd/src/fuse/_08_f.rs
@@ -21,6 +21,7 @@ use ragu_primitives::Element;
 use super::{NativeF, NativeSPrime, RegistryWy};
 use crate::{
     Application, Proof,
+    framework_hooks::HookConfig,
     internal::{
         native,
         native::{RxComponent, RxIndex},
@@ -29,7 +30,9 @@ use crate::{
     proof::ProofBuilder,
 };
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    Application<'_, C, R, HEADER_SIZE, J>
+{
     pub(super) fn compute_f<'dr, D, RNG: CryptoRngCore>(
         &self,
         rng: &mut RNG,
@@ -40,7 +43,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         alpha: &Element<'dr, D>,
         s_prime: &NativeSPrime<C, R>,
         registry_wy: &RegistryWy<C, R>,
-        builder: &mut ProofBuilder<'_, C, R>,
+        builder: &mut ProofBuilder<'_, C, R, J>,
         left: &Proof<C, R>,
         right: &Proof<C, R>,
     ) -> Result<NativeF<C, R>>
@@ -71,9 +74,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         &self,
         rng: &mut RNG,
         native: &NativeF<C, R>,
-        builder: &mut ProofBuilder<'_, C, R>,
+        builder: &mut ProofBuilder<'_, C, R, J>,
     ) -> Result<()> {
-        let bridge_rx = nested::stages::f::Stage::<C::HostCurve, R>::rx(
+        let bridge_rx = nested::stages::f::Stage::<C::HostCurve, R, J::PolyWitnesses>::rx(
             C::ScalarField::random(&mut *rng),
             &nested::stages::f::Witness {
                 native_f: native.commitment,
@@ -93,7 +96,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         alpha: &Element<'dr, D>,
         s_prime: &NativeSPrime<C, R>,
         registry_wy: &RegistryWy<C, R>,
-        builder: &ProofBuilder<'_, C, R>,
+        builder: &ProofBuilder<'_, C, R, J>,
         left: &Proof<C, R>,
         right: &Proof<C, R>,
     ) -> Result<NativeF<C, R>>

--- a/crates/ragu_pcd/src/fuse/_09_eval.rs
+++ b/crates/ragu_pcd/src/fuse/_09_eval.rs
@@ -10,9 +10,13 @@ use ragu_core::{Result, drivers::Driver, maybe::Maybe};
 use ragu_primitives::Element;
 
 use super::{NativeSPrime, RegistryWy};
-use crate::{Application, Proof, internal::native, proof::ProofBuilder};
+use crate::{
+    Application, Proof, framework_hooks::HookConfig, internal::native, proof::ProofBuilder,
+};
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    Application<'_, C, R, HEADER_SIZE, J>
+{
     pub(super) fn compute_eval<'dr, D, RNG: CryptoRngCore>(
         &self,
         rng: &mut RNG,
@@ -21,16 +25,16 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         right: &Proof<C, R>,
         s_prime: &NativeSPrime<C, R>,
         registry_wy: &RegistryWy<C, R>,
-        builder: &mut ProofBuilder<'_, C, R>,
-    ) -> Result<native::stages::eval::Witness<C::CircuitField>>
+        builder: &mut ProofBuilder<'_, C, R, J>,
+    ) -> Result<native::stages::eval::Witness<C::CircuitField, J::PolyWitnesses>>
     where
         D: Driver<'dr, F = C::CircuitField>,
     {
         let u = *u.value().take();
 
         let eval_witness = native::stages::eval::Witness {
-            left: native::stages::eval::ChildEvaluationsWitness::from_proof(left, u),
-            right: native::stages::eval::ChildEvaluationsWitness::from_proof(right, u),
+            left: native::stages::eval::ChildEvaluationsWitness::from_proof(left, u)?,
+            right: native::stages::eval::ChildEvaluationsWitness::from_proof(right, u)?,
             current: native::stages::eval::CurrentStepWitness {
                 // TODO: the registry evaluations here could _theoretically_ be more
                 // efficient if they're computed simultaneously with assistance
@@ -44,7 +48,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                 registry_xy: builder.native_registry_xy_poly().eval(u),
             },
         };
-        let rx = native::stages::eval::Stage::<C, R, HEADER_SIZE>::rx(
+        let rx = native::stages::eval::Stage::<C, R, HEADER_SIZE, J>::rx(
             C::CircuitField::random(&mut *rng),
             &eval_witness,
         )?;

--- a/crates/ragu_pcd/src/fuse/_10_p.rs
+++ b/crates/ragu_pcd/src/fuse/_10_p.rs
@@ -22,9 +22,10 @@ use ragu_primitives::{Element, extract_endoscalar, lift_endoscalar};
 use super::{NativeF, NativeSPrime, RegistryWy};
 use crate::{
     Application, Proof,
+    framework_hooks::HookConfig,
     internal::{
         native::{RxComponent, RxIndex},
-        nested::NUM_ENDOSCALING_POINTS,
+        nested::num_endoscaling_points,
     },
     proof::ProofBuilder,
 };
@@ -47,7 +48,9 @@ impl<C: Cycle, R: Rank> Accumulator<'_, C, R> {
     }
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    Application<'_, C, R, HEADER_SIZE, J>
+{
     pub(super) fn compute_p<'dr, D, RNG: ragu_arithmetic::CryptoRngCore>(
         &self,
         rng: &mut RNG,
@@ -57,7 +60,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         s_prime: &NativeSPrime<C, R>,
         registry_wy: &RegistryWy<C, R>,
         f: &NativeF<C, R>,
-        builder: &mut ProofBuilder<'_, C, R>,
+        builder: &mut ProofBuilder<'_, C, R, J>,
     ) -> Result<()>
     where
         D: Driver<'dr, F = C::CircuitField>,
@@ -86,6 +89,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             };
 
             for proof in [left, right] {
+                // `RxIndex::ALL` is the one order the eval stage's `Write`
+                // impl, `loading`'s point walk, and this accumulation follow.
                 for &id in &RxIndex::ALL {
                     acc.acc(&proof[id], proof.native_rx_commitment(id));
                 }
@@ -102,6 +107,13 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
                     proof.native_registry_xy_commitment(),
                 );
                 acc.acc(proof.native_p_poly(), proof.native_p_commitment());
+                for (poly, commitment) in proof
+                    .witness_polys()
+                    .iter()
+                    .zip(proof.witness_poly_commitments())
+                {
+                    acc.acc(poly, commitment);
+                }
             }
 
             acc.acc(&s_prime.registry_wx0_poly, s_prime.registry_wx0_commitment);
@@ -119,7 +131,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         // and delegate to the shared endoscaling helper, which also
         // sets `nested_endoscalar_rx`, `nested_points_rx`, and
         // `nested_endoscaling_step_rxs` on the builder.
-        let mut points = Vec::with_capacity(NUM_ENDOSCALING_POINTS);
+        let mut points =
+            Vec::with_capacity(num_endoscaling_points(self.hook_layout().witness_polys));
         points.push(f.commitment);
         points.extend_from_slice(&commitments);
 

--- a/crates/ragu_pcd/src/fuse/_11_circuits.rs
+++ b/crates/ragu_pcd/src/fuse/_11_circuits.rs
@@ -4,11 +4,14 @@ use ragu_core::Result;
 
 use crate::{
     Application,
+    framework_hooks::HookConfig,
     internal::{native, native::total_circuit_counts},
     proof::ProofBuilder,
 };
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    Application<'_, C, R, HEADER_SIZE, J>
+{
     pub(super) fn compute_internal_circuits<RNG: CryptoRngCore>(
         &self,
         rng: &mut RNG,
@@ -16,8 +19,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         outer_error_witness: &native::stages::outer_error::Witness<C, native::RevdotParameters>,
         inner_error_witness: &native::stages::inner_error::Witness<C, native::RevdotParameters>,
         query_witness: &native::stages::query::Witness<C>,
-        eval_witness: &native::stages::eval::Witness<C::CircuitField>,
-        builder: &mut ProofBuilder<'_, C, R>,
+        eval_witness: &native::stages::eval::Witness<C::CircuitField, J::PolyWitnesses>,
+        builder: &mut ProofBuilder<'_, C, R, J>,
     ) -> Result<()> {
         let unified = native::unified::Instance {
             bridge_preamble_commitment: builder.bridge_preamble_commitment(),
@@ -48,6 +51,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             C,
             R,
             HEADER_SIZE,
+            J,
             native::RevdotParameters,
         >::new(
             self.params,
@@ -69,6 +73,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             C,
             R,
             HEADER_SIZE,
+            J,
             native::RevdotParameters,
         >::new(self.params)
         .trace(native::circuits::hashes_2::Witness {
@@ -86,6 +91,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             C,
             R,
             HEADER_SIZE,
+            J,
             native::RevdotParameters,
         >::new()
         .trace(native::circuits::inner_collapse::Witness {
@@ -105,6 +111,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             C,
             R,
             HEADER_SIZE,
+            J,
             native::RevdotParameters,
         >::new()
         .trace(native::circuits::outer_collapse::Witness {
@@ -120,7 +127,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
         )?;
 
         let (compute_v_trace, unified) =
-            native::circuits::compute_v::Circuit::<C, R, HEADER_SIZE>::new()
+            native::circuits::compute_v::Circuit::<C, R, HEADER_SIZE, J>::new()
                 .trace(native::circuits::compute_v::Witness {
                     unified,
                     preamble_witness,

--- a/crates/ragu_pcd/src/fuse/mod.rs
+++ b/crates/ragu_pcd/src/fuse/mod.rs
@@ -23,7 +23,8 @@ use ragu_core::{Result, drivers::emulator::Emulator, maybe::Maybe};
 use ragu_primitives::{GadgetExt, Point, vec::CollectFixed};
 
 use crate::{
-    Application, Pcd, RAGU_TAG, internal::transcript::Transcript, proof::ProofBuilder, step::Step,
+    Application, Pcd, RAGU_TAG, framework_hooks::HookConfig, internal::transcript::Transcript,
+    proof::ProofBuilder, step::Step,
 };
 
 /// Ephemeral native-field data for $f(X)$, used only during the fuse step.
@@ -46,7 +47,9 @@ struct NativeSPrime<C: Cycle, R: Rank> {
     registry_wx1_commitment: C::HostCurve,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    Application<'_, C, R, HEADER_SIZE, J>
+{
     /// Fuse two [`Pcd`] into one using a provided [`Step`].
     ///
     /// The provided `step` must have been previously registered with this

--- a/crates/ragu_pcd/src/fuzz_utils.rs
+++ b/crates/ragu_pcd/src/fuzz_utils.rs
@@ -6,7 +6,7 @@ use ragu_circuits::{
     registry::CircuitIndex,
 };
 
-use crate::{Application, Proof};
+use crate::{Application, Proof, framework_hooks::HookConfig};
 
 /// Targeted corruption of a single proof field.
 ///
@@ -65,7 +65,9 @@ impl<C: Cycle, R: Rank> Proof<C, R> {
     }
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    Application<'_, C, R, HEADER_SIZE, J>
+{
     /// Create a trivial (all-zero) proof for testing.
     pub fn test_trivial_proof(&self) -> Proof<C, R> {
         self.trivial_proof()

--- a/crates/ragu_pcd/src/internal/claims.rs
+++ b/crates/ragu_pcd/src/internal/claims.rs
@@ -89,6 +89,9 @@ pub struct Builder<'m, 'rx, A, F: PrimeField, R: Rank> {
     pub a: Vec<A>,
     /// The accumulated `b` polynomials for revdot claims.
     pub b: Vec<Cow<'rx, sparse::Polynomial<F, R>>>,
+    /// The polynomial count its registry was built with — what a nested claim
+    /// resolves its circuit index from. Only the nested side reads it.
+    pub witness_polys: usize,
 }
 
 impl<'m, 'rx, A, F: PrimeField, R: Rank> Builder<'m, 'rx, A, F, R>
@@ -96,7 +99,7 @@ where
     A: Borrow<sparse::Polynomial<F, R>>,
 {
     /// Create a new claim builder.
-    pub fn new(registry: &'m Registry<'m, F, R>, y: F, z: F) -> Self {
+    pub fn new(registry: &'m Registry<'m, F, R>, y: F, z: F, witness_polys: usize) -> Self {
         Self {
             registry,
             y,
@@ -104,6 +107,7 @@ where
             tz: R::tz(z),
             a: Vec::new(),
             b: Vec::new(),
+            witness_polys,
         }
     }
 

--- a/crates/ragu_pcd/src/internal/endoscalar.rs
+++ b/crates/ragu_pcd/src/internal/endoscalar.rs
@@ -6,7 +6,7 @@
 //!
 //! The structure separates points into:
 //! - `initial`: The base case accumulator for step 0
-//! - `inputs`: Additional points to endoscale (length = NUM_POINTS - 1)
+//! - `inputs`: Additional points to endoscale (length = `L::len() - 1`)
 //! - `interstitials`: Output points, one per step
 //!
 //! All steps are uniform: step N initializes from `interstitials[N-1]` (or
@@ -17,6 +17,7 @@
 //! curve type and number of points.
 
 use alloc::vec;
+use core::marker::PhantomData;
 
 use ragu_arithmetic::{
     CurveAffine,
@@ -43,16 +44,6 @@ use ragu_primitives::{
 /// a single circuit in our target circuit size.
 const ENDOSCALINGS_PER_STEP: usize = 4;
 
-/// Number of inputs (excluding initial) for `NUM_POINTS`.
-pub struct InputsLen<const NUM_POINTS: usize>;
-
-impl<const NUM_POINTS: usize> Len for InputsLen<NUM_POINTS> {
-    fn len() -> usize {
-        const { assert!(NUM_POINTS > 0) };
-        NUM_POINTS - 1
-    }
-}
-
 /// Compute the number of endoscaling steps for `num_points` curve points.
 ///
 /// This is `ceil((num_points - 1) / ENDOSCALINGS_PER_STEP).max(1)`.
@@ -63,12 +54,25 @@ pub(crate) const fn num_steps(num_points: usize) -> usize {
     if steps > 1 { steps } else { 1 }
 }
 
-/// Number of steps (= interstitials) for `NUM_POINTS`.
-pub struct NumStepsLen<const NUM_POINTS: usize>;
+/// Number of accumulation inputs for a point count `L`: every point after the
+/// first.
+pub struct InputsLen<L: Len>(PhantomData<L>);
 
-impl<const NUM_POINTS: usize> Len for NumStepsLen<NUM_POINTS> {
+impl<L: Len> Len for InputsLen<L> {
     fn len() -> usize {
-        num_steps(NUM_POINTS)
+        L::len()
+            .checked_sub(1)
+            .expect("an accumulation walk starts from a point, so the list is never empty")
+    }
+}
+
+/// Number of endoscaling steps — and so interstitials — for a point count
+/// `L`: [`num_steps`] at the type level.
+pub struct NumStepsLen<L: Len>(PhantomData<L>);
+
+impl<L: Len> Len for NumStepsLen<L> {
+    fn len() -> usize {
+        num_steps(L::len())
     }
 }
 
@@ -99,17 +103,17 @@ impl<F: Field, R: Rank> Stage<F, R> for EndoscalarStage {
 }
 
 /// Witness for the points stage: initial, inputs, and interstitials.
-#[derive(Clone)]
-pub struct PointsWitness<C: CurveAffine, const NUM_POINTS: usize> {
+/// Typed by the same [`Len`] as the [`Points`] gadget it witnesses.
+pub struct PointsWitness<C: CurveAffine, L: Len> {
     /// Initial accumulator (base case for step 0).
     pub initial: C,
-    /// Inputs (length = NUM_POINTS - 1).
-    pub inputs: FixedVec<C, InputsLen<NUM_POINTS>>,
+    /// Inputs: every point after the first.
+    pub inputs: FixedVec<C, InputsLen<L>>,
     /// Interstitial outputs, one per step.
-    pub interstitials: FixedVec<C, NumStepsLen<NUM_POINTS>>,
+    pub interstitials: FixedVec<C, NumStepsLen<L>>,
 }
 
-impl<C: CurveAffine, const NUM_POINTS: usize> PointsWitness<C, NUM_POINTS>
+impl<C: CurveAffine, L: Len> PointsWitness<C, L>
 where
     C::Scalar: WithSmallOrderMulGroup<3>,
 {
@@ -120,9 +124,9 @@ where
     ///
     /// # Panics
     ///
-    /// Panics if `points.len() != NUM_POINTS`.
+    /// Panics if `points` is not `L::len()` long.
     pub fn new(endoscalar: u128, points: &[C]) -> Self {
-        assert_eq!(points.len(), NUM_POINTS, "expected {NUM_POINTS} points");
+        assert_eq!(points.len(), L::len(), "expected {} points", L::len());
 
         let initial = points[0];
         let points = &points[1..];
@@ -131,7 +135,7 @@ where
         let endoscalar: C::Scalar = ragu_primitives::lift_endoscalar(endoscalar);
 
         // Compute interstitials using chunked Horner iteration
-        let mut interstitials = vec::Vec::with_capacity(NumStepsLen::<NUM_POINTS>::len());
+        let mut interstitials = vec::Vec::with_capacity(NumStepsLen::<L>::len());
         let mut acc = initial.to_curve();
 
         if points.is_empty() {
@@ -161,33 +165,60 @@ where
     }
 }
 
-/// Output gadget containing initial, inputs, and interstitials. See [`PointsWitness`].
+impl<C: CurveAffine, L: Len> Clone for PointsWitness<C, L> {
+    fn clone(&self) -> Self {
+        Self {
+            initial: self.initial,
+            inputs: self.inputs.clone(),
+            interstitials: self.interstitials.clone(),
+        }
+    }
+}
+
+impl<C: CurveAffine, R: Rank, L: Len> Clone for EndoscalingStep<C, R, L> {
+    fn clone(&self) -> Self {
+        Self {
+            step: self.step,
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// Output gadget containing initial, inputs, and interstitials. See
+/// [`PointsWitness`].
 #[derive(Gadget)]
-pub struct Points<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>, const NUM_POINTS: usize> {
+pub struct Points<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>, L: Len> {
     #[ragu(gadget)]
     pub initial: Point<'dr, D, C>,
     #[ragu(gadget)]
-    pub inputs: FixedVec<Point<'dr, D, C>, InputsLen<NUM_POINTS>>,
+    pub inputs: FixedVec<Point<'dr, D, C>, InputsLen<L>>,
     #[ragu(gadget)]
-    pub interstitials: FixedVec<Point<'dr, D, C>, NumStepsLen<NUM_POINTS>>,
+    pub interstitials: FixedVec<Point<'dr, D, C>, NumStepsLen<L>>,
 }
 
 /// Stage for allocating all point witnesses (inputs and interstitials).
-#[derive(Default)]
-pub struct PointsStage<C: CurveAffine, const NUM_POINTS: usize>(core::marker::PhantomData<C>);
+pub struct PointsStage<C: CurveAffine, L: Len> {
+    _marker: PhantomData<(C, L)>,
+}
 
-impl<C: CurveAffine, R: Rank, const NUM_POINTS: usize> Stage<C::Base, R>
-    for PointsStage<C, NUM_POINTS>
-{
+impl<C: CurveAffine, L: Len> Default for PointsStage<C, L> {
+    fn default() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C: CurveAffine, R: Rank, L: Len> Stage<C::Base, R> for PointsStage<C, L> {
     type Parent = EndoscalarStage;
 
     fn values() -> usize {
         // (x, y) coordinates for initial + inputs + interstitials.
-        2 * (1 + InputsLen::<NUM_POINTS>::len() + NumStepsLen::<NUM_POINTS>::len())
+        2 * (1 + InputsLen::<L>::len() + NumStepsLen::<L>::len())
     }
 
-    type Witness<'source> = &'source PointsWitness<C, NUM_POINTS>;
-    type OutputKind = Kind![C::Base; Points<'_, _, C, NUM_POINTS>];
+    type Witness<'source> = &'source PointsWitness<C, L>;
+    type OutputKind = Kind![C::Base; Points<'_, _, C, L>];
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::Base>>(
         &self,
@@ -219,18 +250,19 @@ impl<C: CurveAffine, R: Rank, const NUM_POINTS: usize> Stage<C::Base, R>
 ///   `inputs[N*ENDOSCALINGS_PER_STEP..(N+1)*ENDOSCALINGS_PER_STEP]` (clamped to bounds)
 ///
 /// The circuit constrains that `interstitials[step]` equals the Horner result.
-#[derive(Clone)]
-pub struct EndoscalingStep<C: CurveAffine, R: Rank, const NUM_POINTS: usize> {
+///
+/// `L` is the accumulation's point count, carried as a [`Len`].
+pub struct EndoscalingStep<C: CurveAffine, R: Rank, L: Len> {
     step: usize,
-    _marker: core::marker::PhantomData<(C, R)>,
+    _marker: PhantomData<(C, R, L)>,
 }
 
-impl<C: CurveAffine, R: Rank, const NUM_POINTS: usize> EndoscalingStep<C, R, NUM_POINTS> {
+impl<C: CurveAffine, R: Rank, L: Len> EndoscalingStep<C, R, L> {
     /// Creates a new endoscaling step.
     ///
-    /// Panics if `step >= NumStepsLen::<NUM_POINTS>::len()`.
+    /// Panics if `step >= NumStepsLen::<L>::len()`.
     pub fn new(step: usize) -> Self {
-        let num_steps = NumStepsLen::<NUM_POINTS>::len();
+        let num_steps = NumStepsLen::<L>::len();
         assert!(
             step < num_steps,
             "step {} exceeds available steps (num_steps = {})",
@@ -239,32 +271,30 @@ impl<C: CurveAffine, R: Rank, const NUM_POINTS: usize> EndoscalingStep<C, R, NUM
         );
         Self {
             step,
-            _marker: core::marker::PhantomData,
+            _marker: PhantomData,
         }
     }
 
     /// Range of input indices to iterate over in the Horner loop.
     fn input_range(&self) -> core::ops::Range<usize> {
         let start = self.step * ENDOSCALINGS_PER_STEP;
-        let end = (start + ENDOSCALINGS_PER_STEP).min(InputsLen::<NUM_POINTS>::len());
+        let end = (start + ENDOSCALINGS_PER_STEP).min(InputsLen::<L>::len());
         start..end
     }
 }
 
 /// Witness for an endoscaling step.
-pub struct EndoscalingStepWitness<'source, C: CurveAffine, const NUM_POINTS: usize> {
+pub struct EndoscalingStepWitness<'source, C: CurveAffine, L: Len> {
     /// The endoscalar value.
     pub endoscalar: u128,
     /// Point witnesses (inputs and interstitials).
-    pub points: &'source PointsWitness<C, NUM_POINTS>,
+    pub points: &'source PointsWitness<C, L>,
 }
 
-impl<C: CurveAffine, R: Rank, const NUM_POINTS: usize> MultiStageCircuit<C::Base, R>
-    for EndoscalingStep<C, R, NUM_POINTS>
-{
-    type Last = PointsStage<C, NUM_POINTS>;
+impl<C: CurveAffine, R: Rank, L: Len> MultiStageCircuit<C::Base, R> for EndoscalingStep<C, R, L> {
+    type Last = PointsStage<C, L>;
     type Instance<'source> = ();
-    type Witness<'source> = EndoscalingStepWitness<'source, C, NUM_POINTS>;
+    type Witness<'source> = EndoscalingStepWitness<'source, C, L>;
     type Output = Kind![C::Base; ()];
     type Aux<'source> = ();
 
@@ -282,7 +312,7 @@ impl<C: CurveAffine, R: Rank, const NUM_POINTS: usize> MultiStageCircuit<C::Base
         witness: DriverValue<D, Self::Witness<'source>>,
     ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'source>>>> {
         let (endoscalar_guard, dr) = dr.add_stage::<EndoscalarStage>()?;
-        let (points_guard, dr) = dr.add_stage::<PointsStage<C, NUM_POINTS>>()?;
+        let (points_guard, dr) = dr.add_stage::<PointsStage<C, L>>()?;
         let dr = dr.finish();
 
         // Stages are loaded unenforced here. Curve membership for points and
@@ -344,15 +374,30 @@ mod tests {
         maybe::Maybe,
     };
     use ragu_pasta::{Ep, EpAffine, Fp, Fq};
-    use ragu_primitives::{Endoscalar, vec::Len};
+    use ragu_primitives::{
+        Endoscalar,
+        vec::{ConstLen, Len},
+    };
     use ragu_testing::registry::TestRegistryBuilder;
 
     use super::{
         ENDOSCALINGS_PER_STEP, EndoscalarStage, EndoscalingStep, EndoscalingStepWitness, InputsLen,
-        NumStepsLen, PointsStage, PointsWitness,
+        NumStepsLen, PointsStage, PointsWitness, num_steps,
     };
 
     type R = polynomials::ProductionRank;
+
+    /// The points stage at a test point count.
+    type Points<const NUM_POINTS: usize> = PointsStage<EpAffine, ConstLen<NUM_POINTS>>;
+
+    #[test]
+    fn stage_values_matches_wire_count() {
+        use crate::internal::tests::assert_stage_values;
+
+        assert_stage_values::<Fp, R, _>(&Points::<1>::default());
+        assert_stage_values::<Fp, R, _>(&Points::<11>::default());
+        assert_stage_values::<Fp, R, _>(&Points::<13>::default());
+    }
 
     /// Computes the effective scalar for an endoscalar via emulated `lift`.
     fn compute_effective_scalar(endo: u128) -> Fq {
@@ -382,15 +427,15 @@ mod tests {
 
     /// Helper to compute interstitials for a given set of inputs.
     ///
-    /// Takes the initial point and a separate inputs array (length NUM_POINTS - 1),
-    /// mirroring the new uniform step structure.
-    fn compute_interstitials<const NUM_POINTS: usize>(
+    /// Takes the initial point and a separate inputs array (point count - 1
+    /// entries), mirroring the uniform step structure.
+    fn compute_interstitials(
         endoscalar: u128,
         initial: EpAffine,
         inputs: &[EpAffine],
     ) -> Vec<EpAffine> {
-        let num_steps = NumStepsLen::<NUM_POINTS>::len();
-        let inputs_len = InputsLen::<NUM_POINTS>::len();
+        let num_steps = num_steps(inputs.len() + 1);
+        let inputs_len = inputs.len();
         let mut interstitials = Vec::with_capacity(num_steps);
 
         for step in 0..num_steps {
@@ -423,7 +468,7 @@ mod tests {
     fn test_endoscaling_steps() -> Result<()> {
         // Test with 13 total points (1 initial + 12 inputs = 3 steps of 4)
         const NUM_POINTS: usize = 13;
-        let num_steps = NumStepsLen::<NUM_POINTS>::len();
+        let num_steps = num_steps(NUM_POINTS);
 
         // Generate random endoscalar and base input points.
         let endoscalar: u128 = ragu_arithmetic::rand::rng().random();
@@ -436,27 +481,25 @@ mod tests {
         let expected = compute_horner_native(endoscalar, &base_inputs);
 
         // Construct witness using the constructor
-        let points = PointsWitness::<EpAffine, NUM_POINTS>::new(endoscalar, &base_inputs);
+        let points = PointsWitness::<EpAffine, ConstLen<NUM_POINTS>>::new(endoscalar, &base_inputs);
 
         // Verify final interstitial matches expected
         assert_eq!(points.interstitials[num_steps - 1], expected);
 
         // Run each step through the multi-stage circuit and verify correctness.
         for step in 0..num_steps {
-            let step_circuit = EndoscalingStep::<EpAffine, R, NUM_POINTS>::new(step);
+            let step_circuit = EndoscalingStep::<EpAffine, R, ConstLen<NUM_POINTS>>::new(step);
             let mut builder = TestRegistryBuilder::new();
             let staged_h = builder.register_circuit(MultiStage::new(step_circuit.clone()))?;
             let endo_mask_h = builder.register_bonding(EndoscalarStage::mask()?);
-            let pts_mask_h = builder.register_bonding(PointsStage::<EpAffine, NUM_POINTS>::mask()?);
-            let final_mask_h =
-                builder.register_bonding(PointsStage::<EpAffine, NUM_POINTS>::final_mask()?);
+            let pts_mask_h = builder.register_bonding(Points::<NUM_POINTS>::mask()?);
+            let final_mask_h = builder.register_bonding(Points::<NUM_POINTS>::final_mask()?);
             let registry = builder.finalize()?;
 
             let staged = MultiStage::new(step_circuit);
 
             let endoscalar_rx = <EndoscalarStage as StageExt<Fp, R>>::rx(Fp::ZERO, endoscalar)?;
-            let points_rx =
-                <PointsStage<EpAffine, NUM_POINTS> as StageExt<Fp, R>>::rx(Fp::ZERO, &points)?;
+            let points_rx = <Points<NUM_POINTS> as StageExt<Fp, R>>::rx(Fp::ZERO, &points)?;
             let final_trace = staged
                 .trace(EndoscalingStepWitness {
                     endoscalar,
@@ -489,13 +532,13 @@ mod tests {
         // Step 1: interstitial[0] + inputs[4..8], output interstitial[1]
         // Step 2: interstitial[1] + inputs[8..10], output interstitial[2]
         const NUM_POINTS: usize = 11;
-        let num_steps = NumStepsLen::<NUM_POINTS>::len();
+        let num_steps = num_steps(NUM_POINTS);
 
-        // Verify computed constants match expectations
+        // Verify computed lengths match expectations
         // With 10 inputs, we need ceil(10/4) = 3 steps
         assert_eq!(num_steps, 3);
-        assert_eq!(NumStepsLen::<NUM_POINTS>::len(), 3);
-        assert_eq!(InputsLen::<NUM_POINTS>::len(), 10);
+        assert_eq!(NumStepsLen::<ConstLen<NUM_POINTS>>::len(), 3);
+        assert_eq!(InputsLen::<ConstLen<NUM_POINTS>>::len(), 10);
 
         // Generate random endoscalar and base input points.
         let endoscalar: u128 = ragu_arithmetic::rand::rng().random();
@@ -508,19 +551,19 @@ mod tests {
         let expected = compute_horner_native(endoscalar, &base_inputs);
 
         // Construct witness using the constructor
-        let points = PointsWitness::<EpAffine, NUM_POINTS>::new(endoscalar, &base_inputs);
+        let points = PointsWitness::<EpAffine, ConstLen<NUM_POINTS>>::new(endoscalar, &base_inputs);
 
         // Verify final interstitial matches expected
         assert_eq!(points.interstitials[num_steps - 1], expected);
 
         // Run each step through the multi-stage circuit.
         for step in 0..num_steps {
-            let step_circuit = EndoscalingStep::<EpAffine, R, NUM_POINTS>::new(step);
+            let step_circuit = EndoscalingStep::<EpAffine, R, ConstLen<NUM_POINTS>>::new(step);
             let mut builder = TestRegistryBuilder::new();
             let staged_h = builder.register_circuit(MultiStage::new(step_circuit.clone()))?;
             builder.register_bonding(EndoscalarStage::mask()?);
-            builder.register_bonding(PointsStage::<EpAffine, NUM_POINTS>::mask()?);
-            builder.register_bonding(PointsStage::<EpAffine, NUM_POINTS>::final_mask()?);
+            builder.register_bonding(Points::<NUM_POINTS>::mask()?);
+            builder.register_bonding(Points::<NUM_POINTS>::final_mask()?);
             let registry = builder.finalize()?;
 
             let staged = MultiStage::new(step_circuit);
@@ -536,8 +579,7 @@ mod tests {
             let y = Fp::random(&mut ragu_arithmetic::rand::rng());
 
             let endoscalar_rx = <EndoscalarStage as StageExt<Fp, R>>::rx(Fp::ZERO, endoscalar)?;
-            let points_rx =
-                <PointsStage<EpAffine, NUM_POINTS> as StageExt<Fp, R>>::rx(Fp::ZERO, &points)?;
+            let points_rx = <Points<NUM_POINTS> as StageExt<Fp, R>>::rx(Fp::ZERO, &points)?;
 
             // Verify combined circuit identity.
             let mut lhs = final_rx.clone();
@@ -550,50 +592,49 @@ mod tests {
     }
 
     #[test]
-    fn test_num_steps_len() {
+    fn test_num_steps() {
         // With uniform steps, each step consumes up to 4 inputs.
-        // InputsLen = NUM_POINTS - 1, NumSteps = max(ceil(InputsLen / 4), 1)
+        // inputs = NUM_POINTS - 1, steps = max(ceil(inputs / 4), 1)
         // Assumes NUM_POINTS > 0.
 
         // 1 total point = 0 inputs = 1 step (base case)
-        assert_eq!(NumStepsLen::<1>::len(), 1);
+        assert_eq!(num_steps(1), 1);
 
         // 2-5 total points = 1-4 inputs = 1 step
-        assert_eq!(NumStepsLen::<2>::len(), 1);
-        assert_eq!(NumStepsLen::<3>::len(), 1);
-        assert_eq!(NumStepsLen::<4>::len(), 1);
-        assert_eq!(NumStepsLen::<5>::len(), 1);
+        assert_eq!(num_steps(2), 1);
+        assert_eq!(num_steps(3), 1);
+        assert_eq!(num_steps(4), 1);
+        assert_eq!(num_steps(5), 1);
 
         // 6-9 total points = 5-8 inputs = 2 steps
-        assert_eq!(NumStepsLen::<6>::len(), 2);
-        assert_eq!(NumStepsLen::<7>::len(), 2);
-        assert_eq!(NumStepsLen::<8>::len(), 2);
-        assert_eq!(NumStepsLen::<9>::len(), 2);
+        assert_eq!(num_steps(6), 2);
+        assert_eq!(num_steps(7), 2);
+        assert_eq!(num_steps(8), 2);
+        assert_eq!(num_steps(9), 2);
 
         // 10-13 total points = 9-12 inputs = 3 steps
-        assert_eq!(NumStepsLen::<10>::len(), 3);
-        assert_eq!(NumStepsLen::<11>::len(), 3);
-        assert_eq!(NumStepsLen::<12>::len(), 3);
-        assert_eq!(NumStepsLen::<13>::len(), 3);
+        assert_eq!(num_steps(10), 3);
+        assert_eq!(num_steps(11), 3);
+        assert_eq!(num_steps(12), 3);
+        assert_eq!(num_steps(13), 3);
 
         // 14-17 total points = 13-16 inputs = 4 steps
-        assert_eq!(NumStepsLen::<14>::len(), 4);
-        assert_eq!(NumStepsLen::<15>::len(), 4);
-        assert_eq!(NumStepsLen::<16>::len(), 4);
-        assert_eq!(NumStepsLen::<17>::len(), 4);
+        assert_eq!(num_steps(14), 4);
+        assert_eq!(num_steps(15), 4);
+        assert_eq!(num_steps(16), 4);
+        assert_eq!(num_steps(17), 4);
 
         // 18-21 total points = 17-20 inputs = 5 steps
-        assert_eq!(NumStepsLen::<18>::len(), 5);
-        assert_eq!(NumStepsLen::<19>::len(), 5);
-        assert_eq!(NumStepsLen::<20>::len(), 5);
-        assert_eq!(NumStepsLen::<21>::len(), 5);
+        assert_eq!(num_steps(18), 5);
+        assert_eq!(num_steps(19), 5);
+        assert_eq!(num_steps(20), 5);
+        assert_eq!(num_steps(21), 5);
     }
 
     #[test]
     fn test_input_range() {
-        // Helper to get input_range for a given NUM_POINTS and step
         fn range<const NUM_POINTS: usize>(step: usize) -> core::ops::Range<usize> {
-            EndoscalingStep::<EpAffine, R, NUM_POINTS>::new(step).input_range()
+            EndoscalingStep::<EpAffine, R, ConstLen<NUM_POINTS>>::new(step).input_range()
         }
 
         // NUM_POINTS = 1: 0 inputs, 1 step
@@ -648,13 +689,13 @@ mod tests {
             });
 
             // Compute via PointsWitness::new
-            let from_new = PointsWitness::<EpAffine, NUM_POINTS>::new(endoscalar, &base_inputs);
+            let from_new =
+                PointsWitness::<EpAffine, ConstLen<NUM_POINTS>>::new(endoscalar, &base_inputs);
 
             // Compute manually using test helper
             let initial = base_inputs[0];
             let inputs_slice = &base_inputs[1..];
-            let interstitials_vec =
-                compute_interstitials::<NUM_POINTS>(endoscalar, initial, inputs_slice);
+            let interstitials_vec = compute_interstitials(endoscalar, initial, inputs_slice);
 
             // Verify initial
             assert_eq!(from_new.initial, initial);

--- a/crates/ragu_pcd/src/internal/native/circuits/compute_v.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/compute_v.rs
@@ -59,7 +59,7 @@ use ragu_core::{
     gadgets::Bound,
     maybe::Maybe,
 };
-use ragu_primitives::{Element, Endoscalar, GadgetExt, allocator::Standard};
+use ragu_primitives::{Element, Endoscalar, GadgetExt, allocator::Standard, vec::Len};
 
 use super::super::{
     InternalCircuitIndex, InternalCircuitValues, RxComponent, RxIndex,
@@ -70,10 +70,13 @@ use super::super::{
     },
     unified::{self, OutputBuilder},
 };
-use crate::internal::{
-    claims::Source,
-    fold_revdot::{Parameters, fold_two_layer},
-    native::RevdotParameters,
+use crate::{
+    framework_hooks::HookConfig,
+    internal::{
+        claims::Source,
+        fold_revdot::{Parameters, fold_two_layer},
+        native::RevdotParameters,
+    },
 };
 
 /// Circuit that computes and verifies the claimed evaluation value [$v$].
@@ -83,11 +86,11 @@ use crate::internal::{
 ///
 /// [module-level documentation]: self
 /// [$v$]: unified::Output::v
-pub struct Circuit<C: Cycle, R, const HEADER_SIZE: usize> {
-    _marker: PhantomData<(C, R)>,
+pub struct Circuit<C: Cycle, R, const HEADER_SIZE: usize, J: HookConfig> {
+    _marker: PhantomData<(C, R, J)>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Circuit<C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig> Circuit<C, R, HEADER_SIZE, J> {
     pub fn new() -> MultiStage<C::CircuitField, R, Self> {
         MultiStage::new(Circuit {
             _marker: PhantomData,
@@ -103,7 +106,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Circuit<C, R, HEADER_SIZE> {
 /// - Evaluation component polynomials from eval stage
 ///
 /// [$v$]: unified::Output::v
-pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize> {
+pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize, L: Len> {
     /// The unified instance containing challenges and accumulated coverage.
     pub unified: unified::Instance<C>,
     /// Witness for the preamble stage (provides child proof data).
@@ -111,16 +114,16 @@ pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize> {
     /// Witness for the query stage (provides registry and polynomial evaluations).
     pub query_witness: &'a native_query::Witness<C>,
     /// Witness for the eval stage (provides evaluation component polynomials).
-    pub eval_witness: &'a native_eval::Witness<C::CircuitField>,
+    pub eval_witness: &'a native_eval::Witness<C::CircuitField, L>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> MultiStageCircuit<C::CircuitField, R>
-    for Circuit<C, R, HEADER_SIZE>
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    MultiStageCircuit<C::CircuitField, R> for Circuit<C, R, HEADER_SIZE, J>
 {
-    type Last = native_eval::Stage<C, R, HEADER_SIZE>;
+    type Last = native_eval::Stage<C, R, HEADER_SIZE, J>;
 
     type Instance<'source> = &'source unified::Instance<C>;
-    type Witness<'source> = Witness<'source, C, R, HEADER_SIZE>;
+    type Witness<'source> = Witness<'source, C, R, HEADER_SIZE, J::PolyWitnesses>;
     type Output = unified::InternalOutputKind<C>;
     type Aux<'source> = unified::Instance<C>;
 
@@ -146,9 +149,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> MultiStageCircuit<C::CircuitFi
         // Set up multi-stage circuit pipeline: preamble -> query -> eval.
         // Each stage provides data needed for the v computation.
         let (preamble, builder) =
-            builder.add_stage::<native_preamble::Stage<C, R, HEADER_SIZE>>()?;
-        let (query, builder) = builder.add_stage::<native_query::Stage<C, R, HEADER_SIZE>>()?;
-        let (eval, builder) = builder.add_stage::<native_eval::Stage<C, R, HEADER_SIZE>>()?;
+            builder.add_stage::<native_preamble::Stage<C, R, HEADER_SIZE, J>>()?;
+        let (query, builder) = builder.add_stage::<native_query::Stage<C, R, HEADER_SIZE, J>>()?;
+        let (eval, builder) = builder.add_stage::<native_eval::Stage<C, R, HEADER_SIZE, J>>()?;
         let dr = builder.finish();
 
         // Preamble is enforced because it contains child proof data that must
@@ -283,14 +286,14 @@ struct Denominators<'dr, D: Driver<'dr>> {
 }
 
 impl<'dr, D: Driver<'dr>> Denominators<'dr, D> {
-    fn new<C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usize>(
+    fn new<C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usize, J: HookConfig>(
         dr: &mut D,
         u: &Element<'dr, D>,
         w: &Element<'dr, D>,
         x: &Element<'dr, D>,
         y: &Element<'dr, D>,
         z: &Element<'dr, D>,
-        preamble: &native_preamble::Output<'dr, D, C, HEADER_SIZE>,
+        preamble: &native_preamble::Output<'dr, D, C, HEADER_SIZE, J>,
     ) -> Result<Self>
     where
         D::F: ragu_arithmetic::ff::PrimeField,
@@ -563,10 +566,16 @@ fn compute_axbx<'dr, D: Driver<'dr>, P: Parameters>(
 /// [`compute_f`]: crate::Application::compute_f
 /// [$\alpha$]: unified::Output::alpha
 #[rustfmt::skip]
-fn poly_queries<'a, 'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usize>(
-    eval: &'a native_eval::Output<'dr, D>,
+fn poly_queries<
+    'a, 'dr,
+    D: Driver<'dr>,
+    C: Cycle<CircuitField = D::F>,
+    const HEADER_SIZE: usize,
+    J: HookConfig,
+>(
+    eval: &'a native_eval::Output<'dr, D, J>,
     query: &'a native_query::Output<'dr, D>,
-    preamble: &'a native_preamble::Output<'dr, D, C, HEADER_SIZE>,
+    preamble: &'a native_preamble::Output<'dr, D, C, HEADER_SIZE, J>,
     d: &'a Denominators<'dr, D>,
     computed_ax: &'a Element<'dr, D>,
     computed_bx: &'a Element<'dr, D>,

--- a/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/hashes_1.rs
@@ -96,6 +96,7 @@ use super::super::{
 };
 use crate::{
     RAGU_TAG,
+    framework_hooks::HookConfig,
     internal::{fold_revdot, transcript::Transcript},
 };
 
@@ -127,14 +128,27 @@ pub struct Output<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEAD
 /// circuit.
 ///
 /// [module-level documentation]: self
-pub struct Circuit<'params, C: Cycle, R, const HEADER_SIZE: usize, FP: fold_revdot::Parameters> {
+pub struct Circuit<
+    'params,
+    C: Cycle,
+    R,
+    const HEADER_SIZE: usize,
+    J: HookConfig,
+    FP: fold_revdot::Parameters,
+> {
     params: &'params C::Params,
     log2_circuits: u32,
-    _marker: PhantomData<(R, FP)>,
+    _marker: PhantomData<(R, J, FP)>,
 }
 
-impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    Circuit<'params, C, R, HEADER_SIZE, FP>
+impl<
+    'params,
+    C: Cycle,
+    R: Rank,
+    const HEADER_SIZE: usize,
+    J: HookConfig,
+    FP: fold_revdot::Parameters,
+> Circuit<'params, C, R, HEADER_SIZE, J, FP>
 {
     /// Creates a new multi-stage circuit.
     ///
@@ -179,10 +193,10 @@ pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_rev
     pub outer_error_witness: &'a native_outer_error::Witness<C, FP>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    MultiStageCircuit<C::CircuitField, R> for Circuit<'_, C, R, HEADER_SIZE, FP>
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig, FP: fold_revdot::Parameters>
+    MultiStageCircuit<C::CircuitField, R> for Circuit<'_, C, R, HEADER_SIZE, J, FP>
 {
-    type Last = native_outer_error::Stage<C, R, HEADER_SIZE, FP>;
+    type Last = native_outer_error::Stage<C, R, HEADER_SIZE, J, FP>;
 
     type Instance<'source> = &'source unified::Instance<C>;
     type Witness<'source> = Witness<'source, C, R, HEADER_SIZE, FP>;
@@ -209,9 +223,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         Self: 'dr,
     {
         let (preamble, builder) =
-            builder.add_stage::<native_preamble::Stage<C, R, HEADER_SIZE>>()?;
+            builder.add_stage::<native_preamble::Stage<C, R, HEADER_SIZE, J>>()?;
         let (outer_error, builder) =
-            builder.add_stage::<native_outer_error::Stage<C, R, HEADER_SIZE, FP>>()?;
+            builder.add_stage::<native_outer_error::Stage<C, R, HEADER_SIZE, J, FP>>()?;
         let dr = builder.finish();
 
         let preamble = preamble.unenforced(dr, witness.as_ref().map(|w| w.preamble_witness))?;

--- a/crates/ragu_pcd/src/internal/native/circuits/hashes_2.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/hashes_2.rs
@@ -78,7 +78,10 @@ use super::super::{
     stages::{outer_error as native_outer_error, preamble as native_preamble},
     unified::{self, OutputBuilder},
 };
-use crate::internal::{fold_revdot, transcript::Transcript};
+use crate::{
+    framework_hooks::HookConfig,
+    internal::{fold_revdot, transcript::Transcript},
+};
 
 /// Second hash circuit for Fiat-Shamir challenge derivation.
 ///
@@ -86,13 +89,26 @@ use crate::internal::{fold_revdot, transcript::Transcript};
 /// circuit.
 ///
 /// [module-level documentation]: self
-pub struct Circuit<'params, C: Cycle, R, const HEADER_SIZE: usize, FP: fold_revdot::Parameters> {
+pub struct Circuit<
+    'params,
+    C: Cycle,
+    R,
+    const HEADER_SIZE: usize,
+    J: HookConfig,
+    FP: fold_revdot::Parameters,
+> {
     params: &'params C::Params,
-    _marker: PhantomData<(R, FP)>,
+    _marker: PhantomData<(R, J, FP)>,
 }
 
-impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    Circuit<'params, C, R, HEADER_SIZE, FP>
+impl<
+    'params,
+    C: Cycle,
+    R: Rank,
+    const HEADER_SIZE: usize,
+    J: HookConfig,
+    FP: fold_revdot::Parameters,
+> Circuit<'params, C, R, HEADER_SIZE, J, FP>
 {
     /// Creates a new multi-stage circuit.
     ///
@@ -124,10 +140,10 @@ pub struct Witness<'a, C: Cycle, FP: fold_revdot::Parameters> {
     pub outer_error_witness: &'a native_outer_error::Witness<C, FP>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    MultiStageCircuit<C::CircuitField, R> for Circuit<'_, C, R, HEADER_SIZE, FP>
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig, FP: fold_revdot::Parameters>
+    MultiStageCircuit<C::CircuitField, R> for Circuit<'_, C, R, HEADER_SIZE, J, FP>
 {
-    type Last = native_outer_error::Stage<C, R, HEADER_SIZE, FP>;
+    type Last = native_outer_error::Stage<C, R, HEADER_SIZE, J, FP>;
 
     type Instance<'source> = &'source unified::Instance<C>;
     type Witness<'source> = Witness<'source, C, FP>;
@@ -153,9 +169,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
     where
         Self: 'dr,
     {
-        let builder = builder.skip_stage::<native_preamble::Stage<C, R, HEADER_SIZE>>()?;
+        let builder = builder.skip_stage::<native_preamble::Stage<C, R, HEADER_SIZE, J>>()?;
         let (outer_error, builder) =
-            builder.add_stage::<native_outer_error::Stage<C, R, HEADER_SIZE, FP>>()?;
+            builder.add_stage::<native_outer_error::Stage<C, R, HEADER_SIZE, J, FP>>()?;
         let dr = builder.finish();
 
         let outer_error =

--- a/crates/ragu_pcd/src/internal/native/circuits/inner_collapse.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/inner_collapse.rs
@@ -76,7 +76,7 @@ use super::super::{
     },
     unified::{self, OutputBuilder},
 };
-use crate::internal::fold_revdot;
+use crate::{framework_hooks::HookConfig, internal::fold_revdot};
 
 /// Circuit that verifies layer 1 of the two-layer revdot reduction.
 ///
@@ -84,12 +84,18 @@ use crate::internal::fold_revdot;
 /// performed by this circuit.
 ///
 /// [module-level documentation]: self
-pub struct Circuit<C: Cycle, R, const HEADER_SIZE: usize, FP: fold_revdot::Parameters> {
-    _marker: PhantomData<(C, R, FP)>,
+pub struct Circuit<
+    C: Cycle,
+    R,
+    const HEADER_SIZE: usize,
+    J: HookConfig,
+    FP: fold_revdot::Parameters,
+> {
+    _marker: PhantomData<(C, R, J, FP)>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    Circuit<C, R, HEADER_SIZE, FP>
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig, FP: fold_revdot::Parameters>
+    Circuit<C, R, HEADER_SIZE, J, FP>
 {
     /// Creates a new multi-stage circuit for layer 1 revdot verification.
     pub fn new() -> MultiStage<C::CircuitField, R, Self> {
@@ -111,10 +117,10 @@ pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_rev
     pub outer_error_witness: &'a native_outer_error::Witness<C, FP>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    MultiStageCircuit<C::CircuitField, R> for Circuit<C, R, HEADER_SIZE, FP>
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig, FP: fold_revdot::Parameters>
+    MultiStageCircuit<C::CircuitField, R> for Circuit<C, R, HEADER_SIZE, J, FP>
 {
-    type Last = native_inner_error::Stage<C, R, HEADER_SIZE, FP>;
+    type Last = native_inner_error::Stage<C, R, HEADER_SIZE, J, FP>;
 
     type Instance<'source> = &'source unified::Instance<C>;
     type Witness<'source> = Witness<'source, C, R, HEADER_SIZE, FP>;
@@ -141,11 +147,11 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
         Self: 'dr,
     {
         let (preamble, builder) =
-            builder.add_stage::<native_preamble::Stage<C, R, HEADER_SIZE>>()?;
+            builder.add_stage::<native_preamble::Stage<C, R, HEADER_SIZE, J>>()?;
         let (outer_error, builder) =
-            builder.add_stage::<native_outer_error::Stage<C, R, HEADER_SIZE, FP>>()?;
+            builder.add_stage::<native_outer_error::Stage<C, R, HEADER_SIZE, J, FP>>()?;
         let (inner_error, builder) =
-            builder.add_stage::<native_inner_error::Stage<C, R, HEADER_SIZE, FP>>()?;
+            builder.add_stage::<native_inner_error::Stage<C, R, HEADER_SIZE, J, FP>>()?;
         let dr = builder.finish();
         let preamble = preamble.unenforced(dr, witness.as_ref().map(|w| w.preamble_witness))?;
         let outer_error =

--- a/crates/ragu_pcd/src/internal/native/circuits/outer_collapse.rs
+++ b/crates/ragu_pcd/src/internal/native/circuits/outer_collapse.rs
@@ -74,7 +74,7 @@ use super::super::{
     stages::{outer_error, preamble},
     unified::{self, OutputBuilder},
 };
-use crate::internal::fold_revdot;
+use crate::{framework_hooks::HookConfig, internal::fold_revdot};
 
 /// Circuit that verifies layer 2 of the two-layer revdot reduction.
 ///
@@ -82,12 +82,18 @@ use crate::internal::fold_revdot;
 /// performed by this circuit.
 ///
 /// [module-level documentation]: self
-pub struct Circuit<C: Cycle, R, const HEADER_SIZE: usize, FP: fold_revdot::Parameters> {
-    _marker: PhantomData<(C, R, FP)>,
+pub struct Circuit<
+    C: Cycle,
+    R,
+    const HEADER_SIZE: usize,
+    J: HookConfig,
+    FP: fold_revdot::Parameters,
+> {
+    _marker: PhantomData<(C, R, J, FP)>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    Circuit<C, R, HEADER_SIZE, FP>
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig, FP: fold_revdot::Parameters>
+    Circuit<C, R, HEADER_SIZE, J, FP>
 {
     /// Creates a new multi-stage circuit for layer 2 revdot verification.
     pub fn new() -> MultiStage<C::CircuitField, R, Self> {
@@ -122,10 +128,10 @@ pub struct Witness<'a, C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_rev
     pub outer_error_witness: &'a outer_error::Witness<C, FP>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    MultiStageCircuit<C::CircuitField, R> for Circuit<C, R, HEADER_SIZE, FP>
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig, FP: fold_revdot::Parameters>
+    MultiStageCircuit<C::CircuitField, R> for Circuit<C, R, HEADER_SIZE, J, FP>
 {
-    type Last = outer_error::Stage<C, R, HEADER_SIZE, FP>;
+    type Last = outer_error::Stage<C, R, HEADER_SIZE, J, FP>;
 
     type Instance<'source> = &'source unified::Instance<C>;
     type Witness<'source> = Witness<'source, C, R, HEADER_SIZE, FP>;
@@ -151,9 +157,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
     where
         Self: 'dr,
     {
-        let (preamble, builder) = builder.add_stage::<preamble::Stage<C, R, HEADER_SIZE>>()?;
+        let (preamble, builder) = builder.add_stage::<preamble::Stage<C, R, HEADER_SIZE, J>>()?;
         let (outer_error, builder) =
-            builder.add_stage::<outer_error::Stage<C, R, HEADER_SIZE, FP>>()?;
+            builder.add_stage::<outer_error::Stage<C, R, HEADER_SIZE, J, FP>>()?;
         let dr = builder.finish();
 
         let preamble = preamble.unenforced(dr, witness.as_ref().map(|w| w.preamble_witness))?;

--- a/crates/ragu_pcd/src/internal/native/mod.rs
+++ b/crates/ragu_pcd/src/internal/native/mod.rs
@@ -9,7 +9,7 @@ use ragu_circuits::{
 use ragu_core::Result;
 use ragu_primitives::vec::ConstLen;
 
-use crate::{internal::fold_revdot::Parameters, step};
+use crate::{framework_hooks::HookConfig, internal::fold_revdot::Parameters, step};
 
 /// Default parameters for native revdot folding
 #[derive(Clone, Copy, Default)]
@@ -326,7 +326,7 @@ pub enum RxComponent {
 ///
 /// Does not register internal steps (rerandomize, trivial); those are
 /// registered by the caller after this function returns.
-pub fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>(
+pub fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>(
     mut registry: RegistryBuilder<'params, C::CircuitField, R>,
     params: &'params C::Params,
     log2_circuits: u32,
@@ -337,46 +337,52 @@ pub fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>(
         use InternalCircuitIndex::*;
         registry = match id {
             PreambleStage => {
-                registry.register_bonding(stages::preamble::Stage::<C, R, HEADER_SIZE>::mask()?)
+                registry.register_bonding(stages::preamble::Stage::<C, R, HEADER_SIZE, J>::mask()?)
             }
             InnerErrorStage => registry.register_bonding(stages::inner_error::Stage::<
                 C,
                 R,
                 HEADER_SIZE,
+                J,
                 RevdotParameters,
             >::mask()?),
             OuterErrorStage => registry.register_bonding(stages::outer_error::Stage::<
                 C,
                 R,
                 HEADER_SIZE,
+                J,
                 RevdotParameters,
             >::mask()?),
             QueryStage => {
-                registry.register_bonding(stages::query::Stage::<C, R, HEADER_SIZE>::mask()?)
+                registry.register_bonding(stages::query::Stage::<C, R, HEADER_SIZE, J>::mask()?)
             }
             EvalStage => {
-                registry.register_bonding(stages::eval::Stage::<C, R, HEADER_SIZE>::mask()?)
+                registry.register_bonding(stages::eval::Stage::<C, R, HEADER_SIZE, J>::mask()?)
             }
             InnerErrorFinalStaged => registry.register_bonding(stages::inner_error::Stage::<
                 C,
                 R,
                 HEADER_SIZE,
+                J,
                 RevdotParameters,
             >::final_mask()?),
             OuterErrorFinalStaged => registry.register_bonding(stages::outer_error::Stage::<
                 C,
                 R,
                 HEADER_SIZE,
+                J,
                 RevdotParameters,
             >::final_mask()?),
             EvalFinalStaged => {
-                registry.register_bonding(stages::eval::Stage::<C, R, HEADER_SIZE>::final_mask()?)
+                registry
+                    .register_bonding(stages::eval::Stage::<C, R, HEADER_SIZE, J>::final_mask()?)
             }
             Hashes1Circuit => {
                 registry.register_internal_circuit(circuits::hashes_1::Circuit::<
                     C,
                     R,
                     HEADER_SIZE,
+                    J,
                     RevdotParameters,
                 >::new(params, log2_circuits))?
             }
@@ -384,6 +390,7 @@ pub fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>(
                 C,
                 R,
                 HEADER_SIZE,
+                J,
                 RevdotParameters,
             >::new(params))?,
             InnerCollapseCircuit => {
@@ -391,6 +398,7 @@ pub fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>(
                     C,
                     R,
                     HEADER_SIZE,
+                    J,
                     RevdotParameters,
                 >::new())?
             }
@@ -399,6 +407,7 @@ pub fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>(
                     C,
                     R,
                     HEADER_SIZE,
+                    J,
                     RevdotParameters,
                 >::new())?
             }
@@ -407,6 +416,7 @@ pub fn register_all<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>(
                     C,
                     R,
                     HEADER_SIZE,
+                    J,
                 >::new())?
             }
         };

--- a/crates/ragu_pcd/src/internal/native/stages/eval.rs
+++ b/crates/ragu_pcd/src/internal/native/stages/eval.rs
@@ -307,9 +307,7 @@ mod tests {
     #[test]
     fn stage_values_matches_wire_count() {
         fn check<const POLYS: usize>() {
-            assert_stage_values(
-                &Stage::<Pasta, R, { HEADER_SIZE }, AppHooks<POLYS>>::default(),
-            );
+            assert_stage_values(&Stage::<Pasta, R, { HEADER_SIZE }, AppHooks<POLYS>>::default());
         }
         check::<0>();
         check::<1>();

--- a/crates/ragu_pcd/src/internal/native/stages/eval.rs
+++ b/crates/ragu_pcd/src/internal/native/stages/eval.rs
@@ -26,16 +26,25 @@ use ragu_core::{
     gadgets::{Bound, Gadget, Kind},
     maybe::Maybe,
 };
-use ragu_primitives::{Element, allocator::Allocator, io::Write};
+use ragu_primitives::{
+    Element,
+    allocator::Allocator,
+    io::Write,
+    vec::{CollectFixed, FixedVec, Len},
+};
 
 use crate::{
     Proof,
-    internal::native::{RxComponent, RxValues},
+    framework_hooks::HookConfig,
+    internal::{
+        native::{RxComponent, RxValues},
+        nested::child_endoscaling_points,
+    },
 };
 
 /// Polynomial evaluations at $u$ (from the parent fuse operation) for a child
 /// proof. Supplied by the prover to construct the `eval` stage witness.
-pub struct ChildEvaluationsWitness<F> {
+pub struct ChildEvaluationsWitness<F, L: Len> {
     /// All of the child proof's Rx components are evaluated at $u$.
     pub rx: RxValues<F>,
 
@@ -56,20 +65,36 @@ pub struct ChildEvaluationsWitness<F> {
     /// This polynomial is queried only to insert the claim about $p(X)$ from
     /// the child proof into the accumulator for the fuse step.
     pub p_poly: F,
+
+    /// The child proof's witnessed polynomials, each evaluated at $u$.
+    pub witness_poly_evals: FixedVec<F, L>,
 }
 
-impl<F: PrimeField> ChildEvaluationsWitness<F> {
+impl<F: PrimeField, L: Len> ChildEvaluationsWitness<F, L> {
     /// Create child evaluations witness from a proof evaluated at point u.
-    pub fn from_proof<C: Cycle<CircuitField = F>, R: Rank>(proof: &Proof<C, R>, u: F) -> Self {
-        ChildEvaluationsWitness {
+    pub fn from_proof<C: Cycle<CircuitField = F>, R: Rank>(
+        proof: &Proof<C, R>,
+        u: F,
+    ) -> Result<Self> {
+        Ok(ChildEvaluationsWitness {
             rx: RxValues::from_fn(|id| proof[id].eval(u)),
             a_poly: proof[RxComponent::AbA].eval(u),
             b_poly: proof[RxComponent::AbB].eval(u),
             registry_xy_poly: proof.native_registry_xy_poly().eval(u),
             p_poly: proof.native_p_poly().eval(u),
-        }
+            witness_poly_evals: proof
+                .witness_polys()
+                .iter()
+                .map(|p| p.eval(u))
+                .collect_fixed()?,
+        })
     }
 }
+
+/// The number of components the current fuse step contributes to an
+/// accumulation — one per field of [`CurrentStepWitness`]. This stage's width
+/// and the nested side's endoscaling-point count are both built from it.
+pub const CURRENT_STEP_COMPONENTS: usize = 6;
 
 /// Pre-computed polynomial evaluations at $u$ for the current step.
 pub struct CurrentStepWitness<F> {
@@ -107,12 +132,12 @@ pub struct CurrentStepWitness<F> {
 }
 
 /// Witness for the eval stage.
-pub struct Witness<F> {
+pub struct Witness<F, L: Len> {
     /// Left proof's evaluations at $u$.
-    pub left: ChildEvaluationsWitness<F>,
+    pub left: ChildEvaluationsWitness<F, L>,
 
     /// Right proof's evaluations at $u$.
-    pub right: ChildEvaluationsWitness<F>,
+    pub right: ChildEvaluationsWitness<F, L>,
 
     /// Current fuse step's evaluations at $u$.
     pub current: CurrentStepWitness<F>,
@@ -126,7 +151,7 @@ pub struct Witness<F> {
 /// of the coefficients for the weighted sum with $\beta$ via
 /// [`Horner`](ragu_circuits::horner::Horner) evaluation.
 #[derive(Gadget, Write)]
-pub struct ChildEvaluations<'dr, D: Driver<'dr>> {
+pub struct ChildEvaluations<'dr, D: Driver<'dr>, J: HookConfig> {
     #[ragu(gadget)]
     pub rx: RxValues<Element<'dr, D>>,
     #[ragu(gadget)]
@@ -137,14 +162,18 @@ pub struct ChildEvaluations<'dr, D: Driver<'dr>> {
     pub registry_xy_poly: Element<'dr, D>,
     #[ragu(gadget)]
     pub p_poly: Element<'dr, D>,
+    /// The child's witnessed-polynomial evaluations at $u$
+    /// (the [`Write`] order must match the `_10_p` accumulation order).
+    #[ragu(gadget)]
+    pub witness_poly_evals: FixedVec<Element<'dr, D>, J::PolyWitnesses>,
 }
 
-impl<'dr, D: Driver<'dr>> ChildEvaluations<'dr, D> {
+impl<'dr, D: Driver<'dr>, J: HookConfig> ChildEvaluations<'dr, D, J> {
     /// Allocate child evaluations from pre-computed witness values.
     pub fn alloc<A: Allocator<'dr, D>>(
         dr: &mut D,
         allocator: &mut A,
-        witness: DriverValue<D, &ChildEvaluationsWitness<D::F>>,
+        witness: DriverValue<D, &ChildEvaluationsWitness<D::F, J::PolyWitnesses>>,
     ) -> Result<Self> {
         let rx = RxValues::try_from_fn(|id| {
             Element::alloc(dr, allocator, witness.as_ref().map(|w| *w.rx.get(id)))
@@ -159,6 +188,15 @@ impl<'dr, D: Driver<'dr>> ChildEvaluations<'dr, D> {
                 witness.as_ref().map(|w| w.registry_xy_poly),
             )?,
             p_poly: Element::alloc(dr, allocator, witness.as_ref().map(|w| w.p_poly))?,
+            witness_poly_evals: J::PolyWitnesses::range()
+                .map(|i| {
+                    Element::alloc(
+                        dr,
+                        allocator,
+                        witness.as_ref().map(|w| w.witness_poly_evals[i]),
+                    )
+                })
+                .try_collect_fixed()?,
         })
     }
 }
@@ -167,11 +205,11 @@ impl<'dr, D: Driver<'dr>> ChildEvaluations<'dr, D> {
 ///
 /// This is stage communication data, not part of the circuit's public instance.
 #[derive(Gadget, Write)]
-pub struct Output<'dr, D: Driver<'dr>> {
+pub struct Output<'dr, D: Driver<'dr>, J: HookConfig> {
     #[ragu(gadget)]
-    pub left: ChildEvaluations<'dr, D>,
+    pub left: ChildEvaluations<'dr, D, J>,
     #[ragu(gadget)]
-    pub right: ChildEvaluations<'dr, D>,
+    pub right: ChildEvaluations<'dr, D, J>,
     #[ragu(gadget)]
     pub registry_wx0: Element<'dr, D>,
     #[ragu(gadget)]
@@ -187,21 +225,27 @@ pub struct Output<'dr, D: Driver<'dr>> {
 }
 
 /// The eval stage of the fuse witness.
-#[derive(Default)]
-pub struct Stage<C: Cycle, R, const HEADER_SIZE: usize> {
-    _marker: PhantomData<(C, R)>,
+pub struct Stage<C: Cycle, R, const HEADER_SIZE: usize, J: HookConfig> {
+    _marker: PhantomData<(C, R, J)>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> staging::Stage<C::CircuitField, R>
-    for Stage<C, R, HEADER_SIZE>
+impl<C: Cycle, R, const HEADER_SIZE: usize, J: HookConfig> Default for Stage<C, R, HEADER_SIZE, J> {
+    fn default() -> Self {
+        Stage {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig> staging::Stage<C::CircuitField, R>
+    for Stage<C, R, HEADER_SIZE, J>
 {
-    type Parent = super::query::Stage<C, R, HEADER_SIZE>;
-    type Witness<'source> = &'source Witness<C::CircuitField>;
-    type OutputKind = Kind![C::CircuitField; Output<'_, _>];
+    type Parent = super::query::Stage<C, R, HEADER_SIZE, J>;
+    type Witness<'source> = &'source Witness<C::CircuitField, J::PolyWitnesses>;
+    type OutputKind = Kind![C::CircuitField; Output<'_, _, J>];
 
     fn values() -> usize {
-        // 2 * ChildEvaluations (15 each) + current step elements (6)
-        2 * 15 + 6
+        2 * child_endoscaling_points(J::PolyWitnesses::len()) + CURRENT_STEP_COMPONENTS
     }
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>>(
@@ -255,10 +299,21 @@ mod tests {
     use ragu_pasta::Pasta;
 
     use super::*;
-    use crate::internal::tests::{HEADER_SIZE, R, assert_stage_values};
+    use crate::{
+        AppHooks,
+        internal::tests::{HEADER_SIZE, R, assert_stage_values},
+    };
 
     #[test]
     fn stage_values_matches_wire_count() {
-        assert_stage_values(&Stage::<Pasta, R, { HEADER_SIZE }>::default());
+        fn check<const POLYS: usize>() {
+            assert_stage_values(
+                &Stage::<Pasta, R, { HEADER_SIZE }, AppHooks<POLYS>>::default(),
+            );
+        }
+        check::<0>();
+        check::<1>();
+        check::<4>();
+        check::<8>();
     }
 }

--- a/crates/ragu_pcd/src/internal/native/stages/inner_error.rs
+++ b/crates/ragu_pcd/src/internal/native/stages/inner_error.rs
@@ -18,7 +18,10 @@ use ragu_primitives::{
     vec::{FixedVec, Len},
 };
 
-use crate::internal::fold_revdot::{self, NumErrorTerms};
+use crate::{
+    framework_hooks::HookConfig,
+    internal::fold_revdot::{self, NumErrorTerms},
+};
 
 /// Witness data for the inner error stage (layer 1).
 ///
@@ -43,15 +46,25 @@ pub struct Output<'dr, D: Driver<'dr>, FP: fold_revdot::Parameters> {
 }
 
 /// The inner error stage (layer 1) of the fuse witness.
-#[derive(Default)]
-pub struct Stage<C: Cycle, R, const HEADER_SIZE: usize, FP: fold_revdot::Parameters> {
-    _marker: PhantomData<(C, R, FP)>,
+pub struct Stage<C: Cycle, R, const HEADER_SIZE: usize, J: HookConfig, FP: fold_revdot::Parameters>
+{
+    _marker: PhantomData<(C, R, J, FP)>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    staging::Stage<C::CircuitField, R> for Stage<C, R, HEADER_SIZE, FP>
+impl<C: Cycle, R, const HEADER_SIZE: usize, J: HookConfig, FP: fold_revdot::Parameters> Default
+    for Stage<C, R, HEADER_SIZE, J, FP>
 {
-    type Parent = super::outer_error::Stage<C, R, HEADER_SIZE, FP>;
+    fn default() -> Self {
+        Stage {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig, FP: fold_revdot::Parameters>
+    staging::Stage<C::CircuitField, R> for Stage<C, R, HEADER_SIZE, J, FP>
+{
+    type Parent = super::outer_error::Stage<C, R, HEADER_SIZE, J, FP>;
     type Witness<'source> = &'source Witness<C, FP>;
     type OutputKind = Kind![C::CircuitField; Output<'_, _, FP>];
 
@@ -85,13 +98,22 @@ mod tests {
     use ragu_pasta::Pasta;
 
     use super::*;
-    use crate::internal::{
-        native::RevdotParameters,
-        tests::{HEADER_SIZE, R, assert_stage_values},
+    use crate::{
+        AppHooks,
+        internal::{
+            native::RevdotParameters,
+            tests::{HEADER_SIZE, R, assert_stage_values},
+        },
     };
 
     #[test]
     fn stage_values_matches_wire_count() {
-        assert_stage_values(&Stage::<Pasta, R, { HEADER_SIZE }, RevdotParameters>::default());
+        assert_stage_values(&Stage::<
+            Pasta,
+            R,
+            { HEADER_SIZE },
+            AppHooks<1>,
+            RevdotParameters,
+        >::default());
     }
 }

--- a/crates/ragu_pcd/src/internal/native/stages/outer_error.rs
+++ b/crates/ragu_pcd/src/internal/native/stages/outer_error.rs
@@ -19,7 +19,10 @@ use ragu_primitives::{
     vec::{CollectFixed, FixedVec, Len},
 };
 
-use crate::internal::fold_revdot::{self, NumErrorTerms};
+use crate::{
+    framework_hooks::HookConfig,
+    internal::fold_revdot::{self, NumErrorTerms},
+};
 
 /// $k(Y)$ evaluation values for a single child proof.
 pub struct ChildKyValues<F> {
@@ -104,15 +107,25 @@ pub struct Output<
 }
 
 /// The outer error stage (layer 2) of the fuse witness.
-#[derive(Default)]
-pub struct Stage<C: Cycle, R, const HEADER_SIZE: usize, FP: fold_revdot::Parameters> {
-    _marker: PhantomData<(C, R, FP)>,
+pub struct Stage<C: Cycle, R, const HEADER_SIZE: usize, J: HookConfig, FP: fold_revdot::Parameters>
+{
+    _marker: PhantomData<(C, R, J, FP)>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, FP: fold_revdot::Parameters>
-    staging::Stage<C::CircuitField, R> for Stage<C, R, HEADER_SIZE, FP>
+impl<C: Cycle, R, const HEADER_SIZE: usize, J: HookConfig, FP: fold_revdot::Parameters> Default
+    for Stage<C, R, HEADER_SIZE, J, FP>
 {
-    type Parent = super::preamble::Stage<C, R, HEADER_SIZE>;
+    fn default() -> Self {
+        Stage {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig, FP: fold_revdot::Parameters>
+    staging::Stage<C::CircuitField, R> for Stage<C, R, HEADER_SIZE, J, FP>
+{
+    type Parent = super::preamble::Stage<C, R, HEADER_SIZE, J>;
     type Witness<'source> = &'source Witness<C, FP>;
     type OutputKind = Kind![C::CircuitField; Output<'_, _, FP, C::CircuitPoseidon>];
 
@@ -188,13 +201,22 @@ mod tests {
     use ragu_pasta::Pasta;
 
     use super::*;
-    use crate::internal::{
-        native::RevdotParameters,
-        tests::{HEADER_SIZE, R, assert_stage_values},
+    use crate::{
+        AppHooks,
+        internal::{
+            native::RevdotParameters,
+            tests::{HEADER_SIZE, R, assert_stage_values},
+        },
     };
 
     #[test]
     fn stage_values_matches_wire_count() {
-        assert_stage_values(&Stage::<Pasta, R, { HEADER_SIZE }, RevdotParameters>::default());
+        assert_stage_values(&Stage::<
+            Pasta,
+            R,
+            { HEADER_SIZE },
+            AppHooks<1>,
+            RevdotParameters,
+        >::default());
     }
 }

--- a/crates/ragu_pcd/src/internal/native/stages/preamble.rs
+++ b/crates/ragu_pcd/src/internal/native/stages/preamble.rs
@@ -17,10 +17,17 @@ use ragu_primitives::{
     Boolean, Element, GadgetExt,
     allocator::Allocator,
     consistent::Consistent,
-    vec::{CollectFixed, ConstLen, FixedVec},
+    vec::{CollectFixed, ConstLen, FixedVec, Len},
 };
 
-use crate::{Proof, header::Header, internal::native::unified, step::internal::padded};
+use crate::{
+    Proof,
+    framework_hooks::HookConfig,
+    header::Header,
+    internal::native::unified,
+    poly_commitment::{self, PolyHandle},
+    step::internal::padded,
+};
 
 type HeaderVec<'dr, D, const HEADER_SIZE: usize> = FixedVec<Element<'dr, D>, ConstLen<HEADER_SIZE>>;
 
@@ -77,22 +84,31 @@ pub struct ChildHeaders<'dr, D: Driver<'dr>, const HEADER_SIZE: usize> {
 
 /// Processed inputs from a single child proof in the preamble stage.
 #[derive(Gadget, Consistent)]
-pub struct ProofInputs<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usize>
-{
+pub struct ProofInputs<
+    'dr,
+    D: Driver<'dr>,
+    C: Cycle<CircuitField = D::F>,
+    const HEADER_SIZE: usize,
+    J: HookConfig,
+> {
     /// Headers this child proof claimed for its own children.
     #[ragu(gadget)]
     pub children: ChildHeaders<'dr, D, HEADER_SIZE>,
     /// Output header of this child proof.
     #[ragu(gadget)]
     pub output_header: HeaderVec<'dr, D, HEADER_SIZE>,
+    /// The child's witnessed polynomials; positions it left unused hold the
+    /// canonical padding polynomial.
+    #[ragu(gadget)]
+    pub witness_polys: FixedVec<PolyHandle<'dr, D, C>, J::PolyWitnesses>,
     #[ragu(gadget)]
     pub circuit_id: Element<'dr, D>,
     #[ragu(gadget)]
     pub unified: unified::Output<'dr, D, C>,
 }
 
-impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usize>
-    ProofInputs<'dr, D, C, HEADER_SIZE>
+impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usize, J: HookConfig>
+    ProofInputs<'dr, D, C, HEADER_SIZE, J>
 {
     /// Compute unified k(y) and unified+bridged k(y) values simultaneously,
     /// sharing computation.
@@ -127,14 +143,15 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usiz
         ))
     }
 
-    /// Compute k(y) for the application circuit instance.
-    ///
-    /// Returns `application_ky` = k(y) for `(children.left, children.right, output_header)`.
+    /// Binds the child's hook wires to its committed application rx. The
+    /// adapter writes these same types into the instance, so the layout below
+    /// is the layout it wrote.
     pub fn application_ky(&self, dr: &mut D, y: &Element<'dr, D>) -> Result<Element<'dr, D>> {
         let mut ky = Horner::new(y);
         self.children.left.write(dr, &mut ky)?;
         self.children.right.write(dr, &mut ky)?;
         self.output_header.write(dr, &mut ky)?;
+        self.witness_polys.write(dr, &mut ky)?;
         ky.finish_ky(dr)
     }
 
@@ -149,15 +166,32 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usiz
     }
 }
 
-impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usize>
-    ProofInputs<'dr, D, C, HEADER_SIZE>
+impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usize, J: HookConfig>
+    ProofInputs<'dr, D, C, HEADER_SIZE, J>
 {
-    /// Allocate ProofInputs from a proof reference and pre-computed output header.
+    /// Allocate ProofInputs from a proof reference and pre-computed output
+    /// header; the proof's hook lists are checked against the configured counts.
     pub fn alloc<R: Rank>(
         dr: &mut D,
         proof: DriverValue<D, &Proof<C, R>>,
         output_header: DriverValue<D, &FixedVec<D::F, ConstLen<HEADER_SIZE>>>,
     ) -> Result<Self> {
+        let num_polys = J::PolyWitnesses::len();
+
+        // A child proof reaching the fuse has not passed through `verify`, so
+        // this is its own boundary. `alloc` has no verdict to return, hence
+        // `Err`: a carried artifact whose encoding does not fit its declared
+        // size, not a witness the prover authored in-circuit.
+        D::try_just(|| {
+            if proof.as_ref().take().has_shape(&J::layout()) {
+                Ok(())
+            } else {
+                Err(Error::MalformedEncoding(
+                    "proof does not carry exactly the configured hook lists".into(),
+                ))
+            }
+        })?;
+
         fn alloc_header<'dr, D: Driver<'dr>, const N: usize>(
             dr: &mut D,
             allocator: &mut (),
@@ -185,6 +219,18 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usiz
                 right: alloc_header(dr, allocator, proof.as_ref().map(|p| p.right_header()))?,
             },
             output_header: alloc_header(dr, allocator, output_header.as_ref().map(|h| &h[..]))?,
+            witness_polys: (0..num_polys)
+                .map(|i| {
+                    PolyHandle::alloc(
+                        dr,
+                        D::try_just(|| {
+                            poly_commitment::handle::<C>(
+                                proof.as_ref().take().witness_poly_commitment(i),
+                            )
+                        })?,
+                    )
+                })
+                .try_collect_fixed()?,
             circuit_id: Element::alloc(
                 dr,
                 allocator,
@@ -195,7 +241,7 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usiz
     }
 
     /// Allocate ProofInputs from a proof reference and some unprocessed header
-    /// data.
+    /// data. Shape as in [`alloc`](Self::alloc).
     pub fn alloc_for_verify<R: Rank, H: Header<C::CircuitField>>(
         dr: &mut D,
         proof: DriverValue<D, &Proof<C, R>>,
@@ -226,15 +272,21 @@ impl<'dr, D: Driver<'dr, F = C::CircuitField>, C: Cycle, const HEADER_SIZE: usiz
 /// This is stage communication data, not part of the circuit's public instance.
 /// The verifier never sees these values directly.
 #[derive(Gadget, Consistent)]
-pub struct Output<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usize> {
+pub struct Output<
+    'dr,
+    D: Driver<'dr>,
+    C: Cycle<CircuitField = D::F>,
+    const HEADER_SIZE: usize,
+    J: HookConfig,
+> {
     #[ragu(gadget)]
-    pub left: ProofInputs<'dr, D, C, HEADER_SIZE>,
+    pub left: ProofInputs<'dr, D, C, HEADER_SIZE, J>,
     #[ragu(gadget)]
-    pub right: ProofInputs<'dr, D, C, HEADER_SIZE>,
+    pub right: ProofInputs<'dr, D, C, HEADER_SIZE, J>,
 }
 
-impl<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usize>
-    Output<'dr, D, C, HEADER_SIZE>
+impl<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usize, J: HookConfig>
+    Output<'dr, D, C, HEADER_SIZE, J>
 {
     /// Returns true if both child proofs are trivial proofs.
     pub fn is_base_case(
@@ -248,21 +300,32 @@ impl<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>, const HEADER_SIZE: usiz
     }
 }
 
-#[derive(Default)]
-pub struct Stage<C: Cycle, R, const HEADER_SIZE: usize> {
-    _marker: PhantomData<(C, R)>,
+/// The root of the native stage chain. Per child: three headers, the
+/// polynomial region, the circuit id, and the unified wires.
+pub struct Stage<C: Cycle, R, const HEADER_SIZE: usize, J: HookConfig> {
+    _marker: PhantomData<(C, R, J)>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> staging::Stage<C::CircuitField, R>
-    for Stage<C, R, HEADER_SIZE>
+impl<C: Cycle, R, const HEADER_SIZE: usize, J: HookConfig> Default for Stage<C, R, HEADER_SIZE, J> {
+    fn default() -> Self {
+        Stage {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig> staging::Stage<C::CircuitField, R>
+    for Stage<C, R, HEADER_SIZE, J>
 {
     type Parent = ();
     type Witness<'source> = &'source Witness<'source, C, R, HEADER_SIZE>;
-    type OutputKind = Kind![C::CircuitField; Output<'_, _, C, HEADER_SIZE>];
+    type OutputKind = Kind![
+        C::CircuitField;
+        Output<'_, _, C, HEADER_SIZE, J>
+    ];
 
     fn values() -> usize {
-        // 2 proofs * (3 headers * HEADER_SIZE + 1 circuit_id + unified instance wires)
-        2 * (3 * HEADER_SIZE + 1 + unified::NUM_WIRES)
+        2 * (3 * HEADER_SIZE + J::layout().poly_query_instance_len() + 1 + unified::NUM_WIRES)
     }
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>>(
@@ -294,10 +357,19 @@ mod tests {
     use ragu_pasta::Pasta;
 
     use super::*;
-    use crate::internal::tests::{HEADER_SIZE, R, assert_stage_values};
+    use crate::{
+        AppHooks,
+        internal::tests::{HEADER_SIZE, R, assert_stage_values},
+    };
 
     #[test]
     fn stage_values_matches_wire_count() {
-        assert_stage_values(&Stage::<Pasta, R, { HEADER_SIZE }>::default());
+        fn check<const POLYS: usize>() {
+            assert_stage_values(&Stage::<Pasta, R, { HEADER_SIZE }, AppHooks<POLYS>>::default());
+        }
+        check::<0>();
+        check::<1>();
+        check::<4>();
+        check::<8>();
     }
 }

--- a/crates/ragu_pcd/src/internal/native/stages/query.rs
+++ b/crates/ragu_pcd/src/internal/native/stages/query.rs
@@ -31,6 +31,7 @@ use ragu_primitives::{Element, allocator::Allocator};
 
 use crate::{
     Proof,
+    framework_hooks::HookConfig,
     internal::native::{
         InternalCircuitIndex, InternalCircuitValues, RxComponent, RxIndex, RxValues,
     },
@@ -275,22 +276,35 @@ pub struct Output<'dr, D: Driver<'dr>> {
     pub right: ChildEvaluations<'dr, D>,
 }
 
-/// The query stage of the fuse witness.
-#[derive(Default)]
-pub struct Stage<C: Cycle, R, const HEADER_SIZE: usize> {
-    _marker: PhantomData<(C, R)>,
+/// The query stage of the fuse witness. Shape-free: its width does not depend
+/// on a step's hook counts.
+pub struct Stage<C: Cycle, R, const HEADER_SIZE: usize, J: HookConfig> {
+    _marker: PhantomData<(C, R, J)>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> staging::Stage<C::CircuitField, R>
-    for Stage<C, R, HEADER_SIZE>
+impl<C: Cycle, R, const HEADER_SIZE: usize, J: HookConfig> Default for Stage<C, R, HEADER_SIZE, J> {
+    fn default() -> Self {
+        Stage {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig> staging::Stage<C::CircuitField, R>
+    for Stage<C, R, HEADER_SIZE, J>
 {
-    type Parent = super::preamble::Stage<C, R, HEADER_SIZE>;
+    type Parent = super::preamble::Stage<C, R, HEADER_SIZE, J>;
     type Witness<'source> = &'source Witness<C>;
     type OutputKind = Kind![C::CircuitField; Output<'_, _>];
 
     fn values() -> usize {
-        // InternalCircuitIndex::NUM + registry_wxy (1) + 2 * ChildEvaluations (16 each)
-        InternalCircuitIndex::NUM + 1 + 2 * 16
+        // One fixed-registry evaluation per internal circuit, plus
+        // `registry_wxy`, plus each child's `ChildEvaluations`: one evaluation
+        // per rx component, then `a_poly_at_xz`, `b_poly_at_x`,
+        // `child_registry_xy_at_current_w`,
+        // `current_registry_xy_at_child_circuit_id` and
+        // `current_registry_wy_at_child_x`.
+        InternalCircuitIndex::NUM + 1 + 2 * (RxIndex::NUM + 5)
     }
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>>(
@@ -321,10 +335,13 @@ mod tests {
     use ragu_pasta::Pasta;
 
     use super::*;
-    use crate::internal::tests::{HEADER_SIZE, R, assert_stage_values};
+    use crate::{
+        AppHooks,
+        internal::tests::{HEADER_SIZE, R, assert_stage_values},
+    };
 
     #[test]
     fn stage_values_matches_wire_count() {
-        assert_stage_values(&Stage::<Pasta, R, { HEADER_SIZE }>::default());
+        assert_stage_values(&Stage::<Pasta, R, { HEADER_SIZE }, AppHooks<1>>::default());
     }
 }

--- a/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
@@ -25,21 +25,23 @@ use ragu_core::{
     gadgets::Bound,
     maybe::Maybe,
 };
-use ragu_primitives::GadgetExt as _;
+use ragu_primitives::{GadgetExt as _, vec::Len};
 
 use crate::internal::{
     Side,
     endoscalar::{EndoscalarStage, PointsStage},
-    nested::{NUM_ENDOSCALING_POINTS, stages},
+    nested::{EndoscalingPoints, stages},
 };
 
 /// Copying circuit that relates the current preamble to a child's stages.
-pub struct Circuit<C: CurveAffine, R: Rank> {
+/// `L` is the application's poly count as a
+/// [`Len`](ragu_primitives::vec::Len); a child exposes the same shape.
+pub struct Circuit<C: CurveAffine, R: Rank, L: Len> {
     side: Side,
-    _marker: PhantomData<(C, R)>,
+    _marker: PhantomData<(C, R, L)>,
 }
 
-impl<C: CurveAffine, R: Rank> Circuit<C, R> {
+impl<C: CurveAffine, R: Rank, L: Len> Circuit<C, R, L> {
     pub fn new(side: Side) -> Self {
         Self {
             side,
@@ -48,8 +50,8 @@ impl<C: CurveAffine, R: Rank> Circuit<C, R> {
     }
 }
 
-impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
-    type Last = stages::eval::Stage<C, R>;
+impl<C: CurveAffine, R: Rank, L: Len> MultiStageCircuit<C::Base, R> for Circuit<C, R, L> {
+    type Last = stages::eval::Stage<C, R, L>;
     type Instance<'source> = ();
     type Witness<'source> = ();
     type Output = ();
@@ -69,15 +71,15 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
         _witness: DriverValue<D, ()>,
     ) -> Result<WithAux<Bound<'dr, D, ()>, DriverValue<D, ()>>> {
         let dr = dr.skip_stage::<EndoscalarStage>()?;
-        let (points_guard, dr) = dr.add_stage::<PointsStage<C, NUM_ENDOSCALING_POINTS>>()?;
-        let (preamble_guard, dr) = dr.add_stage::<stages::preamble::Stage<C, R>>()?;
-        let (s_prime_guard, dr) = dr.add_stage::<stages::s_prime::Stage<C, R>>()?;
-        let (inner_error_guard, dr) = dr.add_stage::<stages::inner_error::Stage<C, R>>()?;
-        let (outer_error_guard, dr) = dr.add_stage::<stages::outer_error::Stage<C, R>>()?;
-        let (ab_guard, dr) = dr.add_stage::<stages::ab::Stage<C, R>>()?;
-        let (query_guard, dr) = dr.add_stage::<stages::query::Stage<C, R>>()?;
-        let dr = dr.skip_stage::<stages::f::Stage<C, R>>()?;
-        let (eval_guard, dr) = dr.add_stage::<stages::eval::Stage<C, R>>()?;
+        let (points_guard, dr) = dr.add_stage::<PointsStage<C, EndoscalingPoints<L>>>()?;
+        let (preamble_guard, dr) = dr.add_stage::<stages::preamble::Stage<C, R, L>>()?;
+        let (s_prime_guard, dr) = dr.add_stage::<stages::s_prime::Stage<C, R, L>>()?;
+        let (inner_error_guard, dr) = dr.add_stage::<stages::inner_error::Stage<C, R, L>>()?;
+        let (outer_error_guard, dr) = dr.add_stage::<stages::outer_error::Stage<C, R, L>>()?;
+        let (ab_guard, dr) = dr.add_stage::<stages::ab::Stage<C, R, L>>()?;
+        let (query_guard, dr) = dr.add_stage::<stages::query::Stage<C, R, L>>()?;
+        let dr = dr.skip_stage::<stages::f::Stage<C, R, L>>()?;
+        let (eval_guard, dr) = dr.add_stage::<stages::eval::Stage<C, R, L>>()?;
         let dr = dr.finish();
 
         // Load stage gadgets. Witness values are never accessed — the circuit
@@ -125,12 +127,20 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
             .enforce_equal(dr, &query.registry_xy)?;
         child.stashed_eval.enforce_equal(dr, &eval.native_eval)?;
 
+        for (stashed, current) in child
+            .stashed_witness_polys
+            .iter()
+            .zip(eval.witness_polys.iter())
+        {
+            stashed.enforce_equal(dr, current)?;
+        }
+
         // P: the child's accumulated p commitment is the last interstitial
         // of the child's PointsStage.
         let last_interstitial = points
             .interstitials
             .last()
-            .expect("NUM_ENDOSCALING_POINTS guarantees >= 1 interstitial");
+            .expect("`num_steps` floors at 1, so there is always an interstitial");
         child.stashed_p.enforce_equal(dr, last_interstitial)?;
 
         Ok(WithAux::new((), D::unit()))

--- a/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/copying.rs
@@ -35,7 +35,7 @@ use crate::internal::{
 
 /// Copying circuit that relates the current preamble to a child's stages.
 /// `L` is the application's poly count as a
-/// [`Len`](ragu_primitives::vec::Len); a child exposes the same shape.
+/// [`Len`]; a child exposes the same shape.
 pub struct Circuit<C: CurveAffine, R: Rank, L: Len> {
     side: Side,
     _marker: PhantomData<(C, R, L)>,

--- a/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
@@ -29,23 +29,23 @@ use ragu_core::{
     gadgets::Bound,
     maybe::Maybe,
 };
-use ragu_primitives::{GadgetExt as _, Point};
+use ragu_primitives::{GadgetExt as _, Point, vec::Len};
 
 use crate::internal::{
     endoscalar::{EndoscalarStage, Points, PointsStage},
     native::RxIndex,
-    nested::{NUM_ENDOSCALING_POINTS, stages},
+    nested::{EndoscalingPoints, stages},
 };
 
 /// A cursor over [`PointsStage`] inputs that enforces equality against
 /// corresponding bridge stage elements.
-struct Walker<'pts, 'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
-    points: &'pts Points<'dr, D, C, NUM_ENDOSCALING_POINTS>,
+struct Walker<'pts, 'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>, L: Len> {
+    points: &'pts Points<'dr, D, C, L>,
     index: usize,
 }
 
-impl<'pts, 'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> Walker<'pts, 'dr, D, C> {
-    fn new(points: &'pts Points<'dr, D, C, NUM_ENDOSCALING_POINTS>) -> Self {
+impl<'pts, 'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>, L: Len> Walker<'pts, 'dr, D, C, L> {
+    fn new(points: &'pts Points<'dr, D, C, L>) -> Self {
         Self { points, index: 0 }
     }
 
@@ -66,12 +66,14 @@ impl<'pts, 'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> Walker<'pts, 'dr, D
     }
 }
 
-/// Loading circuit that loads the entire nested stage hierarchy.
-pub struct Circuit<C: CurveAffine, R: Rank> {
-    _marker: PhantomData<(C, R)>,
+/// Loading circuit that loads the entire nested stage hierarchy. `L` is the
+/// application's poly count as a [`Len`](ragu_primitives::vec::Len) — the
+/// only shape this circuit needs.
+pub struct Circuit<C: CurveAffine, R: Rank, L: Len> {
+    _marker: PhantomData<(C, R, L)>,
 }
 
-impl<C: CurveAffine, R: Rank> Circuit<C, R> {
+impl<C: CurveAffine, R: Rank, L: Len> Circuit<C, R, L> {
     pub fn new() -> Self {
         Self {
             _marker: PhantomData,
@@ -79,8 +81,8 @@ impl<C: CurveAffine, R: Rank> Circuit<C, R> {
     }
 }
 
-impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
-    type Last = stages::eval::Stage<C, R>;
+impl<C: CurveAffine, R: Rank, L: Len> MultiStageCircuit<C::Base, R> for Circuit<C, R, L> {
+    type Last = stages::eval::Stage<C, R, L>;
     type Instance<'source> = ();
     type Witness<'source> = ();
     type Output = ();
@@ -100,15 +102,15 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
         _witness: DriverValue<D, ()>,
     ) -> Result<WithAux<Bound<'dr, D, ()>, DriverValue<D, ()>>> {
         let dr = dr.skip_stage::<EndoscalarStage>()?;
-        let (points_guard, dr) = dr.add_stage::<PointsStage<C, NUM_ENDOSCALING_POINTS>>()?;
-        let (preamble_guard, dr) = dr.add_stage::<stages::preamble::Stage<C, R>>()?;
-        let (s_prime_guard, dr) = dr.add_stage::<stages::s_prime::Stage<C, R>>()?;
-        let (inner_error_guard, dr) = dr.add_stage::<stages::inner_error::Stage<C, R>>()?;
-        let dr = dr.skip_stage::<stages::outer_error::Stage<C, R>>()?;
-        let (ab_guard, dr) = dr.add_stage::<stages::ab::Stage<C, R>>()?;
-        let (query_guard, dr) = dr.add_stage::<stages::query::Stage<C, R>>()?;
-        let (f_guard, dr) = dr.add_stage::<stages::f::Stage<C, R>>()?;
-        let dr = dr.skip_stage::<stages::eval::Stage<C, R>>()?;
+        let (points_guard, dr) = dr.add_stage::<PointsStage<C, EndoscalingPoints<L>>>()?;
+        let (preamble_guard, dr) = dr.add_stage::<stages::preamble::Stage<C, R, L>>()?;
+        let (s_prime_guard, dr) = dr.add_stage::<stages::s_prime::Stage<C, R, L>>()?;
+        let (inner_error_guard, dr) = dr.add_stage::<stages::inner_error::Stage<C, R, L>>()?;
+        let dr = dr.skip_stage::<stages::outer_error::Stage<C, R, L>>()?;
+        let (ab_guard, dr) = dr.add_stage::<stages::ab::Stage<C, R, L>>()?;
+        let (query_guard, dr) = dr.add_stage::<stages::query::Stage<C, R, L>>()?;
+        let (f_guard, dr) = dr.add_stage::<stages::f::Stage<C, R, L>>()?;
+        let dr = dr.skip_stage::<stages::eval::Stage<C, R, L>>()?;
         let dr = dr.finish();
 
         // Load stage gadgets. Witness values are never accessed — the circuit
@@ -138,6 +140,9 @@ impl<C: CurveAffine, R: Rank> MultiStageCircuit<C::Base, R> for Circuit<C, R> {
             walker.enforce_equal(dr, &child.stashed_ab_b)?;
             walker.enforce_equal(dr, &child.stashed_registry_xy)?;
             walker.enforce_equal(dr, &child.stashed_p)?;
+            for stashed_witness_poly in child.stashed_witness_polys.iter() {
+                walker.enforce_equal(dr, stashed_witness_poly)?;
+            }
         }
 
         walker.enforce_equal(dr, &s_prime.registry_wx0)?;

--- a/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
+++ b/crates/ragu_pcd/src/internal/nested/circuits/loading.rs
@@ -67,7 +67,7 @@ impl<'pts, 'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>, L: Len> Walker<'pts
 }
 
 /// Loading circuit that loads the entire nested stage hierarchy. `L` is the
-/// application's poly count as a [`Len`](ragu_primitives::vec::Len) — the
+/// application's poly count as a [`Len`] — the
 /// only shape this circuit needs.
 pub struct Circuit<C: CurveAffine, R: Rank, L: Len> {
     _marker: PhantomData<(C, R, L)>,

--- a/crates/ragu_pcd/src/internal/nested/claims.rs
+++ b/crates/ragu_pcd/src/internal/nested/claims.rs
@@ -59,7 +59,7 @@ impl<'m, 'rx, F: PrimeField, R: Rank> Processor<&'rx sparse::Polynomial<F, R>>
         id: InternalCircuitIndex,
         rxs: impl Iterator<Item = &'rx sparse::Polynomial<F, R>>,
     ) {
-        let circuit_id = id.circuit_index();
+        let circuit_id = id.circuit_index(self.witness_polys);
         let rx = sum_polynomials(rxs);
         self.circuit_impl(circuit_id, rx);
     }
@@ -69,7 +69,7 @@ impl<'m, 'rx, F: PrimeField, R: Rank> Processor<&'rx sparse::Polynomial<F, R>>
         id: InternalCircuitIndex,
         groups: impl Iterator<Item = impl Iterator<Item = &'rx sparse::Polynomial<F, R>>>,
     ) -> Result<()> {
-        let circuit_id = id.circuit_index();
+        let circuit_id = id.circuit_index(self.witness_polys);
         let folded = self.fold_bonding_groups(groups);
         self.bonding_impl(circuit_id, folded);
         Ok(())
@@ -86,12 +86,12 @@ impl<'m, 'rx, F: PrimeField, R: Rank> Processor<&'rx sparse::Polynomial<F, R>>
 ///    and all `Bridge*` variants
 ///
 /// This ordering must match the ky_elements ordering from [`ky_values`].
-pub fn build<S, P>(source: &S, processor: &mut P) -> Result<()>
+pub fn build<S, P>(source: &S, processor: &mut P, polys: usize) -> Result<()>
 where
     S: Source<RxComponent = RxIndex>,
     P: Processor<S::Rx>,
 {
-    for &id in &InternalCircuitIndex::ALL {
+    for id in InternalCircuitIndex::all(polys) {
         use InternalCircuitIndex::*;
         match id {
             EndoscalingStep(step) => {
@@ -110,7 +110,7 @@ where
                 processor.bonding_claim(id, source.rx(RxIndex::PointsStage))?;
             }
             PointsFinalStaged => {
-                let num_steps = super::NUM_ENDOSCALING_STEPS;
+                let num_steps = super::num_endoscaling_steps(polys);
                 let final_rxs = (0..num_steps)
                     .flat_map(|step| source.rx(RxIndex::EndoscalingStep(step as u32)));
                 processor.bonding_claim(id, final_rxs)?;
@@ -140,6 +140,9 @@ where
                 processor.bonding_claim(id, source.rx(RxIndex::BridgeEval))?;
             }
             Loading => {
+                // Every stage the circuit configures must be supplied here:
+                // the claim checks the *sum* of these rxs, so a missing stage
+                // makes its constraints vacuous over zero wires.
                 let groups = source
                     .rx(RxIndex::PointsStage)
                     .zip(source.rx(RxIndex::BridgePreamble))
@@ -154,6 +157,7 @@ where
                 processor.grouped_bonding_claim(id, groups)?;
             }
             Copying(side) => {
+                // As in `Loading`: every configured stage must be supplied.
                 let groups = source
                     .rx(RxIndex::ChildPointsStage(side))
                     .zip(source.rx(RxIndex::BridgePreamble))
@@ -191,8 +195,8 @@ pub trait KySource {
 /// Returns:
 /// - `num_steps` ones (for EndoscalingStep circuit checks, single-proof verification)
 /// - Infinite zeros (for stage checks)
-pub fn ky_values<S: KySource>(source: &S) -> impl Iterator<Item = S::Ky> {
-    let num_steps = super::NUM_ENDOSCALING_STEPS;
+pub fn ky_values<S: KySource>(source: &S, polys: usize) -> impl Iterator<Item = S::Ky> {
+    let num_steps = super::num_endoscaling_steps(polys);
 
     // Circuit checks: k(y) = 1 (for single-proof, num_circuit_claims = num_steps)
     core::iter::repeat_n(source.one(), num_steps)

--- a/crates/ragu_pcd/src/internal/nested/mod.rs
+++ b/crates/ragu_pcd/src/internal/nested/mod.rs
@@ -13,6 +13,8 @@
 //! [`ChildWitness`]: stages::preamble::ChildWitness
 //! [`PointsStage`]: crate::internal::endoscalar::PointsStage
 
+use core::marker::PhantomData;
+
 use ragu_arithmetic::Cycle;
 use ragu_circuits::{
     polynomials::Rank,
@@ -20,28 +22,48 @@ use ragu_circuits::{
     staging::{MultiStage, StageExt},
 };
 use ragu_core::Result;
+use ragu_primitives::vec::Len;
 
 pub mod circuits {
     pub mod copying;
     pub mod loading;
 }
 
-use crate::internal::{Side, endoscalar};
+use crate::internal::{
+    Side, endoscalar,
+    native::{RxIndex as NativeRxIndex, stages::eval::CURRENT_STEP_COMPONENTS},
+};
 
-/// Number of curve points accumulated during `compute_p` for nested field
-/// endoscaling verification.
-///
-/// This is the sum of per-child commitment components (for both proofs),
-/// current-step stage proof components, and the `f.commitment` base
-/// polynomial. See `_10_p` for the canonical accumulation order.
-///
-/// The endoscaling circuits process these points across
-/// [`NUM_ENDOSCALING_STEPS`] steps.
-pub const NUM_ENDOSCALING_POINTS: usize = 37;
+/// One child's block in the `_10_p` commitment walk: its native rx
+/// commitments, four extras (`ab_a`, `ab_b`, `registry_xy`, `p`), and one
+/// stashed commitment per witnessed polynomial. Shared with the nested
+/// preamble and the native eval stage, so the accumulation, stash, and `v`
+/// fold orders cannot drift apart.
+pub const fn child_endoscaling_points(polys: usize) -> usize {
+    NativeRxIndex::NUM + 4 + polys
+}
 
-/// Number of endoscaling steps, derived from [`NUM_ENDOSCALING_POINTS`] via
-/// [`endoscalar::num_steps`].
-const NUM_ENDOSCALING_STEPS: usize = endoscalar::num_steps(NUM_ENDOSCALING_POINTS);
+/// Number of curve points accumulated during `compute_p`: the `f.commitment`
+/// base point, one block per child ([`child_endoscaling_points`]), and the
+/// current step's stage components. See `_10_p` for the accumulation order.
+pub const fn num_endoscaling_points(polys: usize) -> usize {
+    // The leading point is `f.commitment`'s base point.
+    1 + 2 * child_endoscaling_points(polys) + CURRENT_STEP_COMPONENTS
+}
+
+/// The number of endoscaling step circuits a fuse runs.
+pub const fn num_endoscaling_steps(polys: usize) -> usize {
+    endoscalar::num_steps(num_endoscaling_points(polys))
+}
+
+/// [`num_endoscaling_points`] at the type level, for a poly count `L`.
+pub struct EndoscalingPoints<L: Len>(PhantomData<L>);
+
+impl<L: Len> Len for EndoscalingPoints<L> {
+    fn len() -> usize {
+        num_endoscaling_points(L::len())
+    }
+}
 
 /// Index of internal nested circuits registered into the registry.
 ///
@@ -79,57 +101,43 @@ pub enum InternalCircuitIndex {
 }
 
 impl InternalCircuitIndex {
-    /// The number of internal circuits registered by [`register_all`],
-    /// equal to the number of entries in [`InternalCircuitIndex::ALL`].
-    pub const NUM: usize = NUM_ENDOSCALING_STEPS + 14;
-
     /// All variants in canonical iteration order.
     ///
     /// This order must match the registry finalization concatenation order
     /// in [`RegistryBuilder::finalize()`](ragu_circuits::registry::RegistryBuilder::finalize)
     /// (circuits before masks), since [`circuit_index()`](Self::circuit_index)
-    /// derives indices from position in this array.
-    pub const ALL: [Self; Self::NUM] = super::const_fns::unwrap_all(Self::all_slots());
-
-    const fn all_slots() -> [Option<Self>; Self::NUM] {
-        use super::const_fns::push;
-
-        let mut slots = [None; Self::NUM];
-        let mut c = 0;
-        {
-            let mut step = 0;
-            while step < NUM_ENDOSCALING_STEPS {
-                push(&mut slots, &mut c, Self::EndoscalingStep(step as u32));
-                step += 1;
-            }
-        }
-        push(&mut slots, &mut c, Self::EndoscalarStage);
-        push(&mut slots, &mut c, Self::PointsStage);
-        push(&mut slots, &mut c, Self::PointsFinalStaged);
-        push(&mut slots, &mut c, Self::BridgePreamble);
-        push(&mut slots, &mut c, Self::BridgeSPrime);
-        push(&mut slots, &mut c, Self::BridgeInnerError);
-        push(&mut slots, &mut c, Self::BridgeOuterError);
-        push(&mut slots, &mut c, Self::BridgeAB);
-        push(&mut slots, &mut c, Self::BridgeQuery);
-        push(&mut slots, &mut c, Self::BridgeF);
-        push(&mut slots, &mut c, Self::BridgeEval);
-        push(&mut slots, &mut c, Self::Loading);
-        push(&mut slots, &mut c, Self::Copying(Side::Left));
-        push(&mut slots, &mut c, Self::Copying(Side::Right));
-        assert!(c == Self::NUM);
-        slots
+    /// derives indices from position in this list.
+    pub fn all(polys: usize) -> impl Iterator<Item = Self> {
+        (0..num_endoscaling_steps(polys))
+            .map(|step| Self::EndoscalingStep(step as u32))
+            .chain([
+                Self::EndoscalarStage,
+                Self::PointsStage,
+                Self::PointsFinalStaged,
+                Self::BridgePreamble,
+                Self::BridgeSPrime,
+                Self::BridgeInnerError,
+                Self::BridgeOuterError,
+                Self::BridgeAB,
+                Self::BridgeQuery,
+                Self::BridgeF,
+                Self::BridgeEval,
+            ])
+            .chain([
+                Self::Loading,
+                Self::Copying(Side::Left),
+                Self::Copying(Side::Right),
+            ])
     }
 
     /// Convert to a [`CircuitIndex`] for registry lookup.
     ///
     /// Circuit indices follow the `RegistryBuilder::finalize()` concatenation
     /// order: internal circuits first, then internal masks.
-    pub fn circuit_index(self) -> CircuitIndex {
-        let pos = Self::ALL
-            .iter()
-            .position(|&v| v == self)
-            .expect("every variant appears in ALL");
+    pub fn circuit_index(self, polys: usize) -> CircuitIndex {
+        let pos = Self::all(polys)
+            .position(|v| v == self)
+            .expect("every variant appears in `all`");
         CircuitIndex::new(pos)
     }
 }
@@ -153,24 +161,6 @@ pub enum ChildBridgeKind {
     Query,
     /// Child proof's `BridgeEval` rx polynomial.
     Eval,
-}
-
-impl ChildBridgeKind {
-    /// All kinds in the canonical slot order.
-    ///
-    /// This constant is the source of truth for the relative order of
-    /// `RxIndex::ChildBridge(kind, side)` entries in [`RxIndex::ALL`]
-    /// (see [`RxIndex::all_slots`]), and is therefore pinned by
-    /// `test_nested_registry_digest` — re-ordering these variants
-    /// changes the nested registry digest.
-    pub const ALL: [Self; 6] = [
-        Self::SPrime,
-        Self::InnerError,
-        Self::OuterError,
-        Self::AB,
-        Self::Query,
-        Self::Eval,
-    ];
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -204,55 +194,6 @@ pub enum RxIndex {
     ChildBridge(ChildBridgeKind, Side),
 }
 
-impl RxIndex {
-    /// The number of rx components in the nested field,
-    /// equal to the number of entries in [`RxIndex::ALL`].
-    pub const NUM: usize = NUM_ENDOSCALING_STEPS + 24;
-
-    /// All variants in canonical order (circuits, then stages).
-    ///
-    /// Must maintain the same ordering convention as
-    /// [`native::RxIndex::ALL`](super::native::RxIndex::ALL).
-    pub const ALL: [Self; Self::NUM] = super::const_fns::unwrap_all(Self::all_slots());
-
-    const fn all_slots() -> [Option<Self>; Self::NUM] {
-        use super::const_fns::push;
-
-        let mut slots = [None; Self::NUM];
-        let mut c = 0;
-        {
-            let mut step = 0;
-            while step < NUM_ENDOSCALING_STEPS {
-                push(&mut slots, &mut c, Self::EndoscalingStep(step as u32));
-                step += 1;
-            }
-        }
-        push(&mut slots, &mut c, Self::EndoscalarStage);
-        push(&mut slots, &mut c, Self::PointsStage);
-        push(&mut slots, &mut c, Self::BridgePreamble);
-        push(&mut slots, &mut c, Self::BridgeSPrime);
-        push(&mut slots, &mut c, Self::BridgeInnerError);
-        push(&mut slots, &mut c, Self::BridgeOuterError);
-        push(&mut slots, &mut c, Self::BridgeAB);
-        push(&mut slots, &mut c, Self::BridgeQuery);
-        push(&mut slots, &mut c, Self::BridgeF);
-        push(&mut slots, &mut c, Self::BridgeEval);
-        push(&mut slots, &mut c, Self::ChildPointsStage(Side::Left));
-        push(&mut slots, &mut c, Self::ChildPointsStage(Side::Right));
-        {
-            let mut i = 0;
-            while i < ChildBridgeKind::ALL.len() {
-                let kind = ChildBridgeKind::ALL[i];
-                push(&mut slots, &mut c, Self::ChildBridge(kind, Side::Left));
-                push(&mut slots, &mut c, Self::ChildBridge(kind, Side::Right));
-                i += 1;
-            }
-        }
-        assert!(c == Self::NUM);
-        slots
-    }
-}
-
 pub mod claims;
 
 pub mod stages {
@@ -270,69 +211,62 @@ pub mod stages {
 ///
 /// Circuits are registered as internal to ensure they occupy prefix indices
 /// before application steps.
-pub fn register_all<'params, C: Cycle, R: Rank>(
+pub fn register_all<'params, C: Cycle, R: Rank, L: Len>(
     mut registry: RegistryBuilder<'params, C::ScalarField, R>,
 ) -> Result<RegistryBuilder<'params, C::ScalarField, R>> {
-    let initial_internal_circuits = registry.num_internal_circuits();
-
     // Circuits first, then masks — matching RegistryBuilder::finalize()
     // concatenation order and InternalCircuitIndex::circuit_index().
-    for &id in &InternalCircuitIndex::ALL {
+    for id in InternalCircuitIndex::all(L::len()) {
         use InternalCircuitIndex::*;
         registry = match id {
             EndoscalingStep(step) => {
                 let step_circuit =
-                    endoscalar::EndoscalingStep::<C::HostCurve, R, NUM_ENDOSCALING_POINTS>::new(
+                    endoscalar::EndoscalingStep::<C::HostCurve, R, EndoscalingPoints<L>>::new(
                         step as usize,
                     );
-                let staged = MultiStage::new(step_circuit);
-                registry.register_internal_circuit(staged)?
+                registry.register_internal_circuit(MultiStage::new(step_circuit))?
             }
             EndoscalarStage => registry.register_bonding(endoscalar::EndoscalarStage::mask()?),
-            PointsStage => registry.register_bonding(endoscalar::PointsStage::<
-                C::HostCurve,
-                NUM_ENDOSCALING_POINTS,
-            >::mask()?),
-            PointsFinalStaged => registry.register_bonding(endoscalar::PointsStage::<
-                C::HostCurve,
-                NUM_ENDOSCALING_POINTS,
-            >::final_mask()?),
+            PointsStage => registry
+                .register_bonding(
+                    endoscalar::PointsStage::<C::HostCurve, EndoscalingPoints<L>>::mask()?,
+                ),
+            PointsFinalStaged => registry
+                .register_bonding(
+                    endoscalar::PointsStage::<C::HostCurve, EndoscalingPoints<L>>::final_mask()?,
+                ),
             BridgePreamble => {
-                registry.register_bonding(stages::preamble::Stage::<C::HostCurve, R>::mask()?)
+                registry.register_bonding(stages::preamble::Stage::<C::HostCurve, R, L>::mask()?)
             }
             BridgeSPrime => {
-                registry.register_bonding(stages::s_prime::Stage::<C::HostCurve, R>::mask()?)
+                registry.register_bonding(stages::s_prime::Stage::<C::HostCurve, R, L>::mask()?)
             }
             BridgeInnerError => {
-                registry.register_bonding(stages::inner_error::Stage::<C::HostCurve, R>::mask()?)
+                registry.register_bonding(stages::inner_error::Stage::<C::HostCurve, R, L>::mask()?)
             }
             BridgeOuterError => {
-                registry.register_bonding(stages::outer_error::Stage::<C::HostCurve, R>::mask()?)
+                registry.register_bonding(stages::outer_error::Stage::<C::HostCurve, R, L>::mask()?)
             }
-            BridgeAB => registry.register_bonding(stages::ab::Stage::<C::HostCurve, R>::mask()?),
+            BridgeAB => registry.register_bonding(stages::ab::Stage::<C::HostCurve, R, L>::mask()?),
             BridgeQuery => {
-                registry.register_bonding(stages::query::Stage::<C::HostCurve, R>::mask()?)
+                registry.register_bonding(stages::query::Stage::<C::HostCurve, R, L>::mask()?)
             }
-            BridgeF => registry.register_bonding(stages::f::Stage::<C::HostCurve, R>::mask()?),
+            BridgeF => registry.register_bonding(stages::f::Stage::<C::HostCurve, R, L>::mask()?),
             BridgeEval => {
-                registry.register_bonding(stages::eval::Stage::<C::HostCurve, R>::mask()?)
+                registry.register_bonding(stages::eval::Stage::<C::HostCurve, R, L>::mask()?)
             }
             Loading => {
-                let circuit = circuits::loading::Circuit::<C::HostCurve, R>::new();
+                let circuit = circuits::loading::Circuit::<C::HostCurve, R, L>::new();
                 registry.register_bonding(MultiStage::new(circuit).into_bonding_object()?)
             }
+            // A copying circuit walks a child, but children expose the same
+            // layout, so the same `L` serves here.
             Copying(side) => {
-                let circuit = circuits::copying::Circuit::<C::HostCurve, R>::new(side);
+                let circuit = circuits::copying::Circuit::<C::HostCurve, R, L>::new(side);
                 registry.register_bonding(MultiStage::new(circuit).into_bonding_object()?)
             }
         };
     }
-
-    assert_eq!(
-        registry.num_internal_circuits(),
-        initial_internal_circuits + InternalCircuitIndex::NUM,
-        "internal circuit count mismatch"
-    );
 
     Ok(registry)
 }

--- a/crates/ragu_pcd/src/internal/nested/mod.rs
+++ b/crates/ragu_pcd/src/internal/nested/mod.rs
@@ -214,6 +214,8 @@ pub mod stages {
 pub fn register_all<'params, C: Cycle, R: Rank, L: Len>(
     mut registry: RegistryBuilder<'params, C::ScalarField, R>,
 ) -> Result<RegistryBuilder<'params, C::ScalarField, R>> {
+    let initial_internal_circuits = registry.num_internal_circuits();
+
     // Circuits first, then masks — matching RegistryBuilder::finalize()
     // concatenation order and InternalCircuitIndex::circuit_index().
     for id in InternalCircuitIndex::all(L::len()) {
@@ -267,6 +269,14 @@ pub fn register_all<'params, C: Cycle, R: Rank, L: Len>(
             }
         };
     }
+
+    // `circuit_index` scans the same `all` list, so the two agree by
+    // construction; this checks that the registry took one slot per entry.
+    assert_eq!(
+        registry.num_internal_circuits(),
+        initial_internal_circuits + InternalCircuitIndex::all(L::len()).count(),
+        "internal circuit count mismatch"
+    );
 
     Ok(registry)
 }

--- a/crates/ragu_pcd/src/internal/nested/stages/ab.rs
+++ b/crates/ragu_pcd/src/internal/nested/stages/ab.rs
@@ -10,7 +10,7 @@ use ragu_core::{
     gadgets::{Bound, Gadget, Kind},
     maybe::Maybe,
 };
-use ragu_primitives::{Point, io::Write};
+use ragu_primitives::{Point, io::Write, vec::Len};
 
 /// Number of curve points in this stage.
 const NUM: usize = 2;
@@ -33,13 +33,20 @@ pub struct Output<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
     pub b: Point<'dr, D, C>,
 }
 
-#[derive(Default)]
-pub struct Stage<C: CurveAffine, R> {
-    _marker: PhantomData<(C, R)>,
+pub struct Stage<C: CurveAffine, R, L> {
+    _marker: PhantomData<(C, R, L)>,
 }
 
-impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stage<C, R> {
-    type Parent = super::outer_error::Stage<C, R>;
+impl<C: CurveAffine, R, L> Default for Stage<C, R, L> {
+    fn default() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C: CurveAffine, R: Rank, L: Len> ragu_circuits::staging::Stage<C::Base, R> for Stage<C, R, L> {
+    type Parent = super::outer_error::Stage<C, R, L>;
     type Witness<'source> = &'source Witness<C>;
     type OutputKind = Kind![C::Base; Output<'_, _, C>];
 
@@ -65,12 +72,13 @@ impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stag
 #[cfg(test)]
 mod tests {
     use ragu_pasta::EqAffine;
+    use ragu_primitives::vec::ConstLen;
 
     use super::*;
     use crate::internal::tests::{R, assert_stage_values};
 
     #[test]
     fn stage_values_matches_wire_count() {
-        assert_stage_values(&Stage::<EqAffine, R>::default());
+        assert_stage_values(&Stage::<EqAffine, R, ConstLen<4>>::default());
     }
 }

--- a/crates/ragu_pcd/src/internal/nested/stages/eval.rs
+++ b/crates/ragu_pcd/src/internal/nested/stages/eval.rs
@@ -10,38 +10,49 @@ use ragu_core::{
     gadgets::{Bound, Gadget, Kind},
     maybe::Maybe,
 };
-use ragu_primitives::{Point, io::Write};
-
-/// Number of curve points in this stage.
-const NUM: usize = 1;
+use ragu_primitives::{
+    Point,
+    io::Write,
+    vec::{FixedVec, Len},
+};
 
 /// Witness data for this bridge stage.
-pub struct Witness<C: CurveAffine> {
+pub struct Witness<C: CurveAffine, L: Len> {
     pub native_eval: C,
+    /// The current step's witness-poly host commitments.
+    pub witness_polys: FixedVec<C, L>,
 }
 
-/// Prover-internal output gadget for this bridge stage.
-///
-/// This is stage communication data, not part of the circuit's
-/// public instance.
+/// This stage's points.
 #[derive(Gadget, Write)]
-pub struct Output<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
+pub struct Output<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>, L: Len> {
     #[ragu(gadget)]
     pub native_eval: Point<'dr, D, C>,
+    #[ragu(gadget)]
+    pub witness_polys: FixedVec<Point<'dr, D, C>, L>,
 }
 
-#[derive(Default)]
-pub struct Stage<C: CurveAffine, R> {
-    _marker: PhantomData<(C, R)>,
+/// The eval bridge stage: `native_eval`, then one bridge per witnessed
+/// polynomial.
+pub struct Stage<C: CurveAffine, R, L> {
+    _marker: PhantomData<(C, R, L)>,
 }
 
-impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stage<C, R> {
-    type Parent = super::f::Stage<C, R>;
-    type Witness<'source> = &'source Witness<C>;
-    type OutputKind = Kind![C::Base; Output<'_, _, C>];
+impl<C: CurveAffine, R, L> Default for Stage<C, R, L> {
+    fn default() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C: CurveAffine, R: Rank, L: Len> ragu_circuits::staging::Stage<C::Base, R> for Stage<C, R, L> {
+    type Parent = super::f::Stage<C, R, L>;
+    type Witness<'source> = &'source Witness<C, L>;
+    type OutputKind = Kind![C::Base; Output<'_, _, C, L>];
 
     fn values() -> usize {
-        NUM * 2
+        2 * (1 + L::len())
     }
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::Base>>(
@@ -54,6 +65,9 @@ impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stag
     {
         Ok(Output {
             native_eval: Point::alloc(dr, witness.as_ref().map(|w| w.native_eval))?,
+            witness_polys: FixedVec::try_from_fn(|i| {
+                Point::alloc(dr, witness.as_ref().map(|w| w.witness_polys[i]))
+            })?,
         })
     }
 }
@@ -61,12 +75,15 @@ impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stag
 #[cfg(test)]
 mod tests {
     use ragu_pasta::EqAffine;
+    use ragu_primitives::vec::ConstLen;
 
     use super::*;
     use crate::internal::tests::{R, assert_stage_values};
 
     #[test]
     fn stage_values_matches_wire_count() {
-        assert_stage_values(&Stage::<EqAffine, R>::default());
+        assert_stage_values(&Stage::<EqAffine, R, ConstLen<0>>::default());
+        assert_stage_values(&Stage::<EqAffine, R, ConstLen<4>>::default());
+        assert_stage_values(&Stage::<EqAffine, R, ConstLen<8>>::default());
     }
 }

--- a/crates/ragu_pcd/src/internal/nested/stages/f.rs
+++ b/crates/ragu_pcd/src/internal/nested/stages/f.rs
@@ -10,7 +10,7 @@ use ragu_core::{
     gadgets::{Bound, Gadget, Kind},
     maybe::Maybe,
 };
-use ragu_primitives::{Point, io::Write};
+use ragu_primitives::{Point, io::Write, vec::Len};
 
 /// Number of curve points in this stage.
 const NUM: usize = 1;
@@ -30,13 +30,20 @@ pub struct Output<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
     pub native_f: Point<'dr, D, C>,
 }
 
-#[derive(Default)]
-pub struct Stage<C: CurveAffine, R> {
-    _marker: PhantomData<(C, R)>,
+pub struct Stage<C: CurveAffine, R, L> {
+    _marker: PhantomData<(C, R, L)>,
 }
 
-impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stage<C, R> {
-    type Parent = super::query::Stage<C, R>;
+impl<C: CurveAffine, R, L> Default for Stage<C, R, L> {
+    fn default() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C: CurveAffine, R: Rank, L: Len> ragu_circuits::staging::Stage<C::Base, R> for Stage<C, R, L> {
+    type Parent = super::query::Stage<C, R, L>;
     type Witness<'source> = &'source Witness<C>;
     type OutputKind = Kind![C::Base; Output<'_, _, C>];
 
@@ -61,12 +68,13 @@ impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stag
 #[cfg(test)]
 mod tests {
     use ragu_pasta::EqAffine;
+    use ragu_primitives::vec::ConstLen;
 
     use super::*;
     use crate::internal::tests::{R, assert_stage_values};
 
     #[test]
     fn stage_values_matches_wire_count() {
-        assert_stage_values(&Stage::<EqAffine, R>::default());
+        assert_stage_values(&Stage::<EqAffine, R, ConstLen<4>>::default());
     }
 }

--- a/crates/ragu_pcd/src/internal/nested/stages/inner_error.rs
+++ b/crates/ragu_pcd/src/internal/nested/stages/inner_error.rs
@@ -10,7 +10,7 @@ use ragu_core::{
     gadgets::{Bound, Gadget, Kind},
     maybe::Maybe,
 };
-use ragu_primitives::{Point, io::Write};
+use ragu_primitives::{Point, io::Write, vec::Len};
 
 /// Number of curve points in this stage.
 const NUM: usize = 2;
@@ -33,13 +33,20 @@ pub struct Output<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
     pub registry_wy: Point<'dr, D, C>,
 }
 
-#[derive(Default)]
-pub struct Stage<C: CurveAffine, R> {
-    _marker: PhantomData<(C, R)>,
+pub struct Stage<C: CurveAffine, R, L> {
+    _marker: PhantomData<(C, R, L)>,
 }
 
-impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stage<C, R> {
-    type Parent = super::s_prime::Stage<C, R>;
+impl<C: CurveAffine, R, L> Default for Stage<C, R, L> {
+    fn default() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C: CurveAffine, R: Rank, L: Len> ragu_circuits::staging::Stage<C::Base, R> for Stage<C, R, L> {
+    type Parent = super::s_prime::Stage<C, R, L>;
     type Witness<'source> = &'source Witness<C>;
     type OutputKind = Kind![C::Base; Output<'_, _, C>];
 
@@ -65,12 +72,13 @@ impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stag
 #[cfg(test)]
 mod tests {
     use ragu_pasta::EqAffine;
+    use ragu_primitives::vec::ConstLen;
 
     use super::*;
     use crate::internal::tests::{R, assert_stage_values};
 
     #[test]
     fn stage_values_matches_wire_count() {
-        assert_stage_values(&Stage::<EqAffine, R>::default());
+        assert_stage_values(&Stage::<EqAffine, R, ConstLen<4>>::default());
     }
 }

--- a/crates/ragu_pcd/src/internal/nested/stages/outer_error.rs
+++ b/crates/ragu_pcd/src/internal/nested/stages/outer_error.rs
@@ -10,7 +10,7 @@ use ragu_core::{
     gadgets::{Bound, Gadget, Kind},
     maybe::Maybe,
 };
-use ragu_primitives::{Point, io::Write};
+use ragu_primitives::{Point, io::Write, vec::Len};
 
 /// Number of curve points in this stage.
 const NUM: usize = 1;
@@ -30,13 +30,20 @@ pub struct Output<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
     pub native_outer_error: Point<'dr, D, C>,
 }
 
-#[derive(Default)]
-pub struct Stage<C: CurveAffine, R> {
-    _marker: PhantomData<(C, R)>,
+pub struct Stage<C: CurveAffine, R, L> {
+    _marker: PhantomData<(C, R, L)>,
 }
 
-impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stage<C, R> {
-    type Parent = super::inner_error::Stage<C, R>;
+impl<C: CurveAffine, R, L> Default for Stage<C, R, L> {
+    fn default() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C: CurveAffine, R: Rank, L: Len> ragu_circuits::staging::Stage<C::Base, R> for Stage<C, R, L> {
+    type Parent = super::inner_error::Stage<C, R, L>;
     type Witness<'source> = &'source Witness<C>;
     type OutputKind = Kind![C::Base; Output<'_, _, C>];
 
@@ -61,12 +68,13 @@ impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stag
 #[cfg(test)]
 mod tests {
     use ragu_pasta::EqAffine;
+    use ragu_primitives::vec::ConstLen;
 
     use super::*;
     use crate::internal::tests::{R, assert_stage_values};
 
     #[test]
     fn stage_values_matches_wire_count() {
-        assert_stage_values(&Stage::<EqAffine, R>::default());
+        assert_stage_values(&Stage::<EqAffine, R, ConstLen<4>>::default());
     }
 }

--- a/crates/ragu_pcd/src/internal/nested/stages/preamble.rs
+++ b/crates/ragu_pcd/src/internal/nested/stages/preamble.rs
@@ -12,15 +12,27 @@ use ragu_core::{
     gadgets::{Bound, Gadget, Kind},
     maybe::Maybe,
 };
-use ragu_primitives::{Point, io::Write};
+use ragu_primitives::{
+    Point,
+    io::Write,
+    vec::{CollectFixed, FixedVec, Len},
+};
 
 use crate::{
     Proof,
-    internal::{endoscalar::PointsStage, native::RxIndex, nested::NUM_ENDOSCALING_POINTS},
+    internal::{
+        endoscalar::PointsStage,
+        native::RxIndex,
+        nested::{EndoscalingPoints, child_endoscaling_points},
+    },
 };
 
-/// Number of curve points in this stage.
-pub const NUM_POINTS: usize = 31;
+/// Number of curve points in this stage: the native preamble commitment plus
+/// one block per child.
+pub const fn num_points(polys: usize) -> usize {
+    // The leading point is the native preamble commitment, not `f.commitment`.
+    1 + 2 * child_endoscaling_points(polys)
+}
 
 /// Witness data for a single child proof in the preamble bridge stage.
 ///
@@ -30,8 +42,7 @@ pub const NUM_POINTS: usize = 31;
 /// exist in the child's unified instance or bridge stages, placed here
 /// so that loading can enforce them against [`PointsStage`] and copying
 /// can verify them against the child's bridge stage content.
-#[derive(Clone)]
-pub struct ChildWitness<C: CurveAffine> {
+pub struct ChildWitness<C: CurveAffine, L: Len> {
     // Field order matches the `_10_p` accumulation order.
     /// Commitment from the child's application circuit.
     pub application: C,
@@ -64,13 +75,39 @@ pub struct ChildWitness<C: CurveAffine> {
     pub stashed_registry_xy: C,
     /// Stashed accumulated P commitment from the child.
     pub stashed_p: C,
+    /// Stashed witness-poly commitments from the child.
+    pub stashed_witness_polys: FixedVec<C, L>,
 }
 
-impl<C: CurveAffine> ChildWitness<C> {
-    /// Construct from a child proof's commitments.
-    pub fn from_proof<CC: Cycle<HostCurve = C>, R: Rank>(proof: &Proof<CC, R>) -> Self {
-        use crate::internal::native::RxComponent;
+// A derive would demand `L: Clone`, which a `Len` marker never is.
+impl<C: CurveAffine, L: Len> Clone for ChildWitness<C, L> {
+    fn clone(&self) -> Self {
         Self {
+            application: self.application,
+            hashes_1: self.hashes_1,
+            hashes_2: self.hashes_2,
+            inner_collapse: self.inner_collapse,
+            outer_collapse: self.outer_collapse,
+            compute_v: self.compute_v,
+            stashed_preamble: self.stashed_preamble,
+            stashed_inner_error: self.stashed_inner_error,
+            stashed_outer_error: self.stashed_outer_error,
+            stashed_query: self.stashed_query,
+            stashed_eval: self.stashed_eval,
+            stashed_ab_a: self.stashed_ab_a,
+            stashed_ab_b: self.stashed_ab_b,
+            stashed_registry_xy: self.stashed_registry_xy,
+            stashed_p: self.stashed_p,
+            stashed_witness_polys: self.stashed_witness_polys.clone(),
+        }
+    }
+}
+
+impl<C: CurveAffine, L: Len> ChildWitness<C, L> {
+    /// Construct from a child proof's commitments.
+    pub fn from_proof<CC: Cycle<HostCurve = C>, R: Rank>(proof: &Proof<CC, R>) -> Result<Self> {
+        use crate::internal::native::RxComponent;
+        Ok(Self {
             application: proof.native_rx_commitment(RxIndex::Application),
             hashes_1: proof.native_rx_commitment(RxIndex::Hashes1),
             hashes_2: proof.native_rx_commitment(RxIndex::Hashes2),
@@ -86,23 +123,24 @@ impl<C: CurveAffine> ChildWitness<C> {
             stashed_ab_b: proof.native_commitment(RxComponent::AbB),
             stashed_registry_xy: proof.native_registry_xy_commitment(),
             stashed_p: proof.native_p_commitment(),
-        }
+            stashed_witness_polys: proof.witness_poly_commitments().collect_fixed()?,
+        })
     }
 }
 
 /// Witness data for the preamble bridge stage.
-pub struct Witness<C: CurveAffine> {
+pub struct Witness<C: CurveAffine, L: Len> {
     /// Commitment from the native preamble stage.
     pub native_preamble: C,
     /// Witness data from the left child proof.
-    pub left: ChildWitness<C>,
+    pub left: ChildWitness<C, L>,
     /// Witness data from the right child proof.
-    pub right: ChildWitness<C>,
+    pub right: ChildWitness<C, L>,
 }
 
-/// Output gadget for a single child proof in the preamble bridge stage.
+/// One child proof's points in the preamble bridge stage.
 #[derive(Gadget, Write)]
-pub struct ChildOutput<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
+pub struct ChildOutput<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>, L: Len> {
     // Field order matches `_10_p` accumulation order.
     /// Point commitment from the child's application circuit.
     #[ragu(gadget)]
@@ -150,10 +188,14 @@ pub struct ChildOutput<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
     /// Stashed accumulated P commitment from the child.
     #[ragu(gadget)]
     pub stashed_p: Point<'dr, D, C>,
+    /// Stashed witness-poly commitments from the child, after the named
+    /// points — the order `_10_p` accumulates.
+    #[ragu(gadget)]
+    pub stashed_witness_polys: FixedVec<Point<'dr, D, C>, L>,
 }
 
-impl<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> core::ops::Index<RxIndex>
-    for ChildOutput<'dr, D, C>
+impl<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>, L: Len> core::ops::Index<RxIndex>
+    for ChildOutput<'dr, D, C, L>
 {
     type Output = Point<'dr, D, C>;
 
@@ -175,8 +217,9 @@ impl<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> core::ops::Index<RxIndex>
     }
 }
 
-impl<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> ChildOutput<'dr, D, C> {
-    fn alloc(dr: &mut D, witness: DriverValue<D, &ChildWitness<C>>) -> Result<Self> {
+impl<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>, L: Len> ChildOutput<'dr, D, C, L> {
+    /// Allocates one child's block, in field order.
+    fn alloc(dr: &mut D, witness: DriverValue<D, &ChildWitness<C, L>>) -> Result<Self> {
         Ok(ChildOutput {
             application: Point::alloc(dr, witness.as_ref().map(|w| w.application))?,
             hashes_1: Point::alloc(dr, witness.as_ref().map(|w| w.hashes_1))?,
@@ -193,6 +236,9 @@ impl<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> ChildOutput<'dr, D, C> {
             stashed_ab_b: Point::alloc(dr, witness.as_ref().map(|w| w.stashed_ab_b))?,
             stashed_registry_xy: Point::alloc(dr, witness.as_ref().map(|w| w.stashed_registry_xy))?,
             stashed_p: Point::alloc(dr, witness.as_ref().map(|w| w.stashed_p))?,
+            stashed_witness_polys: FixedVec::try_from_fn(|i| {
+                Point::alloc(dr, witness.as_ref().map(|w| w.stashed_witness_polys[i]))
+            })?,
         })
     }
 }
@@ -201,30 +247,38 @@ impl<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> ChildOutput<'dr, D, C> {
 ///
 /// This is stage communication data, not part of the circuit's public instance.
 #[derive(Gadget, Write)]
-pub struct Output<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
+pub struct Output<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>, L: Len> {
     /// Point commitment from the native preamble stage.
     #[ragu(gadget)]
     pub native_preamble: Point<'dr, D, C>,
     /// Output gadget for the left child proof.
     #[ragu(gadget)]
-    pub left: ChildOutput<'dr, D, C>,
+    pub left: ChildOutput<'dr, D, C, L>,
     /// Output gadget for the right child proof.
     #[ragu(gadget)]
-    pub right: ChildOutput<'dr, D, C>,
+    pub right: ChildOutput<'dr, D, C, L>,
 }
 
-#[derive(Default)]
-pub struct Stage<C: CurveAffine, R> {
-    _marker: PhantomData<(C, R)>,
+/// The preamble bridge stage: `native_preamble`, then each child's block.
+pub struct Stage<C: CurveAffine, R, L> {
+    _marker: PhantomData<(C, R, L)>,
 }
 
-impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stage<C, R> {
-    type Parent = PointsStage<C, NUM_ENDOSCALING_POINTS>;
-    type Witness<'source> = &'source Witness<C>;
-    type OutputKind = Kind![C::Base; Output<'_, _, C>];
+impl<C: CurveAffine, R, L> Default for Stage<C, R, L> {
+    fn default() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C: CurveAffine, R: Rank, L: Len> ragu_circuits::staging::Stage<C::Base, R> for Stage<C, R, L> {
+    type Parent = PointsStage<C, EndoscalingPoints<L>>;
+    type Witness<'source> = &'source Witness<C, L>;
+    type OutputKind = Kind![C::Base; Output<'_, _, C, L>];
 
     fn values() -> usize {
-        NUM_POINTS * 2
+        num_points(L::len()) * 2
     }
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::Base>>(
@@ -246,12 +300,15 @@ impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stag
 #[cfg(test)]
 mod tests {
     use ragu_pasta::EqAffine;
+    use ragu_primitives::vec::ConstLen;
 
     use super::*;
     use crate::internal::tests::{R, assert_stage_values};
 
     #[test]
     fn stage_values_matches_wire_count() {
-        assert_stage_values(&Stage::<EqAffine, R>::default());
+        assert_stage_values(&Stage::<EqAffine, R, ConstLen<0>>::default());
+        assert_stage_values(&Stage::<EqAffine, R, ConstLen<4>>::default());
+        assert_stage_values(&Stage::<EqAffine, R, ConstLen<8>>::default());
     }
 }

--- a/crates/ragu_pcd/src/internal/nested/stages/query.rs
+++ b/crates/ragu_pcd/src/internal/nested/stages/query.rs
@@ -10,7 +10,7 @@ use ragu_core::{
     gadgets::{Bound, Gadget, Kind},
     maybe::Maybe,
 };
-use ragu_primitives::{Point, io::Write};
+use ragu_primitives::{Point, io::Write, vec::Len};
 
 /// Number of curve points in this stage.
 const NUM: usize = 2;
@@ -33,13 +33,20 @@ pub struct Output<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
     pub registry_xy: Point<'dr, D, C>,
 }
 
-#[derive(Default)]
-pub struct Stage<C: CurveAffine, R> {
-    _marker: PhantomData<(C, R)>,
+pub struct Stage<C: CurveAffine, R, L> {
+    _marker: PhantomData<(C, R, L)>,
 }
 
-impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stage<C, R> {
-    type Parent = super::ab::Stage<C, R>;
+impl<C: CurveAffine, R, L> Default for Stage<C, R, L> {
+    fn default() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C: CurveAffine, R: Rank, L: Len> ragu_circuits::staging::Stage<C::Base, R> for Stage<C, R, L> {
+    type Parent = super::ab::Stage<C, R, L>;
     type Witness<'source> = &'source Witness<C>;
     type OutputKind = Kind![C::Base; Output<'_, _, C>];
 
@@ -65,12 +72,13 @@ impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stag
 #[cfg(test)]
 mod tests {
     use ragu_pasta::EqAffine;
+    use ragu_primitives::vec::ConstLen;
 
     use super::*;
     use crate::internal::tests::{R, assert_stage_values};
 
     #[test]
     fn stage_values_matches_wire_count() {
-        assert_stage_values(&Stage::<EqAffine, R>::default());
+        assert_stage_values(&Stage::<EqAffine, R, ConstLen<4>>::default());
     }
 }

--- a/crates/ragu_pcd/src/internal/nested/stages/s_prime.rs
+++ b/crates/ragu_pcd/src/internal/nested/stages/s_prime.rs
@@ -10,7 +10,7 @@ use ragu_core::{
     gadgets::{Bound, Gadget, Kind},
     maybe::Maybe,
 };
-use ragu_primitives::{Point, io::Write};
+use ragu_primitives::{Point, io::Write, vec::Len};
 
 /// Number of curve points in this stage.
 const NUM: usize = 3;
@@ -43,13 +43,20 @@ pub struct Output<'dr, D: Driver<'dr>, C: CurveAffine<Base = D::F>> {
     pub stashed_preamble: Point<'dr, D, C>,
 }
 
-#[derive(Default)]
-pub struct Stage<C: CurveAffine, R> {
-    _marker: PhantomData<(C, R)>,
+pub struct Stage<C: CurveAffine, R, L> {
+    _marker: PhantomData<(C, R, L)>,
 }
 
-impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stage<C, R> {
-    type Parent = super::preamble::Stage<C, R>;
+impl<C: CurveAffine, R, L> Default for Stage<C, R, L> {
+    fn default() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C: CurveAffine, R: Rank, L: Len> ragu_circuits::staging::Stage<C::Base, R> for Stage<C, R, L> {
+    type Parent = super::preamble::Stage<C, R, L>;
     type Witness<'source> = &'source Witness<C>;
     type OutputKind = Kind![C::Base; Output<'_, _, C>];
 
@@ -76,12 +83,13 @@ impl<C: CurveAffine, R: Rank> ragu_circuits::staging::Stage<C::Base, R> for Stag
 #[cfg(test)]
 mod tests {
     use ragu_pasta::EqAffine;
+    use ragu_primitives::vec::ConstLen;
 
     use super::*;
     use crate::internal::tests::{R, assert_stage_values};
 
     #[test]
     fn stage_values_matches_wire_count() {
-        assert_stage_values(&Stage::<EqAffine, R>::default());
+        assert_stage_values(&Stage::<EqAffine, R, ConstLen<4>>::default());
     }
 }

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -47,6 +47,17 @@ pub const HEADER_SIZE: usize = 105;
 // steps are present.
 const NUM_APP_STEPS: usize = 6000;
 
+fn dummy_app<'params, const HDR: usize>(
+    pasta: &'params <Pasta as ragu_arithmetic::Cycle>::Params,
+    steps: usize,
+) -> crate::Application<'params, Pasta, R, HDR> {
+    ApplicationBuilder::<Pasta, R, HDR>::new(pasta)
+        .register_dummy_circuits(steps)
+        .unwrap()
+        .finalize()
+        .unwrap()
+}
+
 type Preamble = preamble::Stage<Pasta, R, HEADER_SIZE>;
 type OuterError = outer_error::Stage<Pasta, R, HEADER_SIZE, RevdotParameters>;
 type InnerError = inner_error::Stage<Pasta, R, HEADER_SIZE, RevdotParameters>;
@@ -58,11 +69,7 @@ type Eval = eval::Stage<Pasta, R, HEADER_SIZE>;
 fn test_internal_circuit_constraint_counts() {
     let pasta = Pasta::baked();
 
-    let app = ApplicationBuilder::<Pasta, R, HEADER_SIZE>::new()
-        .register_dummy_circuits(NUM_APP_STEPS)
-        .unwrap()
-        .finalize(pasta)
-        .unwrap();
+    let app = dummy_app::<HEADER_SIZE>(pasta, NUM_APP_STEPS);
 
     macro_rules! check_constraints {
         ($variant:ident, mul = $mul:expr, lin = $lin:expr) => {{
@@ -121,11 +128,7 @@ fn print_internal_circuit_constraint_counts() {
 
     let pasta = Pasta::baked();
 
-    let app = ApplicationBuilder::<Pasta, R, HEADER_SIZE>::new()
-        .register_dummy_circuits(NUM_APP_STEPS)
-        .unwrap()
-        .finalize(pasta)
-        .unwrap();
+    let app = dummy_app::<HEADER_SIZE>(pasta, NUM_APP_STEPS);
 
     let variants = [
         ("Hashes1Circuit", InternalCircuitIndex::Hashes1Circuit),
@@ -191,11 +194,7 @@ fn print_internal_stage_parameters() {
 fn test_native_registry_digest() {
     let pasta = Pasta::baked();
 
-    let app = ApplicationBuilder::<Pasta, R, HEADER_SIZE>::new()
-        .register_dummy_circuits(NUM_APP_STEPS)
-        .unwrap()
-        .finalize(pasta)
-        .unwrap();
+    let app = dummy_app::<HEADER_SIZE>(pasta, NUM_APP_STEPS);
 
     let expected = fp!(0x31e1786b198ad8953d0ec1699a2d1c7ed26d312a7c8c67099cb5a517259e54e3);
 
@@ -215,11 +214,7 @@ fn test_native_registry_digest() {
 fn test_nested_registry_digest() {
     let pasta = Pasta::baked();
 
-    let app = ApplicationBuilder::<Pasta, R, HEADER_SIZE>::new()
-        .register_dummy_circuits(NUM_APP_STEPS)
-        .unwrap()
-        .finalize(pasta)
-        .unwrap();
+    let app = dummy_app::<HEADER_SIZE>(pasta, NUM_APP_STEPS);
 
     let expected = fq!(0x2f4bf855b80a694facbe9a2c26ee8d1dae9e15bb7b7eba54ca53f5c166e1d150);
 
@@ -241,11 +236,7 @@ fn print_registry_digests() {
 
     let pasta = Pasta::baked();
 
-    let app = ApplicationBuilder::<Pasta, R, HEADER_SIZE>::new()
-        .register_dummy_circuits(NUM_APP_STEPS)
-        .unwrap()
-        .finalize(pasta)
-        .unwrap();
+    let app = dummy_app::<HEADER_SIZE>(pasta, NUM_APP_STEPS);
 
     let native_digest = app.native_registry.digest();
     let nested_digest = app.nested_registry.digest();

--- a/crates/ragu_pcd/src/internal/tests.rs
+++ b/crates/ragu_pcd/src/internal/tests.rs
@@ -1,8 +1,5 @@
-use native::{
-    InternalCircuitIndex, InternalCircuitValues, RevdotParameters, RxIndex, RxValues,
-    stages::{eval, inner_error, outer_error, preamble, query},
-};
-use ragu_circuits::staging::{Stage, StageExt};
+use native::{InternalCircuitIndex, InternalCircuitValues, RxIndex, RxValues};
+use ragu_circuits::staging::Stage;
 use ragu_pasta::{Pasta, fp, fq};
 
 use super::*;
@@ -17,6 +14,7 @@ use ragu_core::{
     maybe::Empty,
 };
 
+/// A stage allocates exactly `Stage::values()` wires.
 pub fn assert_stage_values<F, R, S>(stage: &S)
 where
     F: PrimeField,
@@ -26,12 +24,13 @@ where
         Gadget<'dr, Emulator<Wireless<Empty, F>>>,
 {
     let mut emulator = Emulator::counter();
-    let output = stage
+    let num_wires = stage
         .witness(&mut emulator, Empty)
-        .expect("allocation should succeed");
-
+        .expect("allocation should succeed")
+        .num_wires()
+        .expect("wire counting should succeed");
     assert_eq!(
-        output.num_wires().expect("wire counting should succeed"),
+        num_wires,
         S::values(),
         "Stage::values() does not match actual wire count"
     );
@@ -47,76 +46,92 @@ pub const HEADER_SIZE: usize = 105;
 // steps are present.
 const NUM_APP_STEPS: usize = 6000;
 
-fn dummy_app<'params, const HDR: usize>(
+fn dummy_app<'params, const HDR: usize, const POLYS: usize>(
     pasta: &'params <Pasta as ragu_arithmetic::Cycle>::Params,
     steps: usize,
-) -> crate::Application<'params, Pasta, R, HDR> {
-    ApplicationBuilder::<Pasta, R, HDR>::new(pasta)
+) -> crate::Application<'params, Pasta, R, HDR, AppHooks<POLYS>> {
+    ApplicationBuilder::<Pasta, R, HDR, AppHooks<POLYS>>::new(pasta)
         .register_dummy_circuits(steps)
         .unwrap()
         .finalize()
         .unwrap()
 }
 
-type Preamble = preamble::Stage<Pasta, R, HEADER_SIZE>;
-type OuterError = outer_error::Stage<Pasta, R, HEADER_SIZE, RevdotParameters>;
-type InnerError = inner_error::Stage<Pasta, R, HEADER_SIZE, RevdotParameters>;
-type Query = query::Stage<Pasta, R, HEADER_SIZE>;
-type Eval = eval::Stage<Pasta, R, HEADER_SIZE>;
+macro_rules! check_constraints {
+    ($app:expr, $variant:ident, mul = $mul:expr, lin = $lin:expr) => {{
+        let circuit_index = InternalCircuitIndex::$variant.circuit_index();
+        let (actual_gates, actual_constraints) =
+            $app.native_registry.constraint_counts(circuit_index);
+        assert_eq!(
+            actual_gates,
+            $mul,
+            "{}: gates: expected {}, got {}",
+            stringify!($variant),
+            $mul,
+            actual_gates
+        );
+        assert_eq!(
+            actual_constraints,
+            $lin,
+            "{}: constraints: expected {}, got {}",
+            stringify!($variant),
+            $lin,
+            actual_constraints
+        );
+    }};
+}
 
 #[rustfmt::skip]
 #[test]
 fn test_internal_circuit_constraint_counts() {
     let pasta = Pasta::baked();
 
-    let app = dummy_app::<HEADER_SIZE>(pasta, NUM_APP_STEPS);
+    let app = dummy_app::<HEADER_SIZE, 0>(pasta, NUM_APP_STEPS);
 
-    macro_rules! check_constraints {
-        ($variant:ident, mul = $mul:expr, lin = $lin:expr) => {{
-            let circuit_index = InternalCircuitIndex::$variant.circuit_index();
-            let (actual_gates, actual_constraints) =
-                app.native_registry.constraint_counts(circuit_index);
-            assert_eq!(
-                actual_gates,
-                $mul,
-                "{}: gates: expected {}, got {}",
-                stringify!($variant),
-                $mul,
-                actual_gates
-            );
-            assert_eq!(
-                actual_constraints,
-                $lin,
-                "{}: constraints: expected {}, got {}",
-                stringify!($variant),
-                $lin,
-                actual_constraints
-            );
-        }};
-    }
+    check_constraints!(app, Hashes1Circuit,       mul = 1451, lin = 2068);
+    check_constraints!(app, Hashes2Circuit,       mul = 1999, lin = 2951);
+    check_constraints!(app, InnerCollapseCircuit, mul = 1876, lin = 1918);
+    check_constraints!(app, OuterCollapseCircuit, mul = 2043, lin = 3042);
+    check_constraints!(app, ComputeVCircuit,      mul = 1255, lin = 1773);
+}
 
-    check_constraints!(Hashes1Circuit,        mul = 1451, lin = 2068);
-    check_constraints!(Hashes2Circuit,        mul = 1999, lin = 2951);
-    check_constraints!(InnerCollapseCircuit,  mul = 1876, lin = 1918);
-    check_constraints!(OuterCollapseCircuit,  mul = 2043, lin = 3042);
-    check_constraints!(ComputeVCircuit,       mul = 1255, lin = 1773);
+/// The stage types `test_internal_stage_parameters` pins, at eight
+/// polynomials.
+mod pinned_chain {
+    use ragu_pasta::Pasta;
+
+    use super::{HEADER_SIZE, R};
+    use crate::{
+        AppHooks,
+        internal::native::{RevdotParameters, stages},
+    };
+
+    type J = AppHooks<8>;
+
+    pub type Preamble = stages::preamble::Stage<Pasta, R, HEADER_SIZE, J>;
+    pub type OuterError = stages::outer_error::Stage<Pasta, R, HEADER_SIZE, J, RevdotParameters>;
+    pub type InnerError = stages::inner_error::Stage<Pasta, R, HEADER_SIZE, J, RevdotParameters>;
+    pub type Query = stages::query::Stage<Pasta, R, HEADER_SIZE, J>;
+    pub type Eval = stages::eval::Stage<Pasta, R, HEADER_SIZE, J>;
 }
 
 #[rustfmt::skip]
 #[test]
 fn test_internal_stage_parameters() {
+    use ragu_circuits::staging::{Stage as _, StageExt as _};
+
     macro_rules! check_stage {
-        ($Stage:ty, skip = $skip:expr, num = $num:expr) => {{
-            assert_eq!(<$Stage>::skip_gates(), $skip, "{}: skip", stringify!($Stage));
-            assert_eq!(<$Stage as StageExt<_, _>>::num_gates(), $num, "{}: num", stringify!($Stage));
+        ($stage:ty, skip = $skip:expr, num = $num:expr) => {{
+            assert_eq!(<$stage>::skip_gates(), $skip, "{}: skip", stringify!($stage));
+            assert_eq!(<$stage>::num_gates(), $num, "{}: num", stringify!($stage));
         }};
     }
 
-    check_stage!(Preamble, skip =   1, num = 345);
-    check_stage!(OuterError,  skip = 346, num = 186);
-    check_stage!(InnerError,  skip = 532, num = 399);
-    check_stage!(Query,   skip = 346, num =  23);
-    check_stage!(Eval,    skip = 369, num =  18);
+    check_stage!(pinned_chain::Preamble,    skip =   1, num = 361);
+    check_stage!(pinned_chain::OuterError,  skip = 362, num = 186);
+    check_stage!(pinned_chain::InnerError,  skip = 548, num = 399);
+    check_stage!(pinned_chain::Query,       skip = 362, num =  23);
+    check_stage!(pinned_chain::Eval,        skip = 385, num =  26);
 }
 
 /// Helper test to print current constraint counts in copy-pasteable format.
@@ -128,7 +143,7 @@ fn print_internal_circuit_constraint_counts() {
 
     let pasta = Pasta::baked();
 
-    let app = dummy_app::<HEADER_SIZE>(pasta, NUM_APP_STEPS);
+    let app = dummy_app::<HEADER_SIZE, 0>(pasta, NUM_APP_STEPS);
 
     let variants = [
         ("Hashes1Circuit", InternalCircuitIndex::Hashes1Circuit),
@@ -149,7 +164,7 @@ fn print_internal_circuit_constraint_counts() {
         let circuit_index = variant.circuit_index();
         let (mul, lin) = app.native_registry.constraint_counts(circuit_index);
         println!(
-            "        check_constraints!({:<24} mul = {:<4}, lin = {});",
+            "    check_constraints!(app, {:<22} mul = {:>4}, lin = {:>4});",
             format!("{},", name),
             mul,
             lin
@@ -161,28 +176,25 @@ fn print_internal_circuit_constraint_counts() {
 /// Run with: `cargo test -p ragu_pcd --release print_internal_stage -- --nocapture`
 #[test]
 fn print_internal_stage_parameters() {
-    use alloc::format;
     use std::println;
 
-    macro_rules! print_stage {
-        ($Stage:ty) => {{
-            let skip = <$Stage>::skip_gates();
-            let num = <$Stage as StageExt<_, _>>::num_gates();
-            println!(
-                "        check_stage!({:<8} skip = {:>3}, num = {:>3});",
-                format!("{},", stringify!($Stage)),
-                skip,
-                num
-            );
-        }};
+    use ragu_circuits::staging::StageExt as _;
+
+    fn line<S: ragu_circuits::staging::Stage<ragu_pasta::Fp, R>>(name: &str) {
+        println!(
+            "    check_stage!(pinned_chain::{:<12} skip = {:>3}, num = {:>3});",
+            alloc::format!("{name},"),
+            S::skip_gates(),
+            S::num_gates()
+        );
     }
 
     println!("\n// Copy-paste the following into test_internal_stage_parameters:");
-    print_stage!(Preamble);
-    print_stage!(OuterError);
-    print_stage!(InnerError);
-    print_stage!(Query);
-    print_stage!(Eval);
+    line::<pinned_chain::Preamble>("Preamble");
+    line::<pinned_chain::OuterError>("OuterError");
+    line::<pinned_chain::InnerError>("InnerError");
+    line::<pinned_chain::Query>("Query");
+    line::<pinned_chain::Eval>("Eval");
 }
 
 /// Verifies the native registry digest matches the expected value.
@@ -194,7 +206,7 @@ fn print_internal_stage_parameters() {
 fn test_native_registry_digest() {
     let pasta = Pasta::baked();
 
-    let app = dummy_app::<HEADER_SIZE>(pasta, NUM_APP_STEPS);
+    let app = dummy_app::<HEADER_SIZE, 0>(pasta, NUM_APP_STEPS);
 
     let expected = fp!(0x31e1786b198ad8953d0ec1699a2d1c7ed26d312a7c8c67099cb5a517259e54e3);
 
@@ -214,7 +226,7 @@ fn test_native_registry_digest() {
 fn test_nested_registry_digest() {
     let pasta = Pasta::baked();
 
-    let app = dummy_app::<HEADER_SIZE>(pasta, NUM_APP_STEPS);
+    let app = dummy_app::<HEADER_SIZE, 0>(pasta, NUM_APP_STEPS);
 
     let expected = fq!(0x2f4bf855b80a694facbe9a2c26ee8d1dae9e15bb7b7eba54ca53f5c166e1d150);
 
@@ -236,7 +248,7 @@ fn print_registry_digests() {
 
     let pasta = Pasta::baked();
 
-    let app = dummy_app::<HEADER_SIZE>(pasta, NUM_APP_STEPS);
+    let app = dummy_app::<HEADER_SIZE, 0>(pasta, NUM_APP_STEPS);
 
     let native_digest = app.native_registry.digest();
     let nested_digest = app.nested_registry.digest();

--- a/crates/ragu_pcd/src/lib.rs
+++ b/crates/ragu_pcd/src/lib.rs
@@ -54,27 +54,21 @@ pub(crate) const RAGU_TAG: &[u8] = b"FIXME";
 pub struct ApplicationBuilder<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize> {
     native_registry: RegistryBuilder<'params, C::CircuitField, R>,
     nested_registry: RegistryBuilder<'params, C::ScalarField, R>,
+    params: &'params C::Params,
     num_application_steps: usize,
     header_map: BTreeMap<header::Suffix, TypeId>,
     _marker: PhantomData<[(); HEADER_SIZE]>,
-}
-
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Default
-    for ApplicationBuilder<'_, C, R, HEADER_SIZE>
-{
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
     ApplicationBuilder<'params, C, R, HEADER_SIZE>
 {
     /// Create an empty [`ApplicationBuilder`] for proof-carrying data.
-    pub fn new() -> Self {
+    pub fn new(params: &'params C::Params) -> Self {
         ApplicationBuilder {
             native_registry: RegistryBuilder::new(),
             nested_registry: RegistryBuilder::new(),
+            params,
             num_application_steps: 0,
             header_map: BTreeMap::new(),
             _marker: PhantomData,
@@ -127,10 +121,8 @@ impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
     ///
     /// Returns an error if internal circuit registration or registry
     /// finalization fails.
-    pub fn finalize(
-        mut self,
-        params: &'params C::Params,
-    ) -> Result<Application<'params, C, R, HEADER_SIZE>> {
+    pub fn finalize(mut self) -> Result<Application<'params, C, R, HEADER_SIZE>> {
+        let params = self.params;
         // Build the native registry:
         // 1. Application circuits (already registered)
         // 2. Internal circuits and masks

--- a/crates/ragu_pcd/src/lib.rs
+++ b/crates/ragu_pcd/src/lib.rs
@@ -9,6 +9,14 @@
 //! - [`step::Step`] — the trait that defines computation nodes (transitions).
 //! - [`header::Header`] — the trait that defines succinct state representations.
 //! - [`Proof`] / [`Pcd`] — the proof and proof-carrying-data structures.
+//!
+//! # The hook layout is declared per application
+//!
+//! How many polynomials a step may witness is a parameter of
+//! [`ApplicationBuilder`]. It is declared rather than folded from the
+//! registered steps because handing a circuit to the registry freezes its
+//! shape, which a maximum over steps would not settle until the last one
+//! arrives. One layout serves every step; steps that use less are padded up.
 
 #![no_std]
 #![allow(clippy::type_complexity, clippy::too_many_arguments)]
@@ -24,11 +32,13 @@ extern crate alloc;
 #[cfg(any(feature = "std", test))]
 extern crate std;
 
+mod framework_hooks;
 mod fuse;
 #[cfg(feature = "unstable-fuzzing")]
 pub mod fuzz_utils;
 pub mod header;
 mod internal;
+mod poly_commitment;
 mod proof;
 pub mod step;
 mod verify;
@@ -36,34 +46,68 @@ mod verify;
 use alloc::collections::BTreeMap;
 use core::{any::TypeId, cell::OnceCell, marker::PhantomData};
 
+pub use framework_hooks::{HookConfig, HookLayout};
 use header::Header;
+pub use poly_commitment::{HANDLE_WIRES, PolyHandle};
 pub use proof::{Pcd, Proof};
 use ragu_arithmetic::{CryptoRngCore, Cycle};
 use ragu_circuits::{
-    polynomials::Rank,
+    polynomials::{Rank, sparse},
     registry::{Registry, RegistryBuilder},
 };
 use ragu_core::{Error, Result};
+use ragu_primitives::vec::ConstLen;
 use step::{Step, internal::adapter::Adapter};
 
 /// Domain separation tag for Ragu PCD protocol.
 // FIXME: choose a permanent domain separation tag before release.
 pub(crate) const RAGU_TAG: &[u8] = b"FIXME";
 
+/// The usual way to write an application's [`HookLayout`]:
+///
+/// ```rust
+/// use ragu_circuits::polynomials::ProductionRank;
+/// use ragu_pasta::Pasta;
+/// use ragu_pcd::{AppHooks, Application};
+///
+/// type MyApp<'params> = Application<'params, Pasta, ProductionRank, 4, AppHooks<3>>;
+/// ```
+pub struct AppHooks<const POLYS: usize>;
+
+/// Convenience alias for an application that does not use hooks.
+pub type NoHooks = AppHooks<0>;
+
+impl<const POLYS: usize> HookConfig for AppHooks<POLYS> {
+    type PolyWitnesses = ConstLen<POLYS>;
+}
+
 /// Builder for an [`Application`] for proof-carrying data.
-pub struct ApplicationBuilder<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize> {
+///
+/// `HEADER_SIZE` is the width of one encoded header and `J` the hook layout —
+/// usually written inline as [`AppHooks`]. Together they are an application
+/// circuit's instance width: three headers plus what [`HookLayout`] prices.
+pub struct ApplicationBuilder<
+    'params,
+    C: Cycle,
+    R: Rank,
+    const HEADER_SIZE: usize,
+    J: HookConfig = NoHooks,
+> {
     native_registry: RegistryBuilder<'params, C::CircuitField, R>,
     nested_registry: RegistryBuilder<'params, C::ScalarField, R>,
     params: &'params C::Params,
     num_application_steps: usize,
     header_map: BTreeMap<header::Suffix, TypeId>,
-    _marker: PhantomData<[(); HEADER_SIZE]>,
+    _marker: PhantomData<(J, [(); HEADER_SIZE])>,
 }
 
-impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
-    ApplicationBuilder<'params, C, R, HEADER_SIZE>
+impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    ApplicationBuilder<'params, C, R, HEADER_SIZE, J>
 {
     /// Create an empty [`ApplicationBuilder`] for proof-carrying data.
+    ///
+    /// The cycle parameters are held from here on: committing a witnessed
+    /// polynomial is the framework's work, so a [`Step`] never sees them.
     pub fn new(params: &'params C::Params) -> Self {
         ApplicationBuilder {
             native_registry: RegistryBuilder::new(),
@@ -91,9 +135,11 @@ impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
         self.prevent_duplicate_suffixes::<S::Left>()?;
         self.prevent_duplicate_suffixes::<S::Right>()?;
 
+        // Building the adapter needs no cycle parameters, so registration
+        // happens here, before `finalize` supplies them.
         self.native_registry =
             self.native_registry
-                .register_circuit(Adapter::<C, S, R, HEADER_SIZE>::new(step))?;
+                .register_circuit(Adapter::<C, S, R, HEADER_SIZE, J>::new(step, self.params))?;
         self.num_application_steps += 1;
 
         Ok(self)
@@ -121,7 +167,7 @@ impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
     ///
     /// Returns an error if internal circuit registration or registry
     /// finalization fails.
-    pub fn finalize(mut self) -> Result<Application<'params, C, R, HEADER_SIZE>> {
+    pub fn finalize(mut self) -> Result<Application<'params, C, R, HEADER_SIZE, J>> {
         let params = self.params;
         // Build the native registry:
         // 1. Application circuits (already registered)
@@ -131,7 +177,7 @@ impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
             internal::native::total_circuit_counts(self.num_application_steps);
 
         // First, register internal circuits and masks
-        self.native_registry = internal::native::register_all::<C, R, HEADER_SIZE>(
+        self.native_registry = internal::native::register_all::<C, R, HEADER_SIZE, J>(
             self.native_registry,
             params,
             log2_circuits,
@@ -139,15 +185,19 @@ impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
 
         // Then, register internal steps
         self.native_registry =
-            self.native_registry
-                .register_internal_step(Adapter::<C, _, R, HEADER_SIZE>::new(
+            self.native_registry.register_internal_step(
+                Adapter::<C, _, R, HEADER_SIZE, J>::new(
                     step::internal::rerandomize::Rerandomize::<()>::new(),
-                ))?;
+                    params,
+                ),
+            )?;
         self.native_registry =
-            self.native_registry
-                .register_internal_step(Adapter::<C, _, R, HEADER_SIZE>::new(
+            self.native_registry.register_internal_step(
+                Adapter::<C, _, R, HEADER_SIZE, J>::new(
                     step::internal::trivial::Trivial::new(),
-                ))?;
+                    params,
+                ),
+            )?;
 
         assert_eq!(
             self.native_registry.log2_circuits(),
@@ -161,7 +211,8 @@ impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
         );
 
         // Register nested internal circuits (no application steps, no headers).
-        self.nested_registry = internal::nested::register_all::<C, R>(self.nested_registry)?;
+        self.nested_registry =
+            internal::nested::register_all::<C, R, J::PolyWitnesses>(self.nested_registry)?;
 
         Ok(Application {
             native_registry: self.native_registry.finalize()?,
@@ -192,17 +243,29 @@ impl<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize>
 }
 
 /// The recursion context that is used to create and verify proof-carrying data.
-pub struct Application<'params, C: Cycle, R: Rank, const HEADER_SIZE: usize> {
+pub struct Application<
+    'params,
+    C: Cycle,
+    R: Rank,
+    const HEADER_SIZE: usize,
+    J: HookConfig = NoHooks,
+> {
     native_registry: Registry<'params, C::CircuitField, R>,
     nested_registry: Registry<'params, C::ScalarField, R>,
     params: &'params C::Params,
     num_application_steps: usize,
     /// Cached seeded trivial proof for rerandomization.
     seeded_trivial: OnceCell<Proof<C, R>>,
-    _marker: PhantomData<[(); HEADER_SIZE]>,
+    _marker: PhantomData<(J, [(); HEADER_SIZE])>,
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    Application<'_, C, R, HEADER_SIZE, J>
+{
+    pub(crate) fn hook_layout(&self) -> HookLayout {
+        J::layout()
+    }
+
     /// Seed a new computation by running a step with trivial inputs.
     ///
     /// This is the entry point for creating leaf nodes in a PCD tree.
@@ -269,5 +332,18 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
     /// Returns a reference to the native [`Registry`].
     pub fn native_registry(&self) -> &Registry<'_, C::CircuitField, R> {
         &self.native_registry
+    }
+
+    /// Commits a polynomial and returns the handle
+    /// [`StepCtx::witness_polynomial`](step::StepCtx::witness_polynomial)
+    /// would produce for it.
+    ///
+    /// For callers outside the circuit — checking a carried header against a
+    /// polynomial they already have. A step is handed its handles.
+    pub fn commit_polynomial<R2: Rank>(
+        &self,
+        polynomial: &sparse::Polynomial<C::CircuitField, R2>,
+    ) -> Result<[C::CircuitField; HANDLE_WIRES]> {
+        poly_commitment::handle::<C>(polynomial.commit_to_affine(C::host_generators(self.params)))
     }
 }

--- a/crates/ragu_pcd/src/poly_commitment.rs
+++ b/crates/ragu_pcd/src/poly_commitment.rs
@@ -1,0 +1,81 @@
+//! Handles to the commitments behind witnessed polynomials.
+//!
+//! A witnessed polynomial is over [`Cycle::CircuitField`], so its commitment
+//! lands on [`Cycle::HostCurve`], whose elements are in
+//! [`Cycle::ScalarField`]. A step cannot hold one, so it gets a handle.
+
+use core::{array, marker::PhantomData};
+
+use ragu_arithmetic::{Cycle, ff::PrimeField, group::GroupEncoding};
+use ragu_circuits::polynomials::{Rank, sparse};
+use ragu_core::{
+    Error, Result,
+    drivers::{Driver, DriverValue},
+    gadgets::Gadget,
+    maybe::Maybe,
+};
+use ragu_primitives::{Element, consistent::Consistent, io::Write};
+
+/// Circuit-field elements a handle occupies.
+pub const HANDLE_WIRES: usize = 2;
+
+/// The commitment's compressed encoding, split across two circuit-field
+/// elements.
+pub(crate) fn handle<C: Cycle>(host: C::HostCurve) -> Result<[C::CircuitField; HANDLE_WIRES]> {
+    let repr = host.to_bytes();
+    let Ok(repr) = <[u8; 32]>::try_from(repr.as_ref()) else {
+        return Err(Error::InvalidWitness(
+            "only 32-byte point encodings are supported".into(),
+        ));
+    };
+    let (lo, hi) = repr.split_at(16);
+
+    let limb = |bytes: &[u8]| {
+        C::CircuitField::from_u128(u128::from_le_bytes(bytes.try_into().expect("16 bytes")))
+    };
+    Ok([limb(lo), limb(hi)])
+}
+
+/// A cross-field handle for a polynomial commitment.
+#[derive(Gadget, Write, Consistent)]
+pub struct PolyHandle<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>> {
+    #[ragu(gadget)]
+    handle: [Element<'dr, D>; HANDLE_WIRES],
+    #[ragu(phantom)]
+    _cycle: PhantomData<C>,
+}
+
+impl<'dr, D: Driver<'dr>, C: Cycle<CircuitField = D::F>> PolyHandle<'dr, D, C> {
+    pub(crate) fn new<R: Rank>(
+        dr: &mut D,
+        params: &C::Params,
+        polynomial: &DriverValue<D, sparse::Polynomial<C::CircuitField, R>>,
+    ) -> Result<(Self, DriverValue<D, C::HostCurve>)> {
+        let to_commit = polynomial.as_ref();
+        let point = D::just(move || {
+            to_commit
+                .take()
+                .commit_to_affine(C::host_generators(params))
+        });
+
+        let cast = point.as_ref();
+        let handle = D::try_just(move || handle::<C>(*cast.take()))?;
+
+        Ok((Self::alloc(dr, handle)?, point))
+    }
+
+    pub(crate) fn alloc(dr: &mut D, handle: DriverValue<D, [D::F; HANDLE_WIRES]>) -> Result<Self> {
+        Ok(Self {
+            handle: [
+                Element::alloc(dr, &mut (), handle.as_ref().map(|h| h[0]))?,
+                Element::alloc(dr, &mut (), handle.as_ref().map(|h| h[1]))?,
+            ],
+            _cycle: PhantomData,
+        })
+    }
+
+    pub(crate) fn value(&self) -> DriverValue<D, [D::F; HANDLE_WIRES]> {
+        let limbs: [_; HANDLE_WIRES] = array::from_fn(|i| self.handle[i].value());
+        D::just(move || limbs.map(|limb| *limb.take()))
+    }
+}

--- a/crates/ragu_pcd/src/proof/builder.rs
+++ b/crates/ragu_pcd/src/proof/builder.rs
@@ -522,16 +522,9 @@ impl<'params, C: Cycle, R: Rank> ProofBuilder<'params, C, R> {
     );
 
     /// Returns the derived alpha for a cached bridge, as a distinct power of
-    /// `bridge_alpha`.
+    /// `bridge_alpha` (see [`bridge_alpha_exponent`]).
     fn bridge_alpha_power(&self, idx: nested::RxIndex) -> C::ScalarField {
-        let n = match idx {
-            nested::RxIndex::BridgeOuterError => 1,
-            nested::RxIndex::BridgeAB => 2,
-            nested::RxIndex::BridgeQuery => 3,
-            nested::RxIndex::BridgeEval => 4,
-            _ => panic!("not a cached bridge: {idx:?}"),
-        };
-        self.bridge_alpha.pow_vartime([n])
+        self.bridge_alpha.pow_vartime([bridge_alpha_exponent(idx)])
     }
 
     cached_bridge!(
@@ -778,5 +771,40 @@ impl<'params, C: Cycle, R: Rank> ProofBuilder<'params, C, R> {
             child_left_stage_rx: take!(child_left_stage_rx),
             child_right_stage_rx: take!(child_right_stage_rx),
         })
+    }
+}
+
+/// The exponent of `bridge_alpha` for a blinded bridge stage; the single
+/// ordering keeps all blinds distinct. Panics on stages blinded with an
+/// in-circuit challenge (`preamble`, `s_prime`, `inner_error`, `f`).
+fn bridge_alpha_exponent(idx: nested::RxIndex) -> u64 {
+    match idx {
+        nested::RxIndex::BridgeOuterError => 1,
+        nested::RxIndex::BridgeAB => 2,
+        nested::RxIndex::BridgeQuery => 3,
+        nested::RxIndex::BridgeEval => 4,
+        _ => panic!("not blinded from bridge_alpha: {idx:?}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the `bridge_alpha` exponent series: no registry digest covers
+    /// these prover-side blinds, so a collision would otherwise be silent.
+    #[test]
+    fn bridge_alpha_exponents_are_the_expected_series() {
+        assert_eq!(bridge_alpha_exponent(nested::RxIndex::BridgeOuterError), 1);
+        assert_eq!(bridge_alpha_exponent(nested::RxIndex::BridgeAB), 2);
+        assert_eq!(bridge_alpha_exponent(nested::RxIndex::BridgeQuery), 3);
+        assert_eq!(bridge_alpha_exponent(nested::RxIndex::BridgeEval), 4);
+    }
+
+    /// Bridges blinded with an in-circuit challenge are not on this series.
+    #[test]
+    #[should_panic(expected = "not blinded from bridge_alpha")]
+    fn unblinded_bridges_are_rejected() {
+        bridge_alpha_exponent(nested::RxIndex::BridgeF);
     }
 }

--- a/crates/ragu_pcd/src/proof/builder.rs
+++ b/crates/ragu_pcd/src/proof/builder.rs
@@ -7,7 +7,7 @@
 //! native commitments already on the builder.
 
 use alloc::vec::Vec;
-use core::cell::OnceCell;
+use core::{cell::OnceCell, marker::PhantomData};
 
 use ragu_arithmetic::{Cycle, ff::Field};
 use ragu_circuits::{
@@ -16,9 +16,10 @@ use ragu_circuits::{
     staging::StageExt,
 };
 use ragu_core::Result;
+use ragu_primitives::vec::FixedVec;
 
 use super::{Cached, Proof};
-use crate::internal::nested;
+use crate::{framework_hooks::HookConfig, internal::nested};
 
 /// Produces `pub(crate) fn $name(&mut self, v: $ty)` that sets an `Option`
 /// field, panicking on double-set.
@@ -181,7 +182,7 @@ macro_rules! cached_bridge {
             if let Some(rx) = self.$rx.get() {
                 return Ok(rx);
             }
-            let rx = nested::stages::$stage::Stage::<C::HostCurve, R>::rx(
+            let rx = nested::stages::$stage::Stage::<C::HostCurve, R, J::PolyWitnesses>::rx(
                 self.bridge_alpha_power($idx),
                 &nested::stages::$stage::Witness {
                     $($wit_field: self.$getter()),*
@@ -206,7 +207,7 @@ macro_rules! cached_bridge {
 /// Native commitment caches are computed lazily from polynomials on first
 /// access. Special commitments (`a`, `b`, `p`) must be provided explicitly
 /// because they are computed via non-standard techniques.
-pub(crate) struct ProofBuilder<'params, C: Cycle, R: Rank> {
+pub(crate) struct ProofBuilder<'params, C: Cycle, R: Rank, J: HookConfig> {
     params: &'params C::Params,
 
     /// Shared alpha source for the four cached bridge commitments.
@@ -302,9 +303,20 @@ pub(crate) struct ProofBuilder<'params, C: Cycle, R: Rank> {
     // Children's stage rx (for copying circuit claims)
     child_left_stage_rx: Option<super::ChildStageRx<C::ScalarField, R>>,
     child_right_stage_rx: Option<super::ChildStageRx<C::ScalarField, R>>,
+
+    // The application's hook regions; `Option` says whether one has been set
+    // yet. A wrong-length list is just an invalid proof, so the polynomials are
+    // held plainly, as are the commitments derived from them; `pad_to_layout`
+    // is what fills them to the layout, and `Proof::has_shape` reports a
+    // mismatch where a proof is consumed.
+    witness_polys: Option<Vec<sparse::Polynomial<C::CircuitField, R>>>,
+    /// Derived from [`witness_polys`](Self::witness_polys) on first access,
+    /// like every other commitment cache here.
+    witness_poly_commitments: OnceCell<Vec<C::HostCurve>>,
+    _marker: PhantomData<J>,
 }
 
-impl<'params, C: Cycle, R: Rank> ProofBuilder<'params, C, R> {
+impl<'params, C: Cycle, R: Rank, J: HookConfig> ProofBuilder<'params, C, R, J> {
     /// Create a new empty builder with the given `bridge_alpha` source for
     /// deriving cached bridge polynomial alphas.
     pub(crate) fn new(params: &'params C::Params, bridge_alpha: C::ScalarField) -> Self {
@@ -379,6 +391,9 @@ impl<'params, C: Cycle, R: Rank> ProofBuilder<'params, C, R> {
             bridge_eval_commitment: OnceCell::new(),
             child_left_stage_rx: None,
             child_right_stage_rx: None,
+            witness_polys: None,
+            witness_poly_commitments: OnceCell::new(),
+            _marker: PhantomData,
         }
     }
 
@@ -556,8 +571,27 @@ impl<'params, C: Cycle, R: Rank> ProofBuilder<'params, C, R> {
         bridge_eval_commitment,
         nested::RxIndex::BridgeEval,
         eval,
-        { native_eval: native_eval_commitment() }
+        { native_eval: native_eval_commitment(), witness_polys: witness_poly_commitments() }
     );
+
+    /// Lazily commits every witnessed polynomial and caches the result — the
+    /// plural counterpart of [`lazy_commitment!`]. The cache is a plain list,
+    /// as `Proof` takes it; the declared length is restored here, for the one
+    /// stage witness that wants it.
+    pub(crate) fn witness_poly_commitments(&self) -> FixedVec<C::HostCurve, J::PolyWitnesses> {
+        let commitments = self.witness_poly_commitments.get_or_init(|| {
+            let host_gen = C::host_generators(self.params);
+            let polys = self
+                .witness_polys
+                .as_ref()
+                .expect("witness_polys not set before deriving their commitments");
+            polys
+                .iter()
+                .map(|poly| poly.commit_to_affine(host_gen))
+                .collect()
+        });
+        FixedVec::from_fn(|index| commitments[index])
+    }
 
     setter!(
         set_nested_endoscaling_step_rxs,
@@ -617,6 +651,12 @@ impl<'params, C: Cycle, R: Rank> ProofBuilder<'params, C, R> {
         super::ChildStageRx<C::ScalarField, R>
     );
 
+    setter!(
+        set_application_polys,
+        witness_polys,
+        Vec<sparse::Polynomial<C::CircuitField, R>>
+    );
+
     getter!(w, w, C::CircuitField);
     getter!(y, y, C::CircuitField);
     getter!(z, z, C::CircuitField);
@@ -668,6 +708,7 @@ impl<'params, C: Cycle, R: Rank> ProofBuilder<'params, C, R> {
         self.nested_endoscaling_step_commitments();
         self.nested_endoscalar_commitment();
         self.nested_points_commitment();
+        self.witness_poly_commitments();
 
         macro_rules! take {
             ($field:ident) => {
@@ -767,9 +808,21 @@ impl<'params, C: Cycle, R: Rank> ProofBuilder<'params, C, R> {
             native_inner_collapse_commitment: cached!(native_inner_collapse_commitment),
             native_outer_collapse_commitment: cached!(native_outer_collapse_commitment),
             native_compute_v_commitment: cached!(native_compute_v_commitment),
+            witness_poly_commitments: self
+                .witness_poly_commitments
+                .take()
+                .expect("witness_poly_commitments not set")
+                .into_iter()
+                .map(Cached)
+                .collect(),
 
             child_left_stage_rx: take!(child_left_stage_rx),
             child_right_stage_rx: take!(child_right_stage_rx),
+
+            // `Proof` is not parameterized by `J`, so the fixed-length lists
+            // become plain ones here; `Proof::has_shape` is where their length
+            // is checked again, at the boundaries that consume a proof.
+            witness_polys: take!(witness_polys).into_iter().collect(),
         })
     }
 }

--- a/crates/ragu_pcd/src/proof/mod.rs
+++ b/crates/ragu_pcd/src/proof/mod.rs
@@ -14,7 +14,7 @@ pub(crate) mod builder;
 use alloc::{vec, vec::Vec};
 
 pub(crate) use builder::ProofBuilder;
-use ragu_arithmetic::{Cycle, ff::Field};
+use ragu_arithmetic::{Cycle, FixedGenerators as _, ff::Field};
 use ragu_circuits::{
     CircuitExt,
     polynomials::{Rank, sparse},
@@ -22,18 +22,22 @@ use ragu_circuits::{
     staging::{MultiStage, StageExt},
 };
 use ragu_core::Result;
-use ragu_primitives::{extract_endoscalar, vec::Len};
+use ragu_primitives::{
+    extract_endoscalar,
+    vec::{FixedVec, Len},
+};
 
 use crate::{
+    framework_hooks::{HookConfig, HookLayout},
     header::Header,
     internal::{
         endoscalar::{
-            EndoscalarStage, EndoscalingStep, EndoscalingStepWitness, NumStepsLen, PointsStage,
-            PointsWitness,
+            EndoscalarStage, EndoscalingStep, EndoscalingStepWitness, PointsStage, PointsWitness,
+            num_steps,
         },
         native::{RxComponent, RxIndex},
         nested,
-        nested::{ChildBridgeKind, NUM_ENDOSCALING_POINTS},
+        nested::{ChildBridgeKind, EndoscalingPoints, num_endoscaling_points},
     },
 };
 
@@ -226,6 +230,11 @@ pub struct Proof<C: Cycle, R: Rank> {
     // Children's stage rx polynomials (for copying circuit claims)
     pub(crate) child_left_stage_rx: ChildStageRx<C::ScalarField, R>,
     pub(crate) child_right_stage_rx: ChildStageRx<C::ScalarField, R>,
+
+    /// The step's witnessed polynomials, carried for one fuse level.
+    witness_polys: Vec<sparse::Polynomial<C::CircuitField, R>>,
+    /// [`witness_polys`](Self::witness_polys)' commitments, in the same order.
+    witness_poly_commitments: Vec<Cached<C::HostCurve>>,
 }
 
 impl<C: Cycle, R: Rank> core::ops::Index<RxIndex> for Proof<C, R> {
@@ -314,6 +323,28 @@ impl<C: Cycle, R: Rank> Proof<C, R> {
 
     pub(crate) fn right_header(&self) -> &[C::CircuitField] {
         &self.right_header
+    }
+
+    /// Whether the hook lists are the ones `layout` declares. `Proof` is not
+    /// parameterized by the hook configuration, so this invariant is checked
+    /// where a proof is *consumed* — at the fuse and at the root.
+    pub(crate) fn has_shape(&self, layout: &HookLayout) -> bool {
+        self.witness_polys.len() == layout.witness_polys
+    }
+
+    pub(crate) fn witness_polys(&self) -> &[sparse::Polynomial<C::CircuitField, R>] {
+        &self.witness_polys
+    }
+
+    /// [`witness_polys`](Self::witness_polys)' commitments, in the same order.
+    pub(crate) fn witness_poly_commitments(
+        &self,
+    ) -> impl ExactSizeIterator<Item = C::HostCurve> + '_ {
+        self.witness_poly_commitments.iter().map(|cached| cached.0)
+    }
+
+    pub(crate) fn witness_poly_commitment(&self, index: usize) -> C::HostCurve {
+        self.witness_poly_commitments[index].0
     }
 
     pub(crate) fn native_registry_xy_poly(&self) -> &sparse::Polynomial<C::CircuitField, R> {
@@ -448,7 +479,9 @@ impl<C: Cycle, R: Rank> Proof<C, R> {
     }
 }
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    crate::Application<'_, C, R, HEADER_SIZE, J>
+{
     /// Runs endoscaling over the host-curve commitments that feed
     /// `PointsStage`, in the order `compute_p` (`_10_p.rs`)
     /// accumulates them. Writes `nested_endoscalar_rx`,
@@ -466,24 +499,25 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
         points: &[C::HostCurve],
         endoscalar_alpha: C::ScalarField,
         points_alpha: C::ScalarField,
-        builder: &mut ProofBuilder<'_, C, R>,
+        builder: &mut ProofBuilder<'_, C, R, J>,
     ) -> Result<C::HostCurve> {
-        assert_eq!(points.len(), NUM_ENDOSCALING_POINTS);
-
-        let witness = PointsWitness::<C::HostCurve, NUM_ENDOSCALING_POINTS>::new(beta_endo, points);
+        let witness = PointsWitness::<C::HostCurve, EndoscalingPoints<J::PolyWitnesses>>::new(
+            beta_endo, points,
+        );
 
         let endoscalar_rx =
             <EndoscalarStage as StageExt<C::ScalarField, R>>::rx(endoscalar_alpha, beta_endo)?;
-        let points_rx = <PointsStage<C::HostCurve, NUM_ENDOSCALING_POINTS> as StageExt<
-            C::ScalarField,
-            R,
-        >>::rx(points_alpha, &witness)?;
+        let points_rx =
+            <PointsStage<C::HostCurve, EndoscalingPoints<J::PolyWitnesses>> as StageExt<
+                C::ScalarField,
+                R,
+            >>::rx(points_alpha, &witness)?;
 
-        let num_steps = NumStepsLen::<NUM_ENDOSCALING_POINTS>::len();
+        let num_steps = num_steps(points.len());
         let mut step_rxs = Vec::with_capacity(num_steps);
         for step in 0..num_steps {
             let step_circuit =
-                EndoscalingStep::<C::HostCurve, R, NUM_ENDOSCALING_POINTS>::new(step);
+                EndoscalingStep::<C::HostCurve, R, EndoscalingPoints<J::PolyWitnesses>>::new(step);
             let staged = MultiStage::new(step_circuit);
             let step_trace = staged
                 .trace(EndoscalingStepWitness {
@@ -493,7 +527,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
                 .into_output();
             let step_rx = self.nested_registry.assemble(
                 &step_trace,
-                nested::InternalCircuitIndex::EndoscalingStep(step as u32).circuit_index(),
+                nested::InternalCircuitIndex::EndoscalingStep(step as u32)
+                    .circuit_index(self.hook_layout().witness_polys),
                 rng,
             )?;
             step_rxs.push(step_rx);
@@ -506,7 +541,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
         Ok(*witness
             .interstitials
             .last()
-            .expect("NUM_ENDOSCALING_POINTS guarantees at least one interstitial"))
+            .expect("the point list guarantees at least one interstitial"))
     }
 
     pub(crate) fn trivial_pcd(&self) -> Pcd<C, R, ()> {
@@ -534,6 +569,17 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
         builder.set_circuit_id(CircuitIndex::new(0));
         builder.set_left_header(vec![C::CircuitField::ZERO; HEADER_SIZE]);
         builder.set_right_header(vec![C::CircuitField::ZERO; HEADER_SIZE]);
+
+        // A trivial proof witnesses nothing itself: every position holds the
+        // application's padding polynomial.
+        // The padding polynomial is the constant 1, so its commitment is g[0]
+        // — which is what the builder derives for every padded polynomial.
+        let padding_com = C::host_generators(self.params).g()[0];
+        builder.set_application_polys(
+            J::PolyWitnesses::range()
+                .map(|_| sparse::Polynomial::from_coeffs(vec![C::CircuitField::ONE]))
+                .collect(),
+        );
 
         // Native rx polynomials (all trivial ones)
         builder.set_native_application_rx(ones_host.clone());
@@ -563,7 +609,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
         // p_commitment for ChildWitness.p), then native_p_poly.
         let nested_gen = C::nested_generators(self.params);
         {
-            let rx = nested::stages::s_prime::Stage::<C::HostCurve, R>::rx(
+            let rx = nested::stages::s_prime::Stage::<C::HostCurve, R, J::PolyWitnesses>::rx(
                 C::ScalarField::ONE,
                 &nested::stages::s_prime::Witness {
                     registry_wx0: host_commitment,
@@ -576,7 +622,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
             builder.set_bridge_s_prime_rx(rx, commitment);
         }
         {
-            let rx = nested::stages::inner_error::Stage::<C::HostCurve, R>::rx(
+            let rx = nested::stages::inner_error::Stage::<C::HostCurve, R, J::PolyWitnesses>::rx(
                 C::ScalarField::ONE,
                 &nested::stages::inner_error::Witness {
                     native_inner_error: host_commitment,
@@ -588,7 +634,7 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
             builder.set_bridge_inner_error_rx(rx, commitment);
         }
         {
-            let rx = nested::stages::f::Stage::<C::HostCurve, R>::rx(
+            let rx = nested::stages::f::Stage::<C::HostCurve, R, J::PolyWitnesses>::rx(
                 C::ScalarField::ONE,
                 &nested::stages::f::Witness {
                     native_f: host_commitment,
@@ -604,7 +650,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
         // cannot silently drift from the real prover path.
         let beta_endo = extract_endoscalar(C::CircuitField::ONE);
         let p_commitment = {
-            let mut points = Vec::with_capacity(NUM_ENDOSCALING_POINTS);
+            let mut points =
+                Vec::with_capacity(num_endoscaling_points(self.hook_layout().witness_polys));
 
             // Initial: native_f commitment.
             points.push(host_commitment);
@@ -622,6 +669,9 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
                 points.push(host_commitment); // AbB
                 points.push(registry_xy_commitment); // RegistryXY
                 points.push(host_commitment); // P placeholder
+                for _ in 0..self.hook_layout().witness_polys {
+                    points.push(padding_com); // witnessed polynomials
+                }
             }
 
             // Current-step bridge inputs.
@@ -667,14 +717,16 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> crate::Application<'_, C, R, H
                 stashed_ab_b: host_commitment,
                 stashed_registry_xy: registry_xy_commitment,
                 stashed_p: p_commitment,
+                stashed_witness_polys: FixedVec::from_fn(|_| padding_com),
             };
-            let rx = nested::stages::preamble::Stage::<C::HostCurve, R>::rx(
+            let witness = nested::stages::preamble::Witness {
+                native_preamble: host_commitment,
+                left: trivial_child_witness.clone(),
+                right: trivial_child_witness,
+            };
+            let rx = nested::stages::preamble::Stage::<C::HostCurve, R, J::PolyWitnesses>::rx(
                 C::ScalarField::ONE,
-                &nested::stages::preamble::Witness {
-                    native_preamble: host_commitment,
-                    left: trivial_child_witness.clone(),
-                    right: trivial_child_witness,
-                },
+                &witness,
             )
             .expect("trivial preamble rx");
             let commitment = rx.commit_to_affine(nested_gen);

--- a/crates/ragu_pcd/src/step/ctx.rs
+++ b/crates/ragu_pcd/src/step/ctx.rs
@@ -1,0 +1,32 @@
+//! The context object threaded through [`Step::witness`](super::Step::witness).
+
+use core::marker::PhantomData;
+
+use ragu_arithmetic::Cycle;
+use ragu_core::drivers::Driver;
+
+/// Framework-side state threaded through
+/// [`Step::witness`](super::Step::witness): so far only the [`Driver`], so a
+/// sub-component called from a step body takes a single `&mut StepCtx`.
+pub struct StepCtx<'a, 'dr, D, C>
+where
+    D: Driver<'dr>,
+    C: Cycle<CircuitField = D::F>,
+{
+    /// The underlying driver, for allocation and constraint emission.
+    pub dr: &'a mut D,
+    _marker: PhantomData<(&'dr (), C)>,
+}
+
+impl<'a, 'dr, D, C> StepCtx<'a, 'dr, D, C>
+where
+    D: Driver<'dr>,
+    C: Cycle<CircuitField = D::F>,
+{
+    pub(crate) fn new(dr: &'a mut D) -> Self {
+        Self {
+            dr,
+            _marker: PhantomData,
+        }
+    }
+}

--- a/crates/ragu_pcd/src/step/ctx.rs
+++ b/crates/ragu_pcd/src/step/ctx.rs
@@ -1,13 +1,18 @@
 //! The context object threaded through [`Step::witness`](super::Step::witness).
 
-use core::marker::PhantomData;
-
 use ragu_arithmetic::Cycle;
-use ragu_core::drivers::Driver;
+use ragu_circuits::polynomials::{Rank, sparse};
+use ragu_core::{
+    Result,
+    drivers::{Driver, DriverValue},
+};
+
+use crate::{framework_hooks::FrameworkHooks, poly_commitment::PolyHandle};
 
 /// Framework-side state threaded through
-/// [`Step::witness`](super::Step::witness): so far only the [`Driver`], so a
-/// sub-component called from a step body takes a single `&mut StepCtx`.
+/// [`Step::witness`](super::Step::witness): the [`Driver`] and the hooks
+/// bundled together, so a sub-component called from a step body takes a single
+/// `&mut StepCtx`.
 pub struct StepCtx<'a, 'dr, D, C>
 where
     D: Driver<'dr>,
@@ -15,7 +20,7 @@ where
 {
     /// The underlying driver, for allocation and constraint emission.
     pub dr: &'a mut D,
-    _marker: PhantomData<(&'dr (), C)>,
+    hooks: &'a mut FrameworkHooks<'dr, D, C>,
 }
 
 impl<'a, 'dr, D, C> StepCtx<'a, 'dr, D, C>
@@ -23,10 +28,39 @@ where
     D: Driver<'dr>,
     C: Cycle<CircuitField = D::F>,
 {
-    pub(crate) fn new(dr: &'a mut D) -> Self {
-        Self {
-            dr,
-            _marker: PhantomData,
-        }
+    pub(crate) fn new(dr: &'a mut D, hooks: &'a mut FrameworkHooks<'dr, D, C>) -> Self {
+        Self { dr, hooks }
+    }
+
+    /// Witnesses one polynomial and returns its [`PolyHandle`] — the instance
+    /// wires the step can open, absorb, or carry in a header.
+    ///
+    /// The framework commits it; the commitment is a host-curve point the
+    /// native circuit cannot hold, so a step never handles one. The
+    /// polynomial's own rank need not be the application's.
+    ///
+    /// No commitment is refused for its value; a step that witnesses more
+    /// polynomials than its layout allows is refused when the instance is
+    /// assembled, not here.
+    pub fn witness_polynomial<R: Rank>(
+        &mut self,
+        polynomial: DriverValue<D, sparse::Polynomial<C::CircuitField, R>>,
+    ) -> Result<PolyHandle<'dr, D, C>> {
+        self.hooks.witness_polynomial(self.dr, polynomial)
+    }
+
+    /// Evaluates the polynomial behind `handle` at `x`, as a prover-only
+    /// value. It synthesizes nothing and proves nothing.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidWitness`](ragu_core::Error::InvalidWitness) if
+    /// `handle` is not one this step witnessed.
+    pub fn evaluate(
+        &mut self,
+        handle: &PolyHandle<'dr, D, C>,
+        x: DriverValue<D, C::CircuitField>,
+    ) -> Result<DriverValue<D, C::CircuitField>> {
+        self.hooks.evaluate(handle, x)
     }
 }

--- a/crates/ragu_pcd/src/step/ctx.rs
+++ b/crates/ragu_pcd/src/step/ctx.rs
@@ -36,8 +36,12 @@ where
     /// wires the step can open, absorb, or carry in a header.
     ///
     /// The framework commits it; the commitment is a host-curve point the
-    /// native circuit cannot hold, so a step never handles one. The
-    /// polynomial's own rank need not be the application's.
+    /// native circuit cannot hold, so a step never handles one.
+    ///
+    /// The polynomial's own rank may be smaller than the application's: the
+    /// coefficients are re-wrapped at the application's rank, and the commitment
+    /// survives because both place coefficient $i$ against generator $i$. A
+    /// larger rank panics during proving.
     ///
     /// No commitment is refused for its value; a step that witnesses more
     /// polynomials than its layout allows is refused when the instance is

--- a/crates/ragu_pcd/src/step/internal/adapter.rs
+++ b/crates/ragu_pcd/src/step/internal/adapter.rs
@@ -14,7 +14,7 @@ use ragu_primitives::{
     vec::{CollectFixed, ConstLen, FixedVec, Len},
 };
 
-use super::super::Step;
+use super::super::{Step, StepCtx};
 use crate::Header;
 
 /// Represents triple a length determined at compile time.
@@ -81,9 +81,11 @@ impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Circuit<C::Circuit
     {
         let (left, right, witness) = witness.cast();
 
-        let ((left, right, output), output_data, step_aux) = self
-            .step
-            .witness::<_, HEADER_SIZE>(dr, witness, left, right)?;
+        let ((left, right, output), output_data, step_aux) = {
+            let mut ctx = StepCtx::<'_, '_, _, C>::new(dr);
+            self.step
+                .witness::<_, HEADER_SIZE>(&mut ctx, witness, left, right)?
+        };
 
         let mut elements = Vec::with_capacity(HEADER_SIZE * 3);
         left.write(dr, &mut elements)?;
@@ -160,7 +162,7 @@ mod tests {
 
         fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HS: usize>(
             &self,
-            dr: &mut D,
+            ctx: &mut StepCtx<'_, 'dr, D, Pasta>,
             _: DriverValue<D, ()>,
             left: DriverValue<D, Fp>,
             right: DriverValue<D, Fp>,
@@ -173,6 +175,7 @@ mod tests {
             DriverValue<D, Fp>,
             DriverValue<D, ()>,
         )> {
+            let dr = &mut *ctx.dr;
             let allocator = &mut Standard::new();
             // Allocate elements for left and right
             let left_elem = Element::alloc(dr, allocator, left)?;

--- a/crates/ragu_pcd/src/step/internal/adapter.rs
+++ b/crates/ragu_pcd/src/step/internal/adapter.rs
@@ -10,38 +10,59 @@ use ragu_core::{
     maybe::Maybe,
 };
 use ragu_primitives::{
-    Element,
+    Element, GadgetExt,
     vec::{CollectFixed, ConstLen, FixedVec, Len},
 };
 
 use super::super::{Step, StepCtx};
-use crate::Header;
+use crate::{
+    Header,
+    framework_hooks::{FrameworkAux, FrameworkHooks, HookConfig},
+};
 
-/// Represents triple a length determined at compile time.
-pub struct TripleConstLen<const N: usize>;
+/// Three headers plus the hooks' instance regions.
+pub struct AdapterLen<const HEADER_SIZE: usize, J: HookConfig>(PhantomData<J>);
 
-impl<const N: usize> Len for TripleConstLen<N> {
+impl<const HEADER_SIZE: usize, J: HookConfig> Len for AdapterLen<HEADER_SIZE, J> {
     fn len() -> usize {
-        N * 3
+        HEADER_SIZE * 3 + J::layout().poly_query_instance_len()
     }
 }
 
-pub(crate) struct Adapter<C, S, R, const HEADER_SIZE: usize> {
-    step: S,
-    _marker: PhantomData<(C, R)>,
+/// Auxiliary data produced by [`Adapter::witness`]: the input headers, the
+/// output data, the inner step's own aux, and the framework hooks' outputs.
+pub(crate) struct AdapterAux<'source, C: Cycle, S: Step<C>, const HEADER_SIZE: usize> {
+    pub left_header: FixedVec<C::CircuitField, ConstLen<HEADER_SIZE>>,
+    pub right_header: FixedVec<C::CircuitField, ConstLen<HEADER_SIZE>>,
+    pub output_data: <S::Output as Header<C::CircuitField>>::Data,
+    pub step_aux: S::Aux<'source>,
+    /// Every framework hook's output; see [`FrameworkAux`].
+    pub framework: FrameworkAux<C>,
 }
 
-impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Adapter<C, S, R, HEADER_SIZE> {
-    pub fn new(step: S) -> Self {
+pub(crate) struct Adapter<'params, C: Cycle, S, R: Rank, const HEADER_SIZE: usize, J: HookConfig> {
+    step: S,
+    /// Held for the hooks; a [`Step`] never sees these.
+    params: &'params C::Params,
+    _marker: PhantomData<(C, R, J)>,
+}
+
+impl<'params, C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    Adapter<'params, C, S, R, HEADER_SIZE, J>
+{
+    /// Wraps `step`; the layout comes from `J`. A step that asks for more than
+    /// it allows overruns [`AdapterLen`], which is what refuses it.
+    pub fn new(step: S, params: &'params C::Params) -> Self {
         Adapter {
             step,
+            params,
             _marker: PhantomData,
         }
     }
 }
 
-impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Circuit<C::CircuitField>
-    for Adapter<C, S, R, HEADER_SIZE>
+impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    Circuit<C::CircuitField> for Adapter<'_, C, S, R, HEADER_SIZE, J>
 {
     type Instance<'source> = (
         FixedVec<C::CircuitField, ConstLen<HEADER_SIZE>>,
@@ -53,15 +74,14 @@ impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Circuit<C::Circuit
         <S::Right as Header<C::CircuitField>>::Data,
         S::Witness<'source>,
     );
-    type Output = Kind![C::CircuitField; FixedVec<Element<'_, _>, TripleConstLen<HEADER_SIZE>>];
-    type Aux<'source> = (
-        (
-            FixedVec<C::CircuitField, ConstLen<HEADER_SIZE>>,
-            FixedVec<C::CircuitField, ConstLen<HEADER_SIZE>>,
-        ),
-        <S::Output as Header<C::CircuitField>>::Data,
-        S::Aux<'source>,
-    );
+    type Output = Kind![
+        C::CircuitField;
+        FixedVec<
+            Element<'_, _>,
+            AdapterLen<HEADER_SIZE, J>,
+        >
+    ];
+    type Aux<'source> = AdapterAux<'source, C, S, HEADER_SIZE>;
 
     fn instance<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>>(
         &self,
@@ -81,16 +101,27 @@ impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Circuit<C::Circuit
     {
         let (left, right, witness) = witness.cast();
 
+        let mut hooks = FrameworkHooks::new(J::layout(), self.params);
         let ((left, right, output), output_data, step_aux) = {
-            let mut ctx = StepCtx::<'_, '_, _, C>::new(dr);
+            let mut ctx = StepCtx::<'_, '_, _, C>::new(dr, &mut hooks);
             self.step
                 .witness::<_, HEADER_SIZE>(&mut ctx, witness, left, right)?
         };
+        // Fill what the body left over, through the same hooks it used.
+        hooks.pad_to_layout::<R>(dr)?;
 
-        let mut elements = Vec::with_capacity(HEADER_SIZE * 3);
+        let mut elements = Vec::with_capacity(AdapterLen::<HEADER_SIZE, J>::len());
         left.write(dr, &mut elements)?;
         right.write(dr, &mut elements)?;
         output.write(dr, &mut elements)?;
+        // Same types `ProofInputs::application_ky` folds into k(Y), so neither
+        // side spells the order out.
+        for poly in hooks.witnessed_polys() {
+            poly.write(dr, &mut elements)?;
+        }
+
+        // Read every hook's wires back out as values for the fuse.
+        let framework = hooks.into_values()?;
 
         let adapter_aux = D::try_just(|| {
             let left_header = elements[0..HEADER_SIZE]
@@ -103,11 +134,13 @@ impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Circuit<C::Circuit
                 .map(|e| *e.value().take())
                 .collect_fixed()?;
 
-            Ok((
-                (left_header, right_header),
-                output_data.take(),
-                step_aux.take(),
-            ))
+            Ok(AdapterAux {
+                left_header,
+                right_header,
+                output_data: output_data.take(),
+                step_aux: step_aux.take(),
+                framework: framework.take(),
+            })
         })?;
 
         Ok(WithAux::new(FixedVec::try_from(elements)?, adapter_aux))
@@ -116,7 +149,7 @@ impl<C: Cycle, S: Step<C>, R: Rank, const HEADER_SIZE: usize> Circuit<C::Circuit
 
 #[cfg(test)]
 mod tests {
-    use ragu_circuits::polynomials::TestRank;
+    use ragu_circuits::Circuit;
     use ragu_core::{
         drivers::emulator::Emulator,
         gadgets::{Bound, Kind},
@@ -127,11 +160,14 @@ mod tests {
 
     use super::*;
     use crate::{
+        NoHooks,
         header::{Header, Suffix},
         step::{Encoded, Index, Step},
     };
 
-    type TestR = TestRank;
+    // The per-polynomial bridge stages need a rank fitting
+    // `skip_gates + num_gates` (~177); `TestRank` (n = 32) is too small.
+    type TestR = ragu_circuits::polynomials::ProductionRank;
     const HEADER_SIZE: usize = 4;
 
     struct TestHeader;
@@ -194,35 +230,12 @@ mod tests {
     }
 
     #[test]
-    fn triple_const_len_returns_3n() {
-        assert_eq!(TripleConstLen::<1>::len(), 3);
-        assert_eq!(TripleConstLen::<4>::len(), 12);
-        assert_eq!(TripleConstLen::<10>::len(), 30);
-    }
-
-    #[test]
-    fn adapter_witness_produces_correct_output_size() {
-        let mut dr = Emulator::execute();
-        let dr = &mut dr;
-
-        let adapter = Adapter::<Pasta, TestStep, TestR, HEADER_SIZE>::new(TestStep);
-        let witness = Always::maybe_just(|| (Fp::from(10u64), Fp::from(20u64), ()));
-
-        let output = adapter
-            .witness(dr, witness)
-            .expect("witness should succeed")
-            .into_output();
-
-        // Output should have 3 * HEADER_SIZE elements (left + right + output headers)
-        assert_eq!(output.len(), HEADER_SIZE * 3);
-    }
-
-    #[test]
     fn adapter_witness_extracts_aux_correctly() {
         let mut dr = Emulator::execute();
         let dr = &mut dr;
 
-        let adapter = Adapter::<Pasta, TestStep, TestR, HEADER_SIZE>::new(TestStep);
+        let adapter =
+            Adapter::<Pasta, TestStep, TestR, HEADER_SIZE, NoHooks>::new(TestStep, Pasta::baked());
         let witness = Always::maybe_just(|| (Fp::from(10u64), Fp::from(20u64), ()));
 
         let aux = adapter
@@ -230,7 +243,13 @@ mod tests {
             .expect("witness should succeed")
             .into_aux();
 
-        let ((left_header, right_header), output_data, _step_aux) = aux.take();
+        let AdapterAux {
+            left_header,
+            right_header,
+            output_data,
+            step_aux: _,
+            framework: _,
+        } = aux.take();
 
         // Left header should start with 10
         assert_eq!(left_header[0], Fp::from(10u64));

--- a/crates/ragu_pcd/src/step/internal/rerandomize.rs
+++ b/crates/ragu_pcd/src/step/internal/rerandomize.rs
@@ -15,7 +15,7 @@ use ragu_core::{
 };
 use ragu_primitives::allocator::Standard;
 
-use super::super::{Encoded, Index, Step};
+use super::super::{Encoded, Index, Step, StepCtx};
 use crate::Header;
 pub(crate) use crate::step::InternalStepIndex::Rerandomize as INTERNAL_ID;
 
@@ -43,7 +43,7 @@ impl<C: Cycle, H: Header<C::CircuitField>> Step<C> for Rerandomize<H> {
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
         &self,
-        dr: &mut D,
+        ctx: &mut StepCtx<'_, 'dr, D, C>,
         _: DriverValue<D, Self::Witness<'source>>,
         left: DriverValue<D, H::Data>,
         right: DriverValue<D, ()>,
@@ -58,9 +58,9 @@ impl<C: Cycle, H: Header<C::CircuitField>> Step<C> for Rerandomize<H> {
     )> {
         let allocator = &mut Standard::new();
         // Use uniform encoding for left to ensure circuit uniformity across header types
-        let left_encoded = Encoded::new_uniform(dr, allocator, left.clone())?;
+        let left_encoded = Encoded::new_uniform(ctx.dr, allocator, left.clone())?;
         // Use standard encoding for right (trivial header)
-        let right = Encoded::new(dr, allocator, right)?;
+        let right = Encoded::new(ctx.dr, allocator, right)?;
 
         // TODO(ebfull): It's possible that the witness for this step needs to
         // be populated with some random data, for actual re-randomization

--- a/crates/ragu_pcd/src/step/internal/rerandomize.rs
+++ b/crates/ragu_pcd/src/step/internal/rerandomize.rs
@@ -89,10 +89,14 @@ fn test_rerandomize_consistency() {
     use ragu_primitives::{Element, allocator::Allocator};
     use ragu_testing::registry::TestRegistryBuilder;
 
-    use crate::header::{Header, Suffix};
+    use crate::{
+        NoHooks,
+        header::{Header, Suffix},
+    };
 
     const HEADER_SIZE: usize = 4;
-    type R = polynomials::TestRank;
+    // `TestRank` (n = 32) is too small for the per-polynomial bridge stages.
+    type R = polynomials::ProductionRank;
 
     struct Single;
     impl Header<Fp> for Single {
@@ -126,12 +130,16 @@ fn test_rerandomize_consistency() {
         }
     }
 
-    let circuit_single = super::adapter::Adapter::<Pasta, Rerandomize<Single>, R, HEADER_SIZE>::new(
-        Rerandomize::new(),
-    );
-    let circuit_pair = super::adapter::Adapter::<Pasta, Rerandomize<Pair>, R, HEADER_SIZE>::new(
-        Rerandomize::new(),
-    );
+    let circuit_single =
+        super::adapter::Adapter::<Pasta, Rerandomize<Single>, R, HEADER_SIZE, NoHooks>::new(
+            Rerandomize::new(),
+            Pasta::baked(),
+        );
+    let circuit_pair =
+        super::adapter::Adapter::<Pasta, Rerandomize<Pair>, R, HEADER_SIZE, NoHooks>::new(
+            Rerandomize::new(),
+            Pasta::baked(),
+        );
 
     let mut builder: TestRegistryBuilder<'_, _, R> = TestRegistryBuilder::new();
     let single_h = builder.register_circuit(circuit_single).unwrap();

--- a/crates/ragu_pcd/src/step/internal/trivial.rs
+++ b/crates/ragu_pcd/src/step/internal/trivial.rs
@@ -10,7 +10,7 @@ use ragu_core::{
 };
 use ragu_primitives::allocator::Standard;
 
-use super::super::{Encoded, Index, Step};
+use super::super::{Encoded, Index, Step, StepCtx};
 use crate::Header;
 pub(crate) use crate::step::InternalStepIndex::Trivial as INTERNAL_ID;
 
@@ -34,7 +34,7 @@ impl<C: Cycle> Step<C> for Trivial {
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
         &self,
-        dr: &mut D,
+        ctx: &mut StepCtx<'_, 'dr, D, C>,
         _: DriverValue<D, Self::Witness<'source>>,
         left: DriverValue<D, ()>,
         right: DriverValue<D, ()>,
@@ -48,8 +48,8 @@ impl<C: Cycle> Step<C> for Trivial {
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let allocator = &mut Standard::new();
-        let left = Encoded::new(dr, allocator, left)?;
-        let right = Encoded::new(dr, allocator, right)?;
+        let left = Encoded::new(ctx.dr, allocator, left)?;
+        let right = Encoded::new(ctx.dr, allocator, right)?;
         let output = Encoded::from_gadget(());
 
         Ok(((left, right, output), D::unit(), D::unit()))

--- a/crates/ragu_pcd/src/step/mod.rs
+++ b/crates/ragu_pcd/src/step/mod.rs
@@ -1,8 +1,10 @@
 //! Merging operations defined for the proof-carrying data computational graph.
 
+mod ctx;
 mod encoder;
 pub(crate) mod internal;
 
+pub use ctx::StepCtx;
 pub use encoder::Encoded;
 use ragu_arithmetic::Cycle;
 use ragu_circuits::registry::CircuitIndex;
@@ -171,9 +173,12 @@ pub trait Step<C: Cycle>: Sized + Send + Sync {
     ///
     /// Returns the encoded headers (left, right, output), the data to be
     /// carried in the resulting PCD, and any auxiliary witness data.
+    ///
+    /// `ctx` bundles the underlying [`Driver`] with the framework hooks;
+    /// hook-free steps just use `ctx.dr`.
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
         &self,
-        dr: &mut D,
+        ctx: &mut StepCtx<'_, 'dr, D, C>,
         witness: DriverValue<D, Self::Witness<'source>>,
         left: DriverValue<D, <Self::Left as Header<C::CircuitField>>::Data>,
         right: DriverValue<D, <Self::Right as Header<C::CircuitField>>::Data>,

--- a/crates/ragu_pcd/src/verify.rs
+++ b/crates/ragu_pcd/src/verify.rs
@@ -252,8 +252,8 @@ mod tests {
 
     fn create_test_app() -> crate::Application<'static, Pasta, TestR, HEADER_SIZE> {
         let pasta = Pasta::baked();
-        ApplicationBuilder::<Pasta, TestR, HEADER_SIZE>::new()
-            .finalize(pasta)
+        ApplicationBuilder::<Pasta, TestR, HEADER_SIZE>::new(pasta)
+            .finalize()
             .expect("failed to create test application")
     }
 

--- a/crates/ragu_pcd/src/verify.rs
+++ b/crates/ragu_pcd/src/verify.rs
@@ -12,6 +12,7 @@ use ragu_primitives::Element;
 
 use crate::{
     Application, Pcd, Proof,
+    framework_hooks::HookConfig,
     header::Header,
     internal::{
         claims,
@@ -20,7 +21,9 @@ use crate::{
     },
 };
 
-impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_SIZE> {
+impl<C: Cycle, R: Rank, const HEADER_SIZE: usize, J: HookConfig>
+    Application<'_, C, R, HEADER_SIZE, J>
+{
     /// Verifies some [`Pcd`] for the provided [`Header`].
     ///
     /// Returns `Ok(true)` if all verification checks pass, `Ok(false)` if
@@ -55,13 +58,21 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             return Ok(false);
         }
 
+        // Reject wrong hook-list lengths up front, so a malformed proof yields
+        // `Ok(false)` rather than `Err` from the pipeline below — the same
+        // reasoning as the header lengths above.
+        let hook_layout = self.hook_layout();
+        if !pcd.proof().has_shape(&hook_layout) {
+            return Ok(false);
+        }
+
         // Compute unified k(y), unified_bridge k(y), and application k(y).
         let (unified_ky, unified_bridge_ky, application_ky) =
             Emulator::emulate_wireless((pcd.proof(), pcd.data().clone(), y), |dr, witness| {
                 let (proof, data, y) = witness.cast();
                 let y = Element::alloc(dr, &mut (), y)?;
                 let proof_inputs =
-                    ProofInputs::<_, C, HEADER_SIZE>::alloc_for_verify::<R, H>(dr, proof, data)?;
+                    ProofInputs::<_, C, HEADER_SIZE, J>::alloc_for_verify::<R, H>(dr, proof, data)?;
 
                 let (unified_ky, unified_bridge_ky) = proof_inputs.unified_ky_values(dr, &y)?;
                 let unified_ky = *unified_ky.value().take();
@@ -73,7 +84,8 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
 
         // Build a and b polynomials for each revdot claim.
         let source = native::SingleProofSource { proof: pcd.proof() };
-        let mut builder = claims::Builder::new(&self.native_registry, y, z);
+        let mut builder =
+            claims::Builder::new(&self.native_registry, y, z, hook_layout.witness_polys);
         native_claims::build(&source, &mut builder)?;
 
         // Check all native revdot claims.
@@ -99,12 +111,20 @@ impl<C: Cycle, R: Rank, const HEADER_SIZE: usize> Application<'_, C, R, HEADER_S
             let nested_source = nested::SingleProofSource { proof: pcd.proof() };
             let y_nested = C::ScalarField::random(&mut rng);
             let z_nested = C::ScalarField::random(&mut rng);
-            let mut nested_builder =
-                claims::Builder::new(&self.nested_registry, y_nested, z_nested);
-            nested_claims::build(&nested_source, &mut nested_builder)?;
+            let mut nested_builder = claims::Builder::new(
+                &self.nested_registry,
+                y_nested,
+                z_nested,
+                hook_layout.witness_polys,
+            );
+            nested_claims::build(
+                &nested_source,
+                &mut nested_builder,
+                hook_layout.witness_polys,
+            )?;
 
             let ky_source = nested::SingleProofKySource::<C::ScalarField>::new();
-            nested::ky_values(&ky_source)
+            nested::ky_values(&ky_source, hook_layout.witness_polys)
                 .zip(nested_builder.a.iter().zip(nested_builder.b.iter()))
                 .all(|(ky, (a, b))| a.revdot(b) == ky)
         };

--- a/crates/ragu_pcd/tests/nontrivial.rs
+++ b/crates/ragu_pcd/tests/nontrivial.rs
@@ -9,14 +9,14 @@ use rand::{SeedableRng, rngs::StdRng};
 #[test]
 fn various_merging_operations() -> Result<()> {
     let pasta = Pasta::baked();
-    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new(pasta)
         .register(WitnessLeaf {
             poseidon_params: Pasta::circuit_poseidon(pasta),
         })?
         .register(Hash2 {
             poseidon_params: Pasta::circuit_poseidon(pasta),
         })?
-        .finalize(pasta)?;
+        .finalize()?;
 
     let mut rng = StdRng::seed_from_u64(1234);
 

--- a/crates/ragu_pcd/tests/registration_errors.rs
+++ b/crates/ragu_pcd/tests/registration_errors.rs
@@ -9,7 +9,7 @@ use ragu_pasta::Pasta;
 use ragu_pcd::{
     ApplicationBuilder,
     header::{Header, Suffix},
-    step::{Encoded, Index, Step},
+    step::{Encoded, Index, Step, StepCtx},
 };
 use ragu_primitives::allocator::{Allocator, Standard};
 
@@ -70,7 +70,7 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step0 {
     type Output = HSuffixA;
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
         &self,
-        dr: &mut D,
+        ctx: &mut StepCtx<'_, 'dr, D, C>,
         _: DriverValue<D, Self::Witness<'source>>,
         left: DriverValue<D, ()>,
         right: DriverValue<D, ()>,
@@ -84,8 +84,8 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step0 {
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let allocator = &mut Standard::new();
-        let left = Encoded::new(dr, allocator, left)?;
-        let right = Encoded::new(dr, allocator, right)?;
+        let left = Encoded::new(ctx.dr, allocator, left)?;
+        let right = Encoded::new(ctx.dr, allocator, right)?;
         let output = Encoded::from_gadget(());
 
         Ok(((left, right, output), D::unit(), D::unit()))
@@ -103,7 +103,7 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step1 {
     type Output = HSuffixB;
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
         &self,
-        dr: &mut D,
+        ctx: &mut StepCtx<'_, 'dr, D, C>,
         _: DriverValue<D, Self::Witness<'source>>,
         left: DriverValue<D, ()>,
         right: DriverValue<D, ()>,
@@ -117,8 +117,8 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step1 {
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let allocator = &mut Standard::new();
-        let left = Encoded::new(dr, allocator, left)?;
-        let right = Encoded::new(dr, allocator, right)?;
+        let left = Encoded::new(ctx.dr, allocator, left)?;
+        let right = Encoded::new(ctx.dr, allocator, right)?;
         let output = Encoded::from_gadget(());
 
         Ok(((left, right, output), D::unit(), D::unit()))
@@ -136,7 +136,7 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step1Dup {
     type Output = HSuffixAOther;
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
         &self,
-        dr: &mut D,
+        ctx: &mut StepCtx<'_, 'dr, D, C>,
         _: DriverValue<D, Self::Witness<'source>>,
         left: DriverValue<D, ()>,
         right: DriverValue<D, ()>,
@@ -150,8 +150,8 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step1Dup {
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let allocator = &mut Standard::new();
-        let left = Encoded::new(dr, allocator, left)?;
-        let right = Encoded::new(dr, allocator, right)?;
+        let left = Encoded::new(ctx.dr, allocator, left)?;
+        let right = Encoded::new(ctx.dr, allocator, right)?;
         let output = Encoded::from_gadget(());
 
         Ok(((left, right, output), D::unit(), D::unit()))
@@ -161,18 +161,18 @@ impl<C: ragu_arithmetic::Cycle> Step<C> for Step1Dup {
 #[test]
 fn register_steps_success_and_finalize() {
     let pasta = Pasta::baked();
-    let builder = ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+    let builder = ApplicationBuilder::<Pasta, ProductionRank, 4>::new(pasta)
         .register(Step0)
         .unwrap()
         .register(Step1)
         .unwrap();
-    builder.finalize(pasta).unwrap();
+    builder.finalize().unwrap();
 }
 
 #[test]
 #[should_panic]
 fn register_steps_out_of_order_should_fail() {
-    ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+    ApplicationBuilder::<Pasta, ProductionRank, 4>::new(Pasta::baked())
         .register(Step1)
         .unwrap();
 }
@@ -180,7 +180,7 @@ fn register_steps_out_of_order_should_fail() {
 #[test]
 #[should_panic]
 fn register_steps_duplicate_suffix_should_fail() {
-    ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+    ApplicationBuilder::<Pasta, ProductionRank, 4>::new(Pasta::baked())
         .register(Step0)
         .unwrap()
         .register(Step1Dup)

--- a/crates/ragu_pcd/tests/rerandomization.rs
+++ b/crates/ragu_pcd/tests/rerandomization.rs
@@ -11,7 +11,7 @@ use ragu_pasta::{Fp, Pasta};
 use ragu_pcd::{
     ApplicationBuilder,
     header::{Header, Suffix},
-    step::{Encoded, Index, Step},
+    step::{Encoded, Index, Step, StepCtx},
 };
 use ragu_primitives::{
     Element,
@@ -62,7 +62,7 @@ impl Step<Pasta> for StepWithData {
     type Output = HeaderWithData;
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = Fp>, const HEADER_SIZE: usize>(
         &self,
-        dr: &mut D,
+        ctx: &mut StepCtx<'_, 'dr, D, Pasta>,
         witness: DriverValue<D, Self::Witness<'source>>,
         left: DriverValue<D, ()>,
         right: DriverValue<D, ()>,
@@ -76,9 +76,9 @@ impl Step<Pasta> for StepWithData {
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let allocator = &mut Standard::new();
-        let left = Encoded::new(dr, allocator, left)?;
-        let right = Encoded::new(dr, allocator, right)?;
-        let output = Encoded::new(dr, allocator, witness.clone())?;
+        let left = Encoded::new(ctx.dr, allocator, left)?;
+        let right = Encoded::new(ctx.dr, allocator, right)?;
+        let output = Encoded::new(ctx.dr, allocator, witness.clone())?;
         Ok(((left, right, output), witness, D::unit()))
     }
 }
@@ -94,7 +94,7 @@ impl<C: Cycle> Step<C> for Step0 {
     type Output = HeaderA;
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
         &self,
-        dr: &mut D,
+        ctx: &mut StepCtx<'_, 'dr, D, C>,
         _: DriverValue<D, Self::Witness<'source>>,
         left: DriverValue<D, ()>,
         right: DriverValue<D, ()>,
@@ -108,8 +108,8 @@ impl<C: Cycle> Step<C> for Step0 {
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let allocator = &mut Standard::new();
-        let left = Encoded::new(dr, allocator, left)?;
-        let right = Encoded::new(dr, allocator, right)?;
+        let left = Encoded::new(ctx.dr, allocator, left)?;
+        let right = Encoded::new(ctx.dr, allocator, right)?;
         let output = Encoded::from_gadget(());
         Ok(((left, right, output), D::unit(), D::unit()))
     }
@@ -125,7 +125,7 @@ impl<C: Cycle> Step<C> for Step1 {
     type Output = HeaderA;
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
         &self,
-        dr: &mut D,
+        ctx: &mut StepCtx<'_, 'dr, D, C>,
         _: DriverValue<D, Self::Witness<'source>>,
         left: DriverValue<D, ()>,
         right: DriverValue<D, ()>,
@@ -139,8 +139,8 @@ impl<C: Cycle> Step<C> for Step1 {
         DriverValue<D, Self::Aux<'source>>,
     )> {
         let allocator = &mut Standard::new();
-        let left = Encoded::new(dr, allocator, left)?;
-        let right = Encoded::new(dr, allocator, right)?;
+        let left = Encoded::new(ctx.dr, allocator, left)?;
+        let right = Encoded::new(ctx.dr, allocator, right)?;
         let output = Encoded::from_gadget(());
         Ok(((left, right, output), D::unit(), D::unit()))
     }
@@ -149,12 +149,12 @@ impl<C: Cycle> Step<C> for Step1 {
 #[test]
 fn rerandomization_flow() {
     let pasta = Pasta::baked();
-    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new(pasta)
         .register(Step0)
         .unwrap()
         .register(Step1)
         .unwrap()
-        .finalize(pasta)
+        .finalize()
         .unwrap();
 
     let mut rng = StdRng::seed_from_u64(1234);
@@ -178,10 +178,10 @@ fn rerandomization_flow() {
 #[test]
 fn multiple_rerandomizations_all_verify() {
     let pasta = Pasta::baked();
-    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new(pasta)
         .register(Step0)
         .unwrap()
-        .finalize(pasta)
+        .finalize()
         .unwrap();
 
     let mut rng = StdRng::seed_from_u64(9999);
@@ -204,10 +204,10 @@ fn multiple_rerandomizations_all_verify() {
 #[test]
 fn rerandomization_preserves_header_data() {
     let pasta = Pasta::baked();
-    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new(pasta)
         .register(StepWithData)
         .unwrap()
-        .finalize(pasta)
+        .finalize()
         .unwrap();
 
     let mut rng = StdRng::seed_from_u64(4321);
@@ -237,12 +237,12 @@ fn rerandomization_preserves_header_data() {
 #[test]
 fn rerandomized_fused_proof_verifies() {
     let pasta = Pasta::baked();
-    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new()
+    let app = ApplicationBuilder::<Pasta, ProductionRank, 4>::new(pasta)
         .register(Step0)
         .unwrap()
         .register(Step1)
         .unwrap()
-        .finalize(pasta)
+        .finalize()
         .unwrap();
 
     let mut rng = StdRng::seed_from_u64(7777);

--- a/crates/ragu_testing/src/pcd/nontrivial.rs
+++ b/crates/ragu_testing/src/pcd/nontrivial.rs
@@ -10,7 +10,7 @@ use ragu_core::{
 };
 use ragu_pcd::{
     header::{Header, Suffix},
-    step::{Encoded, Index, Step},
+    step::{Encoded, Index, Step, StepCtx},
 };
 use ragu_primitives::{
     Element,
@@ -64,7 +64,7 @@ impl<C: Cycle> Step<C> for Hash2<'_, C> {
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
         &self,
-        dr: &mut D,
+        ctx: &mut StepCtx<'_, 'dr, D, C>,
         _: DriverValue<D, Self::Witness<'source>>,
         left: DriverValue<D, C::CircuitField>,
         right: DriverValue<D, C::CircuitField>,
@@ -80,6 +80,7 @@ impl<C: Cycle> Step<C> for Hash2<'_, C> {
     where
         Self: 'dr,
     {
+        let dr = &mut *ctx.dr;
         let allocator = &mut Standard::new();
         let left = Encoded::new(dr, allocator, left)?;
         let right = Encoded::new(dr, allocator, right)?;
@@ -109,7 +110,7 @@ impl<C: Cycle> Step<C> for WitnessLeaf<'_, C> {
 
     fn witness<'dr, 'source: 'dr, D: Driver<'dr, F = C::CircuitField>, const HEADER_SIZE: usize>(
         &self,
-        dr: &mut D,
+        ctx: &mut StepCtx<'_, 'dr, D, C>,
         witness: DriverValue<D, Self::Witness<'source>>,
         _left: DriverValue<D, ()>,
         _right: DriverValue<D, ()>,
@@ -125,6 +126,7 @@ impl<C: Cycle> Step<C> for WitnessLeaf<'_, C> {
     where
         Self: 'dr,
     {
+        let dr = &mut *ctx.dr;
         let allocator = &mut Standard::new();
         let leaf = Element::alloc(dr, allocator, witness)?;
         let mut sponge = Sponge::new(dr, self.poseidon_params);

--- a/qa/fuzz/fuzz_targets/fuzz_verify_reject.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_verify_reject.rs
@@ -38,8 +38,8 @@ unsafe impl Sync for SyncApp {}
 static APP: LazyLock<SyncApp> = LazyLock::new(|| {
     let pasta = Pasta::baked();
     SyncApp(
-        ApplicationBuilder::<C, R, HEADER_SIZE>::new()
-            .finalize(pasta)
+        ApplicationBuilder::<C, R, HEADER_SIZE>::new(pasta)
+            .finalize()
             .expect("failed to create application"),
     )
 });


### PR DESCRIPTION
A step can witness a polynomial commitment, and its proof will carry cleartext coefficients.

## Layout config

`HookConfig` carries per-step budgets as type-level lengths. The budget is
declared rather than discovered, for simplicity. The config is elaborated in
following PRs.

Parameter `J` threads this through `Application`, `ApplicationBuilder`, stages,
and circuit types.

## Step behavior

The `witness_polynomial` hook commits a polynomial to an affine point in the
scalar field, and returns a `PolyHandle`, which is a decomposition of the affine
point into two circuit field elements.

The adapter provides the step body with `StepCtx` and manages `FrameworkHooks`,
and produces padding so each step's behavior is uniform.

## Fuse behavior

Reading a fuse input back, `application_ky` folds the handle region, binding it
into the `k(Y)` claim. `nested::stages::preamble` stashes the commitments as
curve points.

`_10_p` folds each witnessed polynomial into `p(X)` and its commitment into the
endoscaled sum, so what accumulates is the commitment the step pinned.

`Proof` gains the witnessed polys' coefficients and a commitment cache.

## Other changes

- `nested::stages::preamble` gains each polynomial's commitment point
- `native::stages::eval` gains `witness_poly_evals` to challenge each at `u`
- `internal::endoscalar` types use a `Len` parameter instead of const `NUM_POINTS`
- `internal::nested` replaces `NUM_ENDOSCALING_POINTS` with const fns `child_endoscaling_points` and `num_endoscaling_points`
- `internal::nested::register_all` asserts the registry took one slot per `InternalCircuitIndex::all` entry, rather than trusting that the two agree
