### PR TITLE
chore: bump MSRV to 1.97

### DIFF
--- a/.github/actions/rust-nightly-setup/action.yml
+++ b/.github/actions/rust-nightly-setup/action.yml
@@ -18,5 +18,5 @@ runs:
       id: toolchain
       uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master @ 2026-05-23
       with:
-        toolchain: nightly-2026-04-11
+        toolchain: nightly-2026-05-23
         components: ${{ inputs.components }}

--- a/.github/workflows/fuzz-coverage.yml
+++ b/.github/workflows/fuzz-coverage.yml
@@ -81,9 +81,9 @@ jobs:
             ${{ runner.os }}-fuzz-corpus-${{ matrix.target }}-
 
       - name: Install cargo-fuzz
-        # Keep this pin in sync with fuzz-cron.yml. An unlocked install
-        # currently resolves cargo-platform 0.3.3, which requires Rust 1.91,
-        # while this step runs under the repository's Rust 1.90 toolchain.
+        # Keep this pin in sync with fuzz-cron.yml. `--locked` keeps the
+        # resolved dependency set reproducible across runs rather than
+        # drifting with whatever cargo-fuzz's manifest ranges admit today.
         run: cargo install --locked cargo-fuzz@0.13.1
 
       - name: Generate coverage report

--- a/.github/workflows/fuzz-cron.yml
+++ b/.github/workflows/fuzz-cron.yml
@@ -106,9 +106,9 @@ jobs:
             ${{ runner.os }}-fuzz-corpus-${{ matrix.target }}-
 
       - name: Install cargo-fuzz
-        # Keep this pin in sync with fuzz-coverage.yml. An unlocked install
-        # currently resolves cargo-platform 0.3.3, which requires Rust 1.91,
-        # while this step runs under the repository's Rust 1.90 toolchain.
+        # Keep this pin in sync with fuzz-coverage.yml. `--locked` keeps the
+        # resolved dependency set reproducible across runs rather than
+        # drifting with whatever cargo-fuzz's manifest ranges admit today.
         run: cargo install --locked cargo-fuzz@0.13.1
 
       # Replay committed crash reproducers (one execution per file, no

--- a/.github/workflows/vet.yml
+++ b/.github/workflows/vet.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # cargo-vet only reads manifests; it doesn't compile our crates. Bypass
-    # the workspace's rust-toolchain.toml (which pins 1.90.0 + clippy) so we
+    # the workspace's rust-toolchain.toml (which pins 1.97.1 + clippy) so we
     # use the runner's preinstalled stable and avoid rustup component-install
     # conflicts when cargo runs inside the workspace.
     env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ version = "0.0.0"
 authors = ["Sean Bowe <ewillbefull@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2024"
-rust-version = "1.90"
+rust-version = "1.97"
 repository = "https://github.com/tachyon-zcash/ragu"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Requirements
 
-* The minimum supported [Rust](https://rust-lang.org/) version is currently **1.90.0**.
+* The minimum supported [Rust](https://rust-lang.org/) version is currently **1.97.1**.
 * Ragu requires minimal dependencies and currently strives to avoid using dependencies that are not already used in [Zebra](https://github.com/ZcashFoundation/zebra).
 * Ragu's library crates are [`no_std`]-compatible and only need a global allocator; the default `multicore` crate feature uses [`maybe-rayon`] and pulls in `std`. See the [book][book-no-std] for details.
 

--- a/book/src/guide/requirements.md
+++ b/book/src/guide/requirements.md
@@ -1,7 +1,7 @@
 # Requirements
 
 * The minimum supported [Rust](https://rust-lang.org/) version is currently
-  **1.90.0**.
+  **1.97.1**.
 * Ragu requires minimal dependencies and currently strives to avoid using
   dependencies that are not already used in
   [Zebra](https://github.com/ZcashFoundation/zebra).

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ build *ARGS:
 build_release *ARGS:
   cargo build --release --workspace --all-targets {{ARGS}}
 
-_nightly := "nightly-2026-04-11"
+_nightly := "nightly-2026-05-23"
 
 lint: _typos_setup _book_setup
   cargo clippy --workspace --lib --tests --benches -- -D warnings

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,8 +1,14 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.97.1"
 components = ["clippy"]
 
 # Bumping MSRV
 # * update `toolchain.channel` key in `rust-toolchain.toml` (this file)
 # * update `book/src/guide/requirements.md`
+# * update the requirements bullet in `README.md`
 # * update `workspace.package.rust-version` key in root `Cargo.toml`
+# * update the pinned version named in the `vet` job comment in
+#   `.github/workflows/vet.yml`
+# * if the pinned nightly is now older than the new MSRV, rotate it forward in
+#   `justfile` (`_nightly`) and `.github/actions/rust-nightly-setup/action.yml`;
+#   otherwise `cargo` refuses to build the fuzz harness against these crates


### PR DESCRIPTION
Follows same checklist in https://github.com/tachyon-zcash/ragu/pull/229.