### PR TITLE
book: desc public inputs and stage outputs

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -45,7 +45,7 @@
     - [Endoscalars](protocol/extensions/endoscalar.md) <!-- todo -->
     - [Staging](protocol/extensions/staging.md) <!-- todo -->
   - [Recursion](protocol/recursion/index.md)
-    - [Public Inputs](protocol/recursion/public_inputs.md) <!-- todo -->
+    - [Public Inputs](protocol/recursion/public_inputs.md)
   - [Analysis](protocol/analysis.md) <!-- todo -->
   - [Local (Sean's Corner!)]()
     - [Arithmetization](protocol/local/arithmetization.md)

--- a/book/src/protocol/recursion/index.md
+++ b/book/src/protocol/recursion/index.md
@@ -24,13 +24,13 @@ correctly:
 |---------|------|
 | `hashes_1` | Re-derives $w, y, z$ from the transcript (first half) |
 | `hashes_2` | Re-derives $\mu, \nu, \mu', \nu', x, \alpha, u, \text{pre\_beta}$ from the saved transcript state (second half) |
-| `partial_collapse` | Verifies layer-1 folding with $(\mu, \nu)$ |
-| `full_collapse` | Verifies layer-2 folding with $(\mu', \nu')$, handles base case |
+| `inner_collapse` | Verifies layer-1 folding with $(\mu, \nu)$ |
+| `outer_collapse` | Verifies layer-2 folding with $(\mu', \nu')$, handles base case |
 | `compute_v` | Derives effective $\beta$ from $\text{pre\_beta}$ via endoscalar extraction, checks $v = f(u) + \beta \cdot \text{eval}$ |
 
 ### Unified output {#unified-output}
 
-Four of these (`hashes_2`, `partial_collapse`, `full_collapse`,
+Four of these (`hashes_2`, `inner_collapse`, `outer_collapse`,
 `compute_v`) share a common set of public-input wires defined by the
 `Output` structure. The fifth circuit (`hashes_1`) extends this
 structure with the left and right child proof output headers, since it
@@ -38,7 +38,7 @@ additionally binds the proof to specific header data. The shared wires
 include:
 
 - Nested curve commitments from each proof component (preamble, $s'$,
-  error $M$, error $N$, $AB$, query, $f$, eval)
+  `inner_error`, `outer_error`, $AB$, query, $f$, eval)
 - Fiat-Shamir challenges ($w, y, z, \mu, \nu, \mu', \nu', x, \alpha,
   u, \text{pre\_beta}$)
 - Final claim values ($c$ and $v$)
@@ -61,27 +61,28 @@ inside a circuit. Poseidon hashing inside a circuit is expensive, so
 Ragu splits the transcript verification across two internal circuits:
 
 - **hashes_1** derives $w$, $y$, and $z$ by absorbing the preamble,
-  $s'$, and error $M$ commitments. It then saves the sponge state for
-  handoff.
+  $s'$, and inner-error bridge commitments. It then saves the sponge
+  state for handoff.
 - **hashes_2** resumes from the saved sponge state and derives the
   remaining challenges:
   $\mu, \nu, \mu', \nu', x, \alpha, u, \text{pre\_beta}$.
 
 The saved transcript state bridges the two circuits. During fuse, the
-state is captured after the error $M$ commitment is absorbed, serialized
-into field elements, and passed as witness data to the error $N$
-computation.
+state is captured after the inner-error bridge commitment is absorbed,
+serialized into field elements, and carried in the `outer_error` stage's
+witness data.
 
 ## Stage dependencies {#stage-dependencies}
 
 Not every circuit uses every stage's witness data. The stage dependency
 chains are:
 
-- `hashes_1`: preamble → error $N$ → *circuit*
-- `hashes_2`: preamble → error $N$ → *circuit*
-- `partial_collapse`: preamble → error $N$ → error $M$ → *circuit*
-- `full_collapse`: preamble → error $N$ → *circuit*
-- `compute_v`: preamble → query → eval → *circuit*
+- `hashes_1`: preamble -> `outer_error` -> *circuit*
+- `hashes_2`: preamble -> `outer_error` -> *circuit*
+- `inner_collapse`: preamble -> `outer_error` -> `inner_error` ->
+  *circuit*
+- `outer_collapse`: preamble -> `outer_error` -> *circuit*
+- `compute_v`: preamble -> query -> eval -> *circuit*
 
 Each chain determines which stage masks the circuit uses and which
 "final staged" mask applies

--- a/book/src/protocol/recursion/public_inputs.md
+++ b/book/src/protocol/recursion/public_inputs.md
@@ -1,5 +1,112 @@
 # Public Inputs
 
-> **TODO**: This section will explain the distinction between *public inputs*
-> (verifier instance data), *stage outputs* (communication between stages),
-> and *staging circuit outputs* (what the verifier checks).
+Three kinds of data flow through a recursive step, and which is which decides
+what a verifier is trusting. Public inputs are the values it checks. Stage
+outputs pass between stages and never reach it. Staging circuit outputs are the
+public inputs the internal circuits expose, and their shape is what stops an
+internal proof from standing in for an application one.
+
+## Public Inputs
+
+A circuit's public inputs are encoded as a polynomial $k(Y)$, introduced in the
+[NARK](../core/nark.md) chapter. The verifier evaluates $k(y)$ at a random point
+$y$ and checks it against the revdot claim.
+
+Recursion instantiates $k(Y)$ three times: once for the values the internal
+circuits share, once for those same values bound to the child headers, and once
+for the application's own step circuit.
+
+### `unified_ky`
+
+The [unified output](index.md#unified-output) shared by the internal circuits,
+followed by a zero element:
+
+$$k_\text{unified}(Y) = \text{Horner}(\texttt{unified\_output} \,\|\, 0 \,\|\, 1, \; Y)$$
+
+The trailing $1$ comes from the Horner wrapper, which appends it once every wire
+has been absorbed. The zero before it is the suffix that separates internal
+circuits from application circuits, described under
+[substitution](#substitution).
+
+Four of the five internal circuits — `hashes_2`, `inner_collapse`,
+`outer_collapse`, and `compute_v` — use this value directly. The stage and
+final-staged masks take zero for their $k(y)$ values, since staging masks
+enforce those constraints instead.
+
+### `unified_bridge_ky`
+
+The same wires, extended with both child headers:
+
+$$k_\text{bridge}(Y) = \text{Horner}(\texttt{unified\_output} \,\|\, \texttt{left\_header} \,\|\, \texttt{right\_header} \,\|\, 0 \,\|\, 1, \; Y)$$
+
+Binding the headers is what stops a proof from claiming one pair of headers
+while proving a different pair. `hashes_1` uses this rather than
+$k_\text{unified}(y)$, because it is the circuit that binds child headers.
+
+### `application_ky`
+
+The step circuit's own public inputs, with no unified output and no zero suffix:
+
+$$k_\text{app}(Y) = \text{Horner}(\texttt{left\_header} \,\|\, \texttt{right\_header} \,\|\, \texttt{output\_header} \,\|\, 1, \; Y)$$
+
+### Horner Evaluation
+
+Each $k(y)$ is computed by streaming Horner evaluation. Given wires $w_0,
+\ldots, w_{n-1}$ and the trailing constant:
+
+$$k(y) = (\cdots((w_0 \cdot y + w_1) \cdot y + w_2) \cdots + w_{n-1}) \cdot y + 1$$
+
+Wires are absorbed one at a time, with a multiplication by $y$ between each.
+Streaming lets the shared prefix be computed once: $k_\text{unified}$ and
+$k_\text{bridge}$ diverge only after the unified output is absorbed, so the work
+up to that point is shared.
+
+## Stage Outputs
+
+Stage outputs are prover-internal values consumed by later stages or internal
+circuits. A verifier never sees them. The framework separately encodes their
+wire values into a partial trace polynomial and commits to that trace.
+
+The saved transcript state is the stage output worth knowing about. Once the
+inner-error bridge commitment has been absorbed into the sponge, the sponge
+state is serialized into field elements and carried by the `outer_error` stage.
+That is what lets `hashes_1` and `hashes_2` split the Fiat-Shamir re-derivation
+between them, as the [transcript split](index.md#transcript-split) describes.
+
+## Staging Circuit Outputs
+
+Staging circuit outputs are the internal circuits' public inputs: the values the
+recursive verifier actually checks, carried through the $k(Y)$ mechanism above.
+
+The shared `Output` structure holds 29 wires: eight nested-curve commitments at
+two wires each, and thirteen field elements covering the Fiat-Shamir challenges
+and the final values $c$ and $v$. `hashes_1` emits a wider structure that adds
+the two child headers.
+
+Each circuit constrains the wires it is responsible for and reads the rest from
+witness data, so every wire is constrained exactly once and no circuit repeats
+another's work.
+
+The verifier then checks:
+
+1. The raw $c$ value from the $AB$ component, directly — this is the folded
+   revdot scalar rather than a $k(y)$ evaluation.
+2. $k_\text{app}(y)$ against the application circuit's claim.
+3. $k_\text{bridge}(y)$ against the bridge claim.
+4. $k_\text{unified}(y)$ against the claims of the four internal circuits that
+   share it.
+5. Stage and final-staged mask claims against zero.
+
+## Substitution {#substitution}
+
+Internal circuits and application circuits sit at different registry positions,
+so an attacker might try to supply one where the other is expected.
+
+The zero suffix is what prevents it. Internal circuit outputs serialize suffix
+zero, which forces the linear term of $k(Y)$ to zero. An application circuit
+instead serializes its output header suffix. That suffix is always nonzero: one
+is reserved for the trivial header, and application-defined suffixes begin at
+two.
+
+No valid application $k(Y)$ can equal a valid internal $k(Y)$, and substitution
+in either direction fails the verifier's check.


### PR DESCRIPTION
- explains public inputs, stage outputs, and staging circuit outputs.
- document the three recursive (k(Y)) evaluations and substitution protection.
- updates stale recursion circuit and stage names.