### PR TITLE
chore(fuzz): harden soundness oracles

### DIFF
--- a/.github/workflows/fuzz-coverage.yml
+++ b/.github/workflows/fuzz-coverage.yml
@@ -47,6 +47,10 @@ jobs:
           - fuzz_circuit_revdot_identity
           - fuzz_staging
           - fuzz_verify_reject
+          - fuzz_witness_pinning
+          - fuzz_circuit_cheat
+          - fuzz_advice_patcher
+          - fuzz_completeness
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -245,7 +245,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-fuzz-target-
 
-      - name: cargo check fuzz harness
+      - name: Test fuzz support library
+        working-directory: qa/fuzz
+        env:
+          RUSTUP_TOOLCHAIN: ${{ steps.nightly.outputs.toolchain }}
+        run: cargo test --lib
+
+      - name: Check all fuzz targets
         working-directory: qa/fuzz
         env:
           RUSTUP_TOOLCHAIN: ${{ steps.nightly.outputs.toolchain }}

--- a/qa/fuzz/Cargo.toml
+++ b/qa/fuzz/Cargo.toml
@@ -102,7 +102,7 @@ bench = false
 
 # The "patcher" technique (issue #728): mutate one witness input, repair
 # every downstream wire by re-tracing, and assert the assembled constraint
-# identity matches an independent native oracle over a ragu_testing::substrate
+# identity matches an independent native oracle over a generated substrate
 # program (real enforce_zero anchors, full grammar minus value-fallible ops).
 # Also cross-checks the Simulator verdict against the identity to catch
 # driver-vs-wiring disagreements.
@@ -115,7 +115,7 @@ bench = false
 
 # The patcher with a real repair engine (issues #728, #793, #796): a
 # recording Driver captures the constraint graph ragu emits for a
-# ragu_testing::substrate program, then mutations to free advice wires are
+# generated substrate program, then mutations to free advice wires are
 # repaired by propagating through the *captured* constraints (not by
 # re-running gadget logic). Disagreement with the substrate's native oracle
 # is the under-constrained-advice signal that re-trace-based repair cannot

--- a/qa/fuzz/README.md
+++ b/qa/fuzz/README.md
@@ -1,6 +1,6 @@
 # `ragu_testing-fuzz`
 
-cargo-fuzz harness for the Ragu project. 20 fuzz targets + 1 auxiliary
+cargo-fuzz harness for the Ragu project. 24 fuzz targets + 1 auxiliary
 dictionary-extractor tool. Standalone workspace (the `[workspace]` table in
 `Cargo.toml` makes this crate its own root) so nightly + libfuzzer flags
 don't leak into the rest of the repo.
@@ -44,11 +44,11 @@ cargo +nightly fuzz run fuzz_element_ops -- -max_total_time=60
 
 Decode the fuzzer's raw bytes into a program over a stack of
 `Element`/`Boolean` gadget calls, via the shared
-[`ragu_testing::substrate`] op grammar. All consume the same decoder,
+[`ragu_testing_fuzz::substrate`] op grammar. All consume the same decoder,
 driver-generic synthesis dispatch, and (where applicable) native shadow —
 see the "Shared substrate" note at the bottom.
 
-[`ragu_testing::substrate`]: ../../crates/ragu_testing/src/substrate.rs
+[`ragu_testing_fuzz::substrate`]: src/substrate.rs
 
 | Target | What it catches |
 |---|---|
@@ -60,7 +60,7 @@ see the "Shared substrate" note at the bottom.
 ### Soundness / patcher targets
 
 Constraint-side under-constraint oracles over generated
-[`ragu_testing::substrate`] circuits (issues #728, #793, #796). Each starts
+[`ragu_testing_fuzz::substrate`] circuits (issues #728, #793, #796). Each starts
 from a satisfying witness, introduces a prover-style cheat, and demands the
 constraint system reject it.
 
@@ -69,6 +69,7 @@ constraint system reject it.
 | `fuzz_witness_pinning` | Mutates one occupied coefficient of the assembled trace polynomial and demands the revdot identity reject it. The generated circuit is made fully-pinned (an `Anchor` per element) so every live coefficient is constrained — a survivor means the constraint system fails to pin that wire. |
 | `fuzz_circuit_cheat` | Mutates one witness input, re-traces, and asserts the assembled constraint-identity verdict matches an independent native oracle (with a Simulator cross-check). The operational patcher whose "repair" is re-tracing. |
 | `fuzz_advice_patcher` | Captures the emitted constraint graph through a recording driver, mutates free advice wires, and **repairs through the captured constraints** (not gadget logic) before comparing to the native shadow — catches under-constrained *advice* that re-trace-based repair masks. `PATCHER_SELFTEST=1` proves the oracle fires on a planted bug. |
+| `fuzz_completeness` | Runs arbitrary witnesses through anchorless, value-infallible generated circuits; every such witness must be accepted, so rejection is an over-constraint signal independent of the patcher's bounded repair search. |
 
 ### Gadget-API property and identity targets
 
@@ -167,10 +168,10 @@ were insensitive to it — that's the real bug class.
 
 Three workflows in `.github/workflows/`:
 
-- **`rust.yml`** runs `cargo +nightly check --bins` from this directory
-  on every PR. Catches bitrot in the fuzz crate without actually running
-  libFuzzer. Cache key includes `Cargo.toml`, `fuzz_targets/**/*.rs`,
-  and `bin/**/*.rs`.
+- **`rust.yml`** runs `cargo test --lib` and `cargo check --bins` from this
+  directory on every PR. This executes the substrate, recorder, and planted-bug
+  self-tests, then catches bitrot in every target without running libFuzzer.
+  Cache keys include `Cargo.toml`, `fuzz_targets/**/*.rs`, and `bin/**/*.rs`.
 
 - **`fuzz-cron.yml`** runs every target via matrix-parallel for 5 hours
   each on Sundays, Wednesdays, and Fridays at 00:00 UTC. Each target
@@ -187,7 +188,7 @@ Three workflows in `.github/workflows/`:
 ## Shared substrate
 
 The op-stream, soundness/patcher, and generated-circuit targets all build
-on one shared module, [`ragu_testing::substrate`], rather than the
+on one shared module, [`ragu_testing_fuzz::substrate`], rather than the
 per-target `Op` enum each used to copy. The substrate is layered so each
 target consumes only what it needs:
 
@@ -205,9 +206,8 @@ target consumes only what it needs:
    (`ProgramCircuit`), with satisfying-witness `steer`ing, for the
    constraint-level oracles.
 
-Living in `ragu_testing` (a dev-dependency both the fuzz workspace and the
-root workspace can reach) is what lets the same grammar feed both libFuzzer
-targets and deterministic in-tree proptests.
+Living in this standalone fuzz crate's library lets the same grammar feed
+both its libFuzzer binaries and deterministic `cargo test --lib` proptests.
 
 ## Patch table
 
@@ -227,7 +227,7 @@ mismatches at link time.
   `special_value`, `-max_len`, weekly cron).
 - **PR #794** (issues #728/#793/#796) — the patcher technique
   (`fuzz_witness_pinning`, `fuzz_circuit_cheat`, `fuzz_advice_patcher`)
-  and the shared `ragu_testing::substrate`: all op-stream targets migrated
+  and the shared `ragu_testing_fuzz::substrate`: all op-stream targets migrated
   onto it, and the constraint-level targets generalized from the two fixed
   dummy circuits to arbitrary generated ones.
 - Talks/papers referenced in the PR descriptions for technique

--- a/qa/fuzz/fuzz.sh
+++ b/qa/fuzz/fuzz.sh
@@ -61,6 +61,7 @@ TARGETS=(
   fuzz_witness_pinning
   fuzz_circuit_cheat
   fuzz_advice_patcher
+  fuzz_completeness
   fuzz_staging
   fuzz_revdot
   fuzz_fold_revdot

--- a/qa/fuzz/fuzz_targets/fuzz_advice_patcher.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_advice_patcher.rs
@@ -21,9 +21,9 @@
 //!   to equal the earlier one,
 //! * every other `enforce_zero` is a *check*, not a repair rule.
 //!
-//! A fixpoint pass applies those rules until the values stabilise. The
-//! result is the witness a malicious prover could submit: it satisfies
-//! exactly the constraints ragu emitted, and *only* those.
+//! A fixpoint pass searches for a witness a malicious prover could submit.
+//! Acceptance is checked against every captured constraint afterwards; a
+//! failed repair is inconclusive because the solver is deliberately bounded.
 //!
 //! # Vocabulary
 //!
@@ -70,9 +70,10 @@
 //! * `native_satisfied` — does the native shadow, recomputing the full
 //!   dependency chain, still satisfy every anchor?
 //!
-//! The assertion is `ragu_accepts == native_satisfied`. For a correctly
-//! constrained circuit the captured-constraint repair and the native
-//! recompute agree. **If a gadget omits a constraint, repair fails to
+//! The load-bearing assertion is `!(ragu_accepts && !native_satisfied)`.
+//! A rejected repaired witness is inconclusive—the bounded solver may simply
+//! have missed a satisfying extension—and completeness has its own exact
+//! target. **If a gadget omits a constraint, repair fails to
 //! propagate the cheat** (there is no captured rule to carry it), so the
 //! anchored wire keeps its honest value and ragu accepts, while the native
 //! shadow — which knows the true relation — reports the anchor violated.
@@ -125,9 +126,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 static RUNS: AtomicU64 = AtomicU64::new(0);
 /// See [`RUNS`].
 static VACUOUS: AtomicU64 = AtomicU64::new(0);
-/// Runs bailed because a cheat un-skipped an `invert`/`divide` (stack grew).
+/// Runs bailed because a cheat un-skipped an `invert`/`divide`.
 static GREW: AtomicU64 = AtomicU64::new(0);
-/// Runs where a cheat zeroed an `invert`/`divide` input (stack shrank) and
+/// Runs where a cheat zeroed an `invert`/`divide` input and
 /// the zero-divisor rejection check ran instead of bailing.
 static SHRANK: AtomicU64 = AtomicU64::new(0);
 /// Runs where only an `is_zero` result flipped, now compared instead of
@@ -349,10 +350,8 @@ fn patch_round<F: PrimeField<Repr = [u8; 32]>>(input: &Input, decoded: &Program)
     // Capture the honest constraint graph and per-slot wire ids.
     let mut rec = Recorder::<F>::new();
     let mut alloc = TrackingAllocator::default();
-    let stacks = match synthesize(&mut rec, &mut alloc, &program, &honest_anchors) {
-        Ok(s) => s,
-        Err(_) => return,
-    };
+    let stacks = synthesize(&mut rec, &mut alloc, &program, &honest_anchors)
+        .unwrap_or_else(|err| panic!("recorder rejected an honest generated program: {err:?}"));
     let slot_wires: Vec<usize> = stacks.elems.iter().map(|e| *e.wire()).collect();
 
     // The prover controls three kinds of advice: element-stack witnesses
@@ -497,16 +496,16 @@ fn patch_round<F: PrimeField<Repr = [u8; 32]>>(input: &Input, decoded: &Program)
     // and this live re-execution disagree, the recorder mis-captured the
     // circuit and every signal above is suspect.
     let mut playback = Playback::new(ragu_values.clone());
-    if synthesize(&mut playback, &mut (), &program, &honest_anchors).is_ok() {
-        assert_eq!(
-            playback.accepts(),
-            ragu_accepts,
-            "RECORDER CAPTURE BUG: the stored constraint graph accepts={ragu_accepts} but a \
-             fresh playback of the real gadget synthesis says accepts={}. The recorder \
-             mis-captured the circuit. Program: {program:?}",
-            playback.accepts(),
-        );
-    }
+    synthesize(&mut playback, &mut (), &program, &honest_anchors)
+        .unwrap_or_else(|err| panic!("playback diverged from honest circuit shape: {err:?}"));
+    assert_eq!(
+        playback.accepts(),
+        ragu_accepts,
+        "RECORDER CAPTURE BUG: the stored constraint graph accepts={ragu_accepts} but a \
+         fresh playback of the real gadget synthesis says accepts={}. The recorder \
+         mis-captured the circuit. Program: {program:?}",
+        playback.accepts(),
+    );
 
     if bool_cheated {
         assert!(
@@ -543,16 +542,17 @@ fn patch_round<F: PrimeField<Repr = [u8; 32]>>(input: &Input, decoded: &Program)
         },
     );
 
-    // Zero-crossing classification. A cheat can move a gadget input across
-    // zero, changing which ops the native re-evaluation executes:
+    // Zero-crossing classification. Compare the per-op execution trace, not
+    // only final stack lengths: one newly-executed op and one newly-skipped
+    // op can cancel in length while the captured circuit shapes still differ.
     //
-    //  * element stack *shrank* — an `invert`/`divide` whose input the cheat
+    //  * an op was newly skipped — an `invert`/`divide` whose input the cheat
     //    zeroed now skips natively. The honest captured graph still contains
     //    that gadget's nonzero enforcement (`x · x⁻¹ = 1`), which is
     //    unsatisfiable at `x = 0`, so ragu *must* reject. Accepting it means
     //    the nonzero check is under-constrained — a soundness bug. This is
     //    the formerly-bailed case turned into a real oracle.
-    //  * element stack *grew* — an `invert`/`divide` the honest run skipped
+    //  * an op was newly executed — an `invert`/`divide` the honest run skipped
     //    (input honestly zero) now executes. The honest graph never captured
     //    that gadget, so there is nothing to compare against; still out of
     //    model, so bail.
@@ -572,8 +572,20 @@ fn patch_round<F: PrimeField<Repr = [u8; 32]>>(input: &Input, decoded: &Program)
     //    spurious rejections here, not as a solver error — see the
     //    least-commitment section on `recorder::cluster_solve` and the
     //    `regressions/fuzz_advice_patcher/` reproducers.
-    let shrank = mutated.elems.len() < shadow.elems.len();
-    let grew = mutated.elems.len() > shadow.elems.len();
+    assert_eq!(
+        shadow.value_fallible_pushes.len(),
+        mutated.value_fallible_pushes.len(),
+    );
+    let grew = shadow
+        .value_fallible_pushes
+        .iter()
+        .zip(&mutated.value_fallible_pushes)
+        .any(|(&honest, &changed)| !honest && changed);
+    let shrank = shadow
+        .value_fallible_pushes
+        .iter()
+        .zip(&mutated.value_fallible_pushes)
+        .any(|(&honest, &changed)| honest && !changed);
     let bools_flipped = mutated.bools != shadow.bools;
     let native_ok = mutated.anchors == honest_anchors;
 
@@ -617,19 +629,10 @@ fn patch_round<F: PrimeField<Repr = [u8; 32]>>(input: &Input, decoded: &Program)
         return;
     }
 
-    assert_eq!(
-        ragu_accepts,
-        native_ok,
+    assert!(
+        !(ragu_accepts && !native_ok),
         "PATCHER SOUNDNESS SIGNAL: cheating advice (elem {elem_value:?}, fold \
-         {fold_value:?}) and repairing through the captured constraints, ragu {} \
-         the witness but the native oracle says it is {}. {}. Program: {program:?}",
-        if ragu_accepts { "ACCEPTED" } else { "REJECTED" },
-        if native_ok { "satisfied" } else { "VIOLATED" },
-        if ragu_accepts && !native_ok {
-            "ragu accepted a witness the oracle rejects — an under-constrained advice wire \
-             (the soundness direction)"
-        } else {
-            "ragu rejected a witness the oracle accepts — a completeness gap"
-        },
+         {fold_value:?}) and repairing through the captured constraints, ragu ACCEPTED \
+         the witness but the native oracle says it is VIOLATED. Program: {program:?}",
     );
 }

--- a/qa/fuzz/fuzz_targets/fuzz_algebraic_identities.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_algebraic_identities.rs
@@ -136,7 +136,7 @@ fuzz_target!(|input: Input| {
 
     let witness_data = (a_val, b_val, bv_val, bv2_val);
 
-    let _ = Simulator::<Fp>::simulate(witness_data, |dr, witness| {
+    let result = Simulator::<Fp>::simulate(witness_data, |dr, witness| {
         let allocator = &mut Standard::new();
 
         let a = Element::alloc(dr, allocator, witness.as_ref().map(|w| w.0))?;
@@ -306,18 +306,17 @@ fuzz_target!(|input: Input| {
         // alloc_square: pre-square a so we know a*a is a QR; the gadget
         // should return (root, sq) with root*root == sq.
         let a_squared_val = a_val.square();
-        if let Ok((root, sq)) = Element::alloc_square(
+        let (root, sq) = Element::alloc_square(
             dr,
             witness.as_ref().map(|_| a_squared_val),
-        ) {
-            let root_squared = root.mul(dr, &root)?;
-            assert_eq!(
-                *root_squared.value().take(),
-                *sq.value().take(),
-                "alloc_square: root^2 != sq, a={:?}",
-                a_val,
-            );
-        }
+        )?;
+        let root_squared = root.mul(dr, &root)?;
+        assert_eq!(
+            *root_squared.value().take(),
+            *sq.value().take(),
+            "alloc_square: root^2 != sq, a={:?}",
+            a_val,
+        );
 
         // add_coeff(b, 1) == add(b)
         let ac_one = a.add_coeff(dr, &b, Coeff::Arbitrary(Fp::ONE));
@@ -599,4 +598,9 @@ fuzz_target!(|input: Input| {
 
         Ok(())
     });
+    assert!(
+        result.is_ok(),
+        "valid algebraic-identity witness was rejected: {:?}",
+        result.err(),
+    );
 });

--- a/qa/fuzz/fuzz_targets/fuzz_circuit_cheat.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_circuit_cheat.rs
@@ -116,27 +116,36 @@ fn evaluation_point(seed: u64, offset: u64) -> Fp {
 }
 
 /// Does the constraint identity accept `witness` for the registered
-/// `circuit` at two independent points? `None` if assembly/trace fails.
+/// `circuit` at two independent points? Trace, assembly, and `ky` are
+/// structural operations for this value-infallible program, so an error is a
+/// harness or pipeline bug rather than an iteration to discard.
 fn identity_accepts(
     registry: &Registry<'_, Fp, TestRank>,
     circuit: &ProgramCircuit<'_, Fp>,
     witness: [Fp; Preamble::LEN],
     input: &Input,
-) -> Option<bool> {
-    let trace = circuit.trace(witness).ok()?.into_output();
+) -> bool {
+    let trace = circuit
+        .trace(witness)
+        .expect("value-infallible ProgramCircuit trace failed")
+        .into_output();
     let r = registry
         .assemble_with_alpha(&trace, CircuitIndex::new(0), Fp::ZERO)
-        .ok()?;
+        .expect("registered ProgramCircuit trace failed to assemble");
 
     let y = evaluation_point(input.y_seed, 2);
     let z = evaluation_point(input.z_seed, 3);
     let y2 = y * Fp::MULTIPLICATIVE_GENERATOR + Fp::from(5u64);
     let z2 = z * Fp::MULTIPLICATIVE_GENERATOR + Fp::from(7u64);
 
-    Some(
-        identity_lhs(registry, &r, y, z) == circuit.ky((), y).ok()?
-            && identity_lhs(registry, &r, y2, z2) == circuit.ky((), y2).ok()?,
-    )
+    identity_lhs(registry, &r, y, z)
+        == circuit
+            .ky((), y)
+            .expect("ProgramCircuit::ky failed on a unit instance")
+        && identity_lhs(registry, &r, y2, z2)
+            == circuit
+                .ky((), y2)
+                .expect("ProgramCircuit::ky failed on a unit instance")
 }
 
 /// Whether the Simulator accepts `witness` for `program` with `anchors`.
@@ -188,10 +197,7 @@ fuzz_target!(|input: Input| {
         simulator_accepts(&program, honest_witness, &honest_anchors),
         "Simulator rejected the honest witness — completeness bug. {program:?}"
     );
-    let honest_identity = match identity_accepts(&registry, &circuit, honest_witness, &input) {
-        Some(v) => v,
-        None => return,
-    };
+    let honest_identity = identity_accepts(&registry, &circuit, honest_witness, &input);
     assert!(
         honest_identity,
         "constraint identity rejected the honest witness — completeness bug. {program:?}"
@@ -226,10 +232,7 @@ fuzz_target!(|input: Input| {
         },
     );
     let simulator = simulator_accepts(&program, mutated_witness, &honest_anchors);
-    let identity = match identity_accepts(&registry, &circuit, mutated_witness, &input) {
-        Some(v) => v,
-        None => return,
-    };
+    let identity = identity_accepts(&registry, &circuit, mutated_witness, &input);
 
     assert_eq!(
         simulator,

--- a/qa/fuzz/fuzz_targets/fuzz_circuit_revdot_identity.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_circuit_revdot_identity.rs
@@ -111,10 +111,10 @@ fuzz_target!(|input: Input| {
         Err(_) => return, // Rank overflow: program too large for TestRank.
     };
 
-    let trace = match circuit.trace(program.preamble.values::<Fp>()) {
-        Ok(t) => t.into_output(),
-        Err(_) => return,
-    };
+    let trace = circuit
+        .trace(program.preamble.values::<Fp>())
+        .expect("honest steered ProgramCircuit trace failed")
+        .into_output();
     let r = registry
         .assemble_with_alpha(&trace, CircuitIndex::new(0), Fp::ZERO)
         .expect("assemble_with_alpha failed on a registered, satisfying witness");

--- a/qa/fuzz/fuzz_targets/fuzz_circuit_witness.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_circuit_witness.rs
@@ -475,17 +475,22 @@ fn known_routine_native(witness: Fp) -> Fp {
 /// Run the differential alpha-injection check on an assembled trace.
 /// Asserts that two assemblies with distinct `alpha`s differ in exactly
 /// one coefficient position, by exactly the alpha delta. Returns `()` on
-/// success, `None` if either assembly errored (skip the iteration), and
-/// panics on a violated invariant.
+/// success and panics if assembly fails or the invariant is violated. The
+/// trace came from the same registered circuit, so assembly failure is itself
+/// a pipeline bug, not an iteration to discard.
 fn check_alpha_injection(
     registry: &Registry<'_, Fp, TestRank>,
     trace: &ragu_circuits::Trace<Fp>,
     alpha_a: Fp,
     alpha_b: Fp,
-) -> Option<()> {
+) {
     let idx = CircuitIndex::new(0);
-    let poly_a = registry.assemble_with_alpha(trace, idx, alpha_a).ok()?;
-    let poly_b = registry.assemble_with_alpha(trace, idx, alpha_b).ok()?;
+    let poly_a = registry
+        .assemble_with_alpha(trace, idx, alpha_a)
+        .expect("first alpha assembly failed for a registered trace");
+    let poly_b = registry
+        .assemble_with_alpha(trace, idx, alpha_b)
+        .expect("second alpha assembly failed for a registered trace");
 
     let coeffs_a: Vec<Fp> = poly_a.iter_coeffs().collect();
     let coeffs_b: Vec<Fp> = poly_b.iter_coeffs().collect();
@@ -512,7 +517,6 @@ fn check_alpha_injection(
         alpha_a - alpha_b,
         "alpha delta mismatch at coefficient position {diff_idx}"
     );
-    Some(())
 }
 
 fuzz_target!(|input: Input| {
@@ -597,10 +601,9 @@ fuzz_target!(|input: Input| {
             y_seed,
             use_special_x,
         } => {
-            let registry = match BOOL_REGISTRY.as_ref() {
-                Some(r) => r,
-                None => return,
-            };
+            let registry = BOOL_REGISTRY
+                .as_ref()
+                .expect("BoolCircuit registry construction failed");
             let x: Fp = match use_special_x {
                 Some(idx) => special_value(idx),
                 None => Fp::from(x_seed),
@@ -651,10 +654,9 @@ fuzz_target!(|input: Input| {
                 return;
             }
             let base = (EpAffine::generator() * Fq::from(scalar_seed)).to_affine();
-            let registry = match POINT_REGISTRY.as_ref() {
-                Some(r) => r,
-                None => return,
-            };
+            let registry = POINT_REGISTRY
+                .as_ref()
+                .expect("PointCircuit registry construction failed");
             let circuit = PointCircuit;
             let expected: EpAffine = match point_native(base) {
                 Some(p) => p,
@@ -704,10 +706,9 @@ fuzz_target!(|input: Input| {
             witness_seed,
             use_special,
         } => {
-            let registry = match ROUTINE_REGISTRY.as_ref() {
-                Some(r) => r,
-                None => return,
-            };
+            let registry = ROUTINE_REGISTRY
+                .as_ref()
+                .expect("RoutineCircuit registry construction failed");
             let witness: Fp = match use_special {
                 Some(idx) => special_value(idx),
                 None => Fp::from(witness_seed),
@@ -754,10 +755,9 @@ fuzz_target!(|input: Input| {
             witness_seed,
             use_special,
         } => {
-            let registry = match KNOWN_ROUTINE_REGISTRY.as_ref() {
-                Some(r) => r,
-                None => return,
-            };
+            let registry = KNOWN_ROUTINE_REGISTRY
+                .as_ref()
+                .expect("KnownRoutineCircuit registry construction failed");
             let witness: Fp = match use_special {
                 Some(idx) => special_value(idx),
                 None => Fp::from(witness_seed),

--- a/qa/fuzz/fuzz_targets/fuzz_endoscalar.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_endoscalar.rs
@@ -182,42 +182,25 @@ fuzz_target!(|input: Input| {
                     current_native = (-current_native.to_curve()).to_affine();
                 }
                 PointOp::Double => {
-                    match current.double(dr) {
-                        Ok(doubled) => {
-                            current = doubled;
-                            current_native = current_native.to_curve().double().to_affine();
-                        }
-                        Err(_) => break,
-                    }
+                    current = current.double(dr)?;
+                    current_native = current_native.to_curve().double().to_affine();
                 }
                 PointOp::ConditionalEndo(cond) => {
                     let b = Boolean::alloc(dr, allocator, bool_vals.as_ref().map(|v| v[bool_idx]))?;
                     bool_idx += 1;
-                    match current.conditional_endo(dr, &b) {
-                        Ok(result) => {
-                            current = result;
-                            if *cond {
-                                let coords = current_native.coordinates().unwrap();
-                                let new_x = *coords.x() * Fp::ZETA;
-                                current_native =
-                                    EpAffine::from_xy(new_x, *coords.y()).unwrap();
-                            }
-                        }
-                        Err(_) => break,
+                    current = current.conditional_endo(dr, &b)?;
+                    if *cond {
+                        let coords = current_native.coordinates().unwrap();
+                        let new_x = *coords.x() * Fp::ZETA;
+                        current_native = EpAffine::from_xy(new_x, *coords.y()).unwrap();
                     }
                 }
                 PointOp::ConditionalNegate(cond) => {
                     let b = Boolean::alloc(dr, allocator, bool_vals.as_ref().map(|v| v[bool_idx]))?;
                     bool_idx += 1;
-                    match current.conditional_negate(dr, &b) {
-                        Ok(result) => {
-                            current = result;
-                            if *cond {
-                                current_native =
-                                    (-current_native.to_curve()).to_affine();
-                            }
-                        }
-                        Err(_) => break,
+                    current = current.conditional_negate(dr, &b)?;
+                    if *cond {
+                        current_native = (-current_native.to_curve()).to_affine();
                     }
                 }
             }

--- a/qa/fuzz/fuzz_targets/fuzz_multipack.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_multipack.rs
@@ -69,7 +69,7 @@ fuzz_target!(|input: Input| {
 
     let bits_owned: Vec<bool> = input.bits.clone();
 
-    let _ = Simulator::<Fp>::simulate(bits_owned, |dr, witness| {
+    let result = Simulator::<Fp>::simulate(bits_owned, |dr, witness| {
         let allocator = &mut Standard::new();
 
         // Allocate each input bit as a Boolean.
@@ -102,4 +102,9 @@ fuzz_target!(|input: Input| {
 
         Ok(())
     });
+    assert!(
+        result.is_ok(),
+        "multipack rejected a valid boolean witness: {:?}",
+        result.err(),
+    );
 });

--- a/qa/fuzz/fuzz_targets/fuzz_point_identities.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_point_identities.rs
@@ -133,7 +133,7 @@ fuzz_target!(|input: Input| {
     let p_doubled = native_double(p);
     let p_doubled_x = *p_doubled.coordinates().unwrap().x();
 
-    let _ = Simulator::<Fp>::simulate((p, q), |dr, witness| {
+    let result = Simulator::<Fp>::simulate((p, q), |dr, witness| {
         let allocator = &mut Standard::new();
 
         let p_val = witness.as_ref().map(|w| w.0);
@@ -253,4 +253,9 @@ fuzz_target!(|input: Input| {
 
         Ok(())
     });
+    assert!(
+        result.is_ok(),
+        "point identities rejected guarded, valid inputs: {:?}",
+        result.err(),
+    );
 });

--- a/qa/fuzz/fuzz_targets/fuzz_staging.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_staging.rs
@@ -690,8 +690,9 @@ fn check_stage_slot_range(
 /// first — this mirrors production proving at
 /// `crates/ragu_pcd/src/internal/endoscalar.rs:470`.
 ///
-/// Returns `(expected_ky, actual_revdot)` so the caller's panic message
-/// can show both sides of the Invariant B check.
+/// Returns `(expected_ky, actual_revdot)` so the caller's panic message can
+/// show both sides of the Invariant B check. All circuits and registries here
+/// are fixed and valid, so trace or assembly failures are oracle failures.
 fn check_identity<C: Circuit<Fp>>(
     label: &str,
     registry: &Registry<'_, Fp, TestRank>,
@@ -699,11 +700,14 @@ fn check_identity<C: Circuit<Fp>>(
     witness: C::Witness<'_>,
     instance: C::Instance<'_>,
     stage_rx_sum: sparse::Polynomial<Fp, TestRank>,
-    final_mask_registry: Option<&Registry<'_, Fp, TestRank>>,
+    final_mask_registry: &Registry<'_, Fp, TestRank>,
     y: Fp,
     z: Fp,
-) -> Option<(Fp, Fp)> {
-    let trace = circuit.trace(witness).ok()?.into_output();
+) -> (Fp, Fp) {
+    let trace = circuit
+        .trace(witness)
+        .expect("fixed MultiStage circuit trace failed")
+        .into_output();
 
     // alpha = 0 so the algebraic identity holds without an extra revdot
     // term — same rationale as fuzz_circuit_revdot_identity. The stage rx
@@ -721,16 +725,14 @@ fn check_identity<C: Circuit<Fp>>(
     // assembled trace are zero (StageBuilder allocates them as
     // Coeff::Zero), so the SYSTEM gate and earlier gates contribute
     // nothing either.
-    if let Some(fm_reg) = final_mask_registry {
-        let fm_sy = sy_from_mask_registry(fm_reg, y);
-        let fm_actual = multistage_trace.revdot(&fm_sy);
-        assert_eq!(
-            fm_actual,
-            Fp::ZERO,
-            "final_mask check failed for {label}: \
-             assembled_multistage_trace.revdot(final_mask) = {fm_actual:?}, expected 0 at y={y:?}"
-        );
-    }
+    let fm_sy = sy_from_mask_registry(final_mask_registry, y);
+    let fm_actual = multistage_trace.revdot(&fm_sy);
+    assert_eq!(
+        fm_actual,
+        Fp::ZERO,
+        "final_mask check failed for {label}: \
+         assembled_multistage_trace.revdot(final_mask) = {fm_actual:?}, expected 0 at y={y:?}"
+    );
 
     let mut r = multistage_trace;
     r.add_assign(&stage_rx_sum);
@@ -744,7 +746,7 @@ fn check_identity<C: Circuit<Fp>>(
         .ky(instance, y)
         .expect("ky should not fail on a MultiStage Fp instance");
     let actual = r.revdot(&b);
-    Some((expected_ky, actual))
+    (expected_ky, actual)
 }
 
 fuzz_target!(|input: Input| {
@@ -762,10 +764,9 @@ fuzz_target!(|input: Input| {
             b_seed,
             use_special,
         } => {
-            let registry = match SINGLE2W_REGISTRY.as_ref() {
-                Some(r) => r,
-                None => return,
-            };
+            let registry = SINGLE2W_REGISTRY
+                .as_ref()
+                .expect("Single2W registry construction failed");
             let a = maybe_special(a_seed, use_special);
             let b = Fp::from(b_seed);
             let witness = (a, b);
@@ -776,36 +777,35 @@ fuzz_target!(|input: Input| {
             // `rx_configured` and `StageMask::new` together — invariants
             // A/B and final_mask all stay structurally satisfied under
             // such a shift, but this assertion fails immediately.
-            debug_assert_eq!(<StageW2 as Stage<Fp, TestRank>>::skip_gates(), 1);
-            debug_assert_eq!(<StageW2 as StageExt<Fp, TestRank>>::num_gates(), 1);
+            assert_eq!(<StageW2 as Stage<Fp, TestRank>>::skip_gates(), 1);
+            assert_eq!(<StageW2 as StageExt<Fp, TestRank>>::num_gates(), 1);
 
-            let stage_w2_rx = match StageW2::rx(Fp::ZERO, (a, b)) {
-                Ok(p) => p,
-                Err(_) => return,
-            };
+            let stage_w2_rx =
+                StageW2::rx(Fp::ZERO, (a, b)).expect("StageW2::rx failed on a valid witness");
             // Structural cross-mask check (robust replacement for the
             // dropped algebraic version): assert non-zero positions land
             // only in StageW2's declared range or the SYSTEM gate.
             check_stage_slot_range("Single2W/StageW2", &stage_w2_rx, 1, 1);
             // Invariant A: per-stage isolation against the stage's own mask.
-            if let Some(mask_reg) = MASK_REGISTRY_W2.as_ref() {
-                check_stage_isolation("Single2W/StageW2", &stage_w2_rx, mask_reg, y);
-            }
+            let mask_reg = MASK_REGISTRY_W2
+                .as_ref()
+                .expect("StageW2 mask registry construction failed");
+            check_stage_isolation("Single2W/StageW2", &stage_w2_rx, mask_reg, y);
             // Invariant B (with bundled final_mask check on the bare trace):
             // StageW2 is the last (and only) stage in this variant.
-            let Some((expected, actual)) = check_identity(
+            let (expected, actual) = check_identity(
                 "Single2W",
                 registry,
                 &circuit,
                 witness,
                 instance,
                 stage_w2_rx,
-                MASK_REGISTRY_W2_FINAL.as_ref(),
+                MASK_REGISTRY_W2_FINAL
+                    .as_ref()
+                    .expect("StageW2 final-mask registry construction failed"),
                 y,
                 z,
-            ) else {
-                return;
-            };
+            );
             assert_eq!(
                 expected, actual,
                 "Single2W staging identity violated: \
@@ -820,10 +820,9 @@ fuzz_target!(|input: Input| {
             d_seed,
             use_special,
         } => {
-            let registry = match SINGLE4W_REGISTRY.as_ref() {
-                Some(r) => r,
-                None => return,
-            };
+            let registry = SINGLE4W_REGISTRY
+                .as_ref()
+                .expect("Single4W registry construction failed");
             let a = maybe_special(a_seed, use_special);
             let b = Fp::from(b_seed);
             let c = Fp::from(c_seed);
@@ -832,30 +831,29 @@ fuzz_target!(|input: Input| {
             let circuit = MultiStage::<Fp, TestRank, _>::new(Single4W);
             let instance = Single4W::native_instance(witness);
             // Pin StageW4's declared offsets (same rationale as Single2W).
-            debug_assert_eq!(<StageW4 as Stage<Fp, TestRank>>::skip_gates(), 1);
-            debug_assert_eq!(<StageW4 as StageExt<Fp, TestRank>>::num_gates(), 2);
+            assert_eq!(<StageW4 as Stage<Fp, TestRank>>::skip_gates(), 1);
+            assert_eq!(<StageW4 as StageExt<Fp, TestRank>>::num_gates(), 2);
 
-            let stage_w4_rx = match StageW4::rx(Fp::ZERO, witness) {
-                Ok(p) => p,
-                Err(_) => return,
-            };
+            let stage_w4_rx =
+                StageW4::rx(Fp::ZERO, witness).expect("StageW4::rx failed on a valid witness");
             check_stage_slot_range("Single4W/StageW4", &stage_w4_rx, 1, 2);
-            if let Some(mask_reg) = MASK_REGISTRY_W4.as_ref() {
-                check_stage_isolation("Single4W/StageW4", &stage_w4_rx, mask_reg, y);
-            }
-            let Some((expected, actual)) = check_identity(
+            let mask_reg = MASK_REGISTRY_W4
+                .as_ref()
+                .expect("StageW4 mask registry construction failed");
+            check_stage_isolation("Single4W/StageW4", &stage_w4_rx, mask_reg, y);
+            let (expected, actual) = check_identity(
                 "Single4W",
                 registry,
                 &circuit,
                 witness,
                 instance,
                 stage_w4_rx,
-                MASK_REGISTRY_W4_FINAL.as_ref(),
+                MASK_REGISTRY_W4_FINAL
+                    .as_ref()
+                    .expect("StageW4 final-mask registry construction failed"),
                 y,
                 z,
-            ) else {
-                return;
-            };
+            );
             assert_eq!(
                 expected, actual,
                 "Single4W staging identity violated: \
@@ -872,10 +870,9 @@ fuzz_target!(|input: Input| {
             child_d_seed,
             use_special,
         } => {
-            let registry = match CHAIN_REGISTRY.as_ref() {
-                Some(r) => r,
-                None => return,
-            };
+            let registry = CHAIN_REGISTRY
+                .as_ref()
+                .expect("Chain2x4 registry construction failed");
             let parent_a = maybe_special(parent_a_seed, use_special);
             let parent_b = Fp::from(parent_b_seed);
             let child_a = Fp::from(child_a_seed);
@@ -892,34 +889,32 @@ fuzz_target!(|input: Input| {
             // Pin parent and child stage offsets. Catches symmetric
             // `skip_gates` shifts that A/B/final_mask all stay structurally
             // satisfied under.
-            debug_assert_eq!(<StageW2 as Stage<Fp, TestRank>>::skip_gates(), 1);
-            debug_assert_eq!(<StageW2 as StageExt<Fp, TestRank>>::num_gates(), 1);
-            debug_assert_eq!(<StageW4Child as Stage<Fp, TestRank>>::skip_gates(), 2);
-            debug_assert_eq!(<StageW4Child as StageExt<Fp, TestRank>>::num_gates(), 2);
+            assert_eq!(<StageW2 as Stage<Fp, TestRank>>::skip_gates(), 1);
+            assert_eq!(<StageW2 as StageExt<Fp, TestRank>>::num_gates(), 1);
+            assert_eq!(<StageW4Child as Stage<Fp, TestRank>>::skip_gates(), 2);
+            assert_eq!(<StageW4Child as StageExt<Fp, TestRank>>::num_gates(), 2);
 
             // Stages composed in order: StageW2 then StageW4Child. Sum both
             // rx polynomials so the combined `r(X)` is consistent with what
             // the verifier would see after committing each stage separately.
-            let parent_rx = match StageW2::rx(Fp::ZERO, (parent_a, parent_b)) {
-                Ok(p) => p,
-                Err(_) => return,
-            };
-            let child_rx = match StageW4Child::rx(Fp::ZERO, (child_a, child_b, child_c, child_d)) {
-                Ok(p) => p,
-                Err(_) => return,
-            };
+            let parent_rx = StageW2::rx(Fp::ZERO, (parent_a, parent_b))
+                .expect("parent StageW2::rx failed on a valid witness");
+            let child_rx = StageW4Child::rx(Fp::ZERO, (child_a, child_b, child_c, child_d))
+                .expect("child StageW4Child::rx failed on a valid witness");
             // Structural cross-mask: each rx must write only into its own
             // declared range. Stronger than Invariant A; not adversarially
             // foolable via the revdot algebraic identity.
             check_stage_slot_range("Chain/parent StageW2", &parent_rx, 1, 1);
             check_stage_slot_range("Chain/child StageW4Child", &child_rx, 2, 2);
             // Invariant A: each stage checked against its own mask in isolation.
-            if let Some(mask_reg) = MASK_REGISTRY_W2.as_ref() {
-                check_stage_isolation("Chain/parent StageW2", &parent_rx, mask_reg, y);
-            }
-            if let Some(mask_reg) = MASK_REGISTRY_W4_CHILD.as_ref() {
-                check_stage_isolation("Chain/child StageW4Child", &child_rx, mask_reg, y);
-            }
+            let parent_mask = MASK_REGISTRY_W2
+                .as_ref()
+                .expect("StageW2 mask registry construction failed");
+            check_stage_isolation("Chain/parent StageW2", &parent_rx, parent_mask, y);
+            let child_mask = MASK_REGISTRY_W4_CHILD
+                .as_ref()
+                .expect("StageW4Child mask registry construction failed");
+            check_stage_isolation("Chain/child StageW4Child", &child_rx, child_mask, y);
             // Cross-mask discrimination (parent.rx vs child.mask and vice
             // versa) is intentionally NOT asserted here. The check
             // `rx.revdot(foreign_mask) != 0` is structurally fragile under
@@ -942,19 +937,19 @@ fuzz_target!(|input: Input| {
             // `[child_skip + child_num, R::n())`, the post-stage gate range.
             let mut stage_rx_sum = parent_rx;
             stage_rx_sum.add_assign(&child_rx);
-            let Some((expected, actual)) = check_identity(
+            let (expected, actual) = check_identity(
                 "Chain2x4",
                 registry,
                 &circuit,
                 witness,
                 instance,
                 stage_rx_sum,
-                MASK_REGISTRY_W4_CHILD_FINAL.as_ref(),
+                MASK_REGISTRY_W4_CHILD_FINAL
+                    .as_ref()
+                    .expect("StageW4Child final-mask registry construction failed"),
                 y,
                 z,
-            ) else {
-                return;
-            };
+            );
             assert_eq!(
                 expected, actual,
                 "Chain2x4 staging identity violated: \

--- a/qa/fuzz/fuzz_targets/fuzz_verify_reject.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_verify_reject.rs
@@ -8,6 +8,7 @@
 #![no_main]
 
 use arbitrary::Arbitrary;
+use ff::Field;
 use libfuzzer_sys::fuzz_target;
 use pasta_curves::Fp;
 use ragu_circuits::polynomials::ProductionRank;
@@ -57,7 +58,7 @@ enum FuzzCorruption {
     PBlind(u64),
     PEval(u64),
     AbC(u64),
-    CircuitId(u32),
+    CircuitId,
     ChallengeU(u64),
     ChallengeX(u64),
     ChallengeY(u64),
@@ -82,16 +83,31 @@ fuzz_target!(|input: Input| {
 
     let mut proof = TRIVIAL_PROOF.clone();
 
+    // The fixture has challenges equal to one, circuit id zero, and four
+    // header elements. Nudge every fuzzer choice away from those values so
+    // each variant performs a real corruption before rejection is asserted.
+    let nonzero_delta = |v: u64| {
+        let v = Fp::from(v);
+        if v == Fp::ZERO { Fp::ONE } else { v }
+    };
+    let changed_challenge = |v: u64| {
+        let v = Fp::from(v);
+        if v == Fp::ONE { Fp::from(2u64) } else { v }
+    };
+    let wrong_header_len = |v: u8| {
+        let v = v as usize;
+        if v == HEADER_SIZE { HEADER_SIZE + 1 } else { v }
+    };
     let corruption = match input.corruption {
-        FuzzCorruption::PBlind(v) => Corruption::PBlind(Fp::from(v)),
-        FuzzCorruption::PEval(v) => Corruption::PEval(Fp::from(v)),
-        FuzzCorruption::AbC(v) => Corruption::AbC(Fp::from(v)),
-        FuzzCorruption::CircuitId(v) => Corruption::CircuitId(v),
-        FuzzCorruption::ChallengeU(v) => Corruption::ChallengeU(Fp::from(v)),
-        FuzzCorruption::ChallengeX(v) => Corruption::ChallengeX(Fp::from(v)),
-        FuzzCorruption::ChallengeY(v) => Corruption::ChallengeY(Fp::from(v)),
-        FuzzCorruption::LeftHeaderLen(v) => Corruption::LeftHeaderLen(v as usize),
-        FuzzCorruption::RightHeaderLen(v) => Corruption::RightHeaderLen(v as usize),
+        FuzzCorruption::PBlind(v) => Corruption::PBlind(nonzero_delta(v)),
+        FuzzCorruption::PEval(v) => Corruption::PEval(nonzero_delta(v)),
+        FuzzCorruption::AbC(v) => Corruption::AbC(nonzero_delta(v)),
+        FuzzCorruption::CircuitId => Corruption::CircuitId(u32::MAX),
+        FuzzCorruption::ChallengeU(v) => Corruption::ChallengeU(changed_challenge(v)),
+        FuzzCorruption::ChallengeX(v) => Corruption::ChallengeX(changed_challenge(v)),
+        FuzzCorruption::ChallengeY(v) => Corruption::ChallengeY(changed_challenge(v)),
+        FuzzCorruption::LeftHeaderLen(v) => Corruption::LeftHeaderLen(wrong_header_len(v)),
+        FuzzCorruption::RightHeaderLen(v) => Corruption::RightHeaderLen(wrong_header_len(v)),
     };
 
     proof.corrupt(corruption);
@@ -99,6 +115,11 @@ fuzz_target!(|input: Input| {
     let pcd = proof.carry::<()>(());
     let rng = StdRng::seed_from_u64(input.rng_seed);
 
-    // Must never panic. Corrupted proofs should be rejected.
-    let _ = app.verify(&pcd, rng);
+    // Must never panic or accept. Internal computation errors are rejection.
+    let result = app.verify(&pcd, rng);
+    assert!(
+        !matches!(result, Ok(true)),
+        "verifier accepted a deliberately corrupted proof: {:?}",
+        input.corruption,
+    );
 });

--- a/qa/fuzz/fuzz_targets/fuzz_witness_pinning.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_witness_pinning.rs
@@ -211,10 +211,10 @@ fuzz_target!(|input: Input| {
         Err(_) => return, // Rank overflow: program too large for TestRank.
     };
 
-    let trace: Trace<Fp> = match circuit.trace(honest_witness) {
-        Ok(t) => t.into_output(),
-        Err(_) => return,
-    };
+    let trace: Trace<Fp> = circuit
+        .trace(honest_witness)
+        .expect("fully-pinned honest ProgramCircuit trace failed")
+        .into_output();
 
     let y = Fp::from(input.y_seed);
     let z = Fp::from(input.z_seed);

--- a/qa/fuzz/src/recorder.rs
+++ b/qa/fuzz/src/recorder.rs
@@ -1012,15 +1012,14 @@ mod tests {
 
     /// An under-determined subsystem must still be solved: with nothing left
     /// to deduce, the guessing tier has to run and pick a witness rather than
-    /// stalling. Two wires appear only as `p + q = 3`, so neither is forced.
+    /// stalling. Two raw wires appear only as `p + q = 3`, so neither is
+    /// forced.
     #[test]
     fn under_determined_subsystem_still_solved() {
         let one = Recorder::<Fp>::ONE;
         let mut rec = Recorder::<Fp>::new();
-        let seed = rec.push_wire(Fp::from(3u64));
-        let p = rec.add(|lc| lc.add_term(&seed, Coeff::Arbitrary(Fp::from(2u64))));
-        let q = rec.add(|lc| lc.add_term(&seed, Coeff::NegativeOne));
-        // p + q − 3·seed = 0 holds honestly (6 − 3 − 3·… ), pinned via ONE.
+        let p = rec.push_wire(Fp::ONE);
+        let q = rec.push_wire(Fp::from(2u64));
         rec.enforce_zero(|lc| {
             lc.add(&p)
                 .add(&q)
@@ -1029,8 +1028,12 @@ mod tests {
         .unwrap();
         assert!(constraints_hold(&rec.events, &rec.values));
 
+        // Start both unknown wires from a non-satisfying choice. The guessing
+        // tier must retain one free direction and solve the other.
         let mut values = rec.values.clone();
-        repair(&rec.events, &mut values, &[seed]);
+        values[p] += Fp::ONE;
+        values[q] += Fp::ONE;
+        repair(&rec.events, &mut values, &[]);
         assert!(
             constraints_hold(&rec.events, &values),
             "the guessing tier must still resolve an under-determined system",

--- a/qa/fuzz/src/substrate/shadow.rs
+++ b/qa/fuzz/src/substrate/shadow.rs
@@ -105,6 +105,12 @@ pub struct ShadowStacks<F> {
     /// Distinct from "some boolean is true": a `BoolAlloc(true)` or a
     /// `BoolNot` produces a true boolean with no free hint.
     pub is_zero_degenerate: bool,
+    /// Whether each value-fallible op (`Invert`, `Divide`, `AllocRaw`) pushed
+    /// its element, in encounter order. Differential consumers compare this
+    /// trace rather than only the final stack length: one newly-executed op
+    /// and one newly-skipped op can cancel in length while still changing the
+    /// circuit shape between them.
+    pub value_fallible_pushes: Vec<bool>,
 }
 
 /// Evaluates `program` natively with the given advice overrides.
@@ -144,6 +150,7 @@ where
     let mut bools: Vec<bool> = Vec::new();
     let mut anchors = Vec::new();
     let mut is_zero_degenerate = false;
+    let mut value_fallible_pushes = Vec::new();
 
     for (idx, op) in program.ops.iter().enumerate() {
         let elen = elems.len();
@@ -181,6 +188,7 @@ where
                 let a = a as usize % elen;
                 // Mirrors the gadget: inverting zero fails, skipping the push.
                 let inv: Option<F> = elems[a].invert().into();
+                value_fallible_pushes.push(inv.is_some());
                 if let Some(inv) = inv {
                     elems.push(inv);
                 }
@@ -197,6 +205,7 @@ where
                 // Mirrors the gadget: a zero divisor fails enforce_nonzero,
                 // skipping the push.
                 let inv: Option<F> = elems[b].invert().into();
+                value_fallible_pushes.push(inv.is_some());
                 if let Some(inv) = inv {
                     elems.push(elems[a] * inv);
                 }
@@ -222,6 +231,7 @@ where
             Op::AllocRaw(bytes) => {
                 // Mirrors the gadget: non-canonical bytes skip the push.
                 let v: Option<F> = F::from_repr(bytes).into();
+                value_fallible_pushes.push(v.is_some());
                 if let Some(honest) = v {
                     let slot = elems.len();
                     advice.push(AdviceSlot::Elem(slot));
@@ -285,6 +295,7 @@ where
         anchors,
         advice,
         is_zero_degenerate,
+        value_fallible_pushes,
     }
 }
 
@@ -299,6 +310,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use ff::Field;
     use proptest::prelude::*;
     use ragu_core::maybe::Maybe;
     use ragu_pasta::Fp;
@@ -417,5 +429,32 @@ mod tests {
         assert_eq!(s.elems[1], Fp::from(456), "witness slot must move");
         assert!(!s.advice.contains(&AdviceSlot::Elem(0)));
         assert!(s.advice.contains(&AdviceSlot::Elem(1)));
+    }
+
+    /// Opposite skip changes can leave the final stack length unchanged. The
+    /// per-op trace must retain both changes so graph-based consumers bail.
+    #[test]
+    fn value_fallible_trace_detects_net_zero_control_flow_change() {
+        let program = Program {
+            preamble: Preamble {
+                seeds: [0, 1, 7, 11],
+                large_seeds: [[1, 2, 3, 4], [5, 6, 7, 8]],
+                special_seeds: [1, 11],
+                constant_mask: 0,
+            },
+            ops: vec![Op::Invert(0), Op::Invert(1)],
+        };
+        let honest = shadow_eval::<Fp>(&program, Overrides::none());
+        let mutated = shadow_eval::<Fp>(
+            &program,
+            Overrides {
+                elems: &[(0, Fp::ONE), (1, Fp::ZERO)],
+                ..Overrides::none()
+            },
+        );
+
+        assert_eq!(honest.elems.len(), mutated.elems.len());
+        assert_eq!(honest.value_fallible_pushes, [false, true]);
+        assert_eq!(mutated.value_fallible_pushes, [true, false]);
     }
 }


### PR DESCRIPTION
Hardens our fuzzing oracles against false positives and silent skips while adding regression tests and complete CI coverage for all fuzz targets.