### PR TITLE
chore(fuzz): migrate patcher engine to ragu testing

### DIFF
--- a/crates/ragu_testing/src/lib.rs
+++ b/crates/ragu_testing/src/lib.rs
@@ -1,4 +1,14 @@
-//! Test fixtures for Ragu crates.
+//! # `ragu_testing`
+//!
+//! This crate contains test fixtures and harnesses for the Ragu project. This
+//! API is re-exported (as necessary) in other crates and so this crate is only
+//! intended to be used internally by Ragu.
+
+#![forbid(unsafe_code)]
+#![deny(rustdoc::broken_intra_doc_links)]
+#![deny(missing_docs)]
+#![doc(html_favicon_url = "https://tachyon.z.cash/assets/ragu/v1/favicon-32x32.png")]
+#![doc(html_logo_url = "https://tachyon.z.cash/assets/ragu/v1/rustdoc-128x128.png")]
 
 pub mod circuits;
 pub mod patcher;

--- a/crates/ragu_testing/src/lib.rs
+++ b/crates/ragu_testing/src/lib.rs
@@ -1,6 +1,7 @@
 //! Test fixtures for Ragu crates.
 
 pub mod circuits;
+pub mod patcher;
 pub mod pcd;
 pub mod registry;
 pub mod strategies;

--- a/crates/ragu_testing/src/patcher/circuit.rs
+++ b/crates/ragu_testing/src/patcher/circuit.rs
@@ -1,0 +1,152 @@
+//! Running the engine against a [`Circuit`] through its public API.
+//!
+//! [`capture`] synthesizes a circuit's witness through the [`Recorder`] and
+//! then serializes its public output, exactly as trace evaluation does — so
+//! the result carries the constraint graph, the honest wire values, *and*
+//! the wires of the public instance in $k(Y)$ order. [`playback`] re-runs the
+//! same synthesis through [`Playback`] over an injected witness.
+//!
+//! Nothing about the circuit is assumed beyond the trait: it builds its own
+//! allocators (the recorder's `Extra = usize` supports the pooling
+//! [`Standard`](ragu_primitives::allocator::Standard) allocator circuits
+//! normally use), may call routines, and may emit constraints while writing
+//! its output.
+
+use ragu_arithmetic::ff::Field;
+use ragu_circuits::Circuit;
+use ragu_core::{
+    Result,
+    maybe::{Always, MaybeKind},
+};
+use ragu_primitives::{Element, GadgetExt};
+
+use super::{Playback, Recorder};
+
+/// A circuit synthesized through the [`Recorder`].
+pub struct Capture<F> {
+    /// The recording driver after synthesis: the captured constraint graph
+    /// ([`Recorder::events`]), the honest wire values ([`Recorder::values`])
+    /// and the pooled $D$ wires ([`Recorder::extras`]).
+    pub recorder: Recorder<F>,
+    /// The wires of the circuit's public instance, in the order the
+    /// circuit's output gadget writes them — the $k(Y)$ order.
+    pub instance: Vec<usize>,
+}
+
+/// Synthesizes `circuit` on `witness` through the [`Recorder`].
+///
+/// Runs [`Circuit::witness`] and then writes the resulting output gadget
+/// into an element buffer, as trace evaluation does (a `Write` impl may
+/// itself emit constraints, so the write is part of the circuit). The
+/// witness should be satisfying: the engine's oracles assume the captured
+/// values satisfy the captured constraints, which
+/// [`constraints_hold`](super::constraints_hold) verifies.
+///
+/// # Errors
+///
+/// Propagates any error from the circuit's witness generation or from
+/// serializing its output.
+pub fn capture<'witness, F: Field, C: Circuit<F>>(
+    circuit: &C,
+    witness: C::Witness<'witness>,
+) -> Result<Capture<F>> {
+    let mut recorder = Recorder::<F>::new();
+    let output = circuit
+        .witness(&mut recorder, Always::maybe_just(|| witness))?
+        .into_output();
+    let mut buffer: Vec<Element<'_, Recorder<F>>> = Vec::new();
+    output.write(&mut recorder, &mut buffer)?;
+    let instance = buffer.iter().map(|e| *e.wire()).collect();
+    Ok(Capture { recorder, instance })
+}
+
+/// Re-runs `circuit` on `witness` through [`Playback`] over the injected
+/// `values` (indexed by recorder wire, as produced by [`capture`] and
+/// possibly repaired) and reports whether every gate, `C · D = 0`, linear
+/// definition and `enforce_zero` held — and that the synthesis consumed
+/// exactly the injected wires.
+///
+/// # Errors
+///
+/// Propagates any error from the circuit's witness generation or from
+/// serializing its output.
+pub fn playback<'witness, F: Field, C: Circuit<F>>(
+    circuit: &C,
+    witness: C::Witness<'witness>,
+    values: Vec<F>,
+) -> Result<bool> {
+    let mut playback = Playback::<F>::new(values);
+    let output = circuit
+        .witness(&mut playback, Always::maybe_just(|| witness))?
+        .into_output();
+    let mut buffer: Vec<Element<'_, Playback<F>>> = Vec::new();
+    output.write(&mut playback, &mut buffer)?;
+    Ok(playback.accepts())
+}
+
+#[cfg(test)]
+mod tests {
+    use ragu_pasta::Fp;
+
+    use super::*;
+    use crate::{
+        circuits::{MySimpleCircuit, SquareCircuit},
+        patcher::{constraints_hold, discover_free_advice, repair},
+    };
+
+    /// `MySimpleCircuit` proves `a⁵ = b²` and outputs `(a + b, a − b)`.
+    /// Its two witness allocations share one pooled gate: `a` on the gate's
+    /// `a` wire (1), `b` on its `d` wire (4), with `b`/`c` (2, 3) wasted.
+    #[test]
+    fn capture_my_simple_circuit() -> Result<()> {
+        let (a, b) = (Fp::from(4u64), Fp::from(32u64)); // 4⁵ = 1024 = 32²
+        let cap = capture(&MySimpleCircuit, (a, b))?;
+        let rec = &cap.recorder;
+
+        assert!(constraints_hold(&rec.events, &rec.values));
+        assert_eq!(rec.extras, vec![4]);
+        assert_eq!(cap.instance.len(), 2);
+        assert_eq!(rec.values[cap.instance[0]], a + b);
+        assert_eq!(rec.values[cap.instance[1]], a - b);
+        assert!(playback(&MySimpleCircuit, (a, b), rec.values.clone())?);
+
+        // Only the allocations are free: `a`, the wasted `b`, and `d`.
+        // Everything else — the squaring chain, `b²`, both outputs — is
+        // derived from them.
+        assert_eq!(
+            discover_free_advice(&rec.events, &rec.values),
+            vec![1, 2, 4]
+        );
+
+        // Corrupting an output is caught live.
+        let mut corrupted = rec.values.clone();
+        corrupted[cap.instance[0]] += Fp::ONE;
+        assert!(!playback(&MySimpleCircuit, (a, b), corrupted)?);
+
+        Ok(())
+    }
+
+    /// Repairing a cheat on a captured circuit's witness wire: moving `a`
+    /// propagates through every square to the output, which `playback`
+    /// then accepts as a different-but-valid witness.
+    #[test]
+    fn repair_propagates_through_captured_circuit() -> Result<()> {
+        let circuit = SquareCircuit { times: 3 };
+        let cap = capture(&circuit, Fp::from(3u64))?;
+        let rec = &cap.recorder;
+        let free = discover_free_advice(&rec.events, &rec.values);
+        assert_eq!(
+            free,
+            vec![1, 2],
+            "one allocation gate: `a` plus the wasted `b` (`c = a·b` follows)"
+        );
+
+        let mut values = rec.values.clone();
+        values[1] = Fp::from(5u64);
+        repair(&rec.events, &mut values, &free);
+        assert!(constraints_hold(&rec.events, &values));
+        assert_eq!(values[cap.instance[0]], Fp::from(5u64).pow([8u64]));
+        assert!(playback(&circuit, Fp::from(3u64), values)?);
+        Ok(())
+    }
+}

--- a/crates/ragu_testing/src/patcher/circuit.rs
+++ b/crates/ragu_testing/src/patcher/circuit.rs
@@ -86,12 +86,19 @@ pub fn playback<'witness, F: Field, C: Circuit<F>>(
 
 #[cfg(test)]
 mod tests {
+    use ragu_circuits::WithAux;
+    use ragu_core::{
+        drivers::{Driver, DriverValue},
+        gadgets::{Bound, Kind},
+        maybe::Maybe,
+    };
     use ragu_pasta::Fp;
+    use ragu_primitives::allocator::Standard;
 
     use super::*;
     use crate::{
         circuits::{MySimpleCircuit, SquareCircuit},
-        patcher::{constraints_hold, discover_free_advice, repair},
+        patcher::{allocation_waste, constraints_hold, discover_free_advice, repair},
     };
 
     /// `MySimpleCircuit` proves `a⁵ = b²` and outputs `(a + b, a − b)`.
@@ -118,10 +125,98 @@ mod tests {
             vec![1, 2, 4]
         );
 
+        // The census over a *healthy* circuit is empty: every discovered
+        // free wire is a declared input (`a` at 1, `b` at 4) or structural
+        // allocator waste — nothing unexplained.
+        assert_eq!(allocation_waste(&rec.events, &rec.values), vec![(2, 3)]);
+
         // Corrupting an output is caught live.
         let mut corrupted = rec.values.clone();
         corrupted[cap.instance[0]] += Fp::ONE;
         assert!(!playback(&MySimpleCircuit, (a, b), corrupted)?);
+
+        Ok(())
+    }
+
+    /// A deliberately under-constrained circuit: `square` is allocated as
+    /// free advice next to `root` — the `square = root²` gate is never
+    /// emitted — and `square` is the public output.
+    struct UnderconstrainedSquare;
+
+    impl Circuit<Fp> for UnderconstrainedSquare {
+        type Instance<'instance> = Fp;
+        type Output = Kind![Fp; Element<'_, _>];
+        type Witness<'witness> = Fp;
+        type Aux<'witness> = ();
+
+        fn instance<'dr, 'instance: 'dr, D: Driver<'dr, F = Fp>>(
+            &self,
+            dr: &mut D,
+            instance: DriverValue<D, Self::Instance<'instance>>,
+        ) -> Result<Bound<'dr, D, Self::Output>> {
+            Element::alloc(dr, &mut Standard::new(), instance)
+        }
+
+        fn witness<'dr, 'witness: 'dr, D: Driver<'dr, F = Fp>>(
+            &self,
+            dr: &mut D,
+            witness: DriverValue<D, Self::Witness<'witness>>,
+        ) -> Result<WithAux<Bound<'dr, D, Self::Output>, DriverValue<D, Self::Aux<'witness>>>>
+        {
+            let allocator = &mut Standard::new();
+            let _root = Element::alloc(dr, allocator, witness.as_ref().map(|w| *w))?;
+            // BUG (deliberate): the square is prover-chosen advice; nothing
+            // ties it to `root`.
+            let square = Element::alloc(dr, allocator, witness.map(|w| w * w))?;
+            Ok(WithAux::new(square, D::unit()))
+        }
+    }
+
+    /// The whole workflow this module exists for, end to end through the
+    /// public `Circuit` API: capture, discover the free wires, subtract the
+    /// declared inputs and the structural waste — the *unexplained* survivor
+    /// is exactly the unpinned hint. And the survivor is exploitable: cheat
+    /// the input, repair, and every captured constraint still holds (both by
+    /// the stored events and by live playback) while the public output
+    /// stays at its stale value instead of the cheated input's square.
+    #[test]
+    fn census_flags_unpinned_hint() -> Result<()> {
+        let root = Fp::from(7u64);
+        let cap = capture(&UnderconstrainedSquare, root)?;
+        let rec = &cap.recorder;
+        assert!(constraints_hold(&rec.events, &rec.values));
+
+        // One pooled gate: `root` on its `a` (1), waste (2, 3), `square`
+        // redeemed onto the `d` wire (4) — the public output.
+        assert_eq!(cap.instance, vec![4]);
+        let declared = [1usize];
+
+        let discovered = discover_free_advice(&rec.events, &rec.values);
+        let waste = allocation_waste(&rec.events, &rec.values);
+        let unexplained: Vec<usize> = discovered
+            .iter()
+            .copied()
+            .filter(|w| !declared.contains(w) && !waste.iter().any(|&(b, _)| b == *w))
+            .collect();
+        assert_eq!(
+            unexplained,
+            vec![4],
+            "the census must flag exactly the unpinned square hint"
+        );
+
+        // Exploit it: move the declared input, repair, and the constraints
+        // are satisfied while the output ignores the change.
+        let mut values = rec.values.clone();
+        values[declared[0]] += Fp::ONE;
+        repair(&rec.events, &mut values, &discovered);
+        assert!(constraints_hold(&rec.events, &values));
+        assert!(playback(&UnderconstrainedSquare, root, values.clone())?);
+        assert_eq!(
+            values[cap.instance[0]],
+            root.square(),
+            "the output kept its stale value — no constraint carries the cheat"
+        );
+        assert_ne!(values[cap.instance[0]], (root + Fp::ONE).square());
 
         Ok(())
     }

--- a/crates/ragu_testing/src/patcher/discover.rs
+++ b/crates/ragu_testing/src/patcher/discover.rs
@@ -1,0 +1,211 @@
+//! Structural discovery of free advice from a recorded constraint graph.
+//!
+//! The engine's oracles need to know which wires the prover is free to
+//! choose — the advice — and which are derived from them by the
+//! constraints. A fuzz substrate that built the circuit can simply hand over
+//! that list; a circuit captured through its public API cannot, because it
+//! owns its allocators and the [`Recorder`] sees only gates, linear
+//! combinations and enforces. [`discover_free_advice`] recovers the list
+//! from the graph itself.
+//!
+//! # What "free" means here
+//!
+//! A wire is *derived* when the constraints determine it from wires created
+//! before it, and *free* otherwise. Discovery walks the wires in creation
+//! order, always taking the earliest wire the constraints have not yet
+//! determined as the next free one, and then lets the solver deduce
+//! everything that wire unlocks — so a `mul` gate's operands are derived
+//! (they are copy-constrained to earlier wires), its output is derived
+//! (`a·b`), an `invert`'s inverse is derived (back-solved from `x·x⁻¹ = 1`),
+//! while an allocation's `a` wire, a pooled allocation's `d` wire, an
+//! `alloc_square` root, a `Boolean::alloc` bit, and an allocation gate's
+//! wasted `b` are free. Only *forced* deductions count ([`deduce`], never
+//! the repair solver's guessing tier), so a wire reported free is genuinely
+//! undetermined by everything before it.
+//!
+//! # What it does not tell you
+//!
+//! Discovery is structural: it cannot distinguish a genuine witness input
+//! from an unconstrained hint, because both are wires nothing derives. That
+//! is exactly why it is useful — every reported wire that is *not* a known
+//! allocation is a wire a gadget left unpinned — but it also means the
+//! caller, not discovery, decides which free wires are the inputs an oracle
+//! pins and which are the advice it cheats.
+//!
+//! Two consequences of the earliest-first policy and of working at one
+//! witness:
+//!
+//! * An under-determined system reports its *earliest* participant free and
+//!   the rest derived — `p + q = 3` yields `p`, not `q`. The count of free
+//!   wires is what is meaningful, not the particular representatives.
+//! * Determination is judged at the supplied (satisfying) witness, so a
+//!   wire that is pinned generically but not at a special point is reported
+//!   free there: the inverse hint of an honestly-zero `is_zero` input, for
+//!   instance. That is the truth at that witness, not a discovery error.
+
+use ragu_arithmetic::ff::Field;
+
+use super::recorder::{Event, Recorder, deduce};
+
+/// The free-advice wires of a recorded constraint graph, ascending.
+///
+/// `values` must be a satisfying assignment of `events` (an honest capture);
+/// the result is the set of wires the constraints do not determine from
+/// earlier wires, per the module documentation. `values` is not modified.
+pub fn discover_free_advice<F: Field>(events: &[Event<F>], values: &[F]) -> Vec<usize> {
+    let mut scratch = values.to_vec();
+    let mut known = vec![false; scratch.len()];
+    known[Recorder::<F>::ONE] = true;
+
+    let mut free = Vec::new();
+    // The earliest unknown wire only ever moves forward: `known` grows
+    // monotonically and everything before `next` is already known.
+    let mut next = 0;
+    loop {
+        deduce(events, &mut scratch, &mut known);
+        match known[next..].iter().position(|k| !k) {
+            None => break,
+            Some(offset) => {
+                let wire = next + offset;
+                known[wire] = true;
+                free.push(wire);
+                next = wire + 1;
+            }
+        }
+    }
+    free
+}
+
+#[cfg(test)]
+mod tests {
+    use ragu_arithmetic::Coeff;
+    use ragu_core::drivers::{Driver, LinearExpression};
+    use ragu_pasta::Fp;
+    use ragu_primitives::{Boolean, Element};
+
+    use super::*;
+    use crate::patcher::{TrackingAllocator, constraints_hold};
+
+    /// The planted bug behind [`selftest`](super::super::selftest): `square`
+    /// is allocated beside `root` without the `square = root²` gate, so
+    /// both are free — and adding the gate (as `Element::square` emits it:
+    /// a gate with both operands copy-constrained to `root`) makes `square`
+    /// derived again.
+    #[test]
+    fn missing_gate_leaves_square_free() {
+        let root_honest = Fp::from(7u64);
+        let mut rec = Recorder::<Fp>::new();
+        let root = rec.push_wire(root_honest);
+        let square = rec.push_wire(root_honest.square());
+        assert_eq!(
+            discover_free_advice(&rec.events, &rec.values),
+            vec![root, square]
+        );
+
+        let (a, b, c) = rec
+            .mul(|| {
+                Ok((
+                    Coeff::Arbitrary(root_honest),
+                    Coeff::Arbitrary(root_honest),
+                    Coeff::Arbitrary(root_honest.square()),
+                ))
+            })
+            .unwrap();
+        rec.enforce_equal(&a, &root).unwrap();
+        rec.enforce_equal(&b, &root).unwrap();
+        rec.enforce_equal(&c, &square).unwrap();
+        assert!(constraints_hold(&rec.events, &rec.values));
+        assert_eq!(discover_free_advice(&rec.events, &rec.values), vec![root]);
+    }
+
+    /// An under-determined linear relation frees its earliest participant
+    /// only; an anchored wire is derived even though it was allocated.
+    #[test]
+    fn earliest_first_and_anchors() {
+        let one = Recorder::<Fp>::ONE;
+        let mut rec = Recorder::<Fp>::new();
+        let p = rec.push_wire(Fp::ONE);
+        let q = rec.push_wire(Fp::from(2u64));
+        rec.enforce_zero(|lc| {
+            lc.add(&p)
+                .add(&q)
+                .add_term(&one, Coeff::Arbitrary(-Fp::from(3u64)))
+        })
+        .unwrap();
+        assert_eq!(discover_free_advice(&rec.events, &rec.values), vec![p]);
+
+        // Anchor `p` to its honest value the way the fuzz substrate does: a
+        // constant wire, a difference Lin, and a 1-term enforce.
+        let pin = rec.add(|lc| lc.add_term(&one, Coeff::One));
+        let diff = rec.add(|lc| lc.add(&p).add_term(&pin, Coeff::NegativeOne));
+        rec.enforce_zero(|lc| lc.add(&diff)).unwrap();
+        assert!(constraints_hold(&rec.events, &rec.values));
+        assert!(discover_free_advice(&rec.events, &rec.values).is_empty());
+    }
+
+    /// Allocation patterns through the pooling allocator: the `a` wire and
+    /// the wasted `b` of a fresh gate are free, its `c` is derived, and the
+    /// `d` handed out as the next allocation is free; a `Boolean::alloc`'s
+    /// bit is free with its complement and output derived.
+    #[test]
+    fn allocation_patterns() -> ragu_core::Result<()> {
+        let mut rec = Recorder::<Fp>::new();
+        let mut alloc = TrackingAllocator::default();
+        let x = *Element::alloc(
+            &mut rec,
+            &mut alloc,
+            Recorder::<Fp>::just(|| Fp::from(5u64)),
+        )?
+        .wire();
+        let y = *Element::alloc(
+            &mut rec,
+            &mut alloc,
+            Recorder::<Fp>::just(|| Fp::from(9u64)),
+        )?
+        .wire();
+        let bit = *Boolean::alloc(&mut rec, &mut alloc, Recorder::<Fp>::just(|| true))?.wire();
+        let (b, _c) = alloc.wasted[0];
+        assert_eq!(
+            discover_free_advice(&rec.events, &rec.values),
+            vec![x, b, y, bit]
+        );
+        Ok(())
+    }
+
+    /// Determination is value-dependent: `is_zero`'s hints are derived when
+    /// the input is nonzero, but the inverse hint is genuinely free when the
+    /// input is zero (the bit is still pinned, via `x·inv = 1 − bit`).
+    #[test]
+    fn is_zero_hints() -> ragu_core::Result<()> {
+        for (input, expect_inverse_free) in [(Fp::from(7u64), false), (Fp::ZERO, true)] {
+            let mut rec = Recorder::<Fp>::new();
+            let mut alloc = TrackingAllocator::default();
+            let x = Element::alloc(&mut rec, &mut alloc, Recorder::<Fp>::just(|| input))?;
+            x.is_zero(&mut rec, &mut alloc)?;
+            assert!(constraints_hold(&rec.events, &rec.values));
+
+            let (b, _c) = alloc.wasted[0];
+            let mut expected = vec![*x.wire(), b];
+            if expect_inverse_free {
+                // The inverse hint is the `b` wire of the second `is_zero`
+                // gate, `x · inv = 1 − bit`.
+                let inverse = rec
+                    .events
+                    .iter()
+                    .filter_map(|ev| match ev {
+                        Event::Gate { b, .. } => Some(*b),
+                        _ => None,
+                    })
+                    .nth(2)
+                    .expect("is_zero emits two gates after the allocation gate");
+                expected.push(inverse);
+            }
+            assert_eq!(
+                discover_free_advice(&rec.events, &rec.values),
+                expected,
+                "input = {input:?}"
+            );
+        }
+        Ok(())
+    }
+}

--- a/crates/ragu_testing/src/patcher/discover.rs
+++ b/crates/ragu_testing/src/patcher/discover.rs
@@ -20,8 +20,8 @@
 //! while an allocation's `a` wire, a pooled allocation's `d` wire, an
 //! `alloc_square` root, a `Boolean::alloc` bit, and an allocation gate's
 //! wasted `b` are free. Only *forced* deductions count ([`deduce`], never
-//! the repair solver's guessing tier), so a wire reported free is genuinely
-//! undetermined by everything before it.
+//! the repair solver's guessing tier), so a wire reported *derived* is
+//! genuinely determined by the wires before it.
 //!
 //! # What it does not tell you
 //!
@@ -32,8 +32,8 @@
 //! caller, not discovery, decides which free wires are the inputs an oracle
 //! pins and which are the advice it cheats.
 //!
-//! Two consequences of the earliest-first policy and of working at one
-//! witness:
+//! Three consequences of the earliest-first policy, of working at one
+//! witness, and of the solver being bounded:
 //!
 //! * An under-determined system reports its *earliest* participant free and
 //!   the rest derived — `p + q = 3` yields `p`, not `q`. The count of free
@@ -42,10 +42,85 @@
 //!   wire that is pinned generically but not at a special point is reported
 //!   free there: the inverse hint of an honestly-zero `is_zero` input, for
 //!   instance. That is the truth at that witness, not a discovery error.
+//! * "Free" means *the bounded solver could not derive it*: [`deduce`] sees
+//!   no deduction from a gate with both operands unknown, and skips linear
+//!   clusters wider than its cap — and since discovery starts with the
+//!   whole graph unknown, the cluster pass only engages near the end. A
+//!   wire pinned solely through such wide coupling is over-reported as
+//!   free. So the result is a *candidate* list that errs toward reporting
+//!   wires, never toward hiding them — the safe direction for a census
+//!   whose job is flagging suspicious freedom. On ragu's actual emission
+//!   patterns the over-approximation is empty: gadgets pin each hint with
+//!   locally solvable constraints, which is pinned down for the whole fuzz
+//!   substrate by an exactness proptest there (discovery must equal the
+//!   substrate's own allocation list on anchorless programs).
 
 use ragu_arithmetic::ff::Field;
 
 use super::recorder::{Event, Recorder, deduce};
+
+/// The `(b, c)` waste-wire pairs of the allocation gates in a recorded
+/// graph, in emission order — recovered structurally, for callers that did
+/// not build the circuit and so cannot ask the allocator
+/// ([`TrackingAllocator::wasted`](super::TrackingAllocator) is the
+/// synthesis-side ground truth this must match).
+///
+/// An allocation gate is `a · 0 = 0`: its `b` and `c` are honestly zero,
+/// `b` appears in no other constraint, and `c` is referenced at most by the
+/// gate's own [`Event::Extra`] (when a pooling allocator later hands out
+/// the $D$ wire). The classification is sound for any gate matching that
+/// shape regardless of which gadget emitted it: a zero, never-referenced
+/// `b` genuinely is an unconstrained wasted wire. `values` must be the
+/// honest capture — waste is zero by construction there, and a repaired
+/// witness may legitimately move it.
+///
+/// The intended use is subtracting design freedom from a census: the free
+/// wires [`discover_free_advice`] reports minus the circuit's declared
+/// input wires minus these `b` wires are the *unexplained* freedom — hints
+/// some gadget left unpinned.
+pub fn allocation_waste<F: Field>(events: &[Event<F>], values: &[F]) -> Vec<(usize, usize)> {
+    let mut occurrences = vec![0usize; values.len()];
+    let mut extra_on_c = vec![false; values.len()];
+    for ev in events {
+        match ev {
+            Event::Lin { out, terms } => {
+                occurrences[*out] += 1;
+                for (w, _) in terms {
+                    occurrences[*w] += 1;
+                }
+            }
+            Event::Gate { a, b, c } => {
+                occurrences[*a] += 1;
+                occurrences[*b] += 1;
+                occurrences[*c] += 1;
+            }
+            Event::Enforce { terms } => {
+                for (w, _) in terms {
+                    occurrences[*w] += 1;
+                }
+            }
+            Event::Extra { c, d } => {
+                occurrences[*c] += 1;
+                occurrences[*d] += 1;
+                extra_on_c[*c] = true;
+            }
+        }
+    }
+    events
+        .iter()
+        .filter_map(|ev| match ev {
+            Event::Gate { b, c, .. }
+                if values[*b] == F::ZERO
+                    && values[*c] == F::ZERO
+                    && occurrences[*b] == 1
+                    && (occurrences[*c] == 1 || (occurrences[*c] == 2 && extra_on_c[*c])) =>
+            {
+                Some((*b, *c))
+            }
+            _ => None,
+        })
+        .collect()
+}
 
 /// The free-advice wires of a recorded constraint graph, ascending.
 ///
@@ -146,7 +221,10 @@ mod tests {
     /// Allocation patterns through the pooling allocator: the `a` wire and
     /// the wasted `b` of a fresh gate are free, its `c` is derived, and the
     /// `d` handed out as the next allocation is free; a `Boolean::alloc`'s
-    /// bit is free with its complement and output derived.
+    /// bit is free with its complement and output derived. The structural
+    /// waste classifier recovers exactly what the allocator recorded —
+    /// including *not* classifying the boolean gate (whose `b` is the
+    /// referenced complement) as an allocation.
     #[test]
     fn allocation_patterns() -> ragu_core::Result<()> {
         let mut rec = Recorder::<Fp>::new();
@@ -169,6 +247,7 @@ mod tests {
             discover_free_advice(&rec.events, &rec.values),
             vec![x, b, y, bit]
         );
+        assert_eq!(allocation_waste(&rec.events, &rec.values), alloc.wasted);
         Ok(())
     }
 

--- a/crates/ragu_testing/src/patcher/mod.rs
+++ b/crates/ragu_testing/src/patcher/mod.rs
@@ -1,0 +1,52 @@
+//! The patcher engine: under-constraint hunting over a recorded constraint
+//! graph.
+//!
+//! The *patcher* (after zksecurity's "Towards Fuzzing Zero-Knowledge Proof
+//! Circuits") starts from a satisfying witness, lets a malicious prover
+//! rewrite some free advice, and then *repairs* the rest of the witness so
+//! every constraint the circuit emitted still holds — propagating the cheat
+//! exactly as far as the constraints force it and no further. A cheat that
+//! survives repair but changes something the circuit's specification says is
+//! determined is an under-constrained-advice bug. This module is the
+//! driver-level machinery behind that technique; the policy of *what* to
+//! cheat and *which* oracle judges the result belongs to the caller (the
+//! `fuzz_advice_patcher` target in `qa/fuzz` for generated gadget programs;
+//! `ragu_pcd`'s own tests for the internal recursion circuits).
+//!
+//! # Pieces
+//!
+//! * [`Recorder`] — a [`Driver`](ragu_core::drivers::Driver) that captures
+//!   the constraint graph ragu emits (gates, pooled-allocation `C · D = 0`
+//!   constraints, linear-combination wires, `enforce_zero`s) as a flat list
+//!   of [`Event`]s over `usize` wires, alongside the honest wire values.
+//!   [`TrackingAllocator`] is the production pooling allocator with
+//!   bookkeeping of the wires it wastes.
+//! * [`repair`] / [`constraints_hold`] — the repair solver and the
+//!   acceptance check over a recorded graph.
+//! * [`underconstrained_derived`] — the rank/nullity oracle: derived wires
+//!   that can move while every declared free wire is held fixed.
+//! * [`discover_free_advice`] — structural discovery of the free-advice
+//!   candidates a recorded graph exposes (the wires no constraint derives
+//!   from earlier ones).
+//! * [`Playback`] — the independent cross-check: re-runs the same synthesis
+//!   and verifies an injected witness live, so a recorder capture bug cannot
+//!   silently corrupt a verdict.
+//! * [`capture`] / [`playback`] — the [`Circuit`](ragu_circuits::Circuit)
+//!   entry points: run a circuit's `witness` (and its output serialization)
+//!   through the drivers, exposing the wires of its public instance.
+//! * [`selftest`] — a planted under-constrained circuit whose signal must
+//!   fire, so the soundness direction is never vacuous.
+//!
+//! Everything is driven through the `Driver` trait alone; the engine never
+//! needs to know how a circuit was produced.
+
+mod circuit;
+mod discover;
+mod recorder;
+
+pub use circuit::{Capture, capture, playback};
+pub use discover::discover_free_advice;
+pub use recorder::{
+    Event, Playback, Recorder, TrackingAllocator, constraints_hold, repair, selftest,
+    underconstrained_derived,
+};

--- a/crates/ragu_testing/src/patcher/mod.rs
+++ b/crates/ragu_testing/src/patcher/mod.rs
@@ -27,7 +27,8 @@
 //!   that can move while every declared free wire is held fixed.
 //! * [`discover_free_advice`] — structural discovery of the free-advice
 //!   candidates a recorded graph exposes (the wires no constraint derives
-//!   from earlier ones).
+//!   from earlier ones), with [`allocation_waste`] classifying the wires an
+//!   allocator wastes by design so a census can subtract them.
 //! * [`Playback`] — the independent cross-check: re-runs the same synthesis
 //!   and verifies an injected witness live, so a recorder capture bug cannot
 //!   silently corrupt a verdict.
@@ -45,7 +46,7 @@ mod discover;
 mod recorder;
 
 pub use circuit::{Capture, capture, playback};
-pub use discover::discover_free_advice;
+pub use discover::{allocation_waste, discover_free_advice};
 pub use recorder::{
     Event, Playback, Recorder, TrackingAllocator, constraints_hold, repair, selftest,
     underconstrained_derived,

--- a/crates/ragu_testing/src/patcher/recorder.rs
+++ b/crates/ragu_testing/src/patcher/recorder.rs
@@ -536,13 +536,16 @@ impl<F: Field> Rref<F> {
                 continue;
             };
             rows.swap(r, pr);
-            let inv = rows[r][c].invert().unwrap();
-            for v in &mut rows[r][c..] {
+            // Split the pivot row out so the rows above and below it can be
+            // reduced in place against it, without copying it out first.
+            let (above, rest) = rows.split_at_mut(r);
+            let (pivot_row, below) = rest.split_first_mut().expect("r < rows.len()");
+            let inv = pivot_row[c].invert().unwrap();
+            for v in &mut pivot_row[c..] {
                 *v *= inv;
             }
-            let pivot_row = rows[r].clone();
-            for (i, row) in rows.iter_mut().enumerate() {
-                if i != r && row[c] != F::ZERO {
+            for row in above.iter_mut().chain(below) {
+                if row[c] != F::ZERO {
                     let f = row[c];
                     for (v, p) in row[c..].iter_mut().zip(&pivot_row[c..]) {
                         *v -= *p * f;
@@ -890,13 +893,16 @@ fn cluster_solve<F: Field>(
             continue;
         };
         rows.swap(r, pr);
-        let inv = rows[r][c].invert().unwrap();
-        for v in &mut rows[r][c..] {
+        // Split the pivot row out so the rows above and below it can be
+        // reduced in place against it, without copying it out first.
+        let (above, rest) = rows.split_at_mut(r);
+        let (pivot_row, below) = rest.split_first_mut().expect("r < rows.len()");
+        let inv = pivot_row[c].invert().unwrap();
+        for v in &mut pivot_row[c..] {
             *v *= inv;
         }
-        let pivot_row = rows[r].clone();
-        for (i, row) in rows.iter_mut().enumerate() {
-            if i != r && row[c] != F::ZERO {
+        for row in above.iter_mut().chain(below) {
+            if row[c] != F::ZERO {
                 let f = row[c];
                 for (v, p) in row[c..].iter_mut().zip(&pivot_row[c..]) {
                     *v -= *p * f;

--- a/crates/ragu_testing/src/patcher/recorder.rs
+++ b/crates/ragu_testing/src/patcher/recorder.rs
@@ -1,5 +1,5 @@
-//! The patcher engine: a recording driver plus a constraint-graph repair
-//! solver (issues #728, #793, #796).
+//! The recording driver, its playback twin, and the constraint-graph
+//! solver and oracles that run over what it records.
 //!
 //! [`Recorder`] is a [`Driver`] that captures the constraint graph ragu
 //! actually emits during synthesis — every multiplication gate `a·b = c`,
@@ -16,12 +16,16 @@
 //! independent native oracle is the patcher differential: ragu accepting a
 //! witness the oracle rejects is an under-constrained-advice signal.
 //!
-//! The engine lives here rather than in the fuzz target so it is unit
-//! tested ([`selftest`] runs in CI as a plain test) and reusable against
-//! real circuits (issue #793).
+//! Nothing here knows how the circuit was produced: it is driven through
+//! the [`Driver`] trait alone, which is what lets the same engine run a
+//! generated fuzz program, a hand-written test circuit, or — from
+//! `ragu_pcd`'s own tests — an internal recursion circuit. See the
+//! [parent module](super) for the `Circuit`-level entry points.
 
-use ff::{Field, PrimeField};
-use ragu_arithmetic::Coeff;
+use ragu_arithmetic::{
+    Coeff,
+    ff::{Field, PrimeField},
+};
 use ragu_core::{
     Result,
     drivers::{Driver, DriverTypes, LinearExpression},
@@ -78,7 +82,7 @@ pub struct Recorder<F> {
     /// [`Event::Extra`] to be zero whenever its gate's `C` is nonzero and
     /// free otherwise. Like an allocation gate's `a` wire they hold
     /// prover-chosen advice, so callers that know every `alloc` result is
-    /// advice (the substrate) list them among the free wires for
+    /// advice (the fuzz substrate, say) list them among the free wires for
     /// [`underconstrained_derived`].
     pub extras: Vec<usize>,
 }
@@ -223,8 +227,11 @@ impl<'dr, F: Field> Driver<'dr> for Recorder<F> {
 #[derive(Default)]
 pub struct TrackingAllocator {
     inner: Standard<usize>,
-    /// The `b` and `c` wires of every allocation gate, in creation order.
-    pub wasted: Vec<usize>,
+    /// The `(b, c)` wires of every allocation gate, in creation order. `b`
+    /// is a free wire nothing references; `c = a·b` is derived from it (and
+    /// honestly zero), so [`discover_free_advice`](super::discover_free_advice)
+    /// reports the `b`s but not the `c`s.
+    pub wasted: Vec<(usize, usize)>,
 }
 
 impl<'dr, F: Field> Allocator<'dr, Recorder<F>> for TrackingAllocator {
@@ -241,8 +248,7 @@ impl<'dr, F: Field> Allocator<'dr, Recorder<F>> for TrackingAllocator {
         let wire = self.inner.alloc(dr, value)?;
         if dr.values.len() == before + 3 {
             debug_assert_eq!(wire, before, "fresh allocation gate returns its `a` wire");
-            self.wasted.push(before + 1);
-            self.wasted.push(before + 2);
+            self.wasted.push((before + 1, before + 2));
         }
         Ok(wire)
     }
@@ -263,17 +269,17 @@ impl<'dr, F: Field> Allocator<'dr, Recorder<F>> for TrackingAllocator {
 /// entirely over that stored snapshot ([`Event`]s, [`constraints_hold`]); a
 /// capture bug — a mis-folded `Coeff` gain, a dropped term, a swapped wire —
 /// would corrupt every later verdict invisibly. `Playback` re-derives the
-/// verdict from scratch: same `synthesize`, same gadget calls, but its own
-/// linear-combination evaluator reading the injected `values` directly. If
-/// the recorder's stored answer and this live re-execution ever disagree,
+/// verdict from scratch: the same synthesis, the same gadget calls, but its
+/// own linear-combination evaluator reading the injected `values` directly.
+/// If the recorder's stored answer and this live re-execution ever disagree,
 /// the recorder mis-captured the circuit.
 ///
 /// `Wire = usize` and allocation is sequential from the fixed ONE wire, so
-/// running the *same* `synthesize` (with a plain [`Standard`] allocator,
-/// whose gate / `assign_extra` call sequence is exactly what
-/// [`TrackingAllocator`] delegates to) assigns wire `i` exactly the
-/// recorder's wire `i` — so `values` is the recorder's value vector, honest
-/// or repaired, used verbatim.
+/// running the *same* synthesis (with a plain [`Standard`] allocator, whose
+/// gate / `assign_extra` call sequence is exactly what [`TrackingAllocator`]
+/// delegates to) assigns wire `i` exactly the recorder's wire `i` — so
+/// `values` is the recorder's value vector, honest or repaired, used
+/// verbatim.
 pub struct Playback<F> {
     values: Vec<F>,
     next: usize,
@@ -531,15 +537,15 @@ impl<F: Field> Rref<F> {
             };
             rows.swap(r, pr);
             let inv = rows[r][c].invert().unwrap();
-            for x in c..d {
-                rows[r][x] *= inv;
+            for v in &mut rows[r][c..] {
+                *v *= inv;
             }
-            for i in 0..rows.len() {
-                if i != r && rows[i][c] != F::ZERO {
-                    let f = rows[i][c];
-                    for x in c..d {
-                        let t = rows[r][x] * f;
-                        rows[i][x] -= t;
+            let pivot_row = rows[r].clone();
+            for (i, row) in rows.iter_mut().enumerate() {
+                if i != r && row[c] != F::ZERO {
+                    let f = row[c];
+                    for (v, p) in row[c..].iter_mut().zip(&pivot_row[c..]) {
+                        *v -= *p * f;
                     }
                 }
             }
@@ -569,9 +575,11 @@ const CLUSTER_SOLVE_CAP: usize = 96;
 ///
 /// 1. **Single-unknown propagation** (issue #796 item 1): apply any
 ///    constraint with exactly one unknown wire and solve it. `Lin` once all
-///    terms are known; a `Gate` output `c := a·b` or — for `invert`/
-///    `divide` — an *input* `a := c/b` / `b := c/a` (requires the known
-///    operand nonzero); an `Enforce` with one unknown term; an `Extra`
+///    terms are known, or one unknown term once `out` is (an anchored
+///    difference pins its operand); a `Gate` output `c := a·b` or — for
+///    `invert`/`divide` — an *input* `a := c/b` / `b := c/a` (requires the
+///    known operand nonzero), or `c := 0` as soon as either operand is
+///    known to be zero; an `Enforce` with one unknown term; an `Extra`
 ///    whose known side is nonzero, which zeroes the other (`c ≠ 0 ⇒ d = 0`
 ///    and vice versa — a known *zero* side pins nothing).
 /// 2. **Linear-cluster solving** (issue #796 follow-up): when propagation
@@ -625,7 +633,25 @@ pub fn repair<F: Field>(events: &[Event<F>], values: &mut [F], free: &[usize]) {
         propagate(events, values, &mut known);
         // Propagation has stalled; try to crack a coupled linear cluster.
         // If that solves nothing new, the fixpoint is reached.
-        if !cluster_solve(events, values, &mut known) {
+        if !cluster_solve(events, values, &mut known, true) {
+            break;
+        }
+    }
+}
+
+/// Everything the constraints *force* given the `known` wires, and nothing
+/// more: [`repair`] without its guessing tier.
+///
+/// Runs single-unknown propagation and forced linear-cluster deductions to a
+/// fixpoint, marking each deduced wire `known` and writing its value. Unlike
+/// [`repair`] it never pins an under-determined wire to a chosen value, so a
+/// wire it leaves unknown is genuinely not determined by the known set —
+/// the property [`discover_free_advice`](super::discover_free_advice)
+/// builds on.
+pub(super) fn deduce<F: Field>(events: &[Event<F>], values: &mut [F], known: &mut [bool]) {
+    loop {
+        propagate(events, values, known);
+        if !cluster_solve(events, values, known, false) {
             break;
         }
     }
@@ -638,15 +664,47 @@ fn propagate<F: Field>(events: &[Event<F>], values: &mut [F], known: &mut [bool]
         for ev in events {
             match ev {
                 Event::Lin { out, terms } => {
-                    if !known[*out] && terms.iter().all(|(w, _)| known[*w]) {
-                        values[*out] = terms.iter().map(|(w, c)| values[*w] * c).sum();
-                        known[*out] = true;
-                        changed = true;
+                    if !known[*out] {
+                        if terms.iter().all(|(w, _)| known[*w]) {
+                            values[*out] = terms.iter().map(|(w, c)| values[*w] * c).sum();
+                            known[*out] = true;
+                            changed = true;
+                        }
+                    } else {
+                        // `out` is already pinned (by an enforce on it, say):
+                        // a single unknown term is determined by the rest.
+                        let mut unknown = terms.iter().filter(|(w, _)| !known[*w]);
+                        if let Some(&(uw, uc)) = unknown.next()
+                            && unknown.next().is_none()
+                            && uc != F::ZERO
+                        {
+                            // out = Σ cᵢ·wᵢ ⇒ wⱼ = (out − Σ_{i≠j} cᵢ·wᵢ)/cⱼ.
+                            let rest: F = terms
+                                .iter()
+                                .filter(|(w, _)| *w != uw)
+                                .map(|(w, c)| values[*w] * c)
+                                .sum();
+                            values[uw] = (values[*out] - rest) * uc.invert().unwrap();
+                            known[uw] = true;
+                            changed = true;
+                        }
                     }
                 }
                 Event::Gate { a, b, c } => match (known[*a], known[*b], known[*c]) {
                     (true, true, false) => {
                         values[*c] = values[*a] * values[*b];
+                        known[*c] = true;
+                        changed = true;
+                    }
+                    // A zero operand forces a zero output whatever the other
+                    // operand is.
+                    (true, false, false) if values[*a] == F::ZERO => {
+                        values[*c] = F::ZERO;
+                        known[*c] = true;
+                        changed = true;
+                    }
+                    (false, true, false) if values[*b] == F::ZERO => {
+                        values[*c] = F::ZERO;
                         known[*c] = true;
                         changed = true;
                     }
@@ -743,8 +801,15 @@ fn propagate<F: Field>(events: &[Event<F>], values: &mut [F], known: &mut [bool]
 /// anything returns immediately, letting [`propagate`] and a fresh pass run
 /// against the larger known set. Only when nothing at all is forced does the
 /// guessing tier run, which is the documented benign under-determination —
-/// by then every deduction available has already been made.
-fn cluster_solve<F: Field>(events: &[Event<F>], values: &mut [F], known: &mut [bool]) -> bool {
+/// by then every deduction available has already been made. With `guess`
+/// false the guessing tier is skipped altogether, which is what [`deduce`]
+/// needs: a wire left unknown is then genuinely undetermined.
+fn cluster_solve<F: Field>(
+    events: &[Event<F>],
+    values: &mut [F],
+    known: &mut [bool],
+    guess: bool,
+) -> bool {
     // Columns: the still-unknown wires.
     let mut col_of = vec![usize::MAX; values.len()];
     let mut wire_of = Vec::new();
@@ -818,15 +883,15 @@ fn cluster_solve<F: Field>(events: &[Event<F>], values: &mut [F], known: &mut [b
         };
         rows.swap(r, pr);
         let inv = rows[r][c].invert().unwrap();
-        for x in c..=m {
-            rows[r][x] *= inv;
+        for v in &mut rows[r][c..] {
+            *v *= inv;
         }
-        for i in 0..rows.len() {
-            if i != r && rows[i][c] != F::ZERO {
-                let f = rows[i][c];
-                for x in c..=m {
-                    let t = rows[r][x] * f;
-                    rows[i][x] -= t;
+        let pivot_row = rows[r].clone();
+        for (i, row) in rows.iter_mut().enumerate() {
+            if i != r && row[c] != F::ZERO {
+                let f = row[c];
+                for (v, p) in row[c..].iter_mut().zip(&pivot_row[c..]) {
+                    *v -= *p * f;
                 }
             }
         }
@@ -872,6 +937,9 @@ fn cluster_solve<F: Field>(events: &[Event<F>], values: &mut [F], known: &mut [b
     // Tier 2: nothing is forced, so every remaining pivot depends on a free
     // column. Pin those at their honest values and take the resulting
     // solution — a satisfying witness for an under-determined subsystem.
+    if !guess {
+        return false;
+    }
     let mut changed = false;
     for (row_idx, &pc) in pivot_col_of_row.iter().enumerate() {
         // RREF row: x_pc + Σ_{nonpivot j} row[j]·x_j = row[m].
@@ -912,8 +980,8 @@ pub fn constraints_hold<F: Field>(events: &[Event<F>], values: &[F]) -> bool {
 /// move, violating the anchor. The mismatch is the signal.
 ///
 /// This runs as a unit test (`tests::selftest_fires`) and on demand in the
-/// fuzz target (`PATCHER_SELFTEST=1`): proof the soundness direction is not
-/// vacuous.
+/// `fuzz_advice_patcher` target (`PATCHER_SELFTEST=1`): proof the soundness
+/// direction is not vacuous.
 pub fn selftest<F: PrimeField>() {
     let root_honest = F::from(7u64);
 
@@ -922,7 +990,7 @@ pub fn selftest<F: PrimeField>() {
     let square = rec.push_wire(root_honest.square()); // free advice — BUG: not gated to root²
 
     // Anchor `square` to its honest value via `enforce_zero(square - 49)`,
-    // exactly as the substrate's `Op::Anchor` would: a constant wire, a
+    // exactly as the fuzz substrate's `Op::Anchor` does: a constant wire, a
     // difference Lin, and a 1-term check.
     let pin =
         rec.add(|lc| lc.add_term(&Recorder::<F>::ONE, Coeff::Arbitrary(root_honest.square())));
@@ -955,15 +1023,16 @@ pub fn selftest<F: PrimeField>() {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use pasta_curves::{Fp, Fq};
     use ragu_core::{
         drivers::DriverValue,
         gadgets::{Bound, Kind},
         maybe::Maybe,
         routines::{Prediction, Routine},
     };
+    use ragu_pasta::{Fp, Fq};
     use ragu_primitives::{Boolean, Element};
+
+    use super::*;
 
     /// A small routine whose emitted linear relation is visible to both the
     /// recorder and playback drivers.
@@ -1075,7 +1144,7 @@ mod tests {
         // One gate `(a, b, c)` at wires 1..=3 plus the redeemed `d` at 4.
         assert_eq!((a, d), (1, 4));
         assert_eq!(rec.values.len(), 5);
-        assert_eq!(alloc.wasted, vec![2, 3]);
+        assert_eq!(alloc.wasted, vec![(2, 3)]);
         assert_eq!(rec.extras, vec![d]);
         assert!(matches!(
             rec.events.as_slice(),
@@ -1166,7 +1235,7 @@ mod tests {
             Recorder::<Fp>::just(|| Fp::from(9u64)),
         )?
         .wire();
-        let (b, c) = (alloc.wasted[0], alloc.wasted[1]);
+        let (b, c) = alloc.wasted[0];
 
         let mut values = rec.values.clone();
         values[b] = Fp::ONE;

--- a/crates/ragu_testing/src/patcher/recorder.rs
+++ b/crates/ragu_testing/src/patcher/recorder.rs
@@ -639,15 +639,23 @@ pub fn repair<F: Field>(events: &[Event<F>], values: &mut [F], free: &[usize]) {
     }
 }
 
-/// Everything the constraints *force* given the `known` wires, and nothing
-/// more: [`repair`] without its guessing tier.
+/// Everything the *bounded* solver can force given the `known` wires, and
+/// nothing more: [`repair`] without its guessing tier.
 ///
 /// Runs single-unknown propagation and forced linear-cluster deductions to a
 /// fixpoint, marking each deduced wire `known` and writing its value. Unlike
-/// [`repair`] it never pins an under-determined wire to a chosen value, so a
-/// wire it leaves unknown is genuinely not determined by the known set —
-/// the property [`discover_free_advice`](super::discover_free_advice)
-/// builds on.
+/// [`repair`] it never pins an under-determined wire to a chosen value, so
+/// everything it marks known is a genuine consequence of the known set.
+///
+/// The converse is only as strong as the solver: a wire left unknown is one
+/// this bounded procedure could not force. A gate with both operands unknown
+/// contributes no deduction, and a coupled linear cluster wider than
+/// [`CLUSTER_SOLVE_CAP`] is skipped outright — during discovery the unknown
+/// set starts as the whole graph, so on large circuits the cluster pass only
+/// engages near the end and deduction rests on propagation. Wires such a
+/// graph does pin only through wide coupling are reported free anyway:
+/// [`discover_free_advice`](super::discover_free_advice) over-approximates
+/// there, and says so.
 pub(super) fn deduce<F: Field>(events: &[Event<F>], values: &mut [F], known: &mut [bool]) {
     loop {
         propagate(events, values, known);

--- a/crates/ragu_testing/src/pcd/nontrivial.rs
+++ b/crates/ragu_testing/src/pcd/nontrivial.rs
@@ -17,6 +17,8 @@ use ragu_primitives::{
     poseidon::Sponge,
 };
 
+/// A [`Header`] for the leaves of the tree: a single field element, the hash
+/// of the witness the leaf commits to.
 pub struct LeafNode;
 
 impl<F: Field> Header<F> for LeafNode {
@@ -33,6 +35,8 @@ impl<F: Field> Header<F> for LeafNode {
     }
 }
 
+/// A [`Header`] for the internal nodes of the tree: a single field element,
+/// the hash of the two child headers.
 pub struct InternalNode;
 
 impl<F: Field> Header<F> for InternalNode {
@@ -49,7 +53,11 @@ impl<F: Field> Header<F> for InternalNode {
     }
 }
 
+/// A [`Step`] that combines two [`LeafNode`] children into an
+/// [`InternalNode`] by absorbing both into a Poseidon sponge and squeezing
+/// the parent header out of it.
 pub struct Hash2<'params, C: Cycle> {
+    /// The Poseidon parameters the sponge is instantiated with.
     pub poseidon_params: &'params C::CircuitPoseidon,
 }
 
@@ -94,7 +102,10 @@ impl<C: Cycle> Step<C> for Hash2<'_, C> {
     }
 }
 
+/// A [`Step`] with no children that hashes a witnessed field element into a
+/// [`LeafNode`], seeding the tree.
 pub struct WitnessLeaf<'params, C: Cycle> {
+    /// The Poseidon parameters the sponge is instantiated with.
     pub poseidon_params: &'params C::CircuitPoseidon,
 }
 

--- a/qa/fuzz/Cargo.lock
+++ b/qa/fuzz/Cargo.lock
@@ -506,6 +506,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ragu_testing"
+version = "0.0.0"
+dependencies = [
+ "proptest",
+ "ragu_arithmetic",
+ "ragu_circuits",
+ "ragu_core",
+ "ragu_pcd",
+ "ragu_primitives",
+]
+
+[[package]]
 name = "ragu_testing-fuzz"
 version = "0.0.0"
 dependencies = [
@@ -520,6 +532,7 @@ dependencies = [
  "ragu_pasta",
  "ragu_pcd",
  "ragu_primitives",
+ "ragu_testing",
  "rand 0.10.2",
  "zakura-pasta-curves",
 ]

--- a/qa/fuzz/Cargo.toml
+++ b/qa/fuzz/Cargo.toml
@@ -40,6 +40,9 @@ ragu_pasta = { path = "../../crates/ragu_pasta", features = ["baked"] }
 ragu_core = { path = "../../crates/ragu_core" }
 ragu_circuits = { path = "../../crates/ragu_circuits" }
 ragu_pcd = { path = "../../crates/ragu_pcd", features = ["unstable-fuzzing"] }
+# The patcher engine (recording driver, repair solver, oracles) that
+# `fuzz_advice_patcher` drives over generated programs.
+ragu_testing = { path = "../../crates/ragu_testing" }
 proptest = "1"
 rand = "0.10"
 

--- a/qa/fuzz/README.md
+++ b/qa/fuzz/README.md
@@ -169,9 +169,11 @@ were insensitive to it — that's the real bug class.
 Three workflows in `.github/workflows/`:
 
 - **`rust.yml`** runs `cargo test --lib` and `cargo check --bins` from this
-  directory on every PR. This executes the substrate, recorder, and planted-bug
-  self-tests, then catches bitrot in every target without running libFuzzer.
-  Cache keys include `Cargo.toml`, `fuzz_targets/**/*.rs`, and `bin/**/*.rs`.
+  directory on every PR. This executes the substrate self-tests (the patcher
+  engine's own tests, including its planted-bug selftest, run with the
+  workspace in `ragu_testing`), then catches bitrot in every target without
+  running libFuzzer. Cache keys include `Cargo.toml`, `fuzz_targets/**/*.rs`,
+  and `bin/**/*.rs`.
 
 - **`fuzz-cron.yml`** runs every target via matrix-parallel for 5 hours
   each on Sundays, Wednesdays, and Fridays at 00:00 UTC. Each target

--- a/qa/fuzz/fuzz_targets/fuzz_advice_patcher.rs
+++ b/qa/fuzz/fuzz_targets/fuzz_advice_patcher.rs
@@ -85,25 +85,35 @@
 //! must have a trivial null space — an algebraic, mutation-free detector
 //! for wires the constraints fail to pin.
 //!
+//! Every input also runs a **free-advice discovery cross-check**
+//! (`discover_free_advice`): the wires the captured graph leaves
+//! undetermined — found structurally, with no help from the substrate —
+//! must all be allocations the substrate knows it made (advice, pooled $D$
+//! wires, allocation waste). A free wire that is *not* an allocation is a
+//! hint some gadget left unpinned, found without any cheat; and since the
+//! substrate's allocation list is ground truth, the check also keeps
+//! discovery honest for the circuits it will be pointed at without one.
+//!
 //! Every input also runs a **playback cross-check**: the repaired witness is
 //! re-verified by a fresh synthesis of the *real* gadget calls
-//! (`recorder::Playback`) with an independent linear-combination evaluator.
+//! (`patcher::Playback`) with an independent linear-combination evaluator.
 //! If that live re-execution disagrees with the recorder's stored-event
 //! verdict, the recorder mis-captured the circuit and every signal is
 //! suspect — so the engine validates its own model on every run.
 //!
 //! Allocation goes through the production pooling allocator on both sides
-//! (`recorder::TrackingAllocator` wraps a `Standard`; playback uses a plain
+//! (`patcher::TrackingAllocator` wraps a `Standard`; playback uses a plain
 //! `Standard`), so the captured graph includes the gate $D$ wires a pooled
 //! allocation hands out — redeemed from `BoolAlloc`/`IsZero` donations or
 //! paired with the previous allocation — and their `C · D = 0` constraint.
 //!
-//! The engine — the recording driver, the repair solver, and the planted-bug
-//! selftest — lives in `ragu_testing_fuzz::recorder`, where it is unit tested in
-//! CI and reusable against real circuits (issue #793). `PATCHER_SELFTEST=1`
-//! runs that selftest here on demand: a deliberately under-constrained
-//! circuit (a root and a "square" allocated as independent free wires, with
-//! the `square = root²` gate omitted) whose oracle must fire — proof the
+//! The engine — the recording driver, the repair solver, the oracles, and
+//! the planted-bug selftest — lives in `ragu_testing::patcher`, where it is
+//! unit tested in CI and available to `ragu_pcd`'s own tests for the
+//! internal recursion circuits (issue #793). `PATCHER_SELFTEST=1` runs that
+//! selftest here on demand: a deliberately under-constrained circuit (a root
+//! and a "square" allocated as independent free wires, with the
+//! `square = root²` gate omitted) whose oracle must fire — proof the
 //! soundness direction is not vacuous.
 
 #![no_main]
@@ -113,15 +123,13 @@ use ff::PrimeField;
 use libfuzzer_sys::fuzz_target;
 use pasta_curves::{Fp, Fq};
 use ragu_primitives::allocator::Standard;
-use ragu_testing_fuzz::{
-    recorder::{
-        Playback, Recorder, TrackingAllocator, constraints_hold, repair, selftest,
-        underconstrained_derived,
-    },
-    substrate::{
-        AdviceSlot, Limits, OpKind, OpSet, Overrides, Program, anchor_tail, native_satisfied,
-        shadow_eval, special_value, synthesize,
-    },
+use ragu_testing::patcher::{
+    Playback, Recorder, TrackingAllocator, constraints_hold, discover_free_advice, repair,
+    selftest, underconstrained_derived,
+};
+use ragu_testing_fuzz::substrate::{
+    AdviceSlot, Limits, OpKind, OpSet, Overrides, Program, anchor_tail, native_satisfied,
+    shadow_eval, special_value, synthesize,
 };
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -386,19 +394,46 @@ fn patch_round<F: PrimeField<Repr = [u8; 32]>>(input: &Input, decoded: &Program)
         "honest native oracle disagreed with itself (harness bug): {program:?}"
     );
 
+    // The wires the substrate knows it allocated: advice, the gate-D wires
+    // pooled allocation handed out as advice, and allocation waste. These are
+    // the genuine free wires of the honest graph.
+    let allocations: Vec<usize> = stacks
+        .advice_wires
+        .iter()
+        .copied()
+        .chain(rec.extras.iter().copied())
+        .chain(alloc.wasted.iter().flat_map(|&(b, c)| [b, c]))
+        .collect();
+
+    // Free-advice discovery cross-check, independent of any cheat: every
+    // wire the captured graph leaves undetermined must be one of those
+    // allocations. A free wire outside the list is a hint some gadget left
+    // unpinned — and the list is ground truth the engine will not have for
+    // the real circuits, so this also validates discovery itself. Skipped on
+    // the genuine degeneracy — an honest `is_zero(0)`, whose inverse hint is
+    // benignly free — exactly as the rank oracle below is.
+    if !shadow.is_zero_degenerate {
+        let discovered = discover_free_advice(&rec.events, &rec.values);
+        let unexplained: Vec<usize> = discovered
+            .iter()
+            .copied()
+            .filter(|w| !allocations.contains(w))
+            .collect();
+        assert!(
+            unexplained.is_empty(),
+            "DISCOVERY SIGNAL: the captured constraints leave wires {unexplained:?} \
+             free, but the substrate allocated none of them — a gadget hint is \
+             unpinned (or discovery is wrong). Program: {program:?}",
+        );
+    }
+
     // Rank/nullity oracle, independent of any cheat: with the genuine free
-    // wires (advice, the gate-D wires pooled allocation handed out as advice,
-    // allocator waste) held fixed, every remaining wire must be locally
-    // pinned by the captured constraints.
-    // Skipped only on the genuine degeneracy — an honest `is_zero(0)`, whose
-    // inverse hint is benignly free — not on every true boolean (a
-    // `BoolAlloc(true)`/`BoolNot` produces no free hint), and on outsized
-    // graphs.
+    // wires held fixed, every remaining wire must be locally pinned by the
+    // captured constraints. Skipped only on the genuine degeneracy above —
+    // not on every true boolean (a `BoolAlloc(true)`/`BoolNot` produces no
+    // free hint) — and on outsized graphs.
     if rec.values.len() <= RANK_WIRE_CAP && !shadow.is_zero_degenerate {
-        let mut rank_free = stacks.advice_wires.clone();
-        rank_free.extend_from_slice(&rec.extras);
-        rank_free.extend_from_slice(&alloc.wasted);
-        let movable = underconstrained_derived(&rec.events, &rec.values, &rank_free);
+        let movable = underconstrained_derived(&rec.events, &rec.values, &allocations);
         assert!(
             movable.is_empty(),
             "RANK ORACLE SIGNAL: derived wires {movable:?} can move while every \
@@ -585,7 +620,7 @@ fn patch_round<F: PrimeField<Repr = [u8; 32]>>(input: &Input, decoded: &Program)
     //    before guessed ones, which lets the input be deduced first and the
     //    hints fall out by propagation. Weakening that ordering resurfaces as
     //    spurious rejections here, not as a solver error — see the
-    //    least-commitment section on `recorder::cluster_solve` and the
+    //    least-commitment section on `patcher::recorder::cluster_solve` and the
     //    `regressions/fuzz_advice_patcher/` reproducers.
     assert_eq!(
         shadow.value_fallible_pushes.len(),

--- a/qa/fuzz/src/lib.rs
+++ b/qa/fuzz/src/lib.rs
@@ -1,11 +1,13 @@
 //! Shared library for the `ragu_testing-fuzz` targets.
 //!
-//! Holds the machinery the fuzz targets are built on — the generated-program
-//! [`substrate`] (op grammar, byte decoder, driver-generic synthesis, native
-//! shadow, circuit wrapper) and the patcher [`recorder`] engine (recording
-//! driver, repair solver, rank oracle, playback cross-check). Both live here
-//! rather than in `ragu_testing` because the fuzz targets are their only
-//! consumers; the `#[bin]` targets under `fuzz_targets/` depend on this lib.
+//! Holds the generated-program [`substrate`] (op grammar, byte decoder,
+//! driver-generic synthesis, native shadow, circuit wrapper) the fuzz
+//! targets are built on; the `#[bin]` targets under `fuzz_targets/` depend
+//! on this lib. The substrate lives here rather than in `ragu_testing`
+//! because the fuzz targets are its only consumers. The patcher engine
+//! (recording driver, repair solver, rank oracle, free-advice discovery,
+//! playback cross-check) lives in [`ragu_testing::patcher`], where
+//! `ragu_pcd`'s own tests can aim it at the internal recursion circuits;
+//! `fuzz_advice_patcher` drives it over generated programs.
 
-pub mod recorder;
 pub mod substrate;

--- a/qa/fuzz/src/substrate/integration_tests.rs
+++ b/qa/fuzz/src/substrate/integration_tests.rs
@@ -8,7 +8,11 @@
 //!   circuits (the accept direction of `fuzz_circuit_revdot_identity`,
 //!   over arbitrary generated programs instead of two fixed circuits);
 //! * the native shadow's verdict on a mutated witness agrees with the
-//!   Simulator's (a deterministic miniature of `fuzz_circuit_cheat`).
+//!   Simulator's (a deterministic miniature of `fuzz_circuit_cheat`);
+//! * the patcher engine's free-advice discovery, working from the recorded
+//!   constraint graph alone, reproduces the substrate's own allocation list
+//!   (the ground truth `fuzz_advice_patcher`'s discovery cross-check rests
+//!   on).
 
 use ff::Field;
 use proptest::prelude::*;
@@ -19,10 +23,11 @@ use ragu_circuits::{
 };
 use ragu_pasta::Fp;
 use ragu_primitives::{Simulator, allocator::Standard};
+use ragu_testing::patcher::{Recorder, TrackingAllocator, constraints_hold, discover_free_advice};
 
 use super::{
     Capabilities, Limits, Op, OpSet, Overrides, Program, ProgramCircuit, native_satisfied,
-    program_strategy, shadow_eval, steer, synthesize_with_witness,
+    program_strategy, shadow_eval, steer, synthesize, synthesize_with_witness,
 };
 
 /// Left-hand side of the revdot constraint identity for trace polynomial
@@ -139,6 +144,49 @@ proptest! {
             sim.is_ok(),
             native_ok,
             "Simulator and native oracle disagree on a mutated witness",
+        );
+    }
+
+    /// Without anchors nothing pins a wire but the gadgets' own constraints,
+    /// so the free wires the patcher engine discovers from the recorded graph
+    /// alone must be *exactly* the substrate's allocations: the advice, the
+    /// pooled `D` wires, and the wasted `b` of each allocation gate (its
+    /// `c = a·b` is derived). The one value-dependent exception is an honest
+    /// `is_zero(0)`, whose inverse hint is genuinely free at that witness.
+    ///
+    /// This is the ground truth behind the fuzz target's discovery
+    /// cross-check — and the only place discovery is checked against an
+    /// independent list, since the circuits it is ultimately for have none.
+    #[test]
+    fn proptest_discovery_matches_allocations_anchorless(
+        program in program_strategy(
+            OpSet::ALL.without(Capabilities::ANCHORS),
+            Limits::default().max_ops,
+        ),
+    ) {
+        let steered = steer::<Fp>(&program);
+        let shadow = shadow_eval::<Fp>(&steered, Overrides::none());
+        prop_assume!(!shadow.is_zero_degenerate);
+
+        let mut rec = Recorder::<Fp>::new();
+        let mut alloc = TrackingAllocator::default();
+        let stacks = synthesize(&mut rec, &mut alloc, &steered, &[])
+            .expect("recorder must accept an honest steered program");
+        prop_assert!(constraints_hold(&rec.events, &rec.values));
+
+        let mut expected: Vec<usize> = stacks
+            .advice_wires
+            .iter()
+            .copied()
+            .chain(rec.extras.iter().copied())
+            .chain(alloc.wasted.iter().map(|&(b, _)| b))
+            .collect();
+        expected.sort_unstable();
+        expected.dedup();
+        prop_assert_eq!(
+            discover_free_advice(&rec.events, &rec.values),
+            expected,
+            "discovered free wires differ from the substrate's allocations",
         );
     }
 }

--- a/qa/fuzz/src/substrate/integration_tests.rs
+++ b/qa/fuzz/src/substrate/integration_tests.rs
@@ -23,7 +23,9 @@ use ragu_circuits::{
 };
 use ragu_pasta::Fp;
 use ragu_primitives::{Simulator, allocator::Standard};
-use ragu_testing::patcher::{Recorder, TrackingAllocator, constraints_hold, discover_free_advice};
+use ragu_testing::patcher::{
+    Recorder, TrackingAllocator, allocation_waste, constraints_hold, discover_free_advice,
+};
 
 use super::{
     Capabilities, Limits, Op, OpSet, Overrides, Program, ProgramCircuit, native_satisfied,
@@ -173,6 +175,11 @@ proptest! {
         let stacks = synthesize(&mut rec, &mut alloc, &steered, &[])
             .expect("recorder must accept an honest steered program");
         prop_assert!(constraints_hold(&rec.events, &rec.values));
+
+        // The structural waste classifier must agree with the allocator's
+        // own bookkeeping — the same ground-truth game as discovery below,
+        // for the helper a `capture`-based census subtracts with.
+        prop_assert_eq!(&allocation_waste(&rec.events, &rec.values), &alloc.wasted);
 
         let mut expected: Vec<usize> = stacks
             .advice_wires


### PR DESCRIPTION
Stacks on https://github.com/tachyon-zcash/ragu/pull/837 and closes the first bullet point in https://github.com/tachyon-zcash/ragu/issues/793. 

It (1) migrates our patcher engine (patcher is a technique from [zksecurity's paper](https://arxiv.org/abs/2504.14881) that lets us catch under-constrained circuit bugs where you basically mutate a witness, then repair the rest through the constraints so it still satisfies them) from `fuzz_target` into `ragu_testing` and (2) adds an entry point so the engine can be pointed at any `Circuit` implementation .

The patcher loop runs like this: the **harness** (`fuzz_target`) picks a circuit and cheats a wire, the **engine** (`ragu_testing::patcher`) records the constraints, repairs the rest of the witness through them, and reports whether they still hold, and the **harness** again compares that against what the values should be and flags the bug if the circuit accepted the lie.