### PR TITLE
chore(deps): migrate pasta_curves to zakura library 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,20 +695,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "pasta_curves"
-version = "0.5.1"
-source = "git+https://github.com/ebfull/pasta_curves?rev=5a84fc0d13f738f54c43fb1f9e28ecf1d358dcf5#5a84fc0d13f738f54c43fb1f9e28ecf1d358dcf5"
-dependencies = [
- "blake2b_simd",
- "ff",
- "group",
- "lazy_static",
- "rand 0.10.1",
- "static_assertions",
- "subtle",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,11 +825,11 @@ dependencies = [
  "group",
  "gungraun",
  "maybe-rayon",
- "pasta_curves",
  "proptest",
  "ragu_macros",
  "ragu_testing",
  "rand 0.10.1",
+ "zakura-pasta-curves",
 ]
 
 [[package]]
@@ -860,7 +846,6 @@ dependencies = [
  "group",
  "gungraun",
  "maybe-rayon",
- "pasta_curves",
  "proptest",
  "ragu_arithmetic",
  "ragu_core",
@@ -868,6 +853,7 @@ dependencies = [
  "ragu_primitives",
  "ragu_testing",
  "rand 0.10.1",
+ "zakura-pasta-curves",
 ]
 
 [[package]]
@@ -920,7 +906,6 @@ dependencies = [
  "ff",
  "gungraun",
  "maybe-rayon",
- "pasta_curves",
  "proptest",
  "ragu_arithmetic",
  "ragu_circuits",
@@ -929,6 +914,7 @@ dependencies = [
  "ragu_primitives",
  "ragu_testing",
  "rand 0.10.1",
+ "zakura-pasta-curves",
 ]
 
 [[package]]
@@ -1496,6 +1482,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "zakura-pasta-curves"
+version = "1.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e778e0af70387b9f1e988d9a280f936350340c509e5dc26ed32a962c4a708c42"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "lazy_static",
+ "rand 0.10.1",
+ "static_assertions",
+ "subtle",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,9 +85,15 @@ repository = "https://github.com/tachyon-zcash/ragu"
 # Keep ff/group/pasta_curves/rand in sync with qa/fuzz/Cargo.toml. The
 # cargo-fuzz workspace is intentionally isolated and cannot inherit these
 # workspace dependencies.
+#
+# `pasta_curves` is Zakura's fork (crates.io package `zakura-pasta-curves`,
+# library target still `pasta_curves`, published from
+# https://github.com/zakura-core/libraries), so Ragu and Zakura agree on the
+# curve types. The pre-release tag must be named explicitly: cargo's semver
+# rules mean a bare `1` requirement would not match `1.0.0-rc.2`.
 ff = { version = "0.14", default-features = false }
 group = { version = "0.14", default-features = false }
-pasta_curves = { git = "https://github.com/ebfull/pasta_curves", rev = "5a84fc0d13f738f54c43fb1f9e28ecf1d358dcf5", features = ["deferred"] }
+pasta_curves = { package = "zakura-pasta-curves", version = "1.0.0-rc.2", features = ["deferred"] }
 rand = { version = "0.10", default-features = false, features = ["std_rng"] }
 rand_core = { version = "0.10", default-features = false }
 lazy_static = "1.5.0"

--- a/qa/fuzz/Cargo.toml
+++ b/qa/fuzz/Cargo.toml
@@ -29,11 +29,11 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1", features = ["derive"] }
 # This workspace cannot inherit repo-root [workspace.dependencies], so keep
-# these direct ff/group/pasta_curves/rand versions and source pins in sync with
-# the repo-root dependency set.
+# these direct ff/group/pasta_curves/rand versions in sync with the repo-root
+# dependency set.
 ff = { version = "0.14", default-features = false }
 group = { version = "0.14", default-features = false }
-pasta_curves = { git = "https://github.com/ebfull/pasta_curves", rev = "5a84fc0d13f738f54c43fb1f9e28ecf1d358dcf5", features = ["deferred"] }
+pasta_curves = { package = "zakura-pasta-curves", version = "1.0.0-rc.2", features = ["deferred"] }
 ragu_arithmetic = { path = "../../crates/ragu_arithmetic" }
 ragu_primitives = { path = "../../crates/ragu_primitives" }
 ragu_pasta = { path = "../../crates/ragu_pasta", features = ["baked"] }

--- a/qa/supply-chain/config.toml
+++ b/qa/supply-chain/config.toml
@@ -29,9 +29,6 @@ url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/
 ours = "crypto-reviewed"
 theirs = "crypto-reviewed"
 
-[policy.pasta_curves]
-audit-as-crates-io = true
-
 [policy.ragu_gadgets]
 audit-as-crates-io = true
 
@@ -149,6 +146,10 @@ criteria = "safe-to-run"
 
 [[exemptions.wyz]]
 version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.zakura-pasta-curves]]
+version = "1.0.0-rc.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy]]


### PR DESCRIPTION
Migrates `pasta_curves` to Zakura's fork, consumed as the published [`zakura-pasta-curves 1.0.0-rc.2`](https://crates.io/crates/zakura-pasta-curves) release.