### PR TITLE
feat(fv): endoscalar extract gadget

### DIFF
--- a/qa/crates/lean_extraction/src/fingerprint.rs
+++ b/qa/crates/lean_extraction/src/fingerprint.rs
@@ -288,6 +288,10 @@ mod tests {
             element_is_zero::ElementIsZeroInstance,
             element_mul::ElementMulInstance,
             element_square::ElementSquareInstance,
+            endoscalar_alloc::EndoscalarAllocInstance,
+            endoscalar_extract::EndoscalarExtractInstance,
+            endoscalar_group_scale::EndoscalarGroupScaleInstance,
+            endoscalar_lift::EndoscalarLiftInstance,
             nonzero_bank_scope::NonzeroBankScopeInstanceK2,
             point_add_incomplete::PointAddIncompleteInstance,
             point_alloc::{PointAllocInstanceFp, PointAllocInstanceFq},
@@ -325,6 +329,10 @@ mod tests {
         assert_roundtrip::<BooleanAndInstance>();
         assert_roundtrip::<BooleanConditionalSelectInstance>();
         assert_roundtrip::<BooleanConditionalEnforceEqualInstance>();
+        assert_roundtrip::<EndoscalarAllocInstance>();
+        assert_roundtrip::<EndoscalarExtractInstance>();
+        assert_roundtrip::<EndoscalarGroupScaleInstance>();
+        assert_roundtrip::<EndoscalarLiftInstance>();
     }
 
     /// The modulus encoding must round-trip through the canonical field

--- a/qa/crates/lean_extraction/src/instances/endoscalar_extract.rs
+++ b/qa/crates/lean_extraction/src/instances/endoscalar_extract.rs
@@ -1,0 +1,38 @@
+use ragu_pasta::Fp;
+use ragu_primitives::{Element, Endoscalar, EndoscalarChallenge};
+
+use crate::{
+    driver::ExtractionDriver,
+    expr::Expr,
+    instance::{CircuitInstance, WireCollector, WireDeserializer},
+};
+
+pub struct EndoscalarExtractInstance;
+
+impl CircuitInstance for EndoscalarExtractInstance {
+    type Field = Fp;
+
+    /// Drives the real `EndoscalarChallenge::from_element` followed by
+    /// `Endoscalar::extract` — the in-circuit path `compute_v` takes — on a
+    /// single input wire holding the challenge element.
+    ///
+    /// `from_element` emits `Fp::CAPACITY` (254) `Boolean::alloc` gates and
+    /// one recomposition constraint binding their weighted sum to the element
+    /// (`boolean.rs::decompose`); `extract` emits nothing and returns the low
+    /// 128 bits. Under `MaybeKind = Empty` the witness-side range check
+    /// (`try_just`) and the per-bit witness closures never run, so the trace
+    /// is exactly those constraints.
+    ///
+    /// Input wire: `elem` (1 wire). Output: the 128 endoscalar bit wires,
+    /// least significant first.
+    fn circuit(dr: &mut ExtractionDriver<Fp>) -> ragu_core::Result<Vec<Expr<Fp>>> {
+        let input_wires = dr.alloc_input_wires(1);
+        let element_template = Element::constant(dr, Fp::zero());
+        let elem = WireDeserializer::new(input_wires).into_gadget(&element_template)?;
+
+        let challenge = EndoscalarChallenge::from_element(dr, &mut (), elem)?;
+        let endo = Endoscalar::extract(challenge);
+
+        WireCollector::collect_from(&endo)
+    }
+}

--- a/qa/crates/lean_extraction/src/instances/endoscalar_extract.rs
+++ b/qa/crates/lean_extraction/src/instances/endoscalar_extract.rs
@@ -23,6 +23,11 @@ impl CircuitInstance for EndoscalarExtractInstance {
     /// (`try_just`) and the per-bit witness closures never run, so the trace
     /// is exactly those constraints.
     ///
+    /// The unit allocator stands in for `compute_v`'s `Standard` pool: the only
+    /// thing `Boolean::alloc` hands an allocator is its gate's spare `D` wire,
+    /// which the extractor's three-wire model does not have (`Extra = ()`), so
+    /// the choice of allocator leaves the trace unchanged.
+    ///
     /// Input wire: `elem` (1 wire). Output: the 128 endoscalar bit wires,
     /// least significant first.
     fn circuit(dr: &mut ExtractionDriver<Fp>) -> ragu_core::Result<Vec<Expr<Fp>>> {

--- a/qa/crates/lean_extraction/src/instances/endoscalar_lift.rs
+++ b/qa/crates/lean_extraction/src/instances/endoscalar_lift.rs
@@ -2,8 +2,13 @@ use ff::{Field, WithSmallOrderMulGroup};
 use ragu_arithmetic::Coeff;
 use ragu_core::drivers::Driver;
 use ragu_pasta::Fp;
+use ragu_primitives::Element;
 
-use crate::{driver::ExtractionDriver, expr::Expr, instance::CircuitInstance};
+use crate::{
+    driver::ExtractionDriver,
+    expr::Expr,
+    instance::{CircuitInstance, WireCollector},
+};
 
 pub struct EndoscalarLiftInstance;
 
@@ -12,39 +17,28 @@ impl CircuitInstance for EndoscalarLiftInstance {
 
     /// Mirrors `Endoscalar::lift` on the constraint side without going through
     /// `Endoscalar` (whose fields are private). For each of the 64 bit pairs
-    /// `(n, e)`, we inline the `Boolean::and(n, e)` body — one `mul` gate plus
-    /// two `enforce_equal`s — and build the output `Expression` tree to match
-    /// the Lean reimpl's `stepCircuit` shape verbatim. Without this manual tree
-    /// shaping, the actual `Endoscalar::lift` (which uses `acc.double() + .add`
-    /// chains) would produce a left-associated tree that the formal-instance
-    /// proof couldn't byte-equate against the Lean's right-grouped form.
+    /// `(n, e)` the `Boolean::and(n, e)` body is inlined — one `mul` gate plus
+    /// two `enforce_equal`s, the same pattern as `boolean_and.rs`, because
+    /// `Boolean` has no constructor from a bare wire. Everything else is the
+    /// deployed gadget's own `Element` calls (`zero`, `double`, `scale`, `add`,
+    /// `constant`), so the recorded output tree is exactly the one
+    /// `Endoscalar::lift` emits.
     ///
-    /// `boolean_and.rs` follows the same inlining pattern for the same reason
-    /// (no public `Boolean` constructor from a bare wire).
+    /// Input wires: `bits[0..128]` (128 wires). Output: the lifted element.
     fn circuit(dr: &mut ExtractionDriver<Fp>) -> ragu_core::Result<Vec<Expr<Fp>>> {
-        // Allocate 128 input wires: bits[0..128].
         let bit_wires: Vec<Expr<Fp>> = (0..128usize)
             .map(|_| dr.alloc_input_wires(1).into_iter().next().unwrap())
             .collect();
 
-        let zeta = Fp::ZETA;
-        let one = Fp::ONE;
-        let coeff_n = -Fp::from(2);
-        let coeff_e = zeta - one;
-        let coeff_ne = (one - zeta).double();
+        // Same constants, in the same order, as `Endoscalar::lift`.
+        let mut constant_term = (Fp::ZETA + Fp::ONE).double();
+        let coeffs = [
+            -Fp::from(2),
+            Fp::ZETA - Fp::ONE,
+            (Fp::ONE - Fp::ZETA).double(),
+        ];
 
-        // Compute `ctFinal ζ 64 = 2^65 * (ζ+1) + 2^64 - 1`, iteratively the
-        // same way `Endoscalar::lift` does it.
-        let mut ct = (zeta + one).double(); // 2 * (ζ + 1)
-        for _ in 0..64 {
-            ct = ct.double();
-            ct += one;
-        }
-        let ct_final = ct;
-
-        // Build acc as an Expr tree. Start at `Expression.const 0` to mirror
-        // the Lean reimpl's `Fin.foldl 64 ... (Expression.const 0)`.
-        let mut acc: Expr<Fp> = Expr::Const(Coeff::Zero);
+        let mut acc = Element::zero(dr);
 
         for i in 0..64usize {
             let n_wire = &bit_wires[2 * i];
@@ -56,37 +50,27 @@ impl CircuitInstance for EndoscalarLiftInstance {
             let (mul_a, mul_b, mul_c) = dr.mul(|| Ok((Coeff::Zero, Coeff::Zero, Coeff::Zero)))?;
             dr.enforce_equal(&mul_a, n_wire)?;
             dr.enforce_equal(&mul_b, e_wire)?;
-            let ne_wire = mul_c;
 
-            // Build the Lean-shaped `stepCircuit` update:
-            //   acc' = (Const 2 * acc) + ((Const coeff_n * n + Const coeff_e * e) + Const coeff_ne * ne)
-            let term_acc = Expr::Mul(Box::new(Expr::Const(Coeff::Two)), Box::new(acc));
-            let term_n = Expr::Mul(
-                Box::new(Expr::Const(Coeff::Arbitrary(coeff_n))),
-                Box::new(n_wire.clone()),
-            );
-            let term_e = Expr::Mul(
-                Box::new(Expr::Const(Coeff::Arbitrary(coeff_e))),
-                Box::new(e_wire.clone()),
-            );
-            let term_ne = Expr::Mul(
-                Box::new(Expr::Const(Coeff::Arbitrary(coeff_ne))),
-                Box::new(ne_wire),
-            );
-            let inner = Expr::Add(
-                Box::new(Expr::Add(Box::new(term_n), Box::new(term_e))),
-                Box::new(term_ne),
-            );
-            acc = Expr::Add(Box::new(term_acc), Box::new(inner));
+            let n = Element::promote(n_wire.clone(), ExtractionDriver::<Fp>::just(|| Fp::ZERO));
+            let e = Element::promote(e_wire.clone(), ExtractionDriver::<Fp>::just(|| Fp::ZERO));
+            let ne = Element::promote(mul_c, ExtractionDriver::<Fp>::just(|| Fp::ZERO));
+
+            acc = acc.double(dr);
+            constant_term = constant_term.double();
+            constant_term += Fp::ONE;
+
+            let n = n.scale(dr, Coeff::Arbitrary(coeffs[0]));
+            let e = e.scale(dr, Coeff::Arbitrary(coeffs[1]));
+            let ne = ne.scale(dr, Coeff::Arbitrary(coeffs[2]));
+
+            acc = acc.add(dr, &n);
+            acc = acc.add(dr, &e);
+            acc = acc.add(dr, &ne);
         }
 
-        // Final output: `acc + Const ct_final` (mirrors the trailing
-        // `return acc + Expression.const (ctFinal ζ 64)` in the Lean reimpl).
-        let result = Expr::Add(
-            Box::new(acc),
-            Box::new(Expr::Const(Coeff::Arbitrary(ct_final))),
-        );
+        let tmp = Element::constant(dr, constant_term);
+        acc = acc.add(dr, &tmp);
 
-        Ok(vec![result])
+        WireCollector::collect_from(&acc)
     }
 }

--- a/qa/crates/lean_extraction/src/instances/endoscalar_lift.rs
+++ b/qa/crates/lean_extraction/src/instances/endoscalar_lift.rs
@@ -20,9 +20,21 @@ impl CircuitInstance for EndoscalarLiftInstance {
     /// `(n, e)` the `Boolean::and(n, e)` body is inlined — one `mul` gate plus
     /// two `enforce_equal`s, the same pattern as `boolean_and.rs`, because
     /// `Boolean` has no constructor from a bare wire. Everything else is the
-    /// deployed gadget's own `Element` calls (`zero`, `double`, `scale`, `add`,
-    /// `constant`), so the recorded output tree is exactly the one
-    /// `Endoscalar::lift` emits.
+    /// deployed gadget's own `Element` calls (`zero`, `scale`, `add`,
+    /// `constant`), in the deployed order.
+    ///
+    /// **One deliberate divergence**: the deployed `acc.double()` is
+    /// `acc.add(acc)`, which the extraction driver records as `Add(acc, acc)`
+    /// with *two copies* of the accumulator tree — the tree doubles every
+    /// iteration and the output would have `2^64` nodes, which neither the
+    /// encoder nor the Lean fingerprint traversal can materialize (production
+    /// wires are indices, so the shipped circuit never pays this). The instance
+    /// uses `acc.scale(Coeff::Two)` instead, recorded as `Mul(Const 2, acc)`:
+    /// equal in value, one reference, linear in size. The Lean reimpl
+    /// (`Lift.stepCircuit`) mirrors this same shape, so the digest certifies the
+    /// shipped output up to that one value-preserving rewrite — the same class
+    /// of tree-encoding workaround as `group_scale`'s freshening, verified by
+    /// inspection rather than by the fingerprint.
     ///
     /// Input wires: `bits[0..128]` (128 wires). Output: the lifted element.
     fn circuit(dr: &mut ExtractionDriver<Fp>) -> ragu_core::Result<Vec<Expr<Fp>>> {
@@ -55,7 +67,8 @@ impl CircuitInstance for EndoscalarLiftInstance {
             let e = Element::promote(e_wire.clone(), ExtractionDriver::<Fp>::just(|| Fp::ZERO));
             let ne = Element::promote(mul_c, ExtractionDriver::<Fp>::just(|| Fp::ZERO));
 
-            acc = acc.double(dr);
+            // Deployed: `acc.double()` — see the divergence note above.
+            acc = acc.scale(dr, Coeff::Two);
             constant_term = constant_term.double();
             constant_term += Fp::ONE;
 

--- a/qa/crates/lean_extraction/src/instances/mod.rs
+++ b/qa/crates/lean_extraction/src/instances/mod.rs
@@ -17,6 +17,7 @@ pub mod element_is_zero;
 pub mod element_mul;
 pub mod element_square;
 pub mod endoscalar_alloc;
+pub mod endoscalar_extract;
 pub mod endoscalar_group_scale;
 pub mod endoscalar_lift;
 pub mod nonzero_bank_scope;

--- a/qa/crates/lean_extraction/src/main.rs
+++ b/qa/crates/lean_extraction/src/main.rs
@@ -37,6 +37,7 @@ use crate::instances::{
     element_mul::ElementMulInstance,
     element_square::ElementSquareInstance,
     endoscalar_alloc::EndoscalarAllocInstance,
+    endoscalar_extract::EndoscalarExtractInstance,
     endoscalar_group_scale::EndoscalarGroupScaleInstance,
     endoscalar_lift::EndoscalarLiftInstance,
     nonzero_bank_scope::NonzeroBankScopeInstanceK2,
@@ -173,6 +174,10 @@ static EXPORT_TARGETS: &[ExportTarget] = &[
     ExportTarget {
         name: "Ragu.Instances.Endoscalar.Alloc",
         fingerprint: fingerprint_instance::<EndoscalarAllocInstance>,
+    },
+    ExportTarget {
+        name: "Ragu.Instances.Endoscalar.Extract",
+        fingerprint: fingerprint_instance::<EndoscalarExtractInstance>,
     },
     ExportTarget {
         name: "Ragu.Instances.Endoscalar.GroupScale",

--- a/qa/lean/Ragu/Circuits/Boolean/Decompose.lean
+++ b/qa/lean/Ragu/Circuits/Boolean/Decompose.lean
@@ -1,0 +1,194 @@
+import Clean.Circuit
+import Clean.Circuit.Loops
+import Clean.Utils.Bits
+import Mathlib.Tactic.LinearCombination
+import Ragu.Circuits.Boolean.Alloc
+
+namespace Ragu.Circuits.Boolean.Decompose
+open Utils.Bits
+variable {p : ℕ} [Fact p.Prime]
+
+/-- The recomposition `b₀ + 2·b₁ + 4·b₂ + ⋯ + 2ⁿ⁻¹·bₙ₋₁`, shaped exactly as
+the extraction driver's linear-expression accumulator builds it for
+`decompose`'s `lc.add(bit).gain(Two)` loop
+(`qa/crates/lean_extraction/src/linexp.rs`): the coefficient-one first term is
+the bare wire, every later term is `const 2ⁱ * bᵢ` with the constant on the
+left, and the sum is left-nested. An empty accumulator is the constant `0`.
+
+`Utils.Bits.fieldFromBitsExpr` has the same value but a different tree (a
+leading `0`, constants on the right: `0 + b₀ * 2⁰ + b₁ * 2¹ + ⋯`), and the
+fingerprint compares trees, not values, so `main` uses this definition;
+`eval_recomposeExpr` relates it to `fieldFromBits`. -/
+def recomposeExpr : {n : ℕ} → Vector (Expression (F p)) n → Expression (F p)
+  | 0, _ => 0
+  | m + 1, bits =>
+    Fin.foldl m
+      (fun acc (i : Fin m) =>
+        acc + Expression.const (2 ^ (i.val + 1)) * bits[i.val + 1]'(by have := i.isLt; omega))
+      bits[0]
+
+/-- `boolean.rs::decompose`: the canonical `n`-bit little-endian decomposition
+of a field element — `multipack`'s inverse. In Rust `n` is the field's
+`CAPACITY`; the reimpl is polymorphic in it. One `Boolean::alloc` per bit, with
+honest witness `bit i = elem.to_le_bits()[i]`, then a single linear constraint
+binding the weighted sum of the bits to the element. Mirrored here as
+`Circuit.mapFinRange` over `Alloc.circuit` (the hint reads bit `i` of the
+input's canonical representative) and one `assertZero` on `recomposeExpr`.
+
+`n` bits with `2ⁿ < p` represent exactly `[0, 2ⁿ)`, with no wrapped alias, so
+the decomposition is canonical without a range check; an element at or above
+`2ⁿ` has no decomposition and the constraints are unsatisfiable.
+
+The `0` branch keeps the reimpl total in `n` and emits what the Rust loop
+would (an empty accumulator, i.e. `0 - input`); no field has capacity `0`, so
+it is unreachable in practice.
+
+Sub-gadget: `decompose` is `pub(crate)` and reaches the constraint system only
+through `Endoscalar::extract_element`, so it has no extraction instance of its
+own. It is fingerprinted through `Endoscalar.Extract`, whose instance drives
+the real `EndoscalarChallenge::from_element`. -/
+def main : (n : ℕ) → Var field (F p) → Circuit (F p) (Var (fields n) (F p))
+  | 0, input => do
+    assertZero (recomposeExpr (#v[] : Vector (Expression (F p)) 0) - input)
+    pure #v[]
+  | n + 1, input => do
+    let bits ← Circuit.mapFinRange (n + 1) fun (i : Fin (n + 1)) =>
+      Alloc.circuit fun env => (env input).val.testBit i.val
+    assertZero (recomposeExpr bits - input)
+    pure bits
+
+/-- Honest-prover precondition: the element is in range. An out-of-range
+element has no `n`-bit decomposition. -/
+def ProverAssumptions (n : ℕ) (input : F p) (_data : ProverData (F p))
+    (_hint : ProverHint (F p)) :=
+  input.val < 2 ^ n
+
+/-- Verifier-side contract — the same as Clean's `Gadgets.ToBits`: any
+satisfying assignment places the element below `2ⁿ` and makes the output its
+`n`-bit little-endian decomposition. There is no verifier-side precondition:
+the range restriction is enforced by the circuit, not assumed. -/
+def Spec (n : ℕ) (input : F p) (bits : Vector (F p) n) (_data : ProverData (F p)) :=
+  input.val < 2 ^ n ∧ bits = fieldToBits n input
+
+instance elaborated (n : ℕ) : ElaboratedCircuit (F p) field (fields n) where
+  main := main n
+  localLength _ := n * 3
+  localLength_eq _ _ := by
+    rcases n with _ | n
+    · simp [main, circuit_norm]
+    · simp [main, circuit_norm, Alloc.circuit]
+  subcircuitsConsistent _ _ := by
+    rcases n with _ | n
+    · simp [main, circuit_norm]
+    · simp [main, circuit_norm, Alloc.circuit]
+
+/-! ## Bridging `recomposeExpr` to `Utils.Bits`
+
+`eval_recomposeExpr` turns the mirror-shaped expression into Clean's
+value-level `fieldFromBits`, so the canonicity facts of `Utils.Bits`
+(`fieldToBits_fieldFromBits`, `fieldFromBits_lt`, `fieldFromBits_fieldToBits`)
+do the number theory. The two `decomposition_*` lemmas state soundness and
+completeness of the bit/sum constraints for an arbitrary family of bit
+expressions `e`, which keeps the `Alloc` output terms abstract in the main
+proofs. -/
+
+private theorem eval_zero (env : Environment (F p)) :
+    Expression.eval env (0 : Expression (F p)) = 0 := rfl
+
+private theorem eval_recomposeExpr_succ (env : Environment (F p)) (m : ℕ) :
+    ∀ bits : Vector (Expression (F p)) (m + 1),
+      Expression.eval env (recomposeExpr bits) =
+        fieldFromBits (bits.map (Expression.eval env)) := by
+  induction m with
+  | zero =>
+    intro bits
+    rw [fieldFromBits_succ 0]
+    simp [recomposeExpr, fieldFromBits, fromBits]
+  | succ m ih =>
+    intro bits
+    have h_pop := ih bits.pop
+    simp only [recomposeExpr] at h_pop ⊢
+    rw [Fin.foldl_succ_last, fieldFromBits_succ (m + 1), ← Vector.map_pop, ← h_pop]
+    simp [Expression.eval, Vector.getElem_pop', Vector.getElem_map, Fin.val_castSucc,
+      Fin.val_last, mul_comm]
+
+/-- Evaluating the recomposition expression gives `fieldFromBits` of the
+evaluated bits. -/
+theorem eval_recomposeExpr (env : Environment (F p)) {n : ℕ}
+    (bits : Vector (Expression (F p)) n) :
+    Expression.eval env (recomposeExpr bits) =
+      fieldFromBits (bits.map (Expression.eval env)) := by
+  cases n with
+  | zero => simp [recomposeExpr, fieldFromBits, fromBits, eval_zero]
+  | succ m => exact eval_recomposeExpr_succ env m bits
+
+/-- Soundness of the decomposition constraints, for an arbitrary family of
+bit expressions `e`: boolean bits whose recomposition equals `x` force
+`x < 2ⁿ` and make the bits the decomposition of `x`. -/
+private theorem decomposition_sound (env : Environment (F p)) {n : ℕ} (h_cap : 2 ^ n < p)
+    (e : Fin n → Expression (F p)) (x : F p)
+    (h_bool : ∀ i, IsBool (Expression.eval env (e i)))
+    (h_sum : fieldFromBits (Vector.map (Expression.eval env) (Vector.mapFinRange n e)) + -x = 0) :
+    x.val < 2 ^ n ∧
+      Vector.map (Expression.eval env) (Vector.mapFinRange n e) = fieldToBits n x := by
+  generalize h_bits : Vector.map (Expression.eval env) (Vector.mapFinRange n e) = bits at h_sum ⊢
+  have h_bits_bool : ∀ (i : ℕ) (hi : i < n), bits[i] = 0 ∨ bits[i] = 1 := by
+    intro i hi
+    rw [← h_bits]
+    simp only [Vector.getElem_map, Vector.getElem_mapFinRange]
+    exact h_bool ⟨i, hi⟩
+  have hx : x = fieldFromBits bits := by linear_combination -h_sum
+  subst hx
+  exact ⟨fieldFromBits_lt bits h_bits_bool,
+    (fieldToBits_fieldFromBits h_cap bits h_bits_bool).symm⟩
+
+/-- Completeness of the decomposition constraints: if every bit expression
+holds the corresponding bit of an in-range `x`, the recomposition equals `x`. -/
+private theorem decomposition_complete (env : Environment (F p)) {n : ℕ}
+    (e : Fin n → Expression (F p)) (x : F p) (hx : x.val < 2 ^ n)
+    (h_bits : ∀ i : Fin n, Expression.eval env (e i) = if x.val.testBit i.val then 1 else 0) :
+    Expression.eval env (recomposeExpr (Vector.mapFinRange n e)) + -x = 0 := by
+  rw [eval_recomposeExpr]
+  have h_vec : Vector.map (Expression.eval env) (Vector.mapFinRange n e) = fieldToBits n x := by
+    ext i hi
+    simp only [Vector.getElem_map, Vector.getElem_mapFinRange, fieldToBits, toBits,
+      Vector.getElem_mapRange, h_bits ⟨i, hi⟩]
+    simp
+  rw [h_vec, fieldFromBits_fieldToBits hx]
+  ring
+
+theorem soundness (n : ℕ) (h_cap : 2 ^ n < p) :
+    GeneralFormalCircuit.Soundness (F p) (elaborated n) (fun _ _ => True) (Spec n) := by
+  rcases n with _ | n
+  · circuit_proof_start
+    rw [eval_recomposeExpr] at h_holds
+    simp [fieldFromBits, fromBits] at h_holds
+    subst h_holds
+    exact ⟨by simp, (Array.eq_empty_of_size_eq_zero (Vector.size_toArray _)).symm⟩
+  · circuit_proof_start [Alloc.circuit, Alloc.Assumptions, Alloc.Spec]
+    obtain ⟨h_bool, h_sum⟩ := h_holds
+    rw [eval_recomposeExpr] at h_sum
+    exact decomposition_sound env h_cap _ input h_bool h_sum
+
+theorem completeness (n : ℕ) :
+    GeneralFormalCircuit.Completeness (F p) (elaborated n) (ProverAssumptions n)
+      (fun _ _ _ => True) := by
+  rcases n with _ | n
+  · circuit_proof_start
+    have h0 : input = 0 := by
+      rw [← ZMod.val_eq_zero]
+      simpa [Nat.lt_one_iff] using h_assumptions
+    rw [eval_recomposeExpr]
+    simp [fieldFromBits, fromBits, h0]
+  · circuit_proof_start [Alloc.circuit, Alloc.Assumptions, Alloc.Spec,
+      Alloc.ProverAssumptions, Alloc.ProverSpec]
+    exact decomposition_complete env.toEnvironment _ input h_assumptions (fun i => (h_env i).2)
+
+def circuit (n : ℕ) (h_cap : 2 ^ n < p) : GeneralFormalCircuit (F p) field (fields n) :=
+  { elaborated n with
+    Spec := Spec n
+    ProverAssumptions := ProverAssumptions n
+    soundness := soundness n h_cap
+    completeness := completeness n }
+
+end Ragu.Circuits.Boolean.Decompose

--- a/qa/lean/Ragu/Circuits/Endoscalar/Extract.lean
+++ b/qa/lean/Ragu/Circuits/Endoscalar/Extract.lean
@@ -1,31 +1,10 @@
 import Clean.Circuit
-import Clean.Circuit.Loops
 import Clean.Utils.Bits
-import Mathlib.Tactic.LinearCombination
-import Ragu.Circuits.Boolean.Alloc
+import Ragu.Circuits.Boolean.Decompose
 
 namespace Ragu.Circuits.Endoscalar.Extract
 open Utils.Bits
 variable {p : ℕ} [Fact p.Prime]
-
-/-- The recomposition `b₀ + 2·b₁ + 4·b₂ + ⋯ + 2ⁿ⁻¹·bₙ₋₁`, shaped exactly as
-the extraction driver's linear-expression accumulator builds it for
-`decompose`'s `lc.add(bit).gain(Two)` loop
-(`qa/crates/lean_extraction/src/linexp.rs`): the coefficient-one first term is
-the bare wire, every later term is `const 2ⁱ * bᵢ` with the constant on the
-left, and the sum is left-nested. An empty accumulator is the constant `0`.
-
-`Utils.Bits.fieldFromBitsExpr` has the same value but a different tree (a
-leading `0`, constants on the right: `0 + b₀ * 2⁰ + b₁ * 2¹ + ⋯`), and the
-fingerprint compares trees, not values, so `main` uses this definition;
-`eval_recomposeExpr` relates it to `fieldFromBits`. -/
-def recomposeExpr : {n : ℕ} → Vector (Expression (F p)) n → Expression (F p)
-  | 0, _ => 0
-  | m + 1, bits =>
-    Fin.foldl m
-      (fun acc (i : Fin m) =>
-        acc + Expression.const (2 ^ (i.val + 1)) * bits[i.val + 1]'(by have := i.isLt; omega))
-      bits[0]
 
 /-- `Endoscalar::extract` in its canonical-decomposition form: the challenge
 element is decomposed into its `n = F::CAPACITY` little-endian bits and the
@@ -34,33 +13,25 @@ in `crates/ragu_primitives/src/endoscalar.rs` — every challenge constructor
 (`sample` included) goes through it, and it is the only place constraints are
 emitted; `Endoscalar::extract` itself just projects the bits out.
 
-The Rust body is `boolean.rs::decompose`: one `Boolean::alloc` per bit, with
-honest witness `bit i = elem.to_le_bits()[i]`, then a single linear constraint
-binding the weighted sum of the bits to the element. This reimpl mirrors it
-with `Circuit.mapFinRange n` over `Boolean.Alloc.circuit` (the hint reads bit
-`i` of the input's canonical representative) and one `assertZero` on
-`recomposeExpr`.
-
-`n` bits with `2ⁿ < p` represent exactly `[0, 2ⁿ)`, with no wrapped alias, so
-the decomposition is canonical without a range check; an element at or above
-`2ⁿ` has no decomposition and the constraints are unsatisfiable. The native
-range check in `from_element` (`try_just`) runs only during witness generation
-and emits nothing, so it has no counterpart here; `ProverAssumptions` carries
-it. Taking 128 bits needs `128 ≤ n`, mirroring `extract_element`'s
+The Rust body is `Endoscalar::extract_element`: delegate to
+`boolean.rs::decompose`, then keep the first 128 bits. The reimpl delegates
+the same way — `Boolean.Decompose` emits every constraint, and this circuit
+only projects — so the decomposition's canonicity argument lives with
+`Decompose`. Taking 128 bits needs `128 ≤ n`, mirroring `extract_element`'s
 `try_collect_fixed` over the first 128 decomposition bits.
+
+The native range check in `from_element` (`try_just`) runs only during witness
+generation and emits nothing, so it has no counterpart here;
+`ProverAssumptions` carries it.
 
 Extraction instance: `qa/crates/lean_extraction/src/instances/endoscalar_extract.rs`
 (drives the real gadget). Formal instance:
 `qa/lean/Ragu/Instances/Endoscalar/Extract.lean` pins `n = 254`, the Pasta
 capacity. -/
-def main (n : ℕ) (h_len : 128 ≤ n) (input : Var field (F p))
-    : Circuit (F p) (Var (fields 128) (F p)) :=
-  haveI : NeZero n := ⟨by omega⟩
-  do
-    let bits ← Circuit.mapFinRange n fun (i : Fin n) =>
-      Boolean.Alloc.circuit fun env => (env input).val.testBit i.val
-    assertZero (recomposeExpr bits - input)
-    return Vector.ofFn fun (i : Fin 128) => bits[i.val]'(by have := i.isLt; omega)
+def main (n : ℕ) (h_cap : 2 ^ n < p) (h_len : 128 ≤ n) (input : Var field (F p))
+    : Circuit (F p) (Var (fields 128) (F p)) := do
+  let bits ← Boolean.Decompose.circuit n h_cap input
+  return Vector.ofFn fun (i : Fin 128) => bits[i.val]'(by have := i.isLt; omega)
 
 /-- Honest-prover precondition: the element is in range. An out-of-range
 element has no `n`-bit decomposition — the case `from_element` rejects and
@@ -77,123 +48,37 @@ not assumed. -/
 def Spec (n : ℕ) (input : F p) (out : Vector (F p) 128) (_data : ProverData (F p)) :=
   input.val < 2 ^ n ∧ ∀ i : Fin 128, out[i] = if input.val.testBit i.val then 1 else 0
 
-instance elaborated (n : ℕ) (h_len : 128 ≤ n)
+instance elaborated (n : ℕ) (h_cap : 2 ^ n < p) (h_len : 128 ≤ n)
     : ElaboratedCircuit (F p) field (fields 128) where
-  main := main n h_len
+  main := main n h_cap h_len
   localLength _ := n * 3
   localLength_eq _ _ := by
-    simp [main, circuit_norm, Boolean.Alloc.circuit]
+    simp [main, circuit_norm, Boolean.Decompose.circuit]
   subcircuitsConsistent _ _ := by
-    simp [main, circuit_norm, Boolean.Alloc.circuit]
+    simp [main, circuit_norm, Boolean.Decompose.circuit]
 
-/-! ## Bridging `recomposeExpr` to `Utils.Bits`
-
-`eval_recomposeExpr` turns the mirror-shaped expression into Clean's
-value-level `fieldFromBits`, so the canonicity facts of `Utils.Bits`
-(`fieldToBits_fieldFromBits`, `fieldFromBits_lt`, `fieldFromBits_fieldToBits`)
-do the number theory. The two `decomposition_*` lemmas state soundness and
-completeness of the bit/sum constraints for an arbitrary family of bit
-expressions `e`, which keeps the `Boolean.Alloc` output terms abstract in the
-main proofs. -/
-
-private theorem eval_zero (env : Environment (F p)) :
-    Expression.eval env (0 : Expression (F p)) = 0 := rfl
-
-private theorem eval_recomposeExpr_succ (env : Environment (F p)) (m : ℕ) :
-    ∀ bits : Vector (Expression (F p)) (m + 1),
-      Expression.eval env (recomposeExpr bits) =
-        fieldFromBits (bits.map (Expression.eval env)) := by
-  induction m with
-  | zero =>
-    intro bits
-    rw [fieldFromBits_succ 0]
-    simp [recomposeExpr, fieldFromBits, fromBits]
-  | succ m ih =>
-    intro bits
-    have h_pop := ih bits.pop
-    simp only [recomposeExpr] at h_pop ⊢
-    rw [Fin.foldl_succ_last, fieldFromBits_succ (m + 1), ← Vector.map_pop, ← h_pop]
-    simp [Expression.eval, Vector.getElem_pop', Vector.getElem_map, Fin.val_castSucc,
-      Fin.val_last, mul_comm]
-
-/-- Evaluating the recomposition expression gives `fieldFromBits` of the
-evaluated bits. -/
-theorem eval_recomposeExpr (env : Environment (F p)) {n : ℕ}
-    (bits : Vector (Expression (F p)) n) :
-    Expression.eval env (recomposeExpr bits) =
-      fieldFromBits (bits.map (Expression.eval env)) := by
-  cases n with
-  | zero => simp [recomposeExpr, fieldFromBits, fromBits, eval_zero]
-  | succ m => exact eval_recomposeExpr_succ env m bits
-
-/-- Soundness of the decomposition constraints, for an arbitrary family of
-bit expressions `e`: boolean bits whose recomposition equals `x` force
-`x < 2ⁿ` and pin every bit to the corresponding bit of `x`. -/
-private theorem decomposition_sound (env : Environment (F p)) {n : ℕ} (h_cap : 2 ^ n < p)
-    (e : Fin n → Expression (F p)) (x : F p)
-    (h_bool : ∀ i, IsBool (Expression.eval env (e i)))
-    (h_sum : fieldFromBits (Vector.map (Expression.eval env) (Vector.mapFinRange n e)) + -x = 0) :
-    x.val < 2 ^ n ∧
-      ∀ (i : ℕ) (hi : i < n),
-        Expression.eval env (e ⟨i, hi⟩) = if x.val.testBit i then 1 else 0 := by
-  generalize h_bits : Vector.map (Expression.eval env) (Vector.mapFinRange n e) = bits at h_sum
-  have h_bits_i : ∀ (i : ℕ) (hi : i < n), bits[i] = Expression.eval env (e ⟨i, hi⟩) := by
-    intro i hi
-    rw [← h_bits]
-    simp only [Vector.getElem_map, Vector.getElem_mapFinRange]
-  have h_bits_bool : ∀ (i : ℕ) (hi : i < n), bits[i] = 0 ∨ bits[i] = 1 := by
-    intro i hi
-    rw [h_bits_i i hi]
-    exact h_bool ⟨i, hi⟩
-  have hx : x = fieldFromBits bits := by linear_combination -h_sum
-  have h_to := fieldToBits_fieldFromBits h_cap bits h_bits_bool
-  refine ⟨?_, ?_⟩
-  · rw [hx]
-    exact fieldFromBits_lt bits h_bits_bool
-  · intro i hi
-    have h_i := congrArg (fun v => v[i]'hi) h_to
-    simp only [fieldToBits, toBits, Vector.getElem_map, Vector.getElem_mapRange] at h_i
-    rw [← h_bits_i i hi, ← h_i, hx]
-    simp
-
-/-- Completeness of the decomposition constraints: if every bit expression
-holds the corresponding bit of an in-range `x`, the recomposition equals `x`. -/
-private theorem decomposition_complete (env : Environment (F p)) {n : ℕ}
-    (e : Fin n → Expression (F p)) (x : F p) (hx : x.val < 2 ^ n)
-    (h_bits : ∀ i : Fin n, Expression.eval env (e i) = if x.val.testBit i.val then 1 else 0) :
-    Expression.eval env (recomposeExpr (Vector.mapFinRange n e)) + -x = 0 := by
-  rw [eval_recomposeExpr]
-  have h_vec : Vector.map (Expression.eval env) (Vector.mapFinRange n e) = fieldToBits n x := by
-    ext i hi
-    simp only [Vector.getElem_map, Vector.getElem_mapFinRange, fieldToBits, toBits,
-      Vector.getElem_mapRange, h_bits ⟨i, hi⟩]
-    simp
-  rw [h_vec, fieldFromBits_fieldToBits hx]
-  ring
-
-theorem soundness (n : ℕ) (h_len : 128 ≤ n) (h_cap : 2 ^ n < p) :
-    GeneralFormalCircuit.Soundness (F p) (elaborated n h_len) (fun _ _ => True) (Spec n) := by
-  circuit_proof_start [Boolean.Alloc.circuit, Boolean.Alloc.Assumptions, Boolean.Alloc.Spec]
-  obtain ⟨h_bool, h_sum⟩ := h_holds
-  rw [eval_recomposeExpr] at h_sum
-  obtain ⟨h_lt, h_bit⟩ := decomposition_sound env h_cap _ input h_bool h_sum
+theorem soundness (n : ℕ) (h_cap : 2 ^ n < p) (h_len : 128 ≤ n) :
+    GeneralFormalCircuit.Soundness (F p) (elaborated n h_cap h_len) (fun _ _ => True) (Spec n) := by
+  circuit_proof_start [Boolean.Decompose.circuit, Boolean.Decompose.Spec]
+  obtain ⟨h_lt, h_bits⟩ := h_holds
   refine ⟨h_lt, fun i => ?_⟩
-  have := h_bit i.val (by omega)
-  simpa [Vector.getElem_ofFn] using this
+  have h_i := congrArg (fun v => v[i.val]'(by omega)) h_bits
+  simp only [Vector.getElem_map, fieldToBits, toBits, Vector.getElem_mapRange] at h_i
+  simpa [Vector.getElem_ofFn] using h_i
 
-theorem completeness (n : ℕ) (h_len : 128 ≤ n) :
-    GeneralFormalCircuit.Completeness (F p) (elaborated n h_len) (ProverAssumptions n)
+theorem completeness (n : ℕ) (h_cap : 2 ^ n < p) (h_len : 128 ≤ n) :
+    GeneralFormalCircuit.Completeness (F p) (elaborated n h_cap h_len) (ProverAssumptions n)
       (fun _ _ _ => True) := by
-  circuit_proof_start [Boolean.Alloc.circuit, Boolean.Alloc.Assumptions, Boolean.Alloc.Spec,
-    Boolean.Alloc.ProverAssumptions, Boolean.Alloc.ProverSpec]
-  exact decomposition_complete env.toEnvironment _ input h_assumptions (fun i => (h_env i).2)
+  circuit_proof_start [Boolean.Decompose.circuit, Boolean.Decompose.Spec,
+    Boolean.Decompose.ProverAssumptions]
+  exact h_assumptions
 
-def circuit (n : ℕ) (h_len : 128 ≤ n) (h_cap : 2 ^ n < p)
+def circuit (n : ℕ) (h_cap : 2 ^ n < p) (h_len : 128 ≤ n)
     : GeneralFormalCircuit (F p) field (fields 128) :=
-  { elaborated n h_len with
+  { elaborated n h_cap h_len with
     Spec := Spec n
     ProverAssumptions := ProverAssumptions n
-    soundness := soundness n h_len h_cap
-    completeness := completeness n h_len }
+    soundness := soundness n h_cap h_len
+    completeness := completeness n h_cap h_len }
 
 end Ragu.Circuits.Endoscalar.Extract

--- a/qa/lean/Ragu/Circuits/Endoscalar/Extract.lean
+++ b/qa/lean/Ragu/Circuits/Endoscalar/Extract.lean
@@ -1,0 +1,199 @@
+import Clean.Circuit
+import Clean.Circuit.Loops
+import Clean.Utils.Bits
+import Mathlib.Tactic.LinearCombination
+import Ragu.Circuits.Boolean.Alloc
+
+namespace Ragu.Circuits.Endoscalar.Extract
+open Utils.Bits
+variable {p : ℕ} [Fact p.Prime]
+
+/-- The recomposition `b₀ + 2·b₁ + 4·b₂ + ⋯ + 2ⁿ⁻¹·bₙ₋₁`, shaped exactly as
+the extraction driver's linear-expression accumulator builds it for
+`decompose`'s `lc.add(bit).gain(Two)` loop
+(`qa/crates/lean_extraction/src/linexp.rs`): the coefficient-one first term is
+the bare wire, every later term is `const 2ⁱ * bᵢ` with the constant on the
+left, and the sum is left-nested. An empty accumulator is the constant `0`.
+
+`Utils.Bits.fieldFromBitsExpr` has the same value but a different tree (a
+leading `0`, constants on the right: `0 + b₀ * 2⁰ + b₁ * 2¹ + ⋯`), and the
+fingerprint compares trees, not values, so `main` uses this definition;
+`eval_recomposeExpr` relates it to `fieldFromBits`. -/
+def recomposeExpr : {n : ℕ} → Vector (Expression (F p)) n → Expression (F p)
+  | 0, _ => 0
+  | m + 1, bits =>
+    Fin.foldl m
+      (fun acc (i : Fin m) =>
+        acc + Expression.const (2 ^ (i.val + 1)) * bits[i.val + 1]'(by have := i.isLt; omega))
+      bits[0]
+
+/-- `Endoscalar::extract` in its canonical-decomposition form: the challenge
+element is decomposed into its `n = F::CAPACITY` little-endian bits and the
+low 128 of them are the endoscalar. Mirrors `EndoscalarChallenge::from_element`
+in `crates/ragu_primitives/src/endoscalar.rs` — every challenge constructor
+(`sample` included) goes through it, and it is the only place constraints are
+emitted; `Endoscalar::extract` itself just projects the bits out.
+
+The Rust body is `boolean.rs::decompose`: one `Boolean::alloc` per bit, with
+honest witness `bit i = elem.to_le_bits()[i]`, then a single linear constraint
+binding the weighted sum of the bits to the element. This reimpl mirrors it
+with `Circuit.mapFinRange n` over `Boolean.Alloc.circuit` (the hint reads bit
+`i` of the input's canonical representative) and one `assertZero` on
+`recomposeExpr`.
+
+`n` bits with `2ⁿ < p` represent exactly `[0, 2ⁿ)`, with no wrapped alias, so
+the decomposition is canonical without a range check; an element at or above
+`2ⁿ` has no decomposition and the constraints are unsatisfiable. The native
+range check in `from_element` (`try_just`) runs only during witness generation
+and emits nothing, so it has no counterpart here; `ProverAssumptions` carries
+it. Taking 128 bits needs `128 ≤ n`, mirroring `extract_element`'s
+`try_collect_fixed` over the first 128 decomposition bits.
+
+Extraction instance: `qa/crates/lean_extraction/src/instances/endoscalar_extract.rs`
+(drives the real gadget). Formal instance:
+`qa/lean/Ragu/Instances/Endoscalar/Extract.lean` pins `n = 254`, the Pasta
+capacity. -/
+def main (n : ℕ) (h_len : 128 ≤ n) (input : Var field (F p))
+    : Circuit (F p) (Var (fields 128) (F p)) :=
+  haveI : NeZero n := ⟨by omega⟩
+  do
+    let bits ← Circuit.mapFinRange n fun (i : Fin n) =>
+      Boolean.Alloc.circuit fun env => (env input).val.testBit i.val
+    assertZero (recomposeExpr bits - input)
+    return Vector.ofFn fun (i : Fin 128) => bits[i.val]'(by have := i.isLt; omega)
+
+/-- Honest-prover precondition: the element is in range. An out-of-range
+element has no `n`-bit decomposition — the case `from_element` rejects and
+`EndoscalarChallenge::sample` resamples away. -/
+def ProverAssumptions (n : ℕ) (input : F p) (_data : ProverData (F p))
+    (_hint : ProverHint (F p)) :=
+  input.val < 2 ^ n
+
+/-- Verifier-side contract: any satisfying assignment places the element
+below `2ⁿ`, and output wire `i` holds bit `i` of its canonical representative
+(LSB first) — the endoscalar is the low 128 bits of the challenge. There is no
+verifier-side precondition: the range restriction is enforced by the circuit,
+not assumed. -/
+def Spec (n : ℕ) (input : F p) (out : Vector (F p) 128) (_data : ProverData (F p)) :=
+  input.val < 2 ^ n ∧ ∀ i : Fin 128, out[i] = if input.val.testBit i.val then 1 else 0
+
+instance elaborated (n : ℕ) (h_len : 128 ≤ n)
+    : ElaboratedCircuit (F p) field (fields 128) where
+  main := main n h_len
+  localLength _ := n * 3
+  localLength_eq _ _ := by
+    simp [main, circuit_norm, Boolean.Alloc.circuit]
+  subcircuitsConsistent _ _ := by
+    simp [main, circuit_norm, Boolean.Alloc.circuit]
+
+/-! ## Bridging `recomposeExpr` to `Utils.Bits`
+
+`eval_recomposeExpr` turns the mirror-shaped expression into Clean's
+value-level `fieldFromBits`, so the canonicity facts of `Utils.Bits`
+(`fieldToBits_fieldFromBits`, `fieldFromBits_lt`, `fieldFromBits_fieldToBits`)
+do the number theory. The two `decomposition_*` lemmas state soundness and
+completeness of the bit/sum constraints for an arbitrary family of bit
+expressions `e`, which keeps the `Boolean.Alloc` output terms abstract in the
+main proofs. -/
+
+private theorem eval_zero (env : Environment (F p)) :
+    Expression.eval env (0 : Expression (F p)) = 0 := rfl
+
+private theorem eval_recomposeExpr_succ (env : Environment (F p)) (m : ℕ) :
+    ∀ bits : Vector (Expression (F p)) (m + 1),
+      Expression.eval env (recomposeExpr bits) =
+        fieldFromBits (bits.map (Expression.eval env)) := by
+  induction m with
+  | zero =>
+    intro bits
+    rw [fieldFromBits_succ 0]
+    simp [recomposeExpr, fieldFromBits, fromBits]
+  | succ m ih =>
+    intro bits
+    have h_pop := ih bits.pop
+    simp only [recomposeExpr] at h_pop ⊢
+    rw [Fin.foldl_succ_last, fieldFromBits_succ (m + 1), ← Vector.map_pop, ← h_pop]
+    simp [Expression.eval, Vector.getElem_pop', Vector.getElem_map, Fin.val_castSucc,
+      Fin.val_last, mul_comm]
+
+/-- Evaluating the recomposition expression gives `fieldFromBits` of the
+evaluated bits. -/
+theorem eval_recomposeExpr (env : Environment (F p)) {n : ℕ}
+    (bits : Vector (Expression (F p)) n) :
+    Expression.eval env (recomposeExpr bits) =
+      fieldFromBits (bits.map (Expression.eval env)) := by
+  cases n with
+  | zero => simp [recomposeExpr, fieldFromBits, fromBits, eval_zero]
+  | succ m => exact eval_recomposeExpr_succ env m bits
+
+/-- Soundness of the decomposition constraints, for an arbitrary family of
+bit expressions `e`: boolean bits whose recomposition equals `x` force
+`x < 2ⁿ` and pin every bit to the corresponding bit of `x`. -/
+private theorem decomposition_sound (env : Environment (F p)) {n : ℕ} (h_cap : 2 ^ n < p)
+    (e : Fin n → Expression (F p)) (x : F p)
+    (h_bool : ∀ i, IsBool (Expression.eval env (e i)))
+    (h_sum : fieldFromBits (Vector.map (Expression.eval env) (Vector.mapFinRange n e)) + -x = 0) :
+    x.val < 2 ^ n ∧
+      ∀ (i : ℕ) (hi : i < n),
+        Expression.eval env (e ⟨i, hi⟩) = if x.val.testBit i then 1 else 0 := by
+  generalize h_bits : Vector.map (Expression.eval env) (Vector.mapFinRange n e) = bits at h_sum
+  have h_bits_i : ∀ (i : ℕ) (hi : i < n), bits[i] = Expression.eval env (e ⟨i, hi⟩) := by
+    intro i hi
+    rw [← h_bits]
+    simp only [Vector.getElem_map, Vector.getElem_mapFinRange]
+  have h_bits_bool : ∀ (i : ℕ) (hi : i < n), bits[i] = 0 ∨ bits[i] = 1 := by
+    intro i hi
+    rw [h_bits_i i hi]
+    exact h_bool ⟨i, hi⟩
+  have hx : x = fieldFromBits bits := by linear_combination -h_sum
+  have h_to := fieldToBits_fieldFromBits h_cap bits h_bits_bool
+  refine ⟨?_, ?_⟩
+  · rw [hx]
+    exact fieldFromBits_lt bits h_bits_bool
+  · intro i hi
+    have h_i := congrArg (fun v => v[i]'hi) h_to
+    simp only [fieldToBits, toBits, Vector.getElem_map, Vector.getElem_mapRange] at h_i
+    rw [← h_bits_i i hi, ← h_i, hx]
+    simp
+
+/-- Completeness of the decomposition constraints: if every bit expression
+holds the corresponding bit of an in-range `x`, the recomposition equals `x`. -/
+private theorem decomposition_complete (env : Environment (F p)) {n : ℕ}
+    (e : Fin n → Expression (F p)) (x : F p) (hx : x.val < 2 ^ n)
+    (h_bits : ∀ i : Fin n, Expression.eval env (e i) = if x.val.testBit i.val then 1 else 0) :
+    Expression.eval env (recomposeExpr (Vector.mapFinRange n e)) + -x = 0 := by
+  rw [eval_recomposeExpr]
+  have h_vec : Vector.map (Expression.eval env) (Vector.mapFinRange n e) = fieldToBits n x := by
+    ext i hi
+    simp only [Vector.getElem_map, Vector.getElem_mapFinRange, fieldToBits, toBits,
+      Vector.getElem_mapRange, h_bits ⟨i, hi⟩]
+    simp
+  rw [h_vec, fieldFromBits_fieldToBits hx]
+  ring
+
+theorem soundness (n : ℕ) (h_len : 128 ≤ n) (h_cap : 2 ^ n < p) :
+    GeneralFormalCircuit.Soundness (F p) (elaborated n h_len) (fun _ _ => True) (Spec n) := by
+  circuit_proof_start [Boolean.Alloc.circuit, Boolean.Alloc.Assumptions, Boolean.Alloc.Spec]
+  obtain ⟨h_bool, h_sum⟩ := h_holds
+  rw [eval_recomposeExpr] at h_sum
+  obtain ⟨h_lt, h_bit⟩ := decomposition_sound env h_cap _ input h_bool h_sum
+  refine ⟨h_lt, fun i => ?_⟩
+  have := h_bit i.val (by omega)
+  simpa [Vector.getElem_ofFn] using this
+
+theorem completeness (n : ℕ) (h_len : 128 ≤ n) :
+    GeneralFormalCircuit.Completeness (F p) (elaborated n h_len) (ProverAssumptions n)
+      (fun _ _ _ => True) := by
+  circuit_proof_start [Boolean.Alloc.circuit, Boolean.Alloc.Assumptions, Boolean.Alloc.Spec,
+    Boolean.Alloc.ProverAssumptions, Boolean.Alloc.ProverSpec]
+  exact decomposition_complete env.toEnvironment _ input h_assumptions (fun i => (h_env i).2)
+
+def circuit (n : ℕ) (h_len : 128 ≤ n) (h_cap : 2 ^ n < p)
+    : GeneralFormalCircuit (F p) field (fields 128) :=
+  { elaborated n h_len with
+    Spec := Spec n
+    ProverAssumptions := ProverAssumptions n
+    soundness := soundness n h_len h_cap
+    completeness := completeness n h_len }
+
+end Ragu.Circuits.Endoscalar.Extract

--- a/qa/lean/Ragu/Circuits/Endoscalar/GroupScale.lean
+++ b/qa/lean/Ragu/Circuits/Endoscalar/GroupScale.lean
@@ -171,15 +171,12 @@ theorem soundness (curveParams : Point.Spec.CurveParams p) :
     Soundness (F p) (elaborated curveParams)
       (Assumptions curveParams) (Spec curveParams) := by
   circuit_proof_start [Point.ConditionalNegate.circuit, Point.ConditionalNegate.Assumptions,
-    Point.ConditionalNegate.Spec, Point.ConditionalNegate.main,
+    Point.ConditionalNegate.Spec,
     Point.ConditionalEndo.circuit, Point.ConditionalEndo.Assumptions,
-    Point.ConditionalEndo.Spec, Point.ConditionalEndo.main,
-    Boolean.ConditionalSelect.circuit,
+    Point.ConditionalEndo.Spec,
     Point.DoubleAndAddIncompleteUnchecked.circuit,
     Point.DoubleAndAddIncompleteUnchecked.Assumptions,
     Point.DoubleAndAddIncompleteUnchecked.Spec,
-    Point.DoubleAndAddIncompleteUnchecked.main,
-    Element.Divide.circuit, Element.Square.circuit,
     Element.Mul.circuit, Element.Mul.Assumptions, Element.Mul.Spec]
   obtain ⟨h_pt_curve, h_acc_curve, h_n_bool, h_e_bool, h_step_ne⟩ := h_assumptions
   obtain ⟨h_neg, h_endo, h_daa, h_fx, h_fy⟩ := h_holds
@@ -220,15 +217,12 @@ omit [NeZero (2 : F p)] in
 theorem completeness (curveParams : Point.Spec.CurveParams p) :
     Completeness (F p) (elaborated curveParams) (Assumptions curveParams) := by
   circuit_proof_start [Point.ConditionalNegate.circuit, Point.ConditionalNegate.Assumptions,
-    Point.ConditionalNegate.Spec, Point.ConditionalNegate.main,
+    Point.ConditionalNegate.Spec,
     Point.ConditionalEndo.circuit, Point.ConditionalEndo.Assumptions,
-    Point.ConditionalEndo.Spec, Point.ConditionalEndo.main,
-    Boolean.ConditionalSelect.circuit,
+    Point.ConditionalEndo.Spec,
     Point.DoubleAndAddIncompleteUnchecked.circuit,
     Point.DoubleAndAddIncompleteUnchecked.Assumptions,
     Point.DoubleAndAddIncompleteUnchecked.Spec,
-    Point.DoubleAndAddIncompleteUnchecked.main,
-    Element.Divide.circuit, Element.Square.circuit,
     Element.Mul.circuit, Element.Mul.Assumptions, Element.Mul.Spec]
   obtain ⟨h_pt_curve, h_acc_curve, h_n_bool, h_e_bool, h_step_ne⟩ := h_assumptions
   obtain ⟨h_neg_env, h_endo_env, _⟩ := h_env
@@ -267,7 +261,9 @@ def circuit (curveParams : Point.Spec.CurveParams p) :
 
 end Step
 
-instance : Inhabited (Var Point.Spec.Point (F p)) := ⟨⟨0, 0⟩⟩
+/-- `Circuit.foldl` needs an inhabited accumulator type; file-local so it
+leaks into no importer. -/
+local instance : Inhabited (Var Point.Spec.Point (F p)) := ⟨⟨0, 0⟩⟩
 
 /-- `@[irreducible]` is a defeq seal only: it stops the unifier/kernel from
 whnf-unrolling the 64-iteration foldl during structure-update type checks
@@ -402,11 +398,10 @@ theorem soundness (curveParams : Point.Spec.CurveParams p)
   --   4. The top-level `groupScaleNative ≠ none` assumption supplies each
   --      unchecked addition's non-degeneracy via `all_accAfter_ne`, so
   --      `groupScaleNative = some output` follows at m = 64.
-  circuit_proof_start [main, Step.circuit, Step.Assumptions, Step.Spec,
+  circuit_proof_start [Step.circuit, Step.Assumptions, Step.Spec,
     Point.AddIncompleteUnchecked.circuit, Point.AddIncompleteUnchecked.Assumptions,
-    Point.AddIncompleteUnchecked.Spec, Point.AddIncompleteUnchecked.main,
-    Point.Double.circuit, Point.Double.Assumptions, Point.Double.Spec, Point.Double.main,
-    Element.Divide.circuit, Element.Square.circuit, Element.Mul.circuit]
+    Point.AddIncompleteUnchecked.Spec,
+    Point.Double.circuit, Point.Double.Assumptions, Point.Double.Spec]
   obtain ⟨h_pt_curve, h_no2, h_bits, h_native_ne⟩ := h_assumptions
   obtain ⟨h_add, h_double, h_step0, h_steps⟩ := h_holds
   obtain ⟨h_bits_eval, _, _⟩ := h_input
@@ -506,11 +501,10 @@ theorem completeness (curveParams : Point.Spec.CurveParams p)
   -- Assumptions), and per-step `stepNative ≠ none` extracted from
   -- `groupScaleNative ≠ none` via the `accAfter` helpers above. The init
   -- AddIncomplete needs `(ζ-1)·p.x ≠ 0` (from `h_zeta_ne_one` + `h_px_ne`).
-  circuit_proof_start [main, Step.circuit, Step.Assumptions, Step.Spec,
+  circuit_proof_start [Step.circuit, Step.Assumptions, Step.Spec,
     Point.AddIncompleteUnchecked.circuit, Point.AddIncompleteUnchecked.Assumptions,
-    Point.AddIncompleteUnchecked.Spec, Point.AddIncompleteUnchecked.main,
-    Point.Double.circuit, Point.Double.Assumptions, Point.Double.Spec, Point.Double.main,
-    Element.Divide.circuit, Element.Square.circuit, Element.Mul.circuit]
+    Point.AddIncompleteUnchecked.Spec,
+    Point.Double.circuit, Point.Double.Assumptions, Point.Double.Spec]
   obtain ⟨h_pt_curve, h_no2, h_bits, h_native_ne⟩ := h_assumptions
   obtain ⟨h_add_env, h_double_env, h_step0_env, h_steps_env⟩ := h_env
   obtain ⟨h_bits_eval, _, _⟩ := h_input

--- a/qa/lean/Ragu/Circuits/Endoscalar/GroupScale.lean
+++ b/qa/lean/Ragu/Circuits/Endoscalar/GroupScale.lean
@@ -398,7 +398,9 @@ theorem soundness (curveParams : Point.Spec.CurveParams p)
   --   4. The top-level `groupScaleNative ≠ none` assumption supplies each
   --      unchecked addition's non-degeneracy via `all_accAfter_ne`, so
   --      `groupScaleNative = some output` follows at m = 64.
-  circuit_proof_start [Step.circuit, Step.Assumptions, Step.Spec,
+  -- `main` is `@[irreducible]` (see its docstring), so `circuit_proof_start`
+  -- cannot auto-unfold it and it must be named here.
+  circuit_proof_start [main, Step.circuit, Step.Assumptions, Step.Spec,
     Point.AddIncompleteUnchecked.circuit, Point.AddIncompleteUnchecked.Assumptions,
     Point.AddIncompleteUnchecked.Spec,
     Point.Double.circuit, Point.Double.Assumptions, Point.Double.Spec]
@@ -501,7 +503,9 @@ theorem completeness (curveParams : Point.Spec.CurveParams p)
   -- Assumptions), and per-step `stepNative ≠ none` extracted from
   -- `groupScaleNative ≠ none` via the `accAfter` helpers above. The init
   -- AddIncomplete needs `(ζ-1)·p.x ≠ 0` (from `h_zeta_ne_one` + `h_px_ne`).
-  circuit_proof_start [Step.circuit, Step.Assumptions, Step.Spec,
+  -- `main` is `@[irreducible]` (see its docstring), so `circuit_proof_start`
+  -- cannot auto-unfold it and it must be named here.
+  circuit_proof_start [main, Step.circuit, Step.Assumptions, Step.Spec,
     Point.AddIncompleteUnchecked.circuit, Point.AddIncompleteUnchecked.Assumptions,
     Point.AddIncompleteUnchecked.Spec,
     Point.Double.circuit, Point.Double.Assumptions, Point.Double.Spec]

--- a/qa/lean/Ragu/Circuits/Endoscalar/Lift.lean
+++ b/qa/lean/Ragu/Circuits/Endoscalar/Lift.lean
@@ -32,8 +32,9 @@ tied to this reimpl by the fingerprint equivalence check via the formal instance
 in `qa/lean/Ragu/Instances/Endoscalar/Lift.lean`. The Rust instance inlines
 `Boolean::and` (gate + 2 `enforce_equal`s, the same pattern as `boolean_and.rs`,
 because `Boolean` has no constructor from a bare wire) and otherwise drives the
-deployed `Element::{zero, double, scale, add, constant}` calls of
-`Endoscalar::lift`, so the output tree it records is the shipped gadget's. -/
+deployed `Element::{zero, scale, add, constant}` calls of `Endoscalar::lift`,
+with `double` replaced by `scale(2)` for the tree-size reason documented on
+`stepCircuit` — the one value-preserving divergence from the shipped output. -/
 structure Input (F : Type) where
   bits : Vector F 128
 deriving ProvableStruct
@@ -54,14 +55,18 @@ def liftNative (ζ : F p) (bits : Vector (F p) 128) : F p :=
     (2 * (ζ + 1))
 
 /-- Per-iteration symbolic accumulator update (pure expression, no constraints),
-shaped exactly as the deployed `Endoscalar::lift` builds it from `Element`
-operations: `acc.double()` is `acc + acc`, then the three `scale`d terms are
-`add`ed one at a time, so the tree is left-nested with constants on the left.
+shaped as the deployed `Endoscalar::lift` builds it from `Element` operations —
+the three `scale`d terms are `add`ed one at a time, so the tree is left-nested
+with constants on the left — with one deliberate divergence: the deployed
+`acc.double()` is `acc + acc`, which as a *tree* duplicates the accumulator
+every iteration (`2⁶⁴` nodes at the output, unrepresentable by the tree-shaped
+trace encoding that the fingerprint hashes), so both this reimpl and the
+extraction instance use `2 · acc` instead — equal in value, one reference.
 Encodes the native step `2·acc + (n?-1:1)·(e?ζ:1)` as an affine expression in
 `n`, `e`, and `ne = n·e`. The constant `1` from the algebraic identity is *not*
 included here — it's accumulated separately via the closed-form `ctFinal`. -/
 def stepCircuit (ζ : F p) (n e ne acc : Expression (F p)) : Expression (F p) :=
-  acc + acc +
+  Expression.const 2 * acc +
     Expression.const (-2) * n +
     Expression.const (ζ - 1) * e +
     Expression.const (2 * (1 - ζ)) * ne

--- a/qa/lean/Ragu/Circuits/Endoscalar/Lift.lean
+++ b/qa/lean/Ragu/Circuits/Endoscalar/Lift.lean
@@ -29,11 +29,11 @@ The circuit-side `main` separates the two phases of the loop:
 
 Extraction instance: `qa/crates/lean_extraction/src/instances/endoscalar_lift.rs`,
 tied to this reimpl by the fingerprint equivalence check via the formal instance
-in `qa/lean/Ragu/Instances/Endoscalar/Lift.lean`. The Rust instance uses an
-inlined `Boolean::and` (gate + 2 `enforce_equal`s, same pattern as
-`boolean_and.rs`) and shapes its output Expression tree to match this reimpl's
-`stepCircuit` form verbatim, so the structural output encoding in the
-fingerprint digests agrees. -/
+in `qa/lean/Ragu/Instances/Endoscalar/Lift.lean`. The Rust instance inlines
+`Boolean::and` (gate + 2 `enforce_equal`s, the same pattern as `boolean_and.rs`,
+because `Boolean` has no constructor from a bare wire) and otherwise drives the
+deployed `Element::{zero, double, scale, add, constant}` calls of
+`Endoscalar::lift`, so the output tree it records is the shipped gadget's. -/
 structure Input (F : Type) where
   bits : Vector F 128
 deriving ProvableStruct
@@ -53,15 +53,18 @@ def liftNative (ζ : F p) (bits : Vector (F p) 128) : F p :=
         (bits[2 * i.val + 1]'(by have := i.isLt; omega)))
     (2 * (ζ + 1))
 
-/-- Per-iteration symbolic accumulator update (pure expression, no constraints).
+/-- Per-iteration symbolic accumulator update (pure expression, no constraints),
+shaped exactly as the deployed `Endoscalar::lift` builds it from `Element`
+operations: `acc.double()` is `acc + acc`, then the three `scale`d terms are
+`add`ed one at a time, so the tree is left-nested with constants on the left.
 Encodes the native step `2·acc + (n?-1:1)·(e?ζ:1)` as an affine expression in
 `n`, `e`, and `ne = n·e`. The constant `1` from the algebraic identity is *not*
 included here — it's accumulated separately via the closed-form `ctFinal`. -/
 def stepCircuit (ζ : F p) (n e ne acc : Expression (F p)) : Expression (F p) :=
-  Expression.const 2 * acc +
-    (Expression.const (-2) * n +
-     Expression.const (ζ - 1) * e +
-     Expression.const (2 * (1 - ζ)) * ne)
+  acc + acc +
+    Expression.const (-2) * n +
+    Expression.const (ζ - 1) * e +
+    Expression.const (2 * (1 - ζ)) * ne
 
 /-- The constant component of the running accumulator after `k` iterations,
 starting from `2·(ζ+1)`. Each iteration applies `ct → 2·ct + 1`, so the closed

--- a/qa/lean/Ragu/Circuits/Point/AddIncomplete.lean
+++ b/qa/lean/Ragu/Circuits/Point/AddIncomplete.lean
@@ -116,12 +116,10 @@ theorem soundness (curveParams : Spec.CurveParams p) :
   have h_add_eq :
       Spec.Point.add_incomplete { x := x1, y := y1 } { x := x2, y := y2 } =
         some { x := env.get (i₀ + 3 + 3 + 2) + -x1 + -x2,
-               y := env.get (i₀ + 3 + 3 + 3 + 2) + -y1 } := by
-    simp only [Spec.Point.add_incomplete, if_neg h_x_ne, Option.some.injEq,
-      Spec.Point.mk.injEq]
-    refine ⟨?_, ?_⟩
-    · rw [h_sq, h_delta]; ring
-    · rw [h_y_term, h_sq, h_delta]; ring
+               y := env.get (i₀ + 3 + 3 + 3 + 2) + -y1 } :=
+    Lemmas.add_incomplete_eq_of_wires x1 y1 x2 y2
+      (env.get (i₀ + 3)) (env.get (i₀ + 3 + 3 + 2)) (env.get (i₀ + 3 + 3 + 3 + 2))
+      h_x_ne h_delta (by linear_combination h_sq) (by linear_combination h_y_term)
   refine ⟨h_add_eq, ?_⟩
   simpa [h_add_eq] using
     Lemmas.add_incomplete_preserves_membership

--- a/qa/lean/Ragu/Circuits/Point/AddIncomplete.lean
+++ b/qa/lean/Ragu/Circuits/Point/AddIncomplete.lean
@@ -119,7 +119,8 @@ theorem soundness (curveParams : Spec.CurveParams p) :
                y := env.get (i₀ + 3 + 3 + 3 + 2) + -y1 } :=
     Lemmas.add_incomplete_eq_of_wires x1 y1 x2 y2
       (env.get (i₀ + 3)) (env.get (i₀ + 3 + 3 + 2)) (env.get (i₀ + 3 + 3 + 3 + 2))
-      h_x_ne h_delta (by linear_combination h_sq) (by linear_combination h_y_term)
+      h_x_ne h_delta (by linear_combination (id h_sq : @Eq (F p) _ _))
+      (by linear_combination (id h_y_term : @Eq (F p) _ _))
   refine ⟨h_add_eq, ?_⟩
   simpa [h_add_eq] using
     Lemmas.add_incomplete_preserves_membership

--- a/qa/lean/Ragu/Circuits/Point/AddIncompleteUnchecked.lean
+++ b/qa/lean/Ragu/Circuits/Point/AddIncompleteUnchecked.lean
@@ -59,6 +59,16 @@ instance elaborated : ElaboratedCircuit (F p) Inputs Spec.Point where
   main
   -- divide (3) + square (3) + mul_for_y (3) = 9 wires
   localLength _ := 9
+  -- Offsets follow the sub-gadget layout: Divide (3), then Square's product
+  -- wire, then Mul's product wire.
+  output input offset :=
+    ⟨varFromOffset field (offset + 3 + 2) - input.P1.x - input.P2.x,
+     varFromOffset field (offset + 3 + 3 + 2) - input.P1.y⟩
+  output_eq := by
+    intro input offset
+    rcases input with ⟨⟨x1, y1⟩, ⟨x2, y2⟩⟩
+    simp [main, circuit_norm, Element.Divide.circuit, Element.Square.circuit,
+      Element.Mul.circuit]
 
 theorem soundness (curveParams : Spec.CurveParams p) :
     Soundness (F p) elaborated (Assumptions curveParams) (Spec curveParams) := by
@@ -76,12 +86,10 @@ theorem soundness (curveParams : Spec.CurveParams p) :
       Spec.Point.add_incomplete { x := input_P1_x, y := input_P1_y }
           { x := input_P2_x, y := input_P2_y } =
         some { x := env.get (i₀ + 3 + 2) + -input_P1_x + -input_P2_x,
-               y := env.get (i₀ + 3 + 3 + 2) + -input_P1_y } := by
-    simp only [Spec.Point.add_incomplete, if_neg h_x_ne, Option.some.injEq,
-      Spec.Point.mk.injEq]
-    refine ⟨?_, ?_⟩
-    · rw [h_sq, h_delta]; ring
-    · rw [h_y_term, h_sq, h_delta]; ring
+               y := env.get (i₀ + 3 + 3 + 2) + -input_P1_y } :=
+    Lemmas.add_incomplete_eq_of_wires input_P1_x input_P1_y input_P2_x input_P2_y
+      (env.get i₀) (env.get (i₀ + 3 + 2)) (env.get (i₀ + 3 + 3 + 2))
+      h_x_ne h_delta (by linear_combination h_sq) (by linear_combination h_y_term)
   refine ⟨h_add_eq, ?_⟩
   simpa [h_add_eq] using
     Lemmas.add_incomplete_preserves_membership

--- a/qa/lean/Ragu/Circuits/Point/AddIncompleteUnchecked.lean
+++ b/qa/lean/Ragu/Circuits/Point/AddIncompleteUnchecked.lean
@@ -69,6 +69,7 @@ instance elaborated : ElaboratedCircuit (F p) Inputs Spec.Point where
     rcases input with ⟨⟨x1, y1⟩, ⟨x2, y2⟩⟩
     simp [main, circuit_norm, Element.Divide.circuit, Element.Square.circuit,
       Element.Mul.circuit]
+    exact ⟨rfl, rfl⟩
 
 theorem soundness (curveParams : Spec.CurveParams p) :
     Soundness (F p) elaborated (Assumptions curveParams) (Spec curveParams) := by
@@ -89,7 +90,8 @@ theorem soundness (curveParams : Spec.CurveParams p) :
                y := env.get (i₀ + 3 + 3 + 2) + -input_P1_y } :=
     Lemmas.add_incomplete_eq_of_wires input_P1_x input_P1_y input_P2_x input_P2_y
       (env.get i₀) (env.get (i₀ + 3 + 2)) (env.get (i₀ + 3 + 3 + 2))
-      h_x_ne h_delta (by linear_combination h_sq) (by linear_combination h_y_term)
+      h_x_ne h_delta (by linear_combination (id h_sq : @Eq (F p) _ _))
+      (by linear_combination (id h_y_term : @Eq (F p) _ _))
   refine ⟨h_add_eq, ?_⟩
   simpa [h_add_eq] using
     Lemmas.add_incomplete_preserves_membership

--- a/qa/lean/Ragu/Circuits/Point/ConditionalEndo.lean
+++ b/qa/lean/Ragu/Circuits/Point/ConditionalEndo.lean
@@ -38,6 +38,10 @@ instance elaborated (curveParams : Spec.CurveParams p)
     : ElaboratedCircuit (F p) Input Spec.Point where
   main := main curveParams
   localLength _ := 3
+  -- `x` selected against `ζ·x`: the `ConditionalSelect` output is `x + (its Mul wire)`.
+  output input offset := ⟨input.x + varFromOffset field (offset + 2), input.y⟩
+  output_eq := by
+    simp [main, circuit_norm, Boolean.ConditionalSelect.circuit]
 
 theorem soundness (curveParams : Spec.CurveParams p)
     : Soundness (F p) (elaborated curveParams) (Assumptions curveParams) (Spec curveParams) := by

--- a/qa/lean/Ragu/Circuits/Point/ConditionalEndo.lean
+++ b/qa/lean/Ragu/Circuits/Point/ConditionalEndo.lean
@@ -45,9 +45,8 @@ instance elaborated (curveParams : Spec.CurveParams p)
 
 theorem soundness (curveParams : Spec.CurveParams p)
     : Soundness (F p) (elaborated curveParams) (Assumptions curveParams) (Spec curveParams) := by
-  circuit_proof_start
-  simp [circuit_norm, Boolean.ConditionalSelect.circuit,
-    Boolean.ConditionalSelect.Assumptions, Boolean.ConditionalSelect.Spec] at h_holds
+  circuit_proof_start [Boolean.ConditionalSelect.circuit,
+    Boolean.ConditionalSelect.Assumptions, Boolean.ConditionalSelect.Spec]
   exact h_holds h_assumptions
 
 theorem completeness (curveParams : Spec.CurveParams p)

--- a/qa/lean/Ragu/Circuits/Point/ConditionalNegate.lean
+++ b/qa/lean/Ragu/Circuits/Point/ConditionalNegate.lean
@@ -40,9 +40,8 @@ instance elaborated : ElaboratedCircuit (F p) Input Spec.Point where
     simp [main, circuit_norm, Boolean.ConditionalSelect.circuit]
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
-  circuit_proof_start
-  simp [circuit_norm, Boolean.ConditionalSelect.circuit,
-    Boolean.ConditionalSelect.Assumptions, Boolean.ConditionalSelect.Spec] at h_holds
+  circuit_proof_start [Boolean.ConditionalSelect.circuit,
+    Boolean.ConditionalSelect.Assumptions, Boolean.ConditionalSelect.Spec]
   exact h_holds h_assumptions
 
 theorem completeness : Completeness (F p) elaborated Assumptions := by

--- a/qa/lean/Ragu/Circuits/Point/ConditionalNegate.lean
+++ b/qa/lean/Ragu/Circuits/Point/ConditionalNegate.lean
@@ -34,6 +34,10 @@ def Spec (input : Input (F p)) (output : Spec.Point (F p)) :=
 instance elaborated : ElaboratedCircuit (F p) Input Spec.Point where
   main
   localLength _ := 3
+  -- `y` selected against `-y`: the `ConditionalSelect` output is `y + (its Mul wire)`.
+  output input offset := ⟨input.x, input.y + varFromOffset field (offset + 2)⟩
+  output_eq := by
+    simp [main, circuit_norm, Boolean.ConditionalSelect.circuit]
 
 theorem soundness : Soundness (F p) elaborated Assumptions Spec := by
   circuit_proof_start

--- a/qa/lean/Ragu/Circuits/Point/Double.lean
+++ b/qa/lean/Ragu/Circuits/Point/Double.lean
@@ -43,6 +43,16 @@ instance elaborated :
     ElaboratedCircuit (F p) Spec.Point Spec.Point where
   main
   localLength _ := 12
+  -- Offsets follow the sub-gadget layout: Square (3) + Divide (3), then the
+  -- second Square's product wire, then Mul's product wire.
+  output input offset :=
+    ⟨varFromOffset field (offset + 3 + 3 + 2) - (input.x + input.x),
+     varFromOffset field (offset + 3 + 3 + 3 + 2) - input.y⟩
+  output_eq := by
+    intro input offset
+    rcases input with ⟨x, y⟩
+    simp [main, circuit_norm, Element.Square.circuit, Element.Divide.circuit,
+      Element.Mul.circuit]
 
 theorem soundness (curveParams : Spec.CurveParams p) :
     Soundness (F p) elaborated (Assumptions curveParams) (Spec curveParams) := by

--- a/qa/lean/Ragu/Circuits/Point/Double.lean
+++ b/qa/lean/Ragu/Circuits/Point/Double.lean
@@ -53,6 +53,7 @@ instance elaborated :
     rcases input with ⟨x, y⟩
     simp [main, circuit_norm, Element.Square.circuit, Element.Divide.circuit,
       Element.Mul.circuit]
+    exact ⟨rfl, rfl⟩
 
 theorem soundness (curveParams : Spec.CurveParams p) :
     Soundness (F p) elaborated (Assumptions curveParams) (Spec curveParams) := by

--- a/qa/lean/Ragu/Circuits/Point/DoubleAndAddIncomplete.lean
+++ b/qa/lean/Ragu/Circuits/Point/DoubleAndAddIncomplete.lean
@@ -137,50 +137,13 @@ theorem soundness (curveParams : Spec.CurveParams p) :
   have h_x_ne : x_p ≠ x_q := fun h => h_xqxp_ne (by rw [h]; ring)
   have h_r_ne_xp : (env.get (i₀ + 3 + 3 + 2) + -x_p + -x_q) ≠ x_p :=
     fun h => h_xpxr_ne (by rw [h]; ring)
-  have h_diff_ne : x_p - (env.get (i₀ + 3 + 3 + 2) + -x_p + -x_q) ≠ 0 := by
-    rw [sub_eq_add_neg]; exact h_xpxr_ne
-  have h_lam2_mul :
-      env.get (i₀ + 3 + 3 + 3 + 3) * (x_p - (env.get (i₀ + 3 + 3 + 2) + -x_p + -x_q)) = y_p + y_p := by
-    rw [sub_eq_add_neg, h_lam2half, div_mul_cancel₀ _ h_xpxr_ne]
-  have h_slope :
-      (y_p - (env.get (i₀ + 3) *
-            (x_p - (env.get (i₀ + 3 + 3 + 2) + -x_p + -x_q)) - y_p)) /
-          (x_p - (env.get (i₀ + 3 + 3 + 2) + -x_p + -x_q)) =
-        env.get (i₀ + 3 + 3 + 3 + 3) - env.get (i₀ + 3) := by
-    rw [show y_p - (env.get (i₀ + 3) *
-                (x_p - (env.get (i₀ + 3 + 3 + 2) + -x_p + -x_q)) - y_p) =
-            y_p + y_p - env.get (i₀ + 3) *
-                (x_p - (env.get (i₀ + 3 + 3 + 2) + -x_p + -x_q)) by ring]
-    rw [← h_lam2_mul,
-        show env.get (i₀ + 3 + 3 + 3 + 3) *
-              (x_p - (env.get (i₀ + 3 + 3 + 2) + -x_p + -x_q)) -
-            env.get (i₀ + 3) * (x_p - (env.get (i₀ + 3 + 3 + 2) + -x_p + -x_q)) =
-          (env.get (i₀ + 3 + 3 + 3 + 3) - env.get (i₀ + 3)) *
-            (x_p - (env.get (i₀ + 3 + 3 + 2) + -x_p + -x_q)) by ring]
-    exact mul_div_cancel_right₀ _ h_diff_ne
-  -- The intermediate point r = P1 + P2.
-  have h_add_eq1 :
-      ({ x := x_p, y := y_p } : Spec.Point (F p)).add_incomplete { x := x_q, y := y_q } =
-        some { x := env.get (i₀ + 3 + 3 + 2) + -x_p + -x_q,
-               y := env.get (i₀ + 3) *
-                      (x_p - (env.get (i₀ + 3 + 3 + 2) + -x_p + -x_q)) - y_p } := by
-    simp only [Spec.Point.add_incomplete, if_neg h_x_ne, Option.some.injEq, Spec.Point.mk.injEq]
-    refine ⟨?_, ?_⟩
-    · rw [h_sq1, h_lam1]; ring
-    · rw [h_sq1, h_lam1]; ring
-  have h_add_eq2 :
-      ({ x := env.get (i₀ + 3 + 3 + 2) + -x_p + -x_q,
-         y := env.get (i₀ + 3) *
-                (x_p - (env.get (i₀ + 3 + 3 + 2) + -x_p + -x_q)) - y_p } :
-            Spec.Point (F p)).add_incomplete { x := x_p, y := y_p } =
-        some { x := env.get (i₀ + 3 + 3 + 3 + 3 + 3 + 2) +
-                      -(env.get (i₀ + 3 + 3 + 2) + -x_p + -x_q) + -x_p,
-               y := env.get (i₀ + 3 + 3 + 3 + 3 + 3 + 3 + 2) + -y_p } := by
-    simp only [Spec.Point.add_incomplete, if_neg h_r_ne_xp, Option.some.injEq, Spec.Point.mk.injEq]
-    refine ⟨?_, ?_⟩
-    · rw [h_slope, h_sq2]; ring
-    · rw [h_slope, h_yterm, h_sq2]
-      linear_combination (-h_lam2_mul)
+  -- The two chained additions on the circuit's wires (shared algebra).
+  obtain ⟨h_add_eq1, h_add_eq2⟩ := Lemmas.double_and_add_incomplete_eq_of_wires
+    x_p y_p x_q y_q
+    (env.get (i₀ + 3)) (env.get (i₀ + 3 + 3 + 2)) (env.get (i₀ + 3 + 3 + 3 + 3))
+    (env.get (i₀ + 3 + 3 + 3 + 3 + 3 + 2)) (env.get (i₀ + 3 + 3 + 3 + 3 + 3 + 3 + 2))
+    h_x_ne h_lam1 (by linear_combination h_sq1) h_r_ne_xp h_lam2half
+    (by linear_combination h_sq2) (by linear_combination h_yterm)
   refine ⟨_, h_add_eq1, h_add_eq2, ?_⟩
   have h_r_curve := by
     simpa [h_add_eq1] using Lemmas.add_incomplete_preserves_membership

--- a/qa/lean/Ragu/Circuits/Point/DoubleAndAddIncomplete.lean
+++ b/qa/lean/Ragu/Circuits/Point/DoubleAndAddIncomplete.lean
@@ -142,8 +142,8 @@ theorem soundness (curveParams : Spec.CurveParams p) :
     x_p y_p x_q y_q
     (env.get (i₀ + 3)) (env.get (i₀ + 3 + 3 + 2)) (env.get (i₀ + 3 + 3 + 3 + 3))
     (env.get (i₀ + 3 + 3 + 3 + 3 + 3 + 2)) (env.get (i₀ + 3 + 3 + 3 + 3 + 3 + 3 + 2))
-    h_x_ne h_lam1 (by linear_combination h_sq1) h_r_ne_xp h_lam2half
-    (by linear_combination h_sq2) (by linear_combination h_yterm)
+    h_x_ne h_lam1 (by linear_combination (id h_sq1 : @Eq (F p) _ _)) h_r_ne_xp h_lam2half
+    (by linear_combination (id h_sq2 : @Eq (F p) _ _)) (by linear_combination (id h_yterm : @Eq (F p) _ _))
   refine ⟨_, h_add_eq1, h_add_eq2, ?_⟩
   have h_r_curve := by
     simpa [h_add_eq1] using Lemmas.add_incomplete_preserves_membership

--- a/qa/lean/Ragu/Circuits/Point/DoubleAndAddIncompleteUnchecked.lean
+++ b/qa/lean/Ragu/Circuits/Point/DoubleAndAddIncompleteUnchecked.lean
@@ -74,6 +74,17 @@ instance elaborated : ElaboratedCircuit (F p) Inputs Spec.Point where
   main
   -- divide1 (3) + square1 (3) + divide2 (3) + square2 (3) + mul_for_y (3) = 15
   localLength _ := 15
+  -- Offsets follow the sub-gadget layout: `x_r` uses the first Square's
+  -- product wire, `x_s` the second's, `y_s` the trailing Mul's.
+  output input offset :=
+    ⟨varFromOffset field (offset + 3 + 3 + 3 + 2) -
+        (varFromOffset field (offset + 3 + 2) - input.P1.x - input.P2.x) - input.P1.x,
+     varFromOffset field (offset + 3 + 3 + 3 + 3 + 2) - input.P1.y⟩
+  output_eq := by
+    intro input offset
+    rcases input with ⟨⟨x_p, y_p⟩, ⟨x_q, y_q⟩⟩
+    simp [main, circuit_norm, Element.Divide.circuit, Element.Square.circuit,
+      Element.Mul.circuit]
 
 theorem soundness (curveParams : Spec.CurveParams p) :
     Soundness (F p) elaborated (Assumptions curveParams) (Spec curveParams) := by
@@ -114,60 +125,17 @@ theorem soundness (curveParams : Spec.CurveParams p) :
     linear_combination -h
   have h_r_ne_xp : (env.get (i₀ + 3 + 2) + -input_P1_x + -input_P2_x) ≠ input_P1_x :=
     fun h => h_xpr_ne (by rw [h]; ring)
-  have h_diff_ne : input_P1_x - (env.get (i₀ + 3 + 2) + -input_P1_x + -input_P2_x) ≠ 0 := by
-    rw [sub_eq_add_neg]; exact h_xpr_ne
   have h_lam2half : env.get (i₀ + 3 + 3) =
       (input_P1_y + input_P1_y) /
         (input_P1_x + -(env.get (i₀ + 3 + 2) + -input_P1_x + -input_P2_x)) :=
     h_div2 (Or.inl h_xpr_ne)
-  have h_lam2_mul : env.get (i₀ + 3 + 3) *
-      (input_P1_x - (env.get (i₀ + 3 + 2) + -input_P1_x + -input_P2_x)) =
-      input_P1_y + input_P1_y := by
-    rw [sub_eq_add_neg, h_lam2half, div_mul_cancel₀ _ h_xpr_ne]
-  have h_slope :
-      (input_P1_y - (env.get i₀ *
-            (input_P1_x - (env.get (i₀ + 3 + 2) + -input_P1_x + -input_P2_x)) - input_P1_y)) /
-          (input_P1_x - (env.get (i₀ + 3 + 2) + -input_P1_x + -input_P2_x)) =
-        env.get (i₀ + 3 + 3) - env.get i₀ := by
-    rw [show input_P1_y - (env.get i₀ *
-                (input_P1_x - (env.get (i₀ + 3 + 2) + -input_P1_x + -input_P2_x)) - input_P1_y) =
-            input_P1_y + input_P1_y - env.get i₀ *
-                (input_P1_x - (env.get (i₀ + 3 + 2) + -input_P1_x + -input_P2_x)) by ring]
-    rw [← h_lam2_mul,
-        show env.get (i₀ + 3 + 3) *
-              (input_P1_x - (env.get (i₀ + 3 + 2) + -input_P1_x + -input_P2_x)) -
-            env.get i₀ * (input_P1_x - (env.get (i₀ + 3 + 2) + -input_P1_x + -input_P2_x)) =
-          (env.get (i₀ + 3 + 3) - env.get i₀) *
-            (input_P1_x - (env.get (i₀ + 3 + 2) + -input_P1_x + -input_P2_x)) by ring]
-    exact mul_div_cancel_right₀ _ h_diff_ne
-  -- The intermediate point r = P1 + P2, on the circuit's wires.
-  have h_add_eq1 :
-      ({ x := input_P1_x, y := input_P1_y } : Spec.Point (F p)).add_incomplete
-          { x := input_P2_x, y := input_P2_y } =
-        some { x := env.get (i₀ + 3 + 2) + -input_P1_x + -input_P2_x,
-               y := env.get i₀ *
-                      (input_P1_x - (env.get (i₀ + 3 + 2) + -input_P1_x + -input_P2_x)) -
-                    input_P1_y } := by
-    simp only [Spec.Point.add_incomplete, if_neg h_x_ne, Option.some.injEq,
-      Spec.Point.mk.injEq]
-    refine ⟨?_, ?_⟩
-    · rw [h_sq1, h_delta]; ring
-    · rw [h_sq1, h_delta]; ring
-  have h_add_eq2 :
-      ({ x := env.get (i₀ + 3 + 2) + -input_P1_x + -input_P2_x,
-         y := env.get i₀ *
-                (input_P1_x - (env.get (i₀ + 3 + 2) + -input_P1_x + -input_P2_x)) -
-              input_P1_y } :
-            Spec.Point (F p)).add_incomplete { x := input_P1_x, y := input_P1_y } =
-        some { x := env.get (i₀ + 3 + 3 + 3 + 2) +
-                      -(env.get (i₀ + 3 + 2) + -input_P1_x + -input_P2_x) + -input_P1_x,
-               y := env.get (i₀ + 3 + 3 + 3 + 3 + 2) + -input_P1_y } := by
-    simp only [Spec.Point.add_incomplete, if_neg h_r_ne_xp, Option.some.injEq,
-      Spec.Point.mk.injEq]
-    refine ⟨?_, ?_⟩
-    · rw [h_slope, h_sq2]; ring
-    · rw [h_slope, h_yterm, h_sq2]
-      linear_combination (-h_lam2_mul)
+  -- The two chained additions on the circuit's wires (shared algebra).
+  obtain ⟨h_add_eq1, h_add_eq2⟩ := Lemmas.double_and_add_incomplete_eq_of_wires
+    input_P1_x input_P1_y input_P2_x input_P2_y
+    (env.get i₀) (env.get (i₀ + 3 + 2)) (env.get (i₀ + 3 + 3))
+    (env.get (i₀ + 3 + 3 + 3 + 2)) (env.get (i₀ + 3 + 3 + 3 + 3 + 2))
+    h_x_ne h_delta (by linear_combination h_sq1) h_r_ne_xp h_lam2half
+    (by linear_combination h_sq2) (by linear_combination h_yterm)
   refine ⟨_, h_add_eq1, h_add_eq2, ?_⟩
   have h_r_curve := by
     simpa [h_add_eq1] using Lemmas.add_incomplete_preserves_membership

--- a/qa/lean/Ragu/Circuits/Point/DoubleAndAddIncompleteUnchecked.lean
+++ b/qa/lean/Ragu/Circuits/Point/DoubleAndAddIncompleteUnchecked.lean
@@ -85,6 +85,7 @@ instance elaborated : ElaboratedCircuit (F p) Inputs Spec.Point where
     rcases input with ⟨⟨x_p, y_p⟩, ⟨x_q, y_q⟩⟩
     simp [main, circuit_norm, Element.Divide.circuit, Element.Square.circuit,
       Element.Mul.circuit]
+    exact ⟨rfl, rfl⟩
 
 theorem soundness (curveParams : Spec.CurveParams p) :
     Soundness (F p) elaborated (Assumptions curveParams) (Spec curveParams) := by
@@ -134,8 +135,8 @@ theorem soundness (curveParams : Spec.CurveParams p) :
     input_P1_x input_P1_y input_P2_x input_P2_y
     (env.get i₀) (env.get (i₀ + 3 + 2)) (env.get (i₀ + 3 + 3))
     (env.get (i₀ + 3 + 3 + 3 + 2)) (env.get (i₀ + 3 + 3 + 3 + 3 + 2))
-    h_x_ne h_delta (by linear_combination h_sq1) h_r_ne_xp h_lam2half
-    (by linear_combination h_sq2) (by linear_combination h_yterm)
+    h_x_ne h_delta (by linear_combination (id h_sq1 : @Eq (F p) _ _)) h_r_ne_xp h_lam2half
+    (by linear_combination (id h_sq2 : @Eq (F p) _ _)) (by linear_combination (id h_yterm : @Eq (F p) _ _))
   refine ⟨_, h_add_eq1, h_add_eq2, ?_⟩
   have h_r_curve := by
     simpa [h_add_eq1] using Lemmas.add_incomplete_preserves_membership

--- a/qa/lean/Ragu/Circuits/Point/Spec.lean
+++ b/qa/lean/Ragu/Circuits/Point/Spec.lean
@@ -224,4 +224,73 @@ lemma add_incomplete_preserves_membership (p1 p2 : Point (F p)) (cp : CurveParam
   have : p1.y ^ 2 - p1.x ^ 3 - cp.b = p1.y ^ 2 - (p1.x ^ 3 + cp.b) := by ring
   rw [this, hm1, sub_self]
 
+/-! ### Wire-level forms of the incomplete additions
+
+The checked and unchecked `add_incomplete` / `double_and_add_incomplete`
+reimpls emit the same affine-addition gates and differ only in the bank
+bookkeeping around them, so their soundness proofs share the algebra that
+turns the gate outputs into `Point.add_incomplete` equations. The statements
+are in the `a + -b` normal form `circuit_proof_start` produces. -/
+
+/-- One incomplete addition on the circuit's wires: given the chord slope
+`delta`, its square `delta_sq`, and `y_term = delta · (x₁ - x₃)`, the wires
+`(delta_sq - x₁ - x₂, y_term - y₁)` are the affine sum `P₁ + P₂`. -/
+lemma add_incomplete_eq_of_wires (x1 y1 x2 y2 delta delta_sq y_term : F p)
+    (h_ne : x1 ≠ x2)
+    (h_delta : delta = (y2 + -y1) / (x2 + -x1))
+    (h_sq : delta_sq = delta ^ 2)
+    (h_y : y_term = delta * (x1 - (delta_sq + -x1 + -x2))) :
+    Point.add_incomplete ⟨x1, y1⟩ ⟨x2, y2⟩ =
+      some ⟨delta_sq + -x1 + -x2, y_term + -y1⟩ := by
+  subst h_y h_sq h_delta
+  simp only [Point.add_incomplete, if_neg h_ne, Option.some.injEq, Point.mk.injEq]
+  exact ⟨by ring, by ring⟩
+
+/-- The two chained incomplete additions of `double_and_add_incomplete` on the
+circuit's wires: `r = P₁ + P₂` from the first slope `lambda_1`, then
+`r + P₁` from the second slope `lambda_2_half - lambda_1`, where
+`lambda_2_half = 2y₁ / (x₁ - x_r)`. -/
+lemma double_and_add_incomplete_eq_of_wires (x_p y_p x_q y_q : F p)
+    (lambda_1 lambda_1_sq lambda_2_half lambda_2_sq y_term : F p)
+    (h_ne : x_p ≠ x_q)
+    (h_lam1 : lambda_1 = (y_q + -y_p) / (x_q + -x_p))
+    (h_sq1 : lambda_1_sq = lambda_1 ^ 2)
+    (h_r_ne : lambda_1_sq + -x_p + -x_q ≠ x_p)
+    (h_lam2 : lambda_2_half = (y_p + y_p) / (x_p + -(lambda_1_sq + -x_p + -x_q)))
+    (h_sq2 : lambda_2_sq = (lambda_2_half - lambda_1) ^ 2)
+    (h_y : y_term = (lambda_2_half - lambda_1) *
+      (x_p - (lambda_2_sq + -(lambda_1_sq + -x_p + -x_q) + -x_p))) :
+    Point.add_incomplete ⟨x_p, y_p⟩ ⟨x_q, y_q⟩ =
+        some ⟨lambda_1_sq + -x_p + -x_q,
+              lambda_1 * (x_p - (lambda_1_sq + -x_p + -x_q)) - y_p⟩ ∧
+      Point.add_incomplete
+          ⟨lambda_1_sq + -x_p + -x_q, lambda_1 * (x_p - (lambda_1_sq + -x_p + -x_q)) - y_p⟩
+          ⟨x_p, y_p⟩ =
+        some ⟨lambda_2_sq + -(lambda_1_sq + -x_p + -x_q) + -x_p, y_term + -y_p⟩ := by
+  have h_diff_ne : x_p + -(lambda_1_sq + -x_p + -x_q) ≠ 0 := by
+    intro h
+    apply h_r_ne
+    linear_combination -h
+  have h_diff_ne' : x_p - (lambda_1_sq + -x_p + -x_q) ≠ 0 := by
+    rw [sub_eq_add_neg]; exact h_diff_ne
+  have h_lam2_mul :
+      lambda_2_half * (x_p + -(lambda_1_sq + -x_p + -x_q)) = y_p + y_p := by
+    rw [h_lam2]
+    exact div_mul_cancel₀ _ h_diff_ne
+  refine ⟨?_, ?_⟩
+  · subst h_sq1 h_lam1
+    simp only [Point.add_incomplete, if_neg h_ne, Option.some.injEq, Point.mk.injEq]
+    exact ⟨by ring, by ring⟩
+  · have h_slope :
+        (y_p - (lambda_1 * (x_p - (lambda_1_sq + -x_p + -x_q)) - y_p)) /
+            (x_p - (lambda_1_sq + -x_p + -x_q)) =
+          lambda_2_half - lambda_1 := by
+      rw [div_eq_iff h_diff_ne']
+      linear_combination -h_lam2_mul
+    simp only [Point.add_incomplete, if_neg h_r_ne, Option.some.injEq, Point.mk.injEq]
+    refine ⟨?_, ?_⟩
+    · rw [h_slope, h_sq2]; ring
+    · rw [h_slope, h_y, h_sq2]
+      linear_combination -h_lam2_mul
+
 end Ragu.Circuits.Point.Lemmas

--- a/qa/lean/Ragu/Fingerprint/Instances.lean
+++ b/qa/lean/Ragu/Fingerprint/Instances.lean
@@ -38,6 +38,7 @@ def instances : List (String × Ragu.Core.Statements.FormalInstance) := [
   ("Ragu.Instances.Boolean.ConditionalSelect", Ragu.Instances.Boolean.ConditionalSelect.formal_instance),
   ("Ragu.Instances.Boolean.ConditionalEnforceEqual", Ragu.Instances.Boolean.ConditionalEnforceEqual.formal_instance),
   ("Ragu.Instances.Endoscalar.Alloc", Ragu.Instances.Endoscalar.Alloc.formal_instance),
+  ("Ragu.Instances.Endoscalar.Extract", Ragu.Instances.Endoscalar.Extract.formal_instance),
   ("Ragu.Instances.Endoscalar.GroupScale", Ragu.Instances.Endoscalar.GroupScale.formal_instance),
   ("Ragu.Instances.Endoscalar.Lift", Ragu.Instances.Endoscalar.Lift.formal_instance)
 ]

--- a/qa/lean/Ragu/Instances.lean
+++ b/qa/lean/Ragu/Instances.lean
@@ -27,5 +27,6 @@ import Ragu.Instances.Boolean.And
 import Ragu.Instances.Boolean.ConditionalSelect
 import Ragu.Instances.Boolean.ConditionalEnforceEqual
 import Ragu.Instances.Endoscalar.Alloc
+import Ragu.Instances.Endoscalar.Extract
 import Ragu.Instances.Endoscalar.GroupScale
 import Ragu.Instances.Endoscalar.Lift

--- a/qa/lean/Ragu/Instances/Endoscalar/Extract.lean
+++ b/qa/lean/Ragu/Instances/Endoscalar/Extract.lean
@@ -20,6 +20,6 @@ def formal_instance : Core.Statements.FormalInstance where
   serializeOutput
 
   reimplementation :=
-    (Circuits.Endoscalar.Extract.circuit 254 (by decide) (by decide)).toWithHint
+    (Circuits.Endoscalar.Extract.circuit 254 (by decide : 2 ^ 254 < p) (by decide : 128 ≤ 254)).toWithHint
 
 end Ragu.Instances.Endoscalar.Extract

--- a/qa/lean/Ragu/Instances/Endoscalar/Extract.lean
+++ b/qa/lean/Ragu/Instances/Endoscalar/Extract.lean
@@ -1,0 +1,25 @@
+import Ragu.Circuits.Endoscalar.Extract
+import Ragu.Core
+
+namespace Ragu.Instances.Endoscalar.Extract
+
+@[reducible]
+def p := Core.Primes.p
+
+def deserializeInput (input : Vector (Expression (F p)) 1) : Var field (F p) :=
+  input[0]
+
+def serializeOutput (output : Var (fields 128) (F p)) : Vector (Expression (F p)) 128 :=
+  output
+
+/-- Pinned at `n = 254 = Fp::CAPACITY`: the Pasta moduli are 255-bit, so
+`2²⁵⁴ < p` and the 254-bit decomposition is canonical. -/
+def formal_instance : Core.Statements.FormalInstance where
+  p
+  deserializeInput
+  serializeOutput
+
+  reimplementation :=
+    (Circuits.Endoscalar.Extract.circuit 254 (by decide) (by decide)).toWithHint
+
+end Ragu.Instances.Endoscalar.Extract

--- a/qa/lean/lakefile.lean
+++ b/qa/lean/lakefile.lean
@@ -5,9 +5,7 @@ package Ragu where
   leanOptions := #[
     ⟨`pp.unicode.fun, true⟩,
     ⟨`autoImplicit, false⟩,
-    ⟨`relaxedAutoImplicit, false⟩,
-    ⟨`maxHeartbeats, (4000000 : Nat)⟩,
-    ⟨`maxRecDepth, (2000 : Nat)⟩]
+    ⟨`relaxedAutoImplicit, false⟩]
 
 @[default_target]
 lean_lib Ragu where


### PR DESCRIPTION
Follows https://github.com/tachyon-zcash/ragu/pull/711 and implements `Endoscalar::extract` per https://github.com/tachyon-zcash/ragu/pull/767. Recall that the original version of that gadget couldn't close Lean elaboration, as demonstrated in https://github.com/tachyon-zcash/ragu/pull/761.

Also expands scope and resolves other Lean violations against endsosclar gadget in #711 that our [review skill](https://github.com/tachyon-zcash/ragu/tree/main/.claude/skills/fv-review) flagged.