### PR TITLE
feat(fv): trust boundary census

### DIFF
--- a/.claude/skills/fv-preflight/SKILL.md
+++ b/.claude/skills/fv-preflight/SKILL.md
@@ -14,13 +14,13 @@ owned by the `fv-review` skill; the book's FV part is the spec for every concept
 
 ## 0. What CI checks — and what it leaves to this audit
 
-The FV workflow runs three gates, in order: `cargo run --locked -p lean_extraction -- check`
-(the generated Lean files match the exporter), `lake build --wfail` in `qa/fv` (every module
-under `Ragu/` elaborates, warnings fatal), and the fingerprint equivalence check (the Rust
-extractor's trace digests equal the ones Lean computes from the reimplementations). It does
-**not** check that a new instance is registered at all, what axioms a theorem depends on,
-whether `Assumptions` or `Spec` mean anything, whether the Lean interface mirrors the Rust one,
-or whether the prose is true. Those are the sections below.
+The FV workflow runs four gates, in order: `cargo run --locked -p lean_extraction -- check`
+(the generated Lean files match the exporter), the source-tree trust-boundary census,
+`lake build --wfail` in `qa/fv` (every module under `Ragu/` elaborates, warnings fatal, and the
+elaborated endpoint census passes), and the fingerprint equivalence check (the Rust extractor's
+trace digests equal the ones Lean computes from the reimplementations). It does **not** check that
+a new instance is registered at all, whether `Assumptions` or `Spec` mean anything, whether the
+Lean interface mirrors the Rust one, or whether the prose is true. Those are the sections below.
 
 ## 1. Coverage — every new proof elaborates in CI, and every new instance is fingerprinted
 
@@ -45,12 +45,14 @@ stays green over a reimplementation of nothing. Check all five failure modes.
    `git diff main...HEAD` for `EXPORT_TARGETS`, `Ragu.lean`, `Ragu/Lemmas.lean`, and the two
    generated files, and account for every *deleted* line by name. A consolidation that loses
    another PR's instance passes CI and loses the guarantee. Re-run `export` and `check`.
-5. **Axioms are not checked automatically.** Run `#print axioms` on each new endpoint
-   (`soundness`, `completeness`, and any lemma the book or a docstring cites as a result). The
-   expected set is `propext`, `Classical.choice`, `Quot.sound`, and the primality facts
-   `Ragu.Core.Primes.p_prime` / `q_prime`; `Lean.ofReduceBool` and `Lean.trustCompiler` appear
-   only where `native_decide` is involved. Anything else is a trust-surface change (§2) that
-   the PR argues for explicitly.
+5. **Endpoint axioms are checked automatically, but only for discovered endpoints.**
+   `Ragu.Meta.TrustBoundary` directly pins every declaration carrying a `soundness`,
+   `completeness`, error/security-bound, probability-bound, or capstone name component, both Pasta
+   primality theorems, and the executable fingerprint boundary. The source and elaborated censuses
+   reject a missing direct pin. Run `#print axioms`
+   (or add an explicit census entry) for any differently named lemma that the book or a docstring
+   cites as a result. The expected theorem tier is `propext`, `Classical.choice`, and
+   `Quot.sound`; any broader set is a trust-surface change (§2) that the PR argues for explicitly.
 
 Run the exporter `check` and the fingerprint comparison (recipe in the final sweep) before
 handing over.
@@ -92,11 +94,12 @@ For each `native_decide` the diff adds, in order:
 A survivor has to earn the trust it adds: a justification in the PR that says which rungs above
 were tried and why each failed — "it was easier" and "it is only a constant" are not that.
 
-The same logic bans bespoke axioms outright. The only `axiom`s in the tree are the primality
-facts in `Ragu.Core.Primes`; when a fact is proven upstream (Mathlib, Clean), use it rather than
-assume it, and anything else is a theorem or a named hypothesis in `Assumptions`. There should
-be no uses of `@[extern]`, `@[implemented_by]`, `unsafe`, `partial`, or `opaque`, and no new
-uses of `@[csimp]` — none exist today, so any appearance is a review item by itself.
+The same logic bans bespoke axioms outright. The Pasta primality facts are theorems imported from
+the direct, commit-pinned CompElliptic dependency; when a fact is proven upstream, use it rather
+than assume it, and anything else is a theorem or a named hypothesis in `Assumptions`. There should
+be no production uses of `@[extern]`, `@[implemented_by]`, `unsafe`, `partial`, or `opaque`, and
+no new uses of `@[csimp]` — none exist today outside the deliberately forged declarations in
+`Ragu.Meta.Tests`, so any other appearance is a review item by itself.
 
 ## 3. `noncomputable` — proofs may be, the fingerprinted path may not
 
@@ -255,6 +258,7 @@ Before handing over, from the repo root:
 
 ```sh
 cargo run --locked -p lean_extraction -- check
+scripts/check_fv_endpoint_census.sh
 (cd qa/fv && lake build --wfail)
 cargo run --locked -p lean_extraction -- fingerprint | sort > /tmp/fp-rust.txt
 (cd qa/fv && lake env lean --run Ragu/Fingerprint/Main.lean) | sort > /tmp/fp-lean.txt

--- a/.github/workflows/fv.yml
+++ b/.github/workflows/fv.yml
@@ -37,6 +37,7 @@ jobs:
               - '**/Cargo.lock'
               - 'rust-toolchain.toml'
               - 'qa/fv/**'
+              - 'scripts/check_fv_endpoint_census.sh'
               - '.github/workflows/fv.yml'
               - '.github/actions/**'
 
@@ -57,6 +58,9 @@ jobs:
 
       - name: Check exported Lean files are up to date
         run: cargo run --locked -p lean_extraction -- check
+
+      - name: Check FV trust-boundary census coverage
+        run: scripts/check_fv_endpoint_census.sh
 
       # We install elan + invoke `lake` directly instead of using
       # `leanprover/lean-action`: that composite transitively references

--- a/_typos.toml
+++ b/_typos.toml
@@ -19,6 +19,7 @@ ND = "ND" # ND = NewDriver
 Bootle = "Bootle" # person name
 Groth= "Groth" # person name, not Growth
 ba = "ba" # variable name (b*a)
+thm = "thm" # Lean's ConstantInfo.thmInfo constructor
 
 [default]
 extend-ignore-words-re = [

--- a/qa/fv/Ragu/Meta/AxiomCheck.lean
+++ b/qa/fv/Ragu/Meta/AxiomCheck.lean
@@ -4,9 +4,10 @@ import CompElliptic.Meta.AxiomCheck
 # Ragu trust-assertion machinery
 
 Ragu reuses the hardened `assert_axioms` and `assert_computable` commands from its direct,
-commit-pinned CompElliptic dependency. Keeping this project-owned adapter under `Ragu.Meta` makes
-the provenance and local trust boundary explicit without maintaining a divergent copy of the
-checker.
+commit-pinned CompElliptic dependency: `CompElliptic/Meta/AxiomCheck.lean` at commit
+`2c0444035a84db957f27f06433715058d1e890ad`. That checker is the synchronized adaptation of
+Ironwood's `Zcash/Meta/AxiomCheck.lean`; keeping this project-owned adapter under `Ragu.Meta` makes
+the provenance and local trust boundary explicit without maintaining another divergent copy.
 
 The upstream implementation checks fully qualified targets, transitive axiom budgets,
 `native_decide` ownership, compiled-body overrides, unsafe/partial definitions, and

--- a/qa/fv/Ragu/Meta/AxiomCheck.lean
+++ b/qa/fv/Ragu/Meta/AxiomCheck.lean
@@ -1,0 +1,15 @@
+import CompElliptic.Meta.AxiomCheck
+
+/-!
+# Ragu trust-assertion machinery
+
+Ragu reuses the hardened `assert_axioms` and `assert_computable` commands from its direct,
+commit-pinned CompElliptic dependency. Keeping this project-owned adapter under `Ragu.Meta` makes
+the provenance and local trust boundary explicit without maintaining a divergent copy of the
+checker.
+
+The upstream implementation checks fully qualified targets, transitive axiom budgets,
+`native_decide` ownership, compiled-body overrides, unsafe/partial definitions, and
+noncomputability. `Ragu.Meta.EndpointCensus` adds Ragu-specific pin recording and endpoint
+discovery around those commands.
+-/

--- a/qa/fv/Ragu/Meta/CensusCheck.lean
+++ b/qa/fv/Ragu/Meta/CensusCheck.lean
@@ -1,0 +1,11 @@
+import Ragu.Meta.TrustBoundary
+
+/-!
+# Trust-boundary census completeness
+
+`Ragu.Meta.TrustBoundary` imports every current formal-circuit theorem module and records each direct
+trust assertion. This command checks the elaborated environment, complementing the source-tree
+coverage check in `scripts/check_fv_endpoint_census.sh`.
+-/
+
+assert_endpoint_census

--- a/qa/fv/Ragu/Meta/EndpointCensus.lean
+++ b/qa/fv/Ragu/Meta/EndpointCensus.lean
@@ -1,0 +1,125 @@
+import Ragu.Meta.AxiomCheck
+
+/-!
+# Environment-level trust-boundary census
+
+The source-tree check in `scripts/check_fv_endpoint_census.sh` finds endpoint declarations that
+have not been added to the trust boundary. This module enforces the complementary rule against
+Lean's elaborated environment: every project-owned endpoint declaration in the import closure must
+have a direct, successfully elaborated trust assertion.
+
+`census_axioms` and `census_computable` delegate the actual trust checks to the pinned
+`CompElliptic.Meta.AxiomCheck` implementation. They record the target only after that assertion
+succeeds, so an unexpected axiom, `native_decide`, compiled-body override, unsafe/partial target,
+or noncomputable target cannot be laundered into the endpoint census.
+
+This is an accidental-drift guard, not a defence against a deliberately deceptive metaprogram that
+mutates the persistent extension directly. Declaration-emitting metaprograms remain review-sensitive.
+-/
+
+namespace Ragu.Meta
+
+open Lean Elab Command
+
+/-- Names whose direct trust assertions have elaborated successfully. -/
+initialize censusPinExt : SimplePersistentEnvExtension Name NameSet ←
+  registerSimplePersistentEnvExtension {
+    addEntryFn := fun names name => names.insert name
+    addImportedFn := fun imported =>
+      imported.foldl (init := {}) fun names moduleNames =>
+        moduleNames.foldl (fun names name => names.insert name) names
+  }
+
+/-- Record a successfully checked direct trust-boundary entry. -/
+def recordCensusPin (name : Name) : CommandElabM Unit :=
+  modifyEnv fun env => censusPinExt.addEntry env name
+
+/-- Resolve a census target and enforce CompElliptic's fully-qualified-name rule. -/
+def resolveCensusTarget (target : Ident) : CommandElabM Name := do
+  let name ← liftCoreM <| realizeGlobalConstNoOverloadWithInfo target
+  CompElliptic.Meta.checkFullyQualified target name
+  return name
+
+/-- Apply CompElliptic's theorem trust check, then record the successful direct pin. -/
+elab "census_axioms " target:ident : command => do
+  elabCommand (← `(command| assert_axioms $target))
+  recordCensusPin (← resolveCensusTarget target)
+
+/-- Apply CompElliptic's computability check, then record the successful direct pin. -/
+elab "census_computable " target:ident choice:("+choice")? : command => do
+  if choice.isSome then
+    elabCommand (← `(command| assert_computable $target +choice))
+  else
+    elabCommand (← `(command| assert_computable $target))
+  recordCensusPin (← resolveCensusTarget target)
+
+/-- Whether `pat` occurs anywhere in `s`. -/
+def containsSubstring (s pat : String) : Bool :=
+  (s.splitOn pat).length > 1
+
+/-- Whether `marker` occurs as a whole underscore-delimited name component, optionally followed by
+an apostrophe. The marker may occur anywhere: qualifying a result as `soundness_of_...` or
+`circuit_completeness_at_...` must not retire its census obligation. -/
+def hasEndpointMarker (s marker : String) : Bool :=
+  s == marker ||
+    s.startsWith (marker ++ "_") || s.startsWith (marker ++ "'") ||
+    s.endsWith ("_" ++ marker) ||
+    containsSubstring s ("_" ++ marker ++ "_") ||
+    containsSubstring s ("_" ++ marker ++ "'")
+
+/-- Semantic endpoint markers used by Ragu's formal circuit API and future protocol capstones. The
+probability markers retain Ironwood's older spellings so a port cannot escape the census merely by
+preserving its existing name. -/
+def endpointMarkers : List String :=
+  ["soundness", "completeness", "error_bound", "finite_security", "measure_le",
+    "probability_bound", "prob_le", "capstone"]
+
+/-- Other directly trusted endpoints that do not use a circuit-theorem marker. -/
+def namedTrustEndpoints : List String :=
+  ["p_prime", "q_prime", "fingerprint", "instances"]
+
+/-- The endpoint predicate shared with `scripts/check_fv_endpoint_census.sh`. -/
+def isEndpointBaseName (name : String) : Bool :=
+  namedTrustEndpoints.contains name || endpointMarkers.any (hasEndpointMarker name)
+
+/-- Every elaborated constant kind can carry an endpoint-shaped declaration. Keeping this match
+exhaustive makes a new Lean declaration kind fail closed until it is classified. -/
+def isCensusKind : ConstantInfo → Bool
+  | .thmInfo _ => true
+  | .defnInfo _ => true
+  | .axiomInfo _ => true
+  | .opaqueInfo _ => true
+  | .quotInfo _ => true
+  | .inductInfo _ => true
+  | .ctorInfo _ => true
+  | .recInfo _ => true
+
+/-- The module that declared `name`, or the module currently elaborating for a local declaration. -/
+def moduleOf (env : Environment) (name : Name) : Name :=
+  match env.getModuleIdxFor? name with
+  | some idx => env.header.moduleNames[idx.toNat]!
+  | none => env.mainModule
+
+/-- Project-owned endpoint declarations with no successfully elaborated direct trust pin. -/
+def unpinnedEndpoints (env : Environment) (excludeTests : Bool := true) : Array Name := Id.run do
+  let pins := censusPinExt.getState env
+  let mut unpinned : Array Name := #[]
+  for (name, info) in env.constants.toList do
+    unless isCensusKind info do continue
+    if name.isInternal then continue
+    let some base := (match name with | .str _ base => some base | _ => none) | continue
+    unless isEndpointBaseName base do continue
+    let moduleName := moduleOf env name
+    unless moduleName.getRoot == `Ragu do continue
+    if excludeTests && (`Ragu.Meta.Tests).isPrefixOf moduleName then continue
+    unless pins.contains name do unpinned := unpinned.push name
+  return unpinned.qsort Name.lt
+
+/-- Fail unless every endpoint in the elaborated import closure has a direct trust assertion. -/
+elab "assert_endpoint_census" : command => do
+  let unpinned := unpinnedEndpoints (← getEnv)
+  unless unpinned.isEmpty do
+    throwError "endpoint declaration(s) with no direct census_axioms/census_computable entry in \
+      the elaborated import closure: {unpinned.toList}"
+
+end Ragu.Meta

--- a/qa/fv/Ragu/Meta/EndpointCensus.lean
+++ b/qa/fv/Ragu/Meta/EndpointCensus.lean
@@ -3,6 +3,11 @@ import Ragu.Meta.AxiomCheck
 /-!
 # Environment-level trust-boundary census
 
+Ported and adapted from `Zcash/Meta/EndpointCensus.lean` at `zcash/ironwood` commit
+`3c056cbebf2880b54f801c348cb67ce7dc9f2a05`. Ragu uses project-specific endpoint names and wraps
+the direct, commit-pinned CompElliptic checker; its marker-anywhere rule also closes the qualified
+`_prob_le_of_...`-style escape present in that source snapshot.
+
 The source-tree check in `scripts/check_fv_endpoint_census.sh` finds endpoint declarations that
 have not been added to the trust boundary. This module enforces the complementary rule against
 Lean's elaborated environment: every project-owned endpoint declaration in the import closure must
@@ -20,6 +25,7 @@ mutates the persistent extension directly. Declaration-emitting metaprograms rem
 namespace Ragu.Meta
 
 open Lean Elab Command
+open CompElliptic.Meta (nativeFlag)
 
 /-- Names whose direct trust assertions have elaborated successfully. -/
 initialize censusPinExt : SimplePersistentEnvExtension Name NameSet ←
@@ -41,16 +47,20 @@ def resolveCensusTarget (target : Ident) : CommandElabM Name := do
   return name
 
 /-- Apply CompElliptic's theorem trust check, then record the successful direct pin. -/
-elab "census_axioms " target:ident : command => do
-  elabCommand (← `(command| assert_axioms $target))
+elab "census_axioms " target:ident native:(nativeFlag)? : command => do
+  match native with
+  | some native => elabCommand (← `(command| assert_axioms $target $native))
+  | none => elabCommand (← `(command| assert_axioms $target))
   recordCensusPin (← resolveCensusTarget target)
 
 /-- Apply CompElliptic's computability check, then record the successful direct pin. -/
-elab "census_computable " target:ident choice:("+choice")? : command => do
-  if choice.isSome then
-    elabCommand (← `(command| assert_computable $target +choice))
-  else
-    elabCommand (← `(command| assert_computable $target))
+elab "census_computable " target:ident choice:("+choice")? native:(nativeFlag)? : command => do
+  match choice, native with
+  | some _, some native =>
+    elabCommand (← `(command| assert_computable $target +choice $native))
+  | some _, none => elabCommand (← `(command| assert_computable $target +choice))
+  | none, some native => elabCommand (← `(command| assert_computable $target $native))
+  | none, none => elabCommand (← `(command| assert_computable $target))
   recordCensusPin (← resolveCensusTarget target)
 
 /-- Whether `pat` occurs anywhere in `s`. -/
@@ -78,9 +88,21 @@ def endpointMarkers : List String :=
 def namedTrustEndpoints : List String :=
   ["p_prime", "q_prime", "fingerprint", "instances"]
 
-/-- The endpoint predicate shared with `scripts/check_fv_endpoint_census.sh`. -/
+/-- Fully qualified boundary names that are too generic to recognize by base name. -/
+def exactTrustEndpoints : List Name :=
+  [`main]
+
+/-- The base-name half of the endpoint predicate shared with
+`scripts/check_fv_endpoint_census.sh`. -/
 def isEndpointBaseName (name : String) : Bool :=
   namedTrustEndpoints.contains name || endpointMarkers.any (hasEndpointMarker name)
+
+/-- Whether a fully qualified declaration name belongs to Ragu's endpoint policy. -/
+def isEndpointName (name : Name) : Bool :=
+  exactTrustEndpoints.contains name ||
+    match name with
+    | .str _ base => isEndpointBaseName base
+    | _ => false
 
 /-- Every elaborated constant kind can carry an endpoint-shaped declaration. Keeping this match
 exhaustive makes a new Lean declaration kind fail closed until it is classified. -/
@@ -107,8 +129,7 @@ def unpinnedEndpoints (env : Environment) (excludeTests : Bool := true) : Array 
   for (name, info) in env.constants.toList do
     unless isCensusKind info do continue
     if name.isInternal then continue
-    let some base := (match name with | .str _ base => some base | _ => none) | continue
-    unless isEndpointBaseName base do continue
+    unless isEndpointName name do continue
     let moduleName := moduleOf env name
     unless moduleName.getRoot == `Ragu do continue
     if excludeTests && (`Ragu.Meta.Tests).isPrefixOf moduleName then continue

--- a/qa/fv/Ragu/Meta/Tests/EndpointCensus.lean
+++ b/qa/fv/Ragu/Meta/Tests/EndpointCensus.lean
@@ -1,0 +1,78 @@
+import Ragu.Meta.EndpointCensus
+
+namespace Ragu.Meta.Tests.EndpointCensus
+
+/-- Forged qualified soundness endpoint used to exercise the unpinned census path. -/
+theorem soundness_of_unpinned : True := by trivial
+
+/-- Forged qualified completeness endpoint used to exercise definition discovery. -/
+def circuit_completeness_at_unpinned : Bool := true
+
+/-- Forged axiom endpoint used to exercise axiom declaration discovery. -/
+axiom axiom_soundness : True
+
+/-- Forged opaque endpoint used to exercise non-theorem declaration discovery. -/
+opaque opaque_soundness : Bool := true
+
+/-- Forged inductive endpoint used to exercise declaration-kind completeness. -/
+inductive forged_completeness where
+  | witness
+
+/-- Forged structure endpoint; structures elaborate as inductive declarations. -/
+structure structure_completeness : Prop where
+  proof : True
+
+/-- Carrier whose endpoint-shaped constructor exercises constructor discovery. -/
+inductive ConstructorCarrier : Prop where
+  | constructor_soundness
+
+/-- A similarly spelled non-endpoint: `soundness` is not a whole name component. -/
+theorem unsoundness : True := by trivial
+
+/-- A similarly spelled non-endpoint: the marker is followed by an alphanumeric character. -/
+def soundnessHelper : Bool := true
+
+/-- A test endpoint whose computability pin must remove it from the unpinned set. -/
+def pinned_soundness : Bool := true
+
+census_computable Ragu.Meta.Tests.EndpointCensus.pinned_soundness
+
+/-- A test endpoint whose theorem pin must remove it from the unpinned set. -/
+theorem pinned_completeness_of_case : True := by trivial
+
+census_axioms Ragu.Meta.Tests.EndpointCensus.pinned_completeness_of_case
+
+#guard Ragu.Meta.isEndpointBaseName "soundness"
+#guard Ragu.Meta.isEndpointBaseName "soundness_of_qualified_result"
+#guard Ragu.Meta.isEndpointBaseName "circuit_completeness_at_instance"
+#guard Ragu.Meta.isEndpointBaseName "circuit_soundness'"
+#guard Ragu.Meta.isEndpointBaseName "binding_prob_le_of_assumption"
+#guard Ragu.Meta.isEndpointBaseName "deployment_finite_security_at_consensus_max"
+#guard Ragu.Meta.isEndpointBaseName "recursive_verifier_capstone"
+#guard !Ragu.Meta.isEndpointBaseName "unsoundness"
+#guard !Ragu.Meta.isEndpointBaseName "soundnessHelper"
+#guard !Ragu.Meta.isEndpointBaseName "binding_prob_lemma"
+
+run_cmd do
+  let env ← Lean.getEnv
+  let production := Ragu.Meta.unpinnedEndpoints env
+  unless production.isEmpty do
+    throwError "test declarations escaped the production exclusion: {production.toList}"
+
+  let unpinned := Ragu.Meta.unpinnedEndpoints env (excludeTests := false)
+  let expected := #[
+    `Ragu.Meta.Tests.EndpointCensus.soundness_of_unpinned,
+    `Ragu.Meta.Tests.EndpointCensus.circuit_completeness_at_unpinned,
+    `Ragu.Meta.Tests.EndpointCensus.axiom_soundness,
+    `Ragu.Meta.Tests.EndpointCensus.opaque_soundness,
+    `Ragu.Meta.Tests.EndpointCensus.forged_completeness,
+    `Ragu.Meta.Tests.EndpointCensus.structure_completeness,
+    `Ragu.Meta.Tests.EndpointCensus.ConstructorCarrier.constructor_soundness
+  ].qsort Lean.Name.lt
+  unless unpinned == expected do
+    throwError "expected exactly the forged endpoints unpinned, got {unpinned.toList}; expected \
+      {expected.toList}"
+
+assert_endpoint_census
+
+end Ragu.Meta.Tests.EndpointCensus

--- a/qa/fv/Ragu/Meta/Tests/EndpointCensus.lean
+++ b/qa/fv/Ragu/Meta/Tests/EndpointCensus.lean
@@ -1,5 +1,13 @@
 import Ragu.Meta.EndpointCensus
 
+/-!
+# Endpoint-census regression tests
+
+Ported and adapted from `Zcash/Meta/Tests/EndpointCensus.lean` at `zcash/ironwood` commit
+`3c056cbebf2880b54f801c348cb67ce7dc9f2a05`. The qualified-marker, exact-root endpoint, and
+`census_* +native(...)` cases are Ragu-specific extensions.
+-/
+
 namespace Ragu.Meta.Tests.EndpointCensus
 
 /-- Forged qualified soundness endpoint used to exercise the unpinned census path. -/
@@ -42,6 +50,38 @@ theorem pinned_completeness_of_case : True := by trivial
 
 census_axioms Ragu.Meta.Tests.EndpointCensus.pinned_completeness_of_case
 
+/-- A native theorem pin exercises forwarding of Ironwood's exact owner allowance. -/
+theorem pinned_native_soundness : (123456 : Nat) < 123457 := by native_decide
+
+census_axioms Ragu.Meta.Tests.EndpointCensus.pinned_native_soundness +native(
+  Ragu.Meta.Tests.EndpointCensus.pinned_native_soundness)
+
+/-- A computed test value with an owned native certificate and no choice allowance. -/
+structure NativeCertificate where
+  value : Nat
+  small : value < 123457
+
+def pinned_native_only_completeness : NativeCertificate where
+  value := 123456
+  small := pinned_native_soundness
+
+census_computable Ragu.Meta.Tests.EndpointCensus.pinned_native_only_completeness +native(
+  Ragu.Meta.Tests.EndpointCensus.pinned_native_soundness)
+
+/-- A computed test value with both erased choice and an owned native certificate. -/
+structure NativeChoiceCertificate where
+  value : Nat
+  small : value < 123457
+  erased : True
+
+def pinned_native_completeness : NativeChoiceCertificate where
+  value := 123456
+  small := pinned_native_soundness
+  erased := Classical.choice (show Nonempty True from ⟨True.intro⟩)
+
+census_computable Ragu.Meta.Tests.EndpointCensus.pinned_native_completeness +choice +native(
+  Ragu.Meta.Tests.EndpointCensus.pinned_native_soundness)
+
 #guard Ragu.Meta.isEndpointBaseName "soundness"
 #guard Ragu.Meta.isEndpointBaseName "soundness_of_qualified_result"
 #guard Ragu.Meta.isEndpointBaseName "circuit_completeness_at_instance"
@@ -52,6 +92,8 @@ census_axioms Ragu.Meta.Tests.EndpointCensus.pinned_completeness_of_case
 #guard !Ragu.Meta.isEndpointBaseName "unsoundness"
 #guard !Ragu.Meta.isEndpointBaseName "soundnessHelper"
 #guard !Ragu.Meta.isEndpointBaseName "binding_prob_lemma"
+#guard Ragu.Meta.isEndpointName `main
+#guard !Ragu.Meta.isEndpointName `Ragu.Meta.Tests.EndpointCensus.main
 
 run_cmd do
   let env ← Lean.getEnv

--- a/qa/fv/Ragu/Meta/TrustBoundary.lean
+++ b/qa/fv/Ragu/Meta/TrustBoundary.lean
@@ -1,0 +1,193 @@
+import Ragu.Meta.EndpointCensus
+import Ragu.Core
+import Ragu.Fingerprint.Instances
+import Ragu.Fingerprint.Main
+import Ragu.Circuits.Boolean.Alloc
+import Ragu.Circuits.Boolean.And
+import Ragu.Circuits.Boolean.ConditionalEnforceEqual
+import Ragu.Circuits.Boolean.ConditionalSelect
+import Ragu.Circuits.Boolean.Consistent
+import Ragu.Circuits.Boolean.Decompose
+import Ragu.Circuits.Core.Mul
+import Ragu.Circuits.Element.Alloc
+import Ragu.Circuits.Element.AllocSquare
+import Ragu.Circuits.Element.Divide
+import Ragu.Circuits.Element.DivNonzero
+import Ragu.Circuits.Element.EnforceInvertible
+import Ragu.Circuits.Element.EnforceNonzero
+import Ragu.Circuits.Element.EnforceRootOfUnity
+import Ragu.Circuits.Element.EnforceZero
+import Ragu.Circuits.Element.Fold
+import Ragu.Circuits.Element.Invert
+import Ragu.Circuits.Element.Invertible
+import Ragu.Circuits.Element.InvertibleConsistent
+import Ragu.Circuits.Element.InvertWith
+import Ragu.Circuits.Element.IsEqual
+import Ragu.Circuits.Element.IsZero
+import Ragu.Circuits.Element.Mul
+import Ragu.Circuits.Element.Square
+import Ragu.Circuits.Endoscalar.Alloc
+import Ragu.Circuits.Endoscalar.Extract
+import Ragu.Circuits.Endoscalar.GroupScale
+import Ragu.Circuits.Endoscalar.Lift
+import Ragu.Circuits.Horner.Ky
+import Ragu.Circuits.NonzeroBank.Scope
+import Ragu.Circuits.Point.AddIncomplete
+import Ragu.Circuits.Point.AddIncompleteUnchecked
+import Ragu.Circuits.Point.Alloc
+import Ragu.Circuits.Point.ConditionalEndo
+import Ragu.Circuits.Point.ConditionalNegate
+import Ragu.Circuits.Point.Consistent
+import Ragu.Circuits.Point.Double
+import Ragu.Circuits.Point.DoubleAndAddIncomplete
+import Ragu.Circuits.Point.DoubleAndAddIncompleteUnchecked
+import Ragu.Circuits.Point.Spec
+import Ragu.Circuits.Poseidon.Linear
+import Ragu.Circuits.Poseidon.ParamsFp
+import Ragu.Circuits.Poseidon.ParamsFq
+import Ragu.Circuits.Poseidon.Permutation
+import Ragu.Circuits.Poseidon.Round
+import Ragu.Circuits.Poseidon.Sbox
+import Ragu.Circuits.Poseidon.Sponge
+
+/-!
+# Ragu formal-verification trust boundary
+
+Every deliverable `soundness` and `completeness` theorem is pinned directly with
+`census_axioms`, which bounds its transitive kernel axioms to Lean's standard theorem tier and
+rejects undisclosed compiler trust. The census also reserves protocol-level markers such as
+`_error_bound`, `_finite_security`, `_prob_le`, and `_capstone` for the verifier and soundness
+layers that will be added later. The two Pasta primality theorems are pinned at the same tier.
+
+The fingerprint function and generated instance registry are executable boundary artifacts, so
+they use `census_computable`: each must remain a safe, computable definition with the tighter
+computable axiom budget. These checks do not prove that the trusted fingerprint encoders or
+serialization assign the intended semantics, and they do not connect this gadget layer to an
+unfinished Ragu verifier. Those remain separate manual and future refinement obligations.
+
+The entries below are intentionally fully qualified and direct. Transitive coverage disappears
+when a consumer is refactored and therefore does not satisfy the endpoint census.
+-/
+
+/-! ## Boolean circuits -/
+
+census_axioms Ragu.Circuits.Boolean.Alloc.soundness
+census_axioms Ragu.Circuits.Boolean.Alloc.completeness
+census_axioms Ragu.Circuits.Boolean.And.soundness
+census_axioms Ragu.Circuits.Boolean.And.completeness
+census_axioms Ragu.Circuits.Boolean.ConditionalEnforceEqual.soundness
+census_axioms Ragu.Circuits.Boolean.ConditionalEnforceEqual.completeness
+census_axioms Ragu.Circuits.Boolean.ConditionalSelect.soundness
+census_axioms Ragu.Circuits.Boolean.ConditionalSelect.completeness
+census_axioms Ragu.Circuits.Boolean.Consistent.soundness
+census_axioms Ragu.Circuits.Boolean.Consistent.completeness
+census_axioms Ragu.Circuits.Boolean.Decompose.soundness
+census_axioms Ragu.Circuits.Boolean.Decompose.completeness
+
+/-! ## Core and element circuits -/
+
+census_axioms Ragu.Circuits.Core.Mul.soundness
+census_axioms Ragu.Circuits.Core.Mul.completeness
+census_axioms Ragu.Circuits.Element.Alloc.soundness
+census_axioms Ragu.Circuits.Element.Alloc.completeness
+census_axioms Ragu.Circuits.Element.AllocSquare.soundness
+census_axioms Ragu.Circuits.Element.AllocSquare.completeness
+census_axioms Ragu.Circuits.Element.DivNonzero.soundness
+census_axioms Ragu.Circuits.Element.DivNonzero.completeness
+census_axioms Ragu.Circuits.Element.Divide.soundness
+census_axioms Ragu.Circuits.Element.Divide.completeness
+census_axioms Ragu.Circuits.Element.EnforceInvertible.soundness
+census_axioms Ragu.Circuits.Element.EnforceInvertible.completeness
+census_axioms Ragu.Circuits.Element.EnforceNonzero.soundness
+census_axioms Ragu.Circuits.Element.EnforceNonzero.completeness
+census_axioms Ragu.Circuits.Element.EnforceRootOfUnity.soundness
+census_axioms Ragu.Circuits.Element.EnforceRootOfUnity.completeness
+census_axioms Ragu.Circuits.Element.EnforceZero.soundness
+census_axioms Ragu.Circuits.Element.EnforceZero.completeness
+census_axioms Ragu.Circuits.Element.Fold.soundness
+census_axioms Ragu.Circuits.Element.Fold.completeness
+census_axioms Ragu.Circuits.Element.Invert.soundness
+census_axioms Ragu.Circuits.Element.Invert.completeness
+census_axioms Ragu.Circuits.Element.InvertWith.soundness
+census_axioms Ragu.Circuits.Element.InvertWith.completeness
+census_axioms Ragu.Circuits.Element.Invertible.soundness
+census_axioms Ragu.Circuits.Element.Invertible.completeness
+census_axioms Ragu.Circuits.Element.InvertibleConsistent.soundness
+census_axioms Ragu.Circuits.Element.InvertibleConsistent.completeness
+census_axioms Ragu.Circuits.Element.IsEqual.soundness
+census_axioms Ragu.Circuits.Element.IsEqual.completeness
+census_axioms Ragu.Circuits.Element.IsZero.soundness
+census_axioms Ragu.Circuits.Element.IsZero.completeness
+census_axioms Ragu.Circuits.Element.Mul.soundness
+census_axioms Ragu.Circuits.Element.Mul.completeness
+census_axioms Ragu.Circuits.Element.Square.soundness
+census_axioms Ragu.Circuits.Element.Square.completeness
+
+/-! ## Endoscalar, Horner, and nonzero-bank circuits -/
+
+census_axioms Ragu.Circuits.Endoscalar.Alloc.soundness
+census_axioms Ragu.Circuits.Endoscalar.Alloc.completeness
+census_axioms Ragu.Circuits.Endoscalar.Extract.soundness
+census_axioms Ragu.Circuits.Endoscalar.Extract.completeness
+census_axioms Ragu.Circuits.Endoscalar.GroupScale.Step.soundness
+census_axioms Ragu.Circuits.Endoscalar.GroupScale.Step.completeness
+census_axioms Ragu.Circuits.Endoscalar.GroupScale.soundness
+census_axioms Ragu.Circuits.Endoscalar.GroupScale.completeness
+census_axioms Ragu.Circuits.Endoscalar.Lift.soundness
+census_axioms Ragu.Circuits.Endoscalar.Lift.completeness
+census_axioms Ragu.Circuits.Horner.Ky.soundness
+census_axioms Ragu.Circuits.Horner.Ky.completeness
+census_axioms Ragu.Circuits.NonzeroBank.Scope.soundness
+census_axioms Ragu.Circuits.NonzeroBank.Scope.completeness
+
+/-! ## Point circuits -/
+
+census_axioms Ragu.Circuits.Point.AddIncomplete.soundness
+census_axioms Ragu.Circuits.Point.AddIncomplete.completeness
+census_axioms Ragu.Circuits.Point.AddIncompleteUnchecked.soundness
+census_axioms Ragu.Circuits.Point.AddIncompleteUnchecked.completeness
+census_axioms Ragu.Circuits.Point.Alloc.soundness
+census_axioms Ragu.Circuits.Point.Alloc.completeness
+census_axioms Ragu.Circuits.Point.ConditionalEndo.soundness
+census_axioms Ragu.Circuits.Point.ConditionalEndo.completeness
+census_axioms Ragu.Circuits.Point.ConditionalNegate.soundness
+census_axioms Ragu.Circuits.Point.ConditionalNegate.completeness
+census_axioms Ragu.Circuits.Point.Consistent.soundness
+census_axioms Ragu.Circuits.Point.Consistent.completeness
+census_axioms Ragu.Circuits.Point.Double.soundness
+census_axioms Ragu.Circuits.Point.Double.completeness
+census_axioms Ragu.Circuits.Point.DoubleAndAddIncomplete.soundness
+census_axioms Ragu.Circuits.Point.DoubleAndAddIncomplete.completeness
+census_axioms Ragu.Circuits.Point.DoubleAndAddIncompleteUnchecked.soundness
+census_axioms Ragu.Circuits.Point.DoubleAndAddIncompleteUnchecked.completeness
+
+/-! ## Poseidon circuits -/
+
+census_axioms Ragu.Circuits.Poseidon.Permutation.AnyRound.soundness
+census_axioms Ragu.Circuits.Poseidon.Permutation.AnyRound.completeness
+census_axioms Ragu.Circuits.Poseidon.Permutation.soundness
+census_axioms Ragu.Circuits.Poseidon.Permutation.completeness
+census_axioms Ragu.Circuits.Poseidon.Round.Full.soundness
+census_axioms Ragu.Circuits.Poseidon.Round.Full.completeness
+census_axioms Ragu.Circuits.Poseidon.Round.Partial.soundness
+census_axioms Ragu.Circuits.Poseidon.Round.Partial.completeness
+census_axioms Ragu.Circuits.Poseidon.Sbox.soundness
+census_axioms Ragu.Circuits.Poseidon.Sbox.completeness
+census_axioms Ragu.Circuits.Poseidon.Sponge.Hash1.soundness
+census_axioms Ragu.Circuits.Poseidon.Sponge.Hash1.completeness
+census_axioms Ragu.Circuits.Poseidon.Sponge.Blocks.loop_soundness
+census_axioms Ragu.Circuits.Poseidon.Sponge.Blocks.loop_completeness
+census_axioms Ragu.Circuits.Poseidon.Sponge.Blocks.soundness
+census_axioms Ragu.Circuits.Poseidon.Sponge.Blocks.completeness
+census_axioms Ragu.Circuits.Poseidon.Sponge.Squeeze.soundness
+census_axioms Ragu.Circuits.Poseidon.Sponge.Squeeze.completeness
+census_axioms Ragu.Circuits.Poseidon.Sponge.Ragged.soundness
+census_axioms Ragu.Circuits.Poseidon.Sponge.Ragged.completeness
+
+/-! ## Prime-field and executable fingerprint boundary -/
+
+census_axioms Ragu.Core.Primes.p_prime
+census_axioms Ragu.Core.Primes.q_prime
+census_computable Ragu.Core.Statements.FormalInstance.fingerprint +choice
+census_computable Ragu.Fingerprint.instances +choice
+census_computable _root_.main +choice

--- a/scripts/check_fv_endpoint_census.sh
+++ b/scripts/check_fv_endpoint_census.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Check that every Ragu FV endpoint has a direct trust-boundary pin.
 #
+# Ported and adapted from zcash/ironwood's scripts/check_endpoint_census.sh at commit
+# 3c056cbebf2880b54f801c348cb67ce7dc9f2a05. Ragu's marker-anywhere policy intentionally closes
+# that snapshot's qualified _prob_le_of_... endpoint-discovery escape.
+#
 # This source-tree pass sees a newly added module even before it enters `Ragu.Meta.TrustBoundary`'s
 # import closure. `Ragu.Meta.CensusCheck` performs the complementary elaborated-environment check,
 # which
@@ -75,14 +79,15 @@ while IFS= read -r file; do
     [[ $line =~ ^((protected|noncomputable|partial|unsafe)[[:space:]]+)*(theorem|lemma|def|abbrev|instance|axiom|opaque|inductive|structure|class)[[:space:]]+([A-Za-z0-9_.\']+) ]] || continue
 
     declared=${BASH_REMATCH[4]}
-    base=${declared##*.}
-    [[ $base =~ $ENDPOINT_RE ]] || continue
-
     if [[ $declared == *.* || -z $namespace_path ]]; then
       qualified=$declared
     else
       qualified="${namespace_path}.${declared}"
     fi
+
+    base=${declared##*.}
+    # `main` is exact: a generic namespace-local `main` is not the fingerprint executable boundary.
+    [[ $base =~ $ENDPOINT_RE || $qualified == main ]] || continue
 
     count=$((count + 1))
     if ! grep -qxF "$qualified" <<< "$pins"; then

--- a/scripts/check_fv_endpoint_census.sh
+++ b/scripts/check_fv_endpoint_census.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Check that every Ragu FV endpoint has a direct trust-boundary pin.
+#
+# This source-tree pass sees a newly added module even before it enters `Ragu.Meta.TrustBoundary`'s
+# import closure. `Ragu.Meta.CensusCheck` performs the complementary elaborated-environment check,
+# which
+# sees every declaration kind and syntax form in that closure. The marker rule deliberately allows
+# qualifiers after `soundness` / `completeness`; naming an endpoint `_of_...` or `_at_...` must not
+# remove its trust obligation.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ENDPOINT_RE='(^|_)(soundness|completeness|error_bound|finite_security|measure_le|probability_bound|prob_le|capstone)([^A-Za-z0-9]|$)|^(p_prime|q_prime|fingerprint|instances)$'
+
+source_root='qa/fv/Ragu'
+census='qa/fv/Ragu/Meta/TrustBoundary.lean'
+
+if [[ ! -f "$census" ]]; then
+  echo "VIOLATION: no Ragu FV trust-boundary census found" >&2
+  exit 1
+fi
+
+sources=$(find "$source_root" -name '*.lean' \
+  -not -path "$source_root/Meta/Tests/*" \
+  -not -path "$source_root/Meta/TrustBoundary.lean" \
+  -not -path "$source_root/Meta/CensusCheck.lean" | sort)
+
+pins=$(grep -hE '^census_(axioms|computable) ' "$census" \
+  | sed -E 's/^census_(axioms|computable)[[:space:]]+//; s/^_root_\.//; s/[[:space:]].*$//' \
+  | sort -u || true)
+
+status=0
+count=0
+circuit_count=0
+
+# Every circuit module is imported directly into the trust boundary. This closes the source
+# parser's syntax gap: once a module is in the elaborated closure, a custom command or multiline
+# declaration cannot hide an endpoint from `assert_endpoint_census`.
+circuit_sources=$(find "$source_root/Circuits" -name '*.lean' | sort)
+while IFS= read -r file; do
+  module=${file#qa/fv/}
+  module=${module%.lean}
+  module=${module//\//.}
+  circuit_count=$((circuit_count + 1))
+  if ! grep -qxF "import $module" "$census"; then
+    echo "VIOLATION: circuit module ${module} (${file}) is absent from the trust-boundary import closure" >&2
+    status=1
+  fi
+done <<< "$circuit_sources"
+
+while IFS= read -r file; do
+  namespace_path=''
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ $line =~ ^namespace[[:space:]]+([A-Za-z0-9_.\']+) ]]; then
+      opened=${BASH_REMATCH[1]}
+      if [[ -z $namespace_path ]]; then
+        namespace_path=$opened
+      else
+        namespace_path="${namespace_path}.${opened}"
+      fi
+      continue
+    fi
+
+    if [[ $line =~ ^end[[:space:]]+([A-Za-z0-9_.\']+) ]]; then
+      closed=${BASH_REMATCH[1]}
+      if [[ $namespace_path == "$closed" ]]; then
+        namespace_path=''
+      elif [[ $namespace_path == *."$closed" ]]; then
+        namespace_path=${namespace_path%."$closed"}
+      fi
+      continue
+    fi
+
+    if [[ $line =~ ^private[[:space:]] ]]; then continue; fi
+    [[ $line =~ ^((protected|noncomputable|partial|unsafe)[[:space:]]+)*(theorem|lemma|def|abbrev|instance|axiom|opaque|inductive|structure|class)[[:space:]]+([A-Za-z0-9_.\']+) ]] || continue
+
+    declared=${BASH_REMATCH[4]}
+    base=${declared##*.}
+    [[ $base =~ $ENDPOINT_RE ]] || continue
+
+    if [[ $declared == *.* || -z $namespace_path ]]; then
+      qualified=$declared
+    else
+      qualified="${namespace_path}.${declared}"
+    fi
+
+    count=$((count + 1))
+    if ! grep -qxF "$qualified" <<< "$pins"; then
+      echo "VIOLATION: endpoint ${qualified} (${file}) has no direct census_axioms/census_computable entry" >&2
+      status=1
+    fi
+  done < "$file"
+done <<< "$sources"
+
+if [[ $status -eq 0 ]]; then
+  echo "Ragu FV endpoint census: ${circuit_count} circuit module(s) imported; ${count} endpoint declaration(s), all directly pinned."
+fi
+exit $status


### PR DESCRIPTION
Port and adapt Ironwood’s trust boundary census and macros for Ragu. CI now checks every FV endpoint and capstone theorem for `sorrys` and unexpected axiom dependencies.