### PR TITLE
refactor: use typed sources for division and identity errors

### DIFF
--- a/crates/ragu_primitives/src/element.rs
+++ b/crates/ragu_primitives/src/element.rs
@@ -3,7 +3,7 @@
 //! Provides the [`Element`] type representing a wire and its field element
 //! assignment, the fundamental building block for circuit construction.
 
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 use core::borrow::Borrow;
 
 use ragu_arithmetic::{Coeff, ff::Field};
@@ -21,6 +21,26 @@ use crate::{
     consistent::Consistent,
     io::{Buffer, Write},
 };
+
+/// An error indicating that a division's divisor is zero.
+///
+/// [`Element::divide`] and [`Invertible::alloc`] box this type as the source
+/// of [`Error::InvalidWitness`] when the divisor (or the value to invert) is
+/// zero, so callers can detect the condition with
+/// [`Error::invalid_witness_source`].
+///
+/// # Examples
+///
+/// ```
+/// use ragu_core::Error;
+/// use ragu_primitives::DivisionByZeroError;
+///
+/// let err = Error::InvalidWitness(Box::new(DivisionByZeroError));
+/// assert!(err.invalid_witness_source::<DivisionByZeroError>().is_some());
+/// ```
+#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+#[error("division by zero")]
+pub struct DivisionByZeroError;
 
 /// Represents a wire and its witness value.
 ///
@@ -277,8 +297,10 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
     ///
     /// # Errors
     ///
-    /// Returns a witness-generation error if witness input for this element
-    /// is zero.
+    /// Witness generation fails with [`Error::InvalidWitness`] when witness
+    /// input for this element is zero. The boxed source is a
+    /// [`DivisionByZeroError`] value, which callers can detect with
+    /// [`Error::invalid_witness_source`].
     pub fn enforce_invertible(&self, dr: &mut D) -> Result<Invertible<'dr, D>> {
         let invertible = Invertible::alloc(dr, self.value.clone())?;
         self.enforce_equal(dr, invertible.element())?;
@@ -329,8 +351,10 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
     ///
     /// # Errors
     ///
-    /// Returns a witness-generation error if witness input for this element
-    /// is zero.
+    /// Witness generation fails with [`Error::InvalidWitness`] when witness
+    /// input for this element is zero. The boxed source is a
+    /// [`DivisionByZeroError`] value, which callers can detect with
+    /// [`Error::invalid_witness_source`].
     pub fn enforce_nonzero(self, dr: &mut D) -> Result<Nonzero<'dr, D>> {
         Ok(self.enforce_invertible(dr)?.into_element())
     }
@@ -354,8 +378,10 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
     ///
     /// # Errors
     ///
-    /// Returns a witness-generation error if witness input for this element
-    /// is zero.
+    /// Witness generation fails with [`Error::InvalidWitness`] when witness
+    /// input for this element is zero. The boxed source is a
+    /// [`DivisionByZeroError`] value, which callers can detect with
+    /// [`Error::invalid_witness_source`].
     pub fn invert(&self, dr: &mut D) -> Result<Self> {
         self.enforce_invertible(dr)
             .map(|inv| inv.into_inverse().into_inner())
@@ -399,8 +425,10 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
     ///
     /// # Errors
     ///
-    /// Returns a witness-generation error if the quotient assignment cannot
-    /// be computed from witness input.
+    /// Witness generation fails with [`Error::InvalidWitness`] when the
+    /// divisor's witness value is zero. The boxed source is a
+    /// [`DivisionByZeroError`] value, which callers can detect with
+    /// [`Error::invalid_witness_source`].
     pub fn divide(&self, dr: &mut D, divisor: &Nonzero<'dr, D>) -> Result<Self> {
         let quotient_value = D::try_just(|| {
             Ok(*self.value().take()
@@ -409,7 +437,7 @@ impl<'dr, D: Driver<'dr>> Element<'dr, D> {
                     .take()
                     .invert()
                     .into_option()
-                    .ok_or_else(|| Error::InvalidWitness("division by zero".into()))?)
+                    .ok_or_else(|| Error::InvalidWitness(Box::new(DivisionByZeroError)))?)
         })?;
 
         let (quotient, denominator, numerator) = dr.mul(|| {
@@ -730,6 +758,31 @@ mod tests {
         assert!(alloc(F::from(4578u64), F::ZERO).is_err());
 
         Ok(())
+    }
+
+    /// Division by a zero divisor fails in witness generation with the typed
+    /// [`DivisionByZeroError`] source. The divisor bypasses
+    /// [`Element::enforce_nonzero`] via [`Nonzero::new_unchecked`], so this
+    /// exercises the quotient computation itself rather than failing earlier
+    /// in the nonzero constraint.
+    #[test]
+    fn test_divide_by_zero_reports_typed_source() {
+        let result = Simulator::simulate((F::from(4578u64), F::ZERO), |dr, witness| {
+            let (a, b) = witness.cast();
+            let allocator = &mut Standard::new();
+            let a = Element::alloc(dr, allocator, a.clone())?;
+            let b = Element::alloc(dr, allocator, b.clone())?;
+            a.divide(dr, &Nonzero::new_unchecked(b))?;
+            Ok(())
+        });
+
+        let Err(err) = result else {
+            panic!("division by zero must be rejected");
+        };
+        assert_eq!(
+            err.invalid_witness_source::<DivisionByZeroError>(),
+            Some(&DivisionByZeroError)
+        );
     }
 
     #[test]

--- a/crates/ragu_primitives/src/invertible.rs
+++ b/crates/ragu_primitives/src/invertible.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use ragu_arithmetic::{
     Coeff,
     ff::{Field, PrimeField},
@@ -10,7 +12,7 @@ use ragu_core::{
 };
 
 use crate::{
-    Element, GadgetExt,
+    DivisionByZeroError, Element, GadgetExt,
     comparison::GadgetEquals,
     consistent::Consistent,
     io::{Buffer, Write},
@@ -163,14 +165,16 @@ impl<'dr, D: Driver<'dr>> Invertible<'dr, D> {
     ///
     /// # Errors
     ///
-    /// Returns a witness-generation error if `value` is zero.
+    /// Witness generation fails with [`Error::InvalidWitness`] when `value` is
+    /// zero. The boxed source is a [`DivisionByZeroError`] value, which
+    /// callers can detect with [`Error::invalid_witness_source`].
     pub fn alloc(dr: &mut D, value: DriverValue<D, D::F>) -> Result<Self> {
         let inverse_value = D::try_just(|| {
             value
                 .snag()
                 .invert()
                 .into_option()
-                .ok_or_else(|| Error::InvalidWitness("division by zero".into()))
+                .ok_or_else(|| Error::InvalidWitness(Box::new(DivisionByZeroError)))
         })?;
         Self::alloc_with_advice(dr, value, inverse_value)
     }
@@ -427,7 +431,13 @@ mod tests {
             Invertible::alloc(dr, witness.clone())?;
             Ok(())
         });
-        assert!(result.is_err());
+        let Err(err) = result else {
+            panic!("zero must not be invertible");
+        };
+        assert_eq!(
+            err.invalid_witness_source::<DivisionByZeroError>(),
+            Some(&DivisionByZeroError)
+        );
     }
 
     #[test]

--- a/crates/ragu_primitives/src/lib.rs
+++ b/crates/ragu_primitives/src/lib.rs
@@ -36,13 +36,13 @@ mod util;
 pub mod vec;
 
 pub use boolean::{Boolean, multipack};
-pub use element::{Element, multiadd};
+pub use element::{DivisionByZeroError, Element, multiadd};
 pub use endoscalar::{
     Endoscalar, EndoscalarChallenge, EndoscalarRangeError, extract_endoscalar, lift_endoscalar,
 };
 pub use invertible::{Invertible, Nonzero, NonzeroBank};
 use io::{Buffer, Write};
-pub use point::Point;
+pub use point::{Point, PointAtInfinityError};
 use promotion::Demoted;
 use ragu_core::{Result, drivers::Driver, gadgets::Gadget};
 pub use sendable::Sendable;

--- a/crates/ragu_primitives/src/point.rs
+++ b/crates/ragu_primitives/src/point.rs
@@ -4,6 +4,7 @@
 //! constrained coordinates for in-circuit elliptic curve arithmetic. See
 //! [`Point`] for the full list of supported curve assumptions.
 
+use alloc::boxed::Box;
 use core::marker::PhantomData;
 
 use ragu_arithmetic::{Coeff, CurveAffine, ff::WithSmallOrderMulGroup};
@@ -18,6 +19,26 @@ use crate::{
     Boolean, Element, Nonzero, NonzeroBank, comparison::GadgetEquals, consistent::Consistent,
     io::Write,
 };
+
+/// An error indicating that a point is the identity (the point at infinity).
+///
+/// [`Point::alloc`] and [`Point::constant`] box this type as the source of
+/// [`Error::InvalidWitness`] when the input point is the identity, which has
+/// no affine coordinates and so cannot be represented. Callers can detect the
+/// condition with [`Error::invalid_witness_source`].
+///
+/// # Examples
+///
+/// ```
+/// use ragu_core::Error;
+/// use ragu_primitives::PointAtInfinityError;
+///
+/// let err = Error::InvalidWitness(Box::new(PointAtInfinityError));
+/// assert!(err.invalid_witness_source::<PointAtInfinityError>().is_some());
+/// ```
+#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq)]
+#[error("point at infinity cannot be witnessed")]
+pub struct PointAtInfinityError;
 
 /// Represents an affine point on a curve defined over the circuit's field.
 ///
@@ -72,13 +93,14 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
     ///
     /// # Errors
     ///
-    /// Returns a witness-generation error if witness input is the identity.
+    /// Witness generation fails with [`Error::InvalidWitness`] when witness
+    /// input is the identity. The boxed source is a [`PointAtInfinityError`]
+    /// value, which callers can detect with
+    /// [`Error::invalid_witness_source`].
     pub fn alloc(dr: &mut D, p: DriverValue<D, C>) -> Result<Self> {
         let coordinates = D::try_just(|| {
             let coordinates = p.take().coordinates().into_option();
-            coordinates.ok_or_else(|| {
-                Error::InvalidWitness("point at infinity cannot be witnessed".into())
-            })
+            coordinates.ok_or_else(|| Error::InvalidWitness(Box::new(PointAtInfinityError)))
         })?;
 
         let (x, x2) = Element::alloc_square(dr, coordinates.as_ref().map(|p| *p.x()))?;
@@ -102,7 +124,9 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
     ///
     /// # Errors
     ///
-    /// Returns an input error if `p` is the identity.
+    /// Fails with [`Error::InvalidWitness`] when `p` is the identity. The
+    /// boxed source is a [`PointAtInfinityError`] value, which callers can
+    /// detect with [`Error::invalid_witness_source`].
     pub fn constant(dr: &mut D, p: C) -> Result<Self> {
         if let Some(coordinates) = p.coordinates().into_option() {
             let x = Element::constant(dr, *coordinates.x());
@@ -113,9 +137,7 @@ impl<'dr, D: Driver<'dr, F = C::Base>, C: CurveAffine> Point<'dr, D, C> {
                 Nonzero::new_unchecked(y),
             ))
         } else {
-            Err(Error::InvalidWitness(
-                "point at infinity cannot be witnessed".into(),
-            ))
+            Err(Error::InvalidWitness(Box::new(PointAtInfinityError)))
         }
     }
 
@@ -346,6 +368,35 @@ mod tests {
         assert!(alloc(C::identity()).is_err());
 
         Ok(())
+    }
+
+    /// The identity is rejected with the typed [`PointAtInfinityError`]
+    /// source on both the witnessed and constant paths.
+    #[test]
+    fn test_identity_reports_typed_source() {
+        let result = Simulator::simulate(C::identity(), |dr, point| {
+            Point::alloc(dr, point.clone())?;
+            Ok(())
+        });
+        let Err(err) = result else {
+            panic!("identity point must be rejected");
+        };
+        assert_eq!(
+            err.invalid_witness_source::<PointAtInfinityError>(),
+            Some(&PointAtInfinityError)
+        );
+
+        let result = Simulator::simulate(C::identity(), |dr, _| {
+            Point::constant(dr, C::identity())?;
+            Ok(())
+        });
+        let Err(err) = result else {
+            panic!("identity constant must be rejected");
+        };
+        assert_eq!(
+            err.invalid_witness_source::<PointAtInfinityError>(),
+            Some(&PointAtInfinityError)
+        );
     }
 
     #[test]


### PR DESCRIPTION
extends the typed `InvalidWitness` source pattern introduced in #767 to division-by-zero and identity-point failures.