### PR TITLE
chore: use release of maybe-rayon fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,15 +634,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "maybe-rayon"
-version = "0.1.1"
-source = "git+https://github.com/tachyon-zcash/maybe-rayon.git?rev=5c37ee0dd448e8c1edc4529d0b8897ecaff5aad1#5c37ee0dd448e8c1edc4529d0b8897ecaff5aad1"
-dependencies = [
- "cfg-if",
- "rayon",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,11 +815,11 @@ dependencies = [
  "ff",
  "group",
  "gungraun",
- "maybe-rayon",
  "proptest",
  "ragu_macros",
  "ragu_testing",
  "rand 0.10.1",
+ "tachyon-maybe-rayon",
  "zakura-pasta-curves",
 ]
 
@@ -845,7 +836,6 @@ dependencies = [
  "ff",
  "group",
  "gungraun",
- "maybe-rayon",
  "proptest",
  "ragu_arithmetic",
  "ragu_core",
@@ -853,6 +843,7 @@ dependencies = [
  "ragu_primitives",
  "ragu_testing",
  "rand 0.10.1",
+ "tachyon-maybe-rayon",
  "zakura-pasta-curves",
 ]
 
@@ -905,7 +896,6 @@ dependencies = [
  "criterion",
  "ff",
  "gungraun",
- "maybe-rayon",
  "proptest",
  "ragu_arithmetic",
  "ragu_circuits",
@@ -914,6 +904,7 @@ dependencies = [
  "ragu_primitives",
  "ragu_testing",
  "rand 0.10.1",
+ "tachyon-maybe-rayon",
  "zakura-pasta-curves",
 ]
 
@@ -1178,6 +1169,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tachyon-maybe-rayon"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85270e8ca1975f46b1e703622f0720c0b92b36394442843381c31c5c34aca3f9"
+dependencies = [
+ "cfg-if",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,5 +100,5 @@ lazy_static = "1.5.0"
 proptest = "1.11.0"
 gungraun = "0.17.0"
 blake2b_simd = { version = "1.0", default-features = false }
-maybe-rayon = { git = "https://github.com/tachyon-zcash/maybe-rayon.git", rev = "5c37ee0dd448e8c1edc4529d0b8897ecaff5aad1", default-features = false }
+maybe-rayon = { package = "tachyon-maybe-rayon", version = "0.1.2", default-features = false }
 criterion = { version = "0.5", default-features = false }

--- a/qa/supply-chain/config.toml
+++ b/qa/supply-chain/config.toml
@@ -140,6 +140,10 @@ criteria = "safe-to-run"
 version = "0.9.8"
 criteria = "safe-to-deploy"
 
+[[exemptions.tachyon-maybe-rayon]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
 [[exemptions.tempfile]]
 version = "3.24.0"
 criteria = "safe-to-run"


### PR DESCRIPTION
avoid using dependencies from git by pulling the maybe-rayon fork from crates.io